### PR TITLE
feat: add firebase service account helpers

### DIFF
--- a/firebaseHelpers.test.ts
+++ b/firebaseHelpers.test.ts
@@ -1,8 +1,26 @@
 import { describe, expect, it } from 'vitest';
+import { decodeServiceAccount, encodeServiceAccount, ServiceAccount } from './firebaseHelpers';
 
 describe('firebaseHelpers', () => {
-  it('placeholder test', () => {
-    expect(true).toBe(true);
+  const sample: ServiceAccount = {
+    project_id: 'proj',
+    client_email: 'test@example.com',
+    private_key: 'key',
+  };
+
+  it('encodes and decodes a service account', () => {
+    const encoded = encodeServiceAccount(sample);
+    const decoded = decodeServiceAccount(encoded);
+    expect(decoded).toEqual(sample);
+  });
+
+  it('throws on invalid base64 input', () => {
+    expect(() => decodeServiceAccount('not-base64')).toThrow();
+  });
+
+  it('throws when required fields are missing', () => {
+    const partial = Buffer.from(JSON.stringify({ project_id: 'only' })).toString('base64');
+    expect(() => decodeServiceAccount(partial)).toThrow();
   });
 });
 

--- a/firebaseHelpers.ts
+++ b/firebaseHelpers.ts
@@ -1,0 +1,23 @@
+export interface ServiceAccount {
+  project_id: string;
+  client_email: string;
+  private_key: string;
+}
+
+export function decodeServiceAccount(base64: string): ServiceAccount {
+  try {
+    const json = Buffer.from(base64, 'base64').toString('utf-8');
+    const obj = JSON.parse(json) as Partial<ServiceAccount>;
+    if (!obj.project_id || !obj.client_email || !obj.private_key) {
+      throw new Error('Missing required service account fields');
+    }
+    return obj as ServiceAccount;
+  } catch (err) {
+    throw new Error('Invalid service account base64 string');
+  }
+}
+
+export function encodeServiceAccount(sa: ServiceAccount): string {
+  return Buffer.from(JSON.stringify(sa)).toString('base64');
+}
+


### PR DESCRIPTION
## Summary
- add helpers for encoding and decoding Firebase service account JSON
- test service account helpers for encoding, decoding, and validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898747201e4832b977bbbf03b8650f5