### PR TITLE
fix: resolve firebase alias by moving config to index file

### DIFF
--- a/src/firebase/index.ts
+++ b/src/firebase/index.ts
@@ -1,4 +1,4 @@
-// src/firebase.ts
+// src/firebase/index.ts
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';


### PR DESCRIPTION
## Summary
- move firebase config into a dedicated folder with `index.ts` so `@/firebase` alias resolves

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '../serviceAccountKey.json')*
- `npm run build` *(fails: Cannot find module '../serviceAccountKey.json')*

------
https://chatgpt.com/codex/tasks/task_e_688f59616c6c832b9222d95200c8ff76