### PR TITLE
Enable static export and update build script

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,7 +16,7 @@ const nextConfig = {
 
   compress: true,
 
-  output: 'standalone',
+  output: 'export',
 
   experimental: {
     serverActions: {},

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev --turbo",
-    "build": "tsc -b && next build",
+    "build": "tsc -b && next build && next export -o dist",
     "start": "next start",
     "clean": "rimraf dist .next && tsc --build --clean",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- configure Next.js to produce a static export
- update build script to also export to `dist`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module '../serviceAccountKey.json')*
- `firebase deploy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f44d8ac64832b9d39eb693566ee5c