### PR TITLE
fix: rename useInteractionTracker hook

### DIFF
--- a/src/hooks/useInteractionTracker.ts
+++ b/src/hooks/useInteractionTracker.ts
@@ -31,7 +31,7 @@ function useInteractionTracker() {
     event.preventDefault();
   }, []);
 
-  const processStat = (stat: PlayerStats) => {
+  const processStat = (_stat: PlayerStats) => {
     // process player stats here
   };
 


### PR DESCRIPTION
## Summary
- rename `useInteractionTracker` hook file and clean up unused parameter

## Testing
- `npm run lint`
- `npm run build` *(fails: Module 'next' has no exported member 'PageProps')*

------
https://chatgpt.com/codex/tasks/task_e_6898843c8334832b85c9ad6295a037dd