### PR TITLE
Refactor dashboard page rendering

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,80 +1,20 @@
 "use client";
-import Link from "next/link";
+
 import { useAuth } from "@/AuthContext";
-import { useMemo, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import AuthCTA from "@/components/AuthCTA";
+import DashboardLoading from "@/components/DashboardLoading";
+import UserDashboard from "@/components/UserDashboard";
 
 export default function Page() {
-  const { user, logout, loading } = useAuth();
-  const router = useRouter();
+  const { user, loading } = useAuth();
 
-  const firstName = useMemo(() => {
-    if (!user) {
-      return "Guest";
-    }
-    // Prefer first name from displayName, fallback to email prefix
-    return user.displayName?.trim().split(/\s+/)[0] || user.email?.split("@")[0] || "Guest";
-  }, [user]);
-
-  // Redirect unauthenticated visitors to the login page
-  useEffect(() => {
-    if (!loading && !user) {
-      router.replace("/login");
-    }
-  }, [user, loading, router]);
-
-  // It's good practice to show a loading state while auth status is being determined.
-  // This prevents a "Welcome, Guest" flash for logged-in users on page load.
   if (loading) {
-    // A skeleton loader would be even better for UX.
-    return <div className="p-6 text-center text-gray-500">Loading dashboard...</div>;
+    return <DashboardLoading />;
   }
 
   if (!user) {
-    return null;
+    return <AuthCTA />;
   }
 
-  return (
-    <>
-      {/* Page header actions */}
-      <div className="flex items-center justify-between px-6 py-3 border-b bg-white">
-        <h1 className="text-xl font-bold text-gray-900">Statly</h1>
-
-        <div className="flex items-center gap-6">
-          <span className="text-gray-900">
-            Welcome, <span className="font-semibold">{firstName}</span>
-          </span>
-
-          <nav aria-label="Dashboard actions">
-            <ul className="flex items-center gap-4">
-              <li>
-                <Link href="/players" className="text-blue-700 hover:underline">
-                  Players
-                </Link>
-              </li>
-              <li>
-                <Link href="/tradecentre" className="text-blue-700 hover:underline">
-                  Trade Centre
-                </Link>
-              </li>
-            </ul>
-          </nav>
-
-          <button
-            type="button"
-            onClick={logout}
-            className="text-red-700 hover:underline"
-          >
-            Sign out
-          </button>
-        </div>
-      </div>
-
-      {/* Main content */}
-      <main className="p-6">
-        <h2 className="text-2xl font-bold mb-2 text-gray-900">Dashboard</h2>
-        <p className="text-gray-800">Welcome to your dashboard!</p>
-      </main>
-    </>
-  );
+  return <UserDashboard user={user} />;
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,19 +1,27 @@
 "use client";
 
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { useAuth } from "@/AuthContext";
-import AuthCTA from "@/components/AuthCTA";
 import DashboardLoading from "@/components/DashboardLoading";
 import UserDashboard from "@/components/UserDashboard";
 
 export default function Page() {
   const { user, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.replace("/login");
+    }
+  }, [loading, user, router]);
 
   if (loading) {
     return <DashboardLoading />;
   }
 
   if (!user) {
-    return <AuthCTA />;
+    return null;
   }
 
   return <UserDashboard user={user} />;

--- a/src/components/UserDashboard.tsx
+++ b/src/components/UserDashboard.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { useMemo } from 'react';
 import type { User } from 'firebase/auth';
 
 interface UserDashboardProps {
@@ -6,11 +7,19 @@ interface UserDashboardProps {
 }
 
 export default function UserDashboard({ user }: UserDashboardProps) {
+  const firstName = useMemo(() => {
+    return (
+      user.displayName?.trim().split(/\s+/)[0] ||
+      user.email?.split("@")[0] ||
+      "Player"
+    );
+  }, [user]);
+
   return (
     <main className="container mx-auto p-4 sm:p-6 lg:p-8" role="main">
       <header className="mb-8">
         <h1 className="text-3xl font-bold text-foreground">
-          Welcome, {user.displayName || user.email || 'Player'}!
+          Welcome, {firstName}!
         </h1>
         <p className="text-lg text-muted-foreground mt-1">
           Here&apos;s your fantasy dashboard. Good luck this season!


### PR DESCRIPTION
## Summary
- Render dashboard using reusable components for loading, auth prompt, and user view
- Use `UserDashboard` to display authenticated content once user data is available

## Testing
- `npm test` *(fails: No test suite found in file /workspace/Statly/firebaseHelpers.test.ts)*
- `npx eslint src/app/dashboard/page.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6898116cea68832ba7fd7afccef55d60