### PR TITLE
feat: show login prompt for unauthenticated users

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,27 +1,19 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { useAuth } from "@/AuthContext";
 import DashboardLoading from "@/components/DashboardLoading";
+import AuthCTA from "@/components/AuthCTA";
 import UserDashboard from "@/components/UserDashboard";
 
 export default function Page() {
   const { user, loading } = useAuth();
-  const router = useRouter();
-
-  useEffect(() => {
-    if (!loading && !user) {
-      router.replace("/login");
-    }
-  }, [loading, user, router]);
 
   if (loading) {
     return <DashboardLoading />;
   }
 
   if (!user) {
-    return null;
+    return <AuthCTA />;
   }
 
   return <UserDashboard user={user} />;


### PR DESCRIPTION
## Summary
- show AuthCTA when user is not authenticated instead of redirect or returning null

## Testing
- `npm test` (fails: vitest not found)
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68982d08335c832bb794f02e0d9c6353