### PR TITLE
feat: improve sign-out handling

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useAuth } from "@/AuthContext";
-import { useMemo, useEffect, useState } from "react";
+import { useMemo, useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 
 export default function Page() {
@@ -9,16 +9,20 @@ export default function Page() {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
 
-  const handleSignOut = async () => {
+  const handleSignOut = useCallback(async () => {
     setError(null);
     try {
       await logout();
       router.push("/login");
     } catch (err) {
-      console.error(err);
+      if (err instanceof Error) {
+        console.error("Sign-out failed:", err.message);
+      } else {
+        console.error("An unknown error occurred during sign-out:", err);
+      }
       setError("Failed to sign out. Please try again.");
     }
-  };
+  }, [logout, router]);
 
   const firstName = useMemo(() => {
     if (!user) {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,12 +1,24 @@
 "use client";
 import Link from "next/link";
 import { useAuth } from "@/AuthContext";
-import { useMemo, useEffect } from "react";
+import { useMemo, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 export default function Page() {
   const { user, logout, loading } = useAuth();
   const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSignOut = async () => {
+    setError(null);
+    try {
+      await logout();
+      router.push("/login");
+    } catch (err) {
+      console.error(err);
+      setError("Failed to sign out. Please try again.");
+    }
+  };
 
   const firstName = useMemo(() => {
     if (!user) {
@@ -62,13 +74,19 @@ export default function Page() {
 
           <button
             type="button"
-            onClick={logout}
+            onClick={handleSignOut}
             className="text-red-700 hover:underline"
           >
             Sign out
           </button>
         </div>
       </div>
+
+      {error && (
+        <div className="px-6 py-2 text-red-600" role="alert">
+          {error}
+        </div>
+      )}
 
       {/* Main content */}
       <main className="p-6">

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -4,6 +4,7 @@ export default function Loading() {
   return (
     <div className="flex h-screen w-full items-center justify-center">
       <LoadingSpinner />
+      <span className="sr-only">Loading dashboard...</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- handle sign-out with an asynchronous function that awaits logout and redirects to login
- show a friendly error message if sign-out fails

## Testing
- `npm test` *(fails: No test suite found in file /workspace/Statly/firebaseHelpers.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689811722d20832ba9a28e94b0d5cf68