### PR TITLE
test: update firebase service account validation tests

### DIFF
--- a/firebaseHelpers.test.ts
+++ b/firebaseHelpers.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, it } from 'vitest';
+import { parseServiceAccountBase64 } from './firebaseHelpers';
 
 describe('firebaseHelpers', () => {
-  it('placeholder test', () => {
-    expect(true).toBe(true);
+  it('invalid base64 input', () => {
+    expect(() => parseServiceAccountBase64('not-base64')).toThrow(
+      'Invalid service account base64 string'
+    );
+  });
+
+  it('missing required fields', () => {
+    const incomplete = Buffer.from(
+      JSON.stringify({ project_id: 'proj' }),
+      'utf-8'
+    ).toString('base64');
+    expect(() => parseServiceAccountBase64(incomplete)).toThrow(
+      'Missing required service account fields'
+    );
   });
 });
-

--- a/firebaseHelpers.ts
+++ b/firebaseHelpers.ts
@@ -1,0 +1,29 @@
+export interface ServiceAccount {
+  project_id: string;
+  client_email: string;
+  private_key: string;
+}
+
+export function parseServiceAccountBase64(b64: string): ServiceAccount {
+  let json: string;
+  try {
+    json = Buffer.from(b64, 'base64').toString('utf-8');
+  } catch {
+    throw new Error('Invalid service account base64 string');
+  }
+  let data: unknown;
+  try {
+    data = JSON.parse(json);
+  } catch {
+    throw new Error('Invalid service account base64 string');
+  }
+  const { project_id, client_email, private_key } = data as Record<string, unknown>;
+  if (
+    typeof project_id !== 'string' ||
+    typeof client_email !== 'string' ||
+    typeof private_key !== 'string'
+  ) {
+    throw new Error('Missing required service account fields');
+  }
+  return { project_id, client_email, private_key };
+}


### PR DESCRIPTION
## Summary
- add firebase helper to parse base64 service account JSON
- adjust tests to expect clearer error messages for invalid base64 and missing fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68987a229590832ba2065224e4ce2147