### PR TITLE
Add Firebase helpers and MyTeam page

### DIFF
--- a/firebaseHelpers.test.ts
+++ b/firebaseHelpers.test.ts
@@ -1,8 +1,38 @@
-import { describe, expect, it } from 'vitest';
+/* @vitest-environment jsdom */
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  loadUserSettings,
+  saveUserSettings,
+  loadUserLeagueRequests,
+  saveUserLeagueRequests,
+  type LeagueRequest,
+  type UserSettings,
+} from './firebaseHelpers';
+
+const uid = 'user-1';
 
 describe('firebaseHelpers', () => {
-  it('placeholder test', () => {
-    expect(true).toBe(true);
+  beforeEach(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.clear();
+    }
+  });
+
+  it('saves and loads user settings', async () => {
+    const settings: UserSettings = {
+      theme: 'dark',
+      notifications: false,
+      favoriteTeam: 'Cats',
+    };
+    await saveUserSettings(uid, settings);
+    const result = await loadUserSettings(uid);
+    expect(result).toEqual(settings);
+  });
+
+  it('saves and loads league requests', async () => {
+    const requests: LeagueRequest[] = [{ leagueId: 'abc', status: 'Pending' }];
+    await saveUserLeagueRequests(uid, requests);
+    const result = await loadUserLeagueRequests(uid);
+    expect(result).toEqual(requests);
   });
 });
-

--- a/firebaseHelpers.test.ts
+++ b/firebaseHelpers.test.ts
@@ -18,21 +18,39 @@ describe('firebaseHelpers', () => {
     }
   });
 
-  it('saves and loads user settings', async () => {
+  it('saves and loads user settings', () => {
     const settings: UserSettings = {
       theme: 'dark',
       notifications: false,
       favoriteTeam: 'Cats',
     };
-    await saveUserSettings(uid, settings);
-    const result = await loadUserSettings(uid);
+    saveUserSettings(uid, settings);
+    const result = loadUserSettings(uid);
     expect(result).toEqual(settings);
   });
 
-  it('saves and loads league requests', async () => {
+  it('saves and loads league requests', () => {
     const requests: LeagueRequest[] = [{ leagueId: 'abc', status: 'Pending' }];
-    await saveUserLeagueRequests(uid, requests);
-    const result = await loadUserLeagueRequests(uid);
+    saveUserLeagueRequests(uid, requests);
+    const result = loadUserLeagueRequests(uid);
     expect(result).toEqual(requests);
+  });
+
+  it('returns empty object when settings are malformed', () => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(
+      `user_settings:${uid}`,
+      JSON.stringify('not-an-object')
+    );
+    expect(loadUserSettings(uid)).toEqual({});
+  });
+
+  it('returns empty array when league requests are malformed', () => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(
+      `league_requests:${uid}`,
+      JSON.stringify({ bad: 'data' })
+    );
+    expect(loadUserLeagueRequests(uid)).toEqual([]);
   });
 });

--- a/firebaseHelpers.ts
+++ b/firebaseHelpers.ts
@@ -20,17 +20,19 @@ function hasLocalStorage() {
   }
 }
 
-export async function loadUserSettings(uid: string): Promise<Partial<UserSettings>> {
+export function loadUserSettings(uid: string): Partial<UserSettings> {
   if (!hasLocalStorage()) return {};
   try {
     const raw = window.localStorage.getItem(`${SETTINGS_PREFIX}${uid}`);
-    return raw ? JSON.parse(raw) : {};
+    if (!raw) return {};
+    const data = JSON.parse(raw);
+    return typeof data === 'object' && data !== null ? data : {};
   } catch {
     return {};
   }
 }
 
-export async function saveUserSettings(uid: string, settings: UserSettings): Promise<void> {
+export function saveUserSettings(uid: string, settings: UserSettings): void {
   if (!hasLocalStorage()) return;
   try {
     window.localStorage.setItem(
@@ -42,17 +44,22 @@ export async function saveUserSettings(uid: string, settings: UserSettings): Pro
   }
 }
 
-export async function loadUserLeagueRequests(uid: string): Promise<LeagueRequest[]> {
+export function loadUserLeagueRequests(uid: string): LeagueRequest[] {
   if (!hasLocalStorage()) return [];
   try {
     const raw = window.localStorage.getItem(`${LEAGUE_PREFIX}${uid}`);
-    return raw ? JSON.parse(raw) : [];
+    if (!raw) return [];
+    const data = JSON.parse(raw);
+    return Array.isArray(data) ? data : [];
   } catch {
     return [];
   }
 }
 
-export async function saveUserLeagueRequests(uid: string, requests: LeagueRequest[]): Promise<void> {
+export function saveUserLeagueRequests(
+  uid: string,
+  requests: LeagueRequest[]
+): void {
   if (!hasLocalStorage()) return;
   try {
     window.localStorage.setItem(

--- a/firebaseHelpers.ts
+++ b/firebaseHelpers.ts
@@ -1,0 +1,65 @@
+export interface UserSettings {
+  theme: string;
+  notifications: boolean;
+  favoriteTeam: string;
+}
+
+export interface LeagueRequest {
+  leagueId: string;
+  status: string;
+}
+
+const SETTINGS_PREFIX = 'user_settings:';
+const LEAGUE_PREFIX = 'league_requests:';
+
+function hasLocalStorage() {
+  try {
+    return typeof window !== 'undefined' && !!window.localStorage;
+  } catch {
+    return false;
+  }
+}
+
+export async function loadUserSettings(uid: string): Promise<Partial<UserSettings>> {
+  if (!hasLocalStorage()) return {};
+  try {
+    const raw = window.localStorage.getItem(`${SETTINGS_PREFIX}${uid}`);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+export async function saveUserSettings(uid: string, settings: UserSettings): Promise<void> {
+  if (!hasLocalStorage()) return;
+  try {
+    window.localStorage.setItem(
+      `${SETTINGS_PREFIX}${uid}`,
+      JSON.stringify(settings)
+    );
+  } catch (err) {
+    console.error('Failed to save user settings', err);
+  }
+}
+
+export async function loadUserLeagueRequests(uid: string): Promise<LeagueRequest[]> {
+  if (!hasLocalStorage()) return [];
+  try {
+    const raw = window.localStorage.getItem(`${LEAGUE_PREFIX}${uid}`);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function saveUserLeagueRequests(uid: string, requests: LeagueRequest[]): Promise<void> {
+  if (!hasLocalStorage()) return;
+  try {
+    window.localStorage.setItem(
+      `${LEAGUE_PREFIX}${uid}`,
+      JSON.stringify(requests)
+    );
+  } catch (err) {
+    console.error('Failed to save league requests', err);
+  }
+}

--- a/src/Pages/MyTeam.tsx
+++ b/src/Pages/MyTeam.tsx
@@ -7,6 +7,7 @@ import { db } from '@/lib/firebaseClient';
 const MyTeam: React.FC = () => {
   const [players, setPlayers] = useState<Player[]>([]);
   const [team, setTeam] = useState<Team>({ id: 'my-team', players: [] });
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function fetchPlayers() {
@@ -14,12 +15,13 @@ const MyTeam: React.FC = () => {
         const snap = await getDocs(collection(db, 'players'));
         const data: Player[] = snap.docs.map((doc) => ({
           id: doc.id,
-          ...(doc.data() as any),
+          ...(doc.data() as Omit<Player, 'id'>),
         }));
         setPlayers(data);
         setTeam({ id: 'my-team', players: data.map((p) => p.id) });
       } catch (err) {
         console.error('Failed to load players', err);
+        setError('Unable to load players.');
       }
     }
     fetchPlayers();
@@ -28,6 +30,7 @@ const MyTeam: React.FC = () => {
   return (
     <main className="p-4">
       <h1 className="text-2xl font-bold mb-4">My Team</h1>
+      {error && <p className="text-red-500 mb-4">{error}</p>}
       <MyTeamPanel team={team} players={players} />
     </main>
   );

--- a/src/Pages/MyTeam.tsx
+++ b/src/Pages/MyTeam.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import MyTeamPanel from '@/components/MyTeamPanel';
+import type { Player, Team } from '@/types';
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from '@/lib/firebaseClient';
+
+const MyTeam: React.FC = () => {
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [team, setTeam] = useState<Team>({ id: 'my-team', players: [] });
+
+  useEffect(() => {
+    async function fetchPlayers() {
+      try {
+        const snap = await getDocs(collection(db, 'players'));
+        const data: Player[] = snap.docs.map((doc) => ({
+          id: doc.id,
+          ...(doc.data() as any),
+        }));
+        setPlayers(data);
+        setTeam({ id: 'my-team', players: data.map((p) => p.id) });
+      } catch (err) {
+        console.error('Failed to load players', err);
+      }
+    }
+    fetchPlayers();
+  }, []);
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">My Team</h1>
+      <MyTeamPanel team={team} players={players} />
+    </main>
+  );
+};
+
+export default MyTeam;


### PR DESCRIPTION
## Summary
- implement localStorage-based helpers for user settings and league join requests
- add MyTeam page to render players using MyTeamPanel
- test saving/loading helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68982f01db68832bbf6df7ab4608abb5