### PR TITLE
Centralize Firebase service account parsing

### DIFF
--- a/Scripts/cleanPlayerData.ts
+++ b/Scripts/cleanPlayerData.ts
@@ -3,16 +3,17 @@ import { getFirestore } from 'firebase-admin/firestore';
 import { readFileSync } from 'fs';
 
 import type { ServiceAccount } from 'firebase-admin/app';
+import { decodeServiceAccount } from '../src/lib/serviceAccount';
 
 function loadServiceAccount(): ServiceAccount {
   const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
   if (serviceAccountEnv) {
-    return JSON.parse(serviceAccountEnv) as ServiceAccount;
+    return decodeServiceAccount(serviceAccountEnv);
   }
 
-  return JSON.parse(
+  return decodeServiceAccount(
     readFileSync(new URL('../secrets/serviceAccountKey.json', import.meta.url), 'utf8')
-  ) as ServiceAccount;
+  );
 }
 
 if (!getApps().length) {

--- a/Scripts/diffUnmatchedPlayers.ts
+++ b/Scripts/diffUnmatchedPlayers.ts
@@ -1,14 +1,14 @@
 // scripts/diffUnmatchedPlayers.ts
 import fs from 'fs/promises';
 import { initializeApp, cert } from 'firebase-admin/app';
-import type { ServiceAccount } from 'firebase-admin/app';
+import { decodeServiceAccount } from '../src/lib/serviceAccount';
 import { getFirestore } from 'firebase-admin/firestore';
 
 const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
 if (!serviceAccountEnv) {
   throw new Error('Missing GOOGLE_SERVICE_ACCOUNT environment variable');
 }
-const serviceAccount = JSON.parse(serviceAccountEnv) as ServiceAccount;
+const serviceAccount = decodeServiceAccount(serviceAccountEnv);
 
 initializeApp({
   credential: cert(serviceAccount),

--- a/Scripts/seedPlayers.ts
+++ b/Scripts/seedPlayers.ts
@@ -3,13 +3,13 @@ import fs from 'fs/promises';
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import { z } from 'zod';
-import type { ServiceAccount } from 'firebase-admin/app';
+import { decodeServiceAccount } from '../src/lib/serviceAccount';
 
 const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
 if (!serviceAccountEnv) {
   throw new Error('Missing GOOGLE_SERVICE_ACCOUNT environment variable');
 }
-const serviceAccount = JSON.parse(serviceAccountEnv) as ServiceAccount;
+const serviceAccount = decodeServiceAccount(serviceAccountEnv);
 initializeApp({ credential: cert(serviceAccount) });
 const db = getFirestore();
 

--- a/Scripts/seedPlayersFromMatchLogs.ts
+++ b/Scripts/seedPlayersFromMatchLogs.ts
@@ -2,14 +2,14 @@
 import fs from 'fs/promises';
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
-import type { ServiceAccount } from 'firebase-admin/app';
+import { decodeServiceAccount } from '../src/lib/serviceAccount';
 import { z } from 'zod';
 
 const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
 if (!serviceAccountEnv) {
   throw new Error('Missing GOOGLE_SERVICE_ACCOUNT environment variable');
 }
-const serviceAccount = JSON.parse(serviceAccountEnv) as ServiceAccount;
+const serviceAccount = decodeServiceAccount(serviceAccountEnv);
 initializeApp({ credential: cert(serviceAccount) });
 const db = getFirestore();
 

--- a/Scripts/uploadMatchLogs.ts
+++ b/Scripts/uploadMatchLogs.ts
@@ -2,14 +2,14 @@
 import fs from 'fs/promises';
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
-import type { ServiceAccount } from 'firebase-admin/app';
+import { decodeServiceAccount } from '../src/lib/serviceAccount';
 import { z } from 'zod';
 
 const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
 if (!serviceAccountEnv) {
   throw new Error('Missing GOOGLE_SERVICE_ACCOUNT environment variable');
 }
-const serviceAccount = JSON.parse(serviceAccountEnv) as ServiceAccount;
+const serviceAccount = decodeServiceAccount(serviceAccountEnv);
 initializeApp({ credential: cert(serviceAccount) });
 const db = getFirestore();
 

--- a/Scripts/uploadPlayerStats.ts
+++ b/Scripts/uploadPlayerStats.ts
@@ -3,13 +3,13 @@ import fs from 'fs/promises';
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import { z } from 'zod';
-import type { ServiceAccount } from 'firebase-admin/app';
+import { decodeServiceAccount } from '../src/lib/serviceAccount';
 
 const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
 if (!serviceAccountEnv) {
   throw new Error('Missing GOOGLE_SERVICE_ACCOUNT environment variable');
 }
-const serviceAccount = JSON.parse(serviceAccountEnv) as ServiceAccount;
+const serviceAccount = decodeServiceAccount(serviceAccountEnv);
 if (!getApps().length) {
   initializeApp({ credential: cert(serviceAccount) });
 }

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -1,14 +1,12 @@
 import 'server-only';
 import admin from 'firebase-admin';
+import { decodeServiceAccount } from './serviceAccount';
 
 if (!admin.apps.length) {
-  const b64 = process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64;
-  if (!b64) throw new Error('Missing FIREBASE_SERVICE_ACCOUNT_JSON_BASE64');
+  const encoded = process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64;
+  if (!encoded) throw new Error('Missing FIREBASE_SERVICE_ACCOUNT_JSON_BASE64');
 
-  const json = Buffer.from(b64, 'base64').toString('utf-8');
-  const sa = JSON.parse(json) as {
-    project_id: string; client_email: string; private_key: string;
-  };
+  const sa = decodeServiceAccount(encoded);
 
   admin.initializeApp({
     credential: admin.credential.cert({

--- a/src/lib/serviceAccount.test.ts
+++ b/src/lib/serviceAccount.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { encodeServiceAccount, decodeServiceAccount } from './serviceAccount';
+
+const sample = {
+  project_id: 'my-project',
+  client_email: 'test@my-project.iam.gserviceaccount.com',
+  private_key: '-----BEGIN PRIVATE KEY-----\nABCDEF\n-----END PRIVATE KEY-----\n',
+};
+
+describe('serviceAccount helpers', () => {
+  it('encodes and decodes to the same object', () => {
+    const encoded = encodeServiceAccount(sample);
+    const decoded = decodeServiceAccount(encoded);
+    expect(decoded).toEqual(sample);
+  });
+
+  it('decodes plain JSON', () => {
+    const json = JSON.stringify(sample);
+    const decoded = decodeServiceAccount(json);
+    expect(decoded).toEqual(sample);
+  });
+});

--- a/src/lib/serviceAccount.ts
+++ b/src/lib/serviceAccount.ts
@@ -1,0 +1,20 @@
+import type { ServiceAccount } from 'firebase-admin/app';
+
+/**
+ * Encodes a service account object to a base64 string.
+ */
+export function encodeServiceAccount(sa: ServiceAccount): string {
+  const json = JSON.stringify(sa);
+  return Buffer.from(json, 'utf8').toString('base64');
+}
+
+/**
+ * Decodes a service account from either a base64 string or JSON string.
+ */
+export function decodeServiceAccount(value: string): ServiceAccount {
+  const trimmed = value.trim();
+  const json = trimmed.startsWith('{')
+    ? trimmed
+    : Buffer.from(trimmed, 'base64').toString('utf8');
+  return JSON.parse(json) as ServiceAccount;
+}


### PR DESCRIPTION
## Summary
- add `encodeServiceAccount` and `decodeServiceAccount` helpers for consistent service account handling
- refactor Firebase admin and scripts to use the new helpers instead of manual JSON/base64 parsing
- cover encode/decode behavior with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68987a24fe24832bad16518f9b57e583