### PR TITLE
refactor firebase helper parsing

### DIFF
--- a/firebaseHelpers.test.ts
+++ b/firebaseHelpers.test.ts
@@ -23,4 +23,10 @@ describe('parseServiceAccountFromBase64', () => {
       'Missing required service account fields'
     );
   });
+
+  it('throws error for invalid base64 or JSON', () => {
+    expect(() => parseServiceAccountFromBase64('not-base64')).toThrow(
+      'Invalid service account JSON'
+    );
+  });
 });

--- a/firebaseHelpers.ts
+++ b/firebaseHelpers.ts
@@ -20,10 +20,6 @@ export function parseServiceAccountFromBase64(b64: string): ServiceAccount {
       // JSON parsing failure (includes invalid base64 resulting in bad JSON)
       throw new Error('Invalid service account JSON');
     }
-    if (err instanceof Error && err.message.includes('Invalid character')) {
-      // base64 decoding failure
-      throw new Error('Invalid service account JSON');
-    }
     // rethrow other errors, such as field validation
     throw err;
   }


### PR DESCRIPTION
## Summary
- add firebase service account parsing helper and only catch base64/JSON errors
- test service account helper, including missing-field error message

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68987849538c832ba3e822b657a75f92