### PR TITLE
refactor: centralize service account helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,19 +39,11 @@ NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=...
 NEXT_PUBLIC_FIREBASE_APP_ID=...
 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=...
 
-# Service account JSON used by scripts in the Scripts/ directory
-GOOGLE_SERVICE_ACCOUNT='{"type":"service_account",...}'
-# Base64-encoded service account JSON used by src/lib/firebaseAdmin.ts
+# Base64-encoded service account JSON used by scripts and firebaseAdmin.ts
 FIREBASE_SERVICE_ACCOUNT_JSON_BASE64=...
 ```
 
-`GOOGLE_SERVICE_ACCOUNT` should contain the raw JSON for a Firebase service account. You can set it on the command line, for example:
-
-```bash
-export GOOGLE_SERVICE_ACCOUNT="$(cat path/to/serviceAccountKey.json)"
-```
-
-`FIREBASE_SERVICE_ACCOUNT_JSON_BASE64` should contain a base64-encoded service account JSON for admin use in [`src/lib/firebaseAdmin.ts`](src/lib/firebaseAdmin.ts). You can set it on the command line, for example:
+`FIREBASE_SERVICE_ACCOUNT_JSON_BASE64` should contain a base64-encoded service account JSON for admin use in [`src/lib/firebaseAdmin.ts`](src/lib/firebaseAdmin.ts) and scripts under `Scripts/`. You can set it on the command line, for example:
 
 ```bash
 export FIREBASE_SERVICE_ACCOUNT_JSON_BASE64="$(base64 -w0 path/to/serviceAccountKey.json)"

--- a/Scripts/cleanPlayerData.ts
+++ b/Scripts/cleanPlayerData.ts
@@ -1,23 +1,9 @@
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
-import { readFileSync } from 'fs';
-
-import type { ServiceAccount } from 'firebase-admin/app';
-import { decodeServiceAccount } from '../src/lib/serviceAccount';
-
-function loadServiceAccount(): ServiceAccount {
-  const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
-  if (serviceAccountEnv) {
-    return decodeServiceAccount(serviceAccountEnv);
-  }
-
-  return decodeServiceAccount(
-    readFileSync(new URL('../secrets/serviceAccountKey.json', import.meta.url), 'utf8')
-  );
-}
+import { getServiceAccountFromEnv } from '../src/lib/serviceAccount';
 
 if (!getApps().length) {
-  initializeApp({ credential: cert(loadServiceAccount()) });
+  initializeApp({ credential: cert(getServiceAccountFromEnv()) });
 }
 
 const db = getFirestore();

--- a/Scripts/diffUnmatchedPlayers.ts
+++ b/Scripts/diffUnmatchedPlayers.ts
@@ -1,17 +1,11 @@
 // scripts/diffUnmatchedPlayers.ts
 import fs from 'fs/promises';
 import { initializeApp, cert } from 'firebase-admin/app';
-import { decodeServiceAccount } from '../src/lib/serviceAccount';
+import { getServiceAccountFromEnv } from '../src/lib/serviceAccount';
 import { getFirestore } from 'firebase-admin/firestore';
 
-const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
-if (!serviceAccountEnv) {
-  throw new Error('Missing GOOGLE_SERVICE_ACCOUNT environment variable');
-}
-const serviceAccount = decodeServiceAccount(serviceAccountEnv);
-
 initializeApp({
-  credential: cert(serviceAccount),
+  credential: cert(getServiceAccountFromEnv()),
 });
 
 const db = getFirestore();

--- a/Scripts/seedPlayers.ts
+++ b/Scripts/seedPlayers.ts
@@ -3,14 +3,9 @@ import fs from 'fs/promises';
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import { z } from 'zod';
-import { decodeServiceAccount } from '../src/lib/serviceAccount';
+import { getServiceAccountFromEnv } from '../src/lib/serviceAccount';
 
-const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
-if (!serviceAccountEnv) {
-  throw new Error('Missing GOOGLE_SERVICE_ACCOUNT environment variable');
-}
-const serviceAccount = decodeServiceAccount(serviceAccountEnv);
-initializeApp({ credential: cert(serviceAccount) });
+initializeApp({ credential: cert(getServiceAccountFromEnv()) });
 const db = getFirestore();
 
 const PlayerSchema = z.object({

--- a/Scripts/seedPlayersFromMatchLogs.ts
+++ b/Scripts/seedPlayersFromMatchLogs.ts
@@ -2,15 +2,10 @@
 import fs from 'fs/promises';
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
-import { decodeServiceAccount } from '../src/lib/serviceAccount';
+import { getServiceAccountFromEnv } from '../src/lib/serviceAccount';
 import { z } from 'zod';
 
-const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
-if (!serviceAccountEnv) {
-  throw new Error('Missing GOOGLE_SERVICE_ACCOUNT environment variable');
-}
-const serviceAccount = decodeServiceAccount(serviceAccountEnv);
-initializeApp({ credential: cert(serviceAccount) });
+initializeApp({ credential: cert(getServiceAccountFromEnv()) });
 const db = getFirestore();
 
 const MatchLogSchema = z.object({

--- a/Scripts/uploadMatchLogs.ts
+++ b/Scripts/uploadMatchLogs.ts
@@ -2,15 +2,10 @@
 import fs from 'fs/promises';
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
-import { decodeServiceAccount } from '../src/lib/serviceAccount';
+import { getServiceAccountFromEnv } from '../src/lib/serviceAccount';
 import { z } from 'zod';
 
-const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
-if (!serviceAccountEnv) {
-  throw new Error('Missing GOOGLE_SERVICE_ACCOUNT environment variable');
-}
-const serviceAccount = decodeServiceAccount(serviceAccountEnv);
-initializeApp({ credential: cert(serviceAccount) });
+initializeApp({ credential: cert(getServiceAccountFromEnv()) });
 const db = getFirestore();
 
 const MatchLogSchema = z.object({

--- a/Scripts/uploadPlayerStats.ts
+++ b/Scripts/uploadPlayerStats.ts
@@ -3,15 +3,10 @@ import fs from 'fs/promises';
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import { z } from 'zod';
-import { decodeServiceAccount } from '../src/lib/serviceAccount';
+import { getServiceAccountFromEnv } from '../src/lib/serviceAccount';
 
-const serviceAccountEnv = process.env.GOOGLE_SERVICE_ACCOUNT;
-if (!serviceAccountEnv) {
-  throw new Error('Missing GOOGLE_SERVICE_ACCOUNT environment variable');
-}
-const serviceAccount = decodeServiceAccount(serviceAccountEnv);
 if (!getApps().length) {
-  initializeApp({ credential: cert(serviceAccount) });
+  initializeApp({ credential: cert(getServiceAccountFromEnv()) });
 }
 
 const db = getFirestore();

--- a/src/app/api/admin-check/admin-check.ts
+++ b/src/app/api/admin-check/admin-check.ts
@@ -6,10 +6,6 @@ export type AdminCheckResult = {
   ok: boolean;
   env: {
     hasBase64: boolean;
-    hasTriplet: boolean;
-    FIREBASE_PROJECT_ID: boolean;
-    FIREBASE_CLIENT_EMAIL: boolean;
-    FIREBASE_PRIVATE_KEY: boolean;
   };
   firestoreOk?: boolean;
   error?: string;
@@ -19,13 +15,6 @@ export async function adminCheck(): Promise<AdminCheckResult> {
   // Snapshot env booleans once
   const envFlags = {
     hasBase64: Boolean(process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64?.trim()),
-    hasTriplet:
-      Boolean(process.env.FIREBASE_PROJECT_ID) &&
-      Boolean(process.env.FIREBASE_CLIENT_EMAIL) &&
-      Boolean(process.env.FIREBASE_PRIVATE_KEY),
-    FIREBASE_PROJECT_ID: Boolean(process.env.FIREBASE_PROJECT_ID),
-    FIREBASE_CLIENT_EMAIL: Boolean(process.env.FIREBASE_CLIENT_EMAIL),
-    FIREBASE_PRIVATE_KEY: Boolean(process.env.FIREBASE_PRIVATE_KEY),
   };
 
   // Typed converter (avoids `as` casts)

--- a/src/app/api/admin-check/route.ts
+++ b/src/app/api/admin-check/route.ts
@@ -8,9 +8,6 @@ export async function GET() {
   // --- env flags the server can actually see ---
   const env = {
     hasBase64: Boolean(process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64?.trim()),
-    FIREBASE_PROJECT_ID: Boolean(process.env.FIREBASE_PROJECT_ID),
-    FIREBASE_CLIENT_EMAIL: Boolean(process.env.FIREBASE_CLIENT_EMAIL),
-    FIREBASE_PRIVATE_KEY: Boolean(process.env.FIREBASE_PRIVATE_KEY),
   };
 
   // --- decode base64 (metadata only; no secrets echoed back) ---

--- a/src/lib/serviceAccount.test.ts
+++ b/src/lib/serviceAccount.test.ts
@@ -4,6 +4,7 @@ import {
   decodeServiceAccount,
   getServiceAccountFromEnv,
 } from './serviceAccount';
+import type { ServiceAccount } from 'firebase-admin/app';
 
 const sample = {
   project_id: 'my-project',
@@ -41,6 +42,22 @@ describe('serviceAccount helpers', () => {
     delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64;
     expect(() => getServiceAccountFromEnv()).toThrow(
       'Missing FIREBASE_SERVICE_ACCOUNT_JSON_BASE64',
+    );
+    if (orig === undefined) {
+      delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64;
+    } else {
+      process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64 = orig;
+    }
+  });
+
+  it('throws when required fields missing', () => {
+    const orig = process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64;
+    const partial = { project_id: 'x' } as Record<string, unknown>;
+    process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64 = encodeServiceAccount(
+      partial as ServiceAccount,
+    );
+    expect(() => getServiceAccountFromEnv()).toThrow(
+      'Missing required service account fields',
     );
     if (orig === undefined) {
       delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64;


### PR DESCRIPTION
## Summary
- consolidate service account loading into `getServiceAccountFromEnv`
- rely on `FIREBASE_SERVICE_ACCOUNT_JSON_BASE64` for scripts and admin checks
- add validation tests for missing service account fields

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689892a230a0832bb6db7eded70538cc