### PR TITLE
Use env-based Firebase admin client in player page

### DIFF
--- a/src/app/players/[id]/page.tsx
+++ b/src/app/players/[id]/page.tsx
@@ -1,18 +1,9 @@
 // src/app/players/[id]/page.tsx
-import { getFirestore } from 'firebase-admin/firestore';
-import { initializeApp, cert, getApps, type ServiceAccount } from 'firebase-admin/app';
-// @ts-expect-error - local service account file is not checked into repo
-import serviceAccount from '../../../serviceAccountKey.json';
+import { adminDb } from '@/lib/firebaseAdmin';
 import PlayerSummaryCard from '@/components/PlayerSummaryCard';
 
-if (!getApps().length) {
-  initializeApp({ credential: cert(serviceAccount as ServiceAccount) });
-}
-
-const db = getFirestore();
-
 export default async function PlayerPage({ params }: { params: { id: string } }) {
-  const doc = await db.collection('players').doc(params.id).get();
+  const doc = await adminDb.collection('players').doc(params.id).get();
   const data = doc.data();
 
   if (!data) return <div>Player not found</div>;


### PR DESCRIPTION
## Summary
- replace hardcoded serviceAccountKey import with env-driven `adminDb`
- query Firestore via `adminDb` instead of local credential

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f460cd5ac832ba9a4927563efe4c3