### PR TITLE
Add team name optional field and enforce in DraftOrderBar

### DIFF
--- a/src/components/DraftOrderBar.tsx
+++ b/src/components/DraftOrderBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Team } from '../types';
 
 interface DraftOrderBarProps {
-  teams?: Team[];
+  teams?: Array<Team & { name: string }>;
   currentPickIndex: number;
   myTeamId?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface Player {
 // Minimal Team shape used by MyTeamPanel
 export interface Team {
   id: string;
+  name?: string;
   players?: Array<string | number>; // ids of players on the team
 }
 


### PR DESCRIPTION
## Summary
- add optional `name` field to Team type
- require team names for teams in DraftOrderBar

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '../secrets/serviceAccountKey.json', and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68982f069ea0832b883b87974fb83021