### PR TITLE
refactor: inline player page params

### DIFF
--- a/src/app/players/[id]/page.tsx
+++ b/src/app/players/[id]/page.tsx
@@ -1,4 +1,3 @@
-import type { PageProps } from 'next';
 import { notFound } from 'next/navigation';
 import type { Player } from '@/types';
 import { getPlayerIds, getPlayer } from '@/lib/data';
@@ -10,7 +9,7 @@ export async function generateStaticParams() {
 }
 
 // Page metadata
-export async function generateMetadata({ params }: PageProps<{ id: string }>) {
+export async function generateMetadata({ params }: { params: { id: string } }) {
   const { id } = params;
   const player = await getPlayer(id);
   if (!player) return { title: 'Player Not Found' };
@@ -21,7 +20,7 @@ export async function generateMetadata({ params }: PageProps<{ id: string }>) {
   };
 }
 
-export default async function PlayerPage({ params }: PageProps<{ id: string }>) {
+export default async function PlayerPage({ params }: { params: { id: string } }) {
   const { id } = params;
   const player: Player | null = await getPlayer(id);
   if (!player) notFound();


### PR DESCRIPTION
## Summary
- remove Next.js PageProps usage
- inline player page parameter types

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '../secrets/serviceAccountKey.json', and other module and property errors)*

------
https://chatgpt.com/codex/tasks/task_e_68982f0556f8832b907b543b177cad6b