### PR TITLE
feat: add player detail component

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@
 # node_modules
 # build
 # dist
+service-account.json
+serviceAccount.local.json

--- a/src/app/players/[id]/page.tsx
+++ b/src/app/players/[id]/page.tsx
@@ -2,6 +2,7 @@ import type { PageProps } from 'next';
 import { notFound } from 'next/navigation';
 import type { Player } from '@/types';
 import { getPlayerIds, getPlayer } from '@/lib/data';
+import PlayerDetail from '@/components/PlayerDetail';
 
 // Build all player pages at build time
 export async function generateStaticParams() {
@@ -32,11 +33,7 @@ export default async function PlayerPage({ params }: PageProps<{ id: string }>) 
         <h1 className="text-2xl font-semibold">{player.name}</h1>
         <p className="text-sm text-neutral-500">{player.team}</p>
       </header>
-
-      {/* TODO: replace with your PlayerDetail component */}
-      <section aria-label="Player overview">
-        <p className="text-neutral-600">Player profile coming soon.</p>
-      </section>
+      <PlayerDetail player={player} />
     </main>
   );
 }

--- a/src/components/PlayerDetail.tsx
+++ b/src/components/PlayerDetail.tsx
@@ -1,0 +1,34 @@
+import type { Player } from '@/types';
+import PlayerStatsDisplay from './PlayerStatsDisplay';
+
+interface PlayerDetailProps {
+  player: Player;
+}
+
+export default function PlayerDetail({ player }: PlayerDetailProps) {
+  const { name, team, position } = player;
+
+  let bio: string;
+  if (position && team) {
+    bio = `${name} plays ${position} for ${team}.`;
+  } else if (team) {
+    bio = `${name} plays for ${team}.`;
+  } else if (position) {
+    bio = `${name} is a ${position}.`;
+  } else {
+    bio = 'Biography information is unavailable.';
+  }
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold">Biography</h2>
+        <p className="text-neutral-700">{bio}</p>
+      </div>
+      <div>
+        <h2 className="text-xl font-semibold">Statistics</h2>
+        <PlayerStatsDisplay player={player} />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- show detailed player info with new PlayerDetail component
- use PlayerDetail on player pages to render biography and stats
- ignore service account JSON files in Prettier to prevent format errors

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '../../lib/storage/local'..., Module '"next"' has no exported member 'PageProps', etc.)*
- `npm test`
- `npm run format:check` *(fails: Code style issues found in 74 files)*

------
https://chatgpt.com/codex/tasks/task_e_6898744ecd18832b9d76224cb4efe63a