### PR TITLE
Improve Firebase service account validation

### DIFF
--- a/firebaseHelpers.ts
+++ b/firebaseHelpers.ts
@@ -1,0 +1,33 @@
+export interface ServiceAccount {
+  project_id: string;
+  client_email: string;
+  private_key: string;
+}
+
+export function decodeServiceAccount(b64: string): ServiceAccount {
+  let decoded: string;
+  let parsed: Partial<ServiceAccount> | undefined;
+
+  try {
+    decoded = Buffer.from(b64, 'base64').toString('utf-8');
+    parsed = JSON.parse(decoded);
+  } catch {
+    throw new Error('Invalid service account base64 string');
+  }
+
+  const { project_id, client_email, private_key } = parsed ?? {};
+  if (!project_id || !client_email || !private_key) {
+    throw new Error('Missing required service account fields');
+  }
+
+  return { project_id, client_email, private_key };
+}
+
+export function getServiceAccountFromEnv(): ServiceAccount {
+  const b64 = process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64;
+  if (!b64) {
+    throw new Error('Missing FIREBASE_SERVICE_ACCOUNT_JSON_BASE64');
+  }
+  return decodeServiceAccount(b64);
+}
+


### PR DESCRIPTION
## Summary
- Decode and parse service account JSON inside a try/catch, surfacing invalid base64 strings
- Validate required service account fields and throw explicit errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68987a214490832bbd690056da1172bf