### PR TITLE
feat: add dashboard types

### DIFF
--- a/src/lib/mockDashboardData.ts
+++ b/src/lib/mockDashboardData.ts
@@ -1,4 +1,4 @@
-import type { LeagueStanding, RecentActivity, PlayerNews } from '../types';
+import type { LeagueStanding, RecentActivity, PlayerNews } from '@/types';
 
 export const mockStandings: LeagueStanding[] = [
   { rank: 1, teamName: "Matthew's Monstrous Team", wins: 14, losses: 3, ties: 1, percentage: 0.806, gamesBehind: '--' },

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,3 +44,28 @@ export interface Team {
 export type PlayerLite = Pick<Player, 'id' | 'name' | 'team' | 'position'> & {
   [key: string]: unknown;
 };
+
+export interface LeagueStanding {
+  rank: number;
+  teamName: string;
+  wins: number;
+  losses: number;
+  ties: number;
+  percentage: number;
+  gamesBehind: string;
+}
+
+export interface RecentActivity {
+  date: string;
+  type: string;
+  team: string;
+  player: string;
+  details: string;
+}
+
+export interface PlayerNews {
+  player: string;
+  news: string;
+  severity: 'low' | 'medium' | 'high';
+  date: string;
+}


### PR DESCRIPTION
## Summary
- add LeagueStanding, RecentActivity, and PlayerNews interfaces
- use alias import for mockDashboardData

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '../secrets/serviceAccountKey.json', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898351071d4832b81ac9478fb766241