### PR TITLE
feat: use static export for firebase hosting

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,7 +16,7 @@ const nextConfig = {
 
   compress: true,
 
-  output: 'standalone',
+  output: 'export',
 
   experimental: {
     serverActions: {},

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev --turbo",
-    "build": "tsc -b && next build",
+    "build": "tsc -b && next build && next export -o dist",
     "start": "next start",
     "clean": "rimraf dist .next && tsc --build --clean",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- use Next.js static `export` output
- build script exports static files to `dist`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module '../serviceAccountKey.json' or its type declarations)*
- `npx firebase-tools deploy --only hosting --non-interactive` *(fails: Failed to authenticate, run `firebase login`)*

------
https://chatgpt.com/codex/tasks/task_e_688f45daf760832bbfb2a8f6381775dd