### PR TITLE
chore: track package lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # --- Node ---
 node_modules/
-package-lock.json
 npm-debug.log*
 yarn.lock
 pnpm-lock.yaml


### PR DESCRIPTION
## Summary
- remove package-lock.json from .gitignore so lock file stays tracked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898238a09d8832b894a70a8fec27cd5