### PR TITLE
Add test for invalid service account JSON decoding

### DIFF
--- a/firebaseHelpers.test.ts
+++ b/firebaseHelpers.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest';
+import { decodeServiceAccount } from './firebaseHelpers';
 
 describe('firebaseHelpers', () => {
   it('placeholder test', () => {
     expect(true).toBe(true);
+  });
+
+  it('throws on invalid JSON', () => {
+    const bad = Buffer.from('{ not json }').toString('base64');
+    expect(() => decodeServiceAccount(bad)).toThrow(
+      'Invalid service account base64 string'
+    );
   });
 });
 

--- a/firebaseHelpers.ts
+++ b/firebaseHelpers.ts
@@ -1,0 +1,8 @@
+export function decodeServiceAccount(b64: string) {
+  try {
+    const json = Buffer.from(b64, 'base64').toString('utf-8');
+    return JSON.parse(json);
+  } catch {
+    throw new Error('Invalid service account base64 string');
+  }
+}


### PR DESCRIPTION
## Summary
- add `decodeServiceAccount` helper that throws on invalid JSON
- cover invalid JSON case in `firebaseHelpers` test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68987a2392a8832bbf61611c7eb26eb5