### PR TITLE
Handle declined trade offer responses

### DIFF
--- a/src/components/OfferActions.tsx
+++ b/src/components/OfferActions.tsx
@@ -21,14 +21,14 @@ export default function OfferActions() {
         body: JSON.stringify({ incoming, outgoing }),
       });
 
-      if (!res.ok) {
-        throw new Error('Network response was not ok');
+      if (res.ok) {
+        const data = await res.json().catch(() => ({}));
+        const status = (data.status as OfferStatus) ?? 'sent';
+
+        setHistory([{ id, when, incoming: incoming.length, outgoing: outgoing.length, status }, ...history]);
+      } else {
+        setHistory([{ id, when, incoming: incoming.length, outgoing: outgoing.length, status: 'declined' }, ...history]);
       }
-
-      const data = await res.json().catch(() => ({}));
-      const status = (data.status as OfferStatus) ?? 'sent';
-
-      setHistory([{ id, when, incoming: incoming.length, outgoing: outgoing.length, status }, ...history]);
     } catch (error) {
       console.error('Failed to submit offer:', error);
       setHistory([{ id, when, incoming: incoming.length, outgoing: outgoing.length, status: 'failed' }, ...history]);


### PR DESCRIPTION
## Summary
- Avoid parsing trade offer JSON when the server responds with an error
- Mark unsuccessful trade offer submissions as declined instead of failed

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68987944e350832b82d9714378d34278