### PR TITLE
Implement local storage helpers for settings and league requests

### DIFF
--- a/firebaseHelpers.ts
+++ b/firebaseHelpers.ts
@@ -1,6 +1,6 @@
 export type LeagueRequest = {
   leagueId: string;
-  status: string;
+  status: 'Pending' | 'Approved' | 'Rejected';
 };
 
 // Fallback storage for non-browser environments (e.g., tests)
@@ -31,7 +31,12 @@ const storage = getStorage();
 
 export async function loadUserSettings(uid: string): Promise<Record<string, unknown>> {
   const data = storage.getItem(`userSettings_${uid}`);
-  return data ? JSON.parse(data) : {};
+  if (!data) return {};
+  try {
+    return JSON.parse(data);
+  } catch {
+    return {};
+  }
 }
 
 export async function saveUserSettings(
@@ -43,7 +48,12 @@ export async function saveUserSettings(
 
 export async function loadUserLeagueRequests(uid: string): Promise<LeagueRequest[]> {
   const data = storage.getItem(`userLeagueRequests_${uid}`);
-  return data ? JSON.parse(data) : [];
+  if (!data) return [];
+  try {
+    return JSON.parse(data) as LeagueRequest[];
+  } catch {
+    return [];
+  }
 }
 
 export async function saveUserLeagueRequests(

--- a/firebaseHelpers.ts
+++ b/firebaseHelpers.ts
@@ -1,0 +1,55 @@
+export type LeagueRequest = {
+  leagueId: string;
+  status: string;
+};
+
+// Fallback storage for non-browser environments (e.g., tests)
+const memoryStore: Record<string, string> = {};
+
+function getStorage() {
+  try {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      return window.localStorage;
+    }
+  } catch {
+    // ignore access errors
+  }
+
+  return {
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(memoryStore, key)
+        ? memoryStore[key]
+        : null;
+    },
+    setItem(key: string, value: string) {
+      memoryStore[key] = value;
+    },
+  } as Pick<Storage, 'getItem' | 'setItem'>;
+}
+
+const storage = getStorage();
+
+export async function loadUserSettings(uid: string): Promise<Record<string, unknown>> {
+  const data = storage.getItem(`userSettings_${uid}`);
+  return data ? JSON.parse(data) : {};
+}
+
+export async function saveUserSettings(
+  uid: string,
+  settings: Record<string, unknown>
+): Promise<void> {
+  storage.setItem(`userSettings_${uid}`, JSON.stringify(settings));
+}
+
+export async function loadUserLeagueRequests(uid: string): Promise<LeagueRequest[]> {
+  const data = storage.getItem(`userLeagueRequests_${uid}`);
+  return data ? JSON.parse(data) : [];
+}
+
+export async function saveUserLeagueRequests(
+  uid: string,
+  requests: LeagueRequest[]
+): Promise<void> {
+  storage.setItem(`userLeagueRequests_${uid}`, JSON.stringify(requests));
+}
+

--- a/src/Pages/MyTeam.tsx
+++ b/src/Pages/MyTeam.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function MyTeam() {
+  return <div className="p-4">My Team Page</div>;
+}


### PR DESCRIPTION
## Summary
- add storage helpers to persist user settings and league requests
- define `LeagueRequest` type and ensure functions are accessible from Settings page

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find module '../secrets/serviceAccountKey.json' and other missing declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6898351e3d3c832bbfefae7ac580dfbe