### PR TITLE
refactor: update ValueCell rankings hook

### DIFF
--- a/src/hooks/ValueCell.tsx
+++ b/src/hooks/ValueCell.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import * as React from 'react';
-import { useRankings } from '@/lib/hooks/useRankings';
+import { useRankings } from '@/hooks/useRankings';
 
 export default function ValueCell({ playerId }: { playerId: string }) {
-  const { map, isLoading, error } = useRankings();
+  const { get, isLoading, error } = useRankings();
 
   if (isLoading) return <span className="opacity-60">…</span>;
   if (error) return <span className="text-red-500">—</span>;
 
-  const v = map.get(playerId)?.totalValue;
+  const v = get(playerId)?.totalValue;
   return <span>{typeof v === 'number' ? v.toFixed(2) : '—'}</span>;
 }


### PR DESCRIPTION
## Summary
- refactor ValueCell hook to import `useRankings` from new path
- adapt ValueCell to use `get` accessor from updated hook

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Module '"next"' has no exported member 'PageProps', plus other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_689884b1f5e0832b82507c4f6bb8a425