### PR TITLE
feat: add firebase initialization helper

### DIFF
--- a/firebaseHelpers.test.ts
+++ b/firebaseHelpers.test.ts
@@ -1,8 +1,46 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe('firebaseHelpers', () => {
-  it('placeholder test', () => {
-    expect(true).toBe(true);
-  });
+vi.mock('firebase-admin/app', () => {
+  return {
+    initializeApp: vi.fn(),
+    cert: vi.fn((sa) => sa),
+    getApps: vi.fn(() => []),
+  };
 });
 
+vi.mock('firebase-admin/firestore', () => {
+  return {
+    getFirestore: vi.fn(() => ({ firestore: true })),
+  };
+});
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe('firebaseHelpers', () => {
+  it('initializes successfully when GOOGLE_SERVICE_ACCOUNT is set', async () => {
+    process.env.GOOGLE_SERVICE_ACCOUNT = JSON.stringify({
+      project_id: 'demo',
+      private_key: 'key',
+      client_email: 'demo@demo.iam.gserviceaccount.com',
+    });
+
+    const { initFirebase } = await import('./firebaseHelpers');
+    const db = initFirebase();
+    expect(db).toEqual({ firestore: true });
+
+    const app = await import('firebase-admin/app');
+    expect(app.initializeApp).toHaveBeenCalledOnce();
+    expect(app.cert).toHaveBeenCalledWith(
+      expect.objectContaining({ project_id: 'demo' })
+    );
+  });
+
+  it('throws an error when GOOGLE_SERVICE_ACCOUNT is missing', async () => {
+    delete process.env.GOOGLE_SERVICE_ACCOUNT;
+    const { initFirebase } = await import('./firebaseHelpers');
+    expect(() => initFirebase()).toThrow('Missing GOOGLE_SERVICE_ACCOUNT');
+  });
+});

--- a/firebaseHelpers.ts
+++ b/firebaseHelpers.ts
@@ -1,0 +1,64 @@
+import { initializeApp, cert, getApps } from 'firebase-admin/app';
+import { getFirestore, type Firestore } from 'firebase-admin/firestore';
+import type { ServiceAccount } from 'firebase-admin/app';
+
+/**
+ * Initializes a Firebase Admin app using the GOOGLE_SERVICE_ACCOUNT
+ * environment variable. The variable should contain the raw JSON of a
+ * service account. The initialized Firestore instance is memoised and
+ * returned on subsequent calls.
+ */
+export function initFirebase(): Firestore {
+  if (db) return db;
+
+  const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
+  if (!serviceAccountEnv) {
+    throw new Error('Missing GOOGLE_SERVICE_ACCOUNT environment variable');
+  }
+
+  let serviceAccount: ServiceAccount;
+  try {
+    serviceAccount = JSON.parse(serviceAccountEnv) as ServiceAccount;
+  } catch {
+    throw new Error('Invalid GOOGLE_SERVICE_ACCOUNT JSON');
+  }
+
+  if (!getApps().length) {
+    initializeApp({ credential: cert(serviceAccount) });
+  }
+
+  db = getFirestore();
+  return db;
+}
+
+let db: Firestore | null = null;
+
+export interface LeagueRequest {
+  leagueId: string;
+  status: string;
+}
+
+export async function loadUserSettings(uid: string): Promise<Record<string, unknown> | undefined> {
+  const firestore = initFirebase();
+  const doc = await firestore.collection('userSettings').doc(uid).get();
+  return doc.exists ? (doc.data() as Record<string, unknown>) : undefined;
+}
+
+export async function saveUserSettings(uid: string, settings: Record<string, unknown>): Promise<void> {
+  const firestore = initFirebase();
+  await firestore.collection('userSettings').doc(uid).set(settings, { merge: true });
+}
+
+export async function loadUserLeagueRequests(uid: string): Promise<LeagueRequest[]> {
+  const firestore = initFirebase();
+  const doc = await firestore.collection('userLeagueRequests').doc(uid).get();
+  return doc.exists ? ((doc.data()?.requests as LeagueRequest[]) || []) : [];
+}
+
+export async function saveUserLeagueRequests(uid: string, requests: LeagueRequest[]): Promise<void> {
+  const firestore = initFirebase();
+  await firestore
+    .collection('userLeagueRequests')
+    .doc(uid)
+    .set({ requests }, { merge: true });
+}


### PR DESCRIPTION
## Summary
- add Firebase Admin initialization helper that reads `GOOGLE_SERVICE_ACCOUNT`
- add Firestore helpers for user settings and league requests
- test initialization success and error when env variable missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898556d3150832b9d7a2329ce9fd25b