### PR TITLE
Fix history state updates to prevent stale closure

### DIFF
--- a/src/components/OfferActions.tsx
+++ b/src/components/OfferActions.tsx
@@ -28,10 +28,16 @@ export default function OfferActions() {
       const data = await res.json().catch(() => ({}));
       const status = (data.status as OfferStatus) ?? 'sent';
 
-      setHistory([{ id, when, incoming: incoming.length, outgoing: outgoing.length, status }, ...history]);
+      setHistory(h => [
+        { id, when, incoming: incoming.length, outgoing: outgoing.length, status },
+        ...h,
+      ]);
     } catch (error) {
       console.error('Failed to submit offer:', error);
-      setHistory([{ id, when, incoming: incoming.length, outgoing: outgoing.length, status: 'failed' }, ...history]);
+      setHistory(h => [
+        { id, when, incoming: incoming.length, outgoing: outgoing.length, status: 'failed' },
+        ...h,
+      ]);
     } finally {
       clearAll();
     }


### PR DESCRIPTION
## Summary
- use functional state updater when recording offer history to avoid stale closure

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68987942bb68832ba08b560ac5d65054