### PR TITLE
feat: add dashboard data types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -44,3 +44,33 @@ export interface Team {
 export type PlayerLite = Pick<Player, 'id' | 'name' | 'team' | 'position'> & {
   [key: string]: unknown;
 };
+
+// ----- Dashboard Types -----
+
+// Standings row used on the leaderboard/dashboard
+export interface LeagueStanding {
+  rank: number;
+  teamName: string;
+  wins: number;
+  losses: number;
+  ties: number;
+  percentage: number;
+  gamesBehind: string;
+}
+
+// Activity feed entry for recent league events
+export interface RecentActivity {
+  date: string;
+  type: 'Added' | 'Dropped' | 'Trade';
+  team: string;
+  player: string;
+  details: string;
+}
+
+// News snippet associated with a player
+export interface PlayerNews {
+  player: string;
+  news: string;
+  severity: 'low' | 'medium' | 'high';
+  date: string;
+}


### PR DESCRIPTION
## Summary
- define `LeagueStanding`, `RecentActivity`, and `PlayerNews` types
- expose types to support mock dashboard data

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '../secrets/serviceAccountKey.json' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68982f0b8574832bab59c6c25ce3129f