### PR TITLE
fix hook imports

### DIFF
--- a/src/components/TradeCentreClient.tsx
+++ b/src/components/TradeCentreClient.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState, useCallback, useEffect } from 'react';
 import Link from 'next/link';
-import { useDebounce } from '@/Hooks/useDebounce';
+import { useDebounce } from '@/hooks/useDebounce';
 import type { Player } from '@/types';
 import { statLabels, TradeCentreStrings } from '@/lib/constants';
 import { useTradeStore } from '@/state/tradeStore';

--- a/src/hooks/ValueCell.tsx
+++ b/src/hooks/ValueCell.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import * as React from 'react';
-import { useRankings } from '@/lib/hooks/useRankings';
+import { useRankings } from '@/hooks/useRankings';
 
 export default function ValueCell({ playerId }: { playerId: string }) {
-  const { map, isLoading, error } = useRankings();
+  const { get, isLoading, error } = useRankings();
 
   if (isLoading) return <span className="opacity-60">…</span>;
   if (error) return <span className="text-red-500">—</span>;
 
-  const v = map.get(playerId)?.totalValue;
+  const v = get(playerId)?.totalValue;
   return <span>{typeof v === 'number' ? v.toFixed(2) : '—'}</span>;
 }


### PR DESCRIPTION
## Summary
- remove stray root-level useDebounce and point TradeCentreClient to hooks version
- use hooks/useRankings in ValueCell

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68982f0a6be8832ba295cc258cb0e871