### PR TITLE
Configure ESLint env and TypeScript libs for browser & Node

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ import eslintPluginJsxA11y from 'eslint-plugin-jsx-a11y';
 import parser from '@typescript-eslint/parser';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import js from '@eslint/js';
+import globals from 'globals';
 
 export default [
   {
@@ -24,11 +25,16 @@ export default [
       parser,
       parserOptions: {
         sourceType: 'module',
-        ecmaVersion: 2022,
+        ecmaVersion: 2020,
         ecmaFeatures: {
           jsx: true,
         },
         project: './tsconfig.json',
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.es2020,
       },
     },
     plugins: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,7 @@ import eslintPluginJsxA11y from 'eslint-plugin-jsx-a11y';
 import parser from '@typescript-eslint/parser';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import js from '@eslint/js';
+import globals from 'globals';
 
 export default [
   {
@@ -24,11 +25,16 @@ export default [
       parser,
       parserOptions: {
         sourceType: 'module',
-        ecmaVersion: 2022,
+        ecmaVersion: 2020,
         ecmaFeatures: {
           jsx: true,
         },
         project: './tsconfig.json',
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.es2020,
       },
     },
     plugins: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": ["ES2020", "DOM"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -29,7 +29,7 @@
         "name": "next"
       }
     ],
-    "types": []
+    "types": ["node"]
   },
   "include": ["**/*.ts", "**/*.tsx", "next-env.d.ts", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- configure ESLint to recognize browser, Node and ES2020 globals
- add ES2020 and DOM libs with Node types in tsconfig

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Player is not defined, and 53 other errors)*
- `npm run typecheck` *(fails: multiple modules missing and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e886ba764832bbdb6901a4a253af7