### PR TITLE
Redirect unauthenticated dashboard visitors

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 import Link from "next/link";
 import { useAuth } from "@/AuthContext";
-import { useMemo } from "react";
+import { useMemo, useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 export default function Page() {
-  const { user, logout } = useAuth();
+  const { user, logout, loading } = useAuth();
+  const router = useRouter();
 
   const firstName = useMemo(() => {
     if (!user) {
@@ -14,15 +16,23 @@ export default function Page() {
     return user.displayName?.trim().split(/\s+/)[0] || user.email?.split("@")[0] || "Guest";
   }, [user]);
 
+  // Redirect unauthenticated visitors to the login page
+  useEffect(() => {
+    if (!loading && !user) {
+      router.replace("/login");
+    }
+  }, [user, loading, router]);
+
   // It's good practice to show a loading state while auth status is being determined.
   // This prevents a "Welcome, Guest" flash for logged-in users on page load.
-  if (user === undefined) {
+  if (loading) {
     // A skeleton loader would be even better for UX.
     return <div className="p-6 text-center text-gray-500">Loading dashboard...</div>;
   }
 
-  // TODO: For protected routes, handle the case where the user is not logged in (user is null).
-  // This is often done with a redirect in a layout or middleware.
+  if (!user) {
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Redirect unauthenticated users from the dashboard to the login page with a client-side hook
- Display a loading state while authentication status is resolved

## Testing
- `npm test` *(fails: No test suite found in firebaseHelpers.test.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68980ac3f178832baf50a1e784184369