### PR TITLE
fix: simplify path alias

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,13 +22,7 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/app/*": ["src/app/*"],
-      "@/components/*": ["src/components/*"],
-      "@/lib/*": ["src/lib/*"],
-      "@/context/*": ["src/Context/*"],
-      "@/AuthContext": ["src/AuthContext"],
-      "@/firebase": ["src/firebase"],
-      "@/firebase/*": ["src/firebase/*"]
+      "@/*": ["src/*"]
     },
     "allowImportingTsExtensions": true,
     "plugins": [


### PR DESCRIPTION
## Summary
- simplify TypeScript path alias config so `@/` points to `src`

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module '../serviceAccountKey.json')*

------
https://chatgpt.com/codex/tasks/task_e_688eccabc518832ba884c8eff24ebc50