### PR TITLE
feat: allow optional team names

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface Player {
 // Minimal Team shape used by MyTeamPanel
 export interface Team {
   id: string;
+  name?: string;
   players?: Array<string | number>; // ids of players on the team
 }
 


### PR DESCRIPTION
## Summary
- allow Team interface to include optional `name`
- confirm UI components expect and provide team names

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898351800d0832b9410f5c4456c0751