### PR TITLE
Redirect unauthenticated users to login

### DIFF
--- a/src/components/AuthCTA.tsx
+++ b/src/components/AuthCTA.tsx
@@ -7,7 +7,7 @@ export default function AuthCTA() {
       <p className="text-muted-foreground mt-2">Please sign in to view your dashboard.</p>
       <div className="mt-4">
         <Link
-          href="/"
+          href="/login"
           className="inline-flex items-center rounded-lg bg-primary px-4 py-2 font-semibold text-primary-foreground hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
         >
           Sign In


### PR DESCRIPTION
## Summary
- Update AuthCTA component to link unauthenticated users to `/login`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: ERESOLVE could not resolve dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6898167c45d4832b979a2447ca296649