### PR TITLE
refactor: add esm entry check to cleanPlayerData script

### DIFF
--- a/Scripts/cleanPlayerData.ts
+++ b/Scripts/cleanPlayerData.ts
@@ -51,7 +51,7 @@ async function cleanPlayers(verbose = false) {
   console.log(`\n✅ Cleaned ${updated} player documents.`);
 }
 
-if (require.main === module) {
+if (import.meta.url === `file://${process.argv[1]}`) {
   cleanPlayers().catch((err) => {
     console.error('Error cleaning player data:', err);
   });


### PR DESCRIPTION
## Summary
- switch script entry check to ESM-compatible `import.meta.url`
- keep behavior when run directly by invoking `cleanPlayers`

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check` *(fails: service-account.json invalid JSON, serviceAccount.local.json invalid expression)*
- `node --loader ts-node/esm Scripts/cleanPlayerData.ts` *(fails: No connection established to Firestore emulator)*

------
https://chatgpt.com/codex/tasks/task_e_68986b9544ac832b8326bd5f6fcd562a