### PR TITLE
test: use Firestore Admin in watchlist test

### DIFF
--- a/firebaseHelpers.test.ts
+++ b/firebaseHelpers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test, vi } from 'vitest';
+
+interface MockRef {
+  set: (data: unknown) => Promise<void>;
+  get: () => Promise<{ exists: boolean; data: () => unknown }>;
+}
+
+interface MockCollection {
+  doc: (id: string) => MockRef;
+}
+
+interface MockAdminDb {
+  collection: (name: string) => MockCollection;
+}
+
+describe('Firestore Admin watchlist helpers', () => {
+  test('sets and retrieves watchlist data using admin SDK', async () => {
+    const userId = 'user1';
+    const playerIds = ['player1', 'player2'];
+
+    const set = vi.fn(async () => {});
+    const snapshotData = { playerIds };
+    const get = vi.fn(async () => ({ exists: true, data: () => snapshotData }));
+    const doc = vi.fn((): MockRef => ({ set, get }));
+    const collection = vi.fn((): MockCollection => ({ doc }));
+    const adminDb: MockAdminDb = { collection };
+
+    const ref = adminDb.collection('watchlists').doc(userId);
+    await ref.set({ playerIds });
+
+    const snapshot = await ref.get();
+    const data = snapshot.exists ? snapshot.data() : null;
+
+    expect(collection).toHaveBeenCalledWith('watchlists');
+    expect(doc).toHaveBeenCalledWith(userId);
+    expect(set).toHaveBeenCalledWith({ playerIds });
+    expect(get).toHaveBeenCalled();
+    expect(data).toEqual(snapshotData);
+  });
+});


### PR DESCRIPTION
## Summary
- use Firestore Admin collection/doc calls in firebaseHelpers.test
- verify watchlist retrieval via snapshot

## Testing
- `npx eslint firebaseHelpers.test.ts --config eslint.config.js --ext .ts`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688ec7a84f60832bb2cf3448bb333b42