### PR TITLE
Use lowercase hooks alias in TradeCentreClient

### DIFF
--- a/src/components/TradeCentreClient.tsx
+++ b/src/components/TradeCentreClient.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState, useCallback, useEffect } from 'react';
 import Link from 'next/link';
-import { useDebounce } from '@/Hooks/useDebounce';
+import { useDebounce } from '@/hooks/useDebounce';
 import type { Player } from '@/types';
 import { statLabels, TradeCentreStrings } from '@/lib/constants';
 import { useTradeStore } from '@/state/tradeStore';


### PR DESCRIPTION
## Summary
- use lowercase hooks alias in TradeCentreClient

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '../secrets/serviceAccountKey.json', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689835144fe4832ba5a48d8a299ef53a