### PR TITLE
feat: expand player fields

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -27,6 +27,13 @@ const normalizeKey = (k: string) => {
     venue: 'venue',
     date: 'date',
     status: 'status',
+    injury: 'injury',
+    'injury status': 'injury',
+    injury_status: 'injury',
+    games: 'games',
+    'games played': 'games',
+    gms: 'games',
+    summary: 'summary',
 
     // UI core stats
     k: 'kicks',
@@ -155,7 +162,22 @@ async function loadAllPlayers(): Promise<Player[]> {
       if (key in r) stats[key] = (r as AnyObj)[key];
     }
 
-    return { id, name, team, position, ...(r as AnyObj), stats } as Player;
+    const injury = pick<string>(r, ['injury']);
+    const gamesRaw = pick<number | string>(r, ['games']);
+    const games = gamesRaw != null && !Number.isNaN(Number(gamesRaw)) ? Number(gamesRaw) : undefined;
+    const summary = pick<Record<string, number>>(r, ['summary']);
+
+    return {
+      id,
+      name,
+      team,
+      position,
+      ...(r as AnyObj),
+      injury,
+      games,
+      summary,
+      stats,
+    } as Player;
   });
 
   players.sort((a, b) => a.name.localeCompare(b.name));

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,9 @@ export interface Player {
   position?: string;
   stats?: Record<string, number | string>;
   avg?: number;
+  injury?: string;
+  games?: number;
+  summary?: Record<string, number>;
 
   // Optional detailed stats
   kicks?: number;


### PR DESCRIPTION
## Summary
- add optional injury, games, and summary fields to Player type
- normalize and populate injury, games, and summary data when loading players

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '../secrets/serviceAccountKey.json', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68982f083584832b894fbef9344e743b