### PR TITLE
refactor: support Next.js env for API helper and scripts

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:3000
+NEXT_PUBLIC_API_URL=http://localhost:3000

--- a/Scripts/cleanPlayerData.ts
+++ b/Scripts/cleanPlayerData.ts
@@ -1,15 +1,6 @@
-import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
+import { adminDb } from '../src/lib/firebaseAdmin';
 
-import type { ServiceAccount } from 'firebase-admin/app';
-
-import serviceAccount from '../serviceAccountKey.json' assert { type: 'json' };
-
-if (!getApps().length) {
-  initializeApp({ credential: cert(serviceAccount as ServiceAccount) });
-}
-
-const db = getFirestore();
+const db = adminDb;
 
 async function cleanPlayers(verbose = false) {
   const snapshot = await db.collection('players').get();

--- a/Scripts/diffUnmatchedPlayers.ts
+++ b/Scripts/diffUnmatchedPlayers.ts
@@ -1,15 +1,8 @@
 // scripts/diffUnmatchedPlayers.ts
 import fs from 'fs/promises';
-import { initializeApp, cert } from 'firebase-admin/app';
-import type { ServiceAccount } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
-import serviceAccount from '../serviceAccountKey.json' assert { type: 'json' };
+import { adminDb } from '../src/lib/firebaseAdmin';
 
-initializeApp({
-  credential: cert(serviceAccount as ServiceAccount),
-});
-
-const db = getFirestore();
+const db = adminDb;
 
 function clean(name: string): string {
   return name.toLowerCase().replace(/\s+/g, ' ').trim();

--- a/Scripts/seedPlayers.ts
+++ b/Scripts/seedPlayers.ts
@@ -1,14 +1,9 @@
 // scripts/seedPlayers.ts
 import fs from 'fs/promises';
-import { initializeApp, cert } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
 import { z } from 'zod';
-import serviceAccountRaw from '../serviceAccountKey.json' assert { type: 'json' };
-import type { ServiceAccount } from 'firebase-admin/app';
+import { adminDb } from '../src/lib/firebaseAdmin';
 
-const serviceAccount = serviceAccountRaw as ServiceAccount;
-initializeApp({ credential: cert(serviceAccount) });
-const db = getFirestore();
+const db = adminDb;
 
 const PlayerSchema = z.object({
   id: z.string(),

--- a/Scripts/seedPlayersFromMatchLogs.ts
+++ b/Scripts/seedPlayersFromMatchLogs.ts
@@ -1,14 +1,9 @@
 // scripts/seedPlayersFromMatchLog.ts
 import fs from 'fs/promises';
-import { initializeApp, cert } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
-import serviceAccountRaw from '../serviceAccountKey.json' assert { type: 'json' };
-import type { ServiceAccount } from 'firebase-admin/app';
 import { z } from 'zod';
+import { adminDb } from '../src/lib/firebaseAdmin';
 
-const serviceAccount = serviceAccountRaw as ServiceAccount;
-initializeApp({ credential: cert(serviceAccount) });
-const db = getFirestore();
+const db = adminDb;
 
 const MatchLogSchema = z.object({
   Player: z.string(),

--- a/Scripts/uploadMatchLogs.ts
+++ b/Scripts/uploadMatchLogs.ts
@@ -1,14 +1,9 @@
 // scripts/uploadMatchLogs.ts
 import fs from 'fs/promises';
-import { initializeApp, cert } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
-import serviceAccountRaw from '../serviceAccountKey.json' assert { type: 'json' };
-import type { ServiceAccount } from 'firebase-admin/app';
 import { z } from 'zod';
+import { adminDb } from '../src/lib/firebaseAdmin';
 
-const serviceAccount = serviceAccountRaw as ServiceAccount;
-initializeApp({ credential: cert(serviceAccount) });
-const db = getFirestore();
+const db = adminDb;
 
 const MatchLogSchema = z.object({
   Match_id: z.number(),

--- a/Scripts/uploadPlayerStats.ts
+++ b/Scripts/uploadPlayerStats.ts
@@ -1,17 +1,9 @@
 // scripts/uploadPlayerStats.ts
 import fs from 'fs/promises';
-import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
 import { z } from 'zod';
-import type { ServiceAccount } from 'firebase-admin/app';
-import serviceAccountRaw from '../serviceAccountKey.json' assert { type: 'json' };
+import { adminDb } from '../src/lib/firebaseAdmin';
 
-const serviceAccount = serviceAccountRaw as ServiceAccount;
-if (!getApps().length) {
-  initializeApp({ credential: cert(serviceAccount) });
-}
-
-const db = getFirestore();
+const db = adminDb;
 
 const PlayerStatSchema = z.object({
   Player: z.string(),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,10 +1,10 @@
 // src/lib/api.ts
 
 export async function fetchFromAPI<T>(path: string, options?: RequestInit): Promise<T> {
-  const rawBaseUrl = import.meta.env.VITE_API_URL;
+  const rawBaseUrl = process.env.NEXT_PUBLIC_API_URL;
 
   if (!rawBaseUrl) {
-    throw new Error('Missing VITE_API_URL in environment variables.');
+    throw new Error('Missing NEXT_PUBLIC_API_URL in environment variables.');
   }
 
   const baseUrl = rawBaseUrl.replace(/\/$/, '');


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_API_URL` instead of `VITE_API_URL`
- surface `NEXT_PUBLIC_API_URL` in development `.env`
- replace service account JSON imports in scripts with `adminDb` from firebaseAdmin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688f5b2bee5c832ba8ea2b725f95aace