### PR TITLE
feat: improve service account loading for clean player data script

### DIFF
--- a/Scripts/cleanPlayerData.ts
+++ b/Scripts/cleanPlayerData.ts
@@ -1,16 +1,22 @@
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
+import { readFileSync } from 'fs';
 
 import type { ServiceAccount } from 'firebase-admin/app';
 
-const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
-if (!serviceAccountEnv) {
-  throw new Error('Missing GOOGLE_SERVICE_ACCOUNT environment variable');
+function loadServiceAccount(): ServiceAccount {
+  const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
+  if (serviceAccountEnv) {
+    return JSON.parse(serviceAccountEnv) as ServiceAccount;
+  }
+
+  return JSON.parse(
+    readFileSync(new URL('../secrets/serviceAccountKey.json', import.meta.url), 'utf8')
+  ) as ServiceAccount;
 }
-const serviceAccount = JSON.parse(serviceAccountEnv) as ServiceAccount;
 
 if (!getApps().length) {
-  initializeApp({ credential: cert(serviceAccount) });
+  initializeApp({ credential: cert(loadServiceAccount()) });
 }
 
 const db = getFirestore();


### PR DESCRIPTION
## Summary
- add `loadServiceAccount` utility with env var and local file fallback
- initialize Firebase once and expose Firestore instance for cleaning players

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '../../lib/storage/local' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68986b931564832b90ad86604e6f9777