### PR TITLE
chore: ensure ESLint ignores match directories anywhere

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,8 +29,8 @@ export default [
       '**/build/**',
       '**/coverage/**',
       '**/public/**',
-      'out/**',
-      'Statly.worktrees/**',
+      '**/out/**',
+      '**/Statly.worktrees/**',
       // local config/meta files
       'eslint.config.js',
       'tailwind.config.*',


### PR DESCRIPTION
## Summary
- prefix ESLint ignore patterns with `**/` so directories match anywhere in the tree

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689827ac415c832b8273fbe26096706a