### PR TITLE
feat: add auth CTA and dashboard loading

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 import Link from "next/link";
 import { useAuth } from "@/AuthContext";
-import { useMemo, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useMemo } from "react";
+import DashboardLoading from "@/components/DashboardLoading";
+import AuthCTA from "@/components/AuthCTA";
 
 export default function Page() {
   const { user, logout, loading } = useAuth();
-  const router = useRouter();
 
   const firstName = useMemo(() => {
     if (!user) {
@@ -16,22 +16,14 @@ export default function Page() {
     return user.displayName?.trim().split(/\s+/)[0] || user.email?.split("@")[0] || "Guest";
   }, [user]);
 
-  // Redirect unauthenticated visitors to the login page
-  useEffect(() => {
-    if (!loading && !user) {
-      router.replace("/login");
-    }
-  }, [user, loading, router]);
-
   // It's good practice to show a loading state while auth status is being determined.
   // This prevents a "Welcome, Guest" flash for logged-in users on page load.
   if (loading) {
-    // A skeleton loader would be even better for UX.
-    return <div className="p-6 text-center text-gray-500">Loading dashboard...</div>;
+    return <DashboardLoading />;
   }
 
   if (!user) {
-    return null;
+    return <AuthCTA />;
   }
 
   return (

--- a/src/components/AuthCTA.tsx
+++ b/src/components/AuthCTA.tsx
@@ -1,14 +1,14 @@
-import Link from 'next/link';
+import Link from "next/link";
 
 export default function AuthCTA() {
   return (
-    <main className="container mx-auto p-4 sm:p-6 lg:p-8" role="main">
-      <h1 className="text-3xl font-bold">You&apos;re not signed in</h1>
-      <p className="text-muted-foreground mt-2">Please sign in to view your dashboard.</p>
-      <div className="mt-4">
+    <main className="p-6 text-center space-y-4" role="main">
+      <h1 className="text-2xl font-bold text-gray-900">You&apos;re not signed in</h1>
+      <p className="text-gray-600">Please sign in to view your dashboard.</p>
+      <div>
         <Link
           href="/"
-          className="inline-flex items-center rounded-lg bg-primary px-4 py-2 font-semibold text-primary-foreground hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          className="inline-flex items-center rounded bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600"
         >
           Sign In
         </Link>

--- a/src/components/DashboardLoading.tsx
+++ b/src/components/DashboardLoading.tsx
@@ -1,7 +1,18 @@
+import LoadingSpinner from "./LoadingSpinner";
+
 export default function DashboardLoading() {
   return (
-    <main className="container mx-auto p-4 sm:p-6 lg:p-8" role="main" aria-busy="true">
-      <h1 className="text-2xl font-bold">Loading your dashboard…</h1>
+    <main
+      className="flex flex-col items-center p-6 space-y-6"
+      role="main"
+      aria-busy="true"
+    >
+      <LoadingSpinner />
+      <div className="w-full max-w-md space-y-4 animate-pulse">
+        <div className="h-6 w-3/4 mx-auto rounded bg-gray-200 dark:bg-gray-700" />
+        <div className="h-4 w-full rounded bg-gray-200 dark:bg-gray-700" />
+        <div className="h-4 w-5/6 rounded bg-gray-200 dark:bg-gray-700" />
+      </div>
     </main>
   );
 }

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 const LoadingSpinner: React.FC = () => {
   return (
-    <div className="flex justify-center items-center">
-      <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+    <div className="flex items-center justify-center">
+      <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-t-2 border-blue-600"></div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- replace inline dashboard load message with `<DashboardLoading />` and show `<AuthCTA />` when unauthenticated
- add spinner-driven dashboard loading skeleton styled to match theme
- introduce themed auth call-to-action and update spinner styling

## Testing
- `npm test` (fails: No test suite found in file /workspace/Statly/firebaseHelpers.test.ts)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898116ff0e8832ba552ff05f0c266e1