### PR TITLE
Exclude utility scripts from TypeScript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,6 +46,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "Scripts/**"
   ]
 }


### PR DESCRIPTION
## Summary
- prevent compilation issues by ignoring `Scripts/**` in tsconfig

## Testing
- `npm test`
- `npm run typecheck` *(fails: File '/workspace/Statly/firebaseHelpers.ts' is not a module, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68982efbc51c832bbb8bdaad4c01b3ad