### PR TITLE
Add Trade Centre link from home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/AuthContext';
 import AuthForm from '@/components/AuthForm';
+import Link from 'next/link';
 
 export default function LoginPage() {
   const { user, loading } = useAuth();
@@ -22,8 +23,11 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-[calc(100vh-100px)] flex-col items-center justify-center">
+    <div className="flex min-h-[calc(100vh-100px)] flex-col items-center justify-center space-y-4">
       <AuthForm />
+      <Link href="/tradecentre" className="text-blue-600 underline">
+        Visit Trade Centre
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add a link on the home page allowing visitors to navigate to the Trade Centre

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ad555438832ba16308cfd6ed9794