### PR TITLE
chore: reference secrets service account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ dist/
 .firebaserc
 firebase-debug.log
 serviceAccountKey.json
+secrets/serviceAccountKey.json
+!secrets/serviceAccountKey.example.json
 statly-*.json
 
 # --- Environment Files ---

--- a/Scripts/cleanPlayerData.ts
+++ b/Scripts/cleanPlayerData.ts
@@ -3,7 +3,7 @@ import { getFirestore } from 'firebase-admin/firestore';
 
 import type { ServiceAccount } from 'firebase-admin/app';
 
-import serviceAccount from '../serviceAccountKey.json' assert { type: 'json' };
+import serviceAccount from '../secrets/serviceAccountKey.json' assert { type: 'json' };
 
 if (!getApps().length) {
   initializeApp({ credential: cert(serviceAccount as ServiceAccount) });

--- a/Scripts/diffUnmatchedPlayers.ts
+++ b/Scripts/diffUnmatchedPlayers.ts
@@ -3,7 +3,7 @@ import fs from 'fs/promises';
 import { initializeApp, cert } from 'firebase-admin/app';
 import type { ServiceAccount } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
-import serviceAccount from '../serviceAccountKey.json' assert { type: 'json' };
+import serviceAccount from '../secrets/serviceAccountKey.json' assert { type: 'json' };
 
 initializeApp({
   credential: cert(serviceAccount as ServiceAccount),

--- a/Scripts/seedPlayers.ts
+++ b/Scripts/seedPlayers.ts
@@ -3,7 +3,7 @@ import fs from 'fs/promises';
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import { z } from 'zod';
-import serviceAccountRaw from '../serviceAccountKey.json' assert { type: 'json' };
+import serviceAccountRaw from '../secrets/serviceAccountKey.json' assert { type: 'json' };
 import type { ServiceAccount } from 'firebase-admin/app';
 
 const serviceAccount = serviceAccountRaw as ServiceAccount;

--- a/Scripts/seedPlayersFromMatchLogs.ts
+++ b/Scripts/seedPlayersFromMatchLogs.ts
@@ -2,7 +2,7 @@
 import fs from 'fs/promises';
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
-import serviceAccountRaw from '../serviceAccountKey.json' assert { type: 'json' };
+import serviceAccountRaw from '../secrets/serviceAccountKey.json' assert { type: 'json' };
 import type { ServiceAccount } from 'firebase-admin/app';
 import { z } from 'zod';
 

--- a/Scripts/uploadMatchLogs.ts
+++ b/Scripts/uploadMatchLogs.ts
@@ -2,7 +2,7 @@
 import fs from 'fs/promises';
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
-import serviceAccountRaw from '../serviceAccountKey.json' assert { type: 'json' };
+import serviceAccountRaw from '../secrets/serviceAccountKey.json' assert { type: 'json' };
 import type { ServiceAccount } from 'firebase-admin/app';
 import { z } from 'zod';
 

--- a/Scripts/uploadPlayerStats.ts
+++ b/Scripts/uploadPlayerStats.ts
@@ -4,7 +4,7 @@ import { initializeApp, cert, getApps } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import { z } from 'zod';
 import type { ServiceAccount } from 'firebase-admin/app';
-import serviceAccountRaw from '../serviceAccountKey.json' assert { type: 'json' };
+import serviceAccountRaw from '../secrets/serviceAccountKey.json' assert { type: 'json' };
 
 const serviceAccount = serviceAccountRaw as ServiceAccount;
 if (!getApps().length) {

--- a/secrets/serviceAccountKey.example.json
+++ b/secrets/serviceAccountKey.example.json
@@ -1,0 +1,8 @@
+{
+  "type": "service_account",
+  "project_id": "PROJECT_ID",
+  "private_key_id": "PRIVATE_KEY_ID",
+  "private_key": "PRIVATE_KEY",
+  "client_email": "CLIENT_EMAIL",
+  "client_id": "CLIENT_ID"
+}


### PR DESCRIPTION
## Summary
- update Firebase admin scripts to import credentials from `secrets/serviceAccountKey.json`
- add `serviceAccountKey.example.json` and ignore real `serviceAccountKey.json`

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688f68468188832b945e975efb7d0af0