### PR TITLE
refactor: update firebase client import

### DIFF
--- a/Scripts/seedRoomMeta.ts
+++ b/Scripts/seedRoomMeta.ts
@@ -1,4 +1,4 @@
-import { db } from '@/firebase';
+import { db } from '@/lib/firebaseClient';
 import { doc, updateDoc } from 'firebase/firestore';
 
 type RoomStatus = 'pending' | 'active' | 'completed';
@@ -32,3 +32,4 @@ async function seedRoomMeta() {
 }
 
 seedRoomMeta();
+


### PR DESCRIPTION
## Summary
- refactor seedRoomMeta script to use shared firebaseClient for Firestore access

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module '../secrets/serviceAccountKey.json')*
- `NODE_ENV=development NEXT_PUBLIC_FIREBASE_API_KEY=foo NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=foo NEXT_PUBLIC_FIREBASE_PROJECT_ID=foo NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=foo NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=foo NEXT_PUBLIC_FIREBASE_APP_ID=foo NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=foo node --loader ts-node/esm -e "import { db } from './src/lib/firebaseClient.ts'; console.log('db type', db.constructor.name);"`

------
https://chatgpt.com/codex/tasks/task_e_68982eff3140832bb4284adaa8366b3b