### PR TITLE
feat: improve dashboard loading accessibility

### DIFF
--- a/src/components/DashboardLoading.tsx
+++ b/src/components/DashboardLoading.tsx
@@ -1,6 +1,16 @@
+import LoadingSpinner from './LoadingSpinner';
+
 export default function DashboardLoading() {
   return (
-    <main className="container mx-auto p-4 sm:p-6 lg:p-8" role="main" aria-busy="true">
+    <main
+      className="container mx-auto p-4 sm:p-6 lg:p-8"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <div role="status" className="flex flex-col items-center">
+        <LoadingSpinner />
+        <span className="sr-only">Loading dashboard...</span>
+      </div>
       <h1 className="text-2xl font-bold">Loading your dashboard…</h1>
     </main>
   );


### PR DESCRIPTION
## Summary
- add visually hidden loading message near dashboard spinner
- mark loading container with `aria-live` and `role="status"`

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6898167dcfac832b86d1f52740b7bf7b