### PR TITLE
fix: correct firebase client import

### DIFF
--- a/Scripts/seedRoomMeta.ts
+++ b/Scripts/seedRoomMeta.ts
@@ -1,4 +1,4 @@
-import { db } from '@/firebase';
+import { db } from '@/lib/firebaseClient';
 import { doc, setDoc, Timestamp, collection, getDocs } from 'firebase/firestore';
 
 const isTest = process.env.NODE_ENV === 'test' || process.argv.includes('--test');


### PR DESCRIPTION
## Summary
- fix seedRoomMeta script to import Firestore client from lib/firebaseClient

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689884b0918c832b9f5112202f1ed87b