### PR TITLE
Fetch current user's team for TradeCentre

### DIFF
--- a/src/app/tradecentre/TradeCentreShellClient.tsx
+++ b/src/app/tradecentre/TradeCentreShellClient.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import TradeCentreShell from '@/components/TradeCentreShell';
+import { useAuth } from '@/AuthContext';
+import { db } from '@/lib/firebaseClient';
+import { doc, getDoc } from 'firebase/firestore';
+import type { PlayerLite } from '@/types';
+
+interface Props {
+  players: PlayerLite[];
+}
+
+export default function TradeCentreShellClient({ players }: Props) {
+  const { user } = useAuth();
+  const [myTeamId, setMyTeamId] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (!user) return;
+    const fetchTeam = async () => {
+      try {
+        const snap = await getDoc(doc(db, 'users', user.uid));
+        const teamId = snap.data()?.teamId as string | undefined;
+        setMyTeamId(teamId);
+      } catch (err) {
+        console.error('Failed to load team ID', err);
+      }
+    };
+    fetchTeam();
+  }, [user]);
+
+  return <TradeCentreShell initialPlayers={players} myTeam={myTeamId} />;
+}
+

--- a/src/app/tradecentre/page.tsx
+++ b/src/app/tradecentre/page.tsx
@@ -1,14 +1,8 @@
 // src/app/tradecentre/page.tsx
 import * as React from 'react';
 import Link from 'next/link';
-import TradeCentreShell from '@/components/TradeCentreShell';
-
-type PlayerLite = {
-  id: string;
-  name: string;
-  team?: string;
-  position?: string;
-};
+import TradeCentreShellClient from './TradeCentreShellClient';
+import type { PlayerLite } from '@/types';
 
 // --- server-side fetch of a small player list to render the page ---
 async function fetchPlayers(): Promise<PlayerLite[]> {
@@ -63,7 +57,7 @@ export default async function TradeCentrePage() {
           <pre className="mt-1 whitespace-pre-wrap text-xs">{error}</pre>
         </div>
       ) : (
-        <TradeCentreShell initialPlayers={players} myTeam={undefined /* your team id */} />
+        <TradeCentreShellClient players={players} />
       )}
     </main>
   );


### PR DESCRIPTION
## Summary
- Retrieve signed-in user's team ID from Firestore
- Pass team ID to TradeCentreShell so correct team is shown

## Testing
- `npm test` *(fails: No test suite found in file /workspace/Statly/firebaseHelpers.test.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897f6c15c6c832bb85d2900742be9e0