### PR TITLE
feat: add weekend summary via GitHub models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment variables
+VITE_API_URL=http://localhost:3000
+# Token used to access GitHub-hosted OpenAI models
+GITHUB_TOKEN=
+# Standard OpenAI API key (if using OpenAI directly)
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -47,7 +47,15 @@ NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=...
 GOOGLE_SERVICE_ACCOUNT='{"type":"service_account",...}'
 # Base64-encoded service account JSON used by src/lib/firebaseAdmin.ts
 FIREBASE_SERVICE_ACCOUNT_JSON_BASE64=...
+
+# Token for GitHub-hosted language models used in the weekend summary
+GITHUB_TOKEN=...
+
+# Standard OpenAI API key if you prefer using OpenAI directly
+OPENAI_API_KEY=...
 ```
+
+The weekend summary endpoint relies on external language models. These services impose rate limits, so caching the summary or limiting how often it is refreshed is recommended.
 
 Copy `secrets/serviceAccountKey.example.json` to `secrets/serviceAccountKey.json` and fill it with your Firebase service account credentials.
 

--- a/src/app/api/weekend-summary/route.ts
+++ b/src/app/api/weekend-summary/route.ts
@@ -1,0 +1,66 @@
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import OpenAI from 'openai';
+import { getPlayers } from '@/lib/data';
+
+interface CachedSummary {
+  summary: string;
+  timestamp: number;
+}
+
+let cache: CachedSummary | null = null;
+
+export async function GET() {
+  try {
+    const now = Date.now();
+    if (cache && now - cache.timestamp < 1000 * 60 * 60) {
+      return NextResponse.json({ summary: cache.summary });
+    }
+
+    const players = await getPlayers();
+    const top = players
+      .sort(
+        (a, b) =>
+          (Number(b.stats?.aflFantasy) || 0) -
+          (Number(a.stats?.aflFantasy) || 0)
+      )
+      .slice(0, 5)
+      .map((p) => ({
+        name: p.name,
+        team: p.team,
+        goals: p.stats?.goals,
+        aflFantasy: p.stats?.aflFantasy,
+      }));
+
+    const client = new OpenAI({
+      apiKey: process.env.GITHUB_TOKEN,
+      baseURL: process.env.OPENAI_BASE_URL || 'https://models.inference.ai.azure.com',
+    });
+
+    const prompt = `Provide a concise 2-3 sentence summary of the AFL weekend based on these top player stats: ${JSON.stringify(
+      top
+    )}`;
+
+    const completion = await client.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.7,
+      max_tokens: 150,
+    });
+
+    const summary =
+      completion.choices[0]?.message?.content?.trim() ||
+      'No summary available.';
+
+    cache = { summary, timestamp: now };
+
+    return NextResponse.json({ summary });
+  } catch (error) {
+    console.error('weekend-summary error', error);
+    return NextResponse.json(
+      { summary: 'Summary unavailable' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/UserDashboard.tsx
+++ b/src/components/UserDashboard.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { useMemo } from 'react';
 import type { User } from 'firebase/auth';
+import WeekendSummary from './WeekendSummary';
 
 interface UserDashboardProps {
   user: User;
@@ -59,6 +60,8 @@ export default function UserDashboard({ user }: UserDashboardProps) {
             Enter Draft &rarr;
           </Link>
         </article>
+
+        <WeekendSummary />
       </section>
     </main>
   );

--- a/src/components/WeekendSummary.tsx
+++ b/src/components/WeekendSummary.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function WeekendSummary() {
+  const [summary, setSummary] = useState<string>('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchSummary() {
+      try {
+        const res = await fetch('/api/weekend-summary');
+        if (!res.ok) throw new Error('Failed to load');
+        const data = await res.json();
+        setSummary(data.summary || '');
+      } catch (err) {
+        setError((err as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchSummary();
+  }, []);
+
+  return (
+    <article className="p-6 bg-card text-card-foreground shadow-md rounded-xl border border-border">
+      <h2 className="text-xl font-bold mb-2">Weekend Summary</h2>
+      {loading && <p className="text-muted-foreground">Loading...</p>}
+      {error && (
+        <p className="text-red-500">
+          Error loading summary: {error}
+        </p>
+      )}
+      {!loading && !error && <p className="text-muted-foreground">{summary}</p>}
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- add API endpoint that summarizes weekend stats using GitHub-hosted OpenAI models
- create WeekendSummary dashboard card fetching data from new endpoint
- document `GITHUB_TOKEN` and `OPENAI_API_KEY` env vars with rate-limit note

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Module '"next"' has no exported member 'PageProps', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68989ef422dc832bb0e792a9f88171b3