### PR TITLE
feat: add injury alerts for out players

### DIFF
--- a/src/app/rosters/page.tsx
+++ b/src/app/rosters/page.tsx
@@ -3,13 +3,9 @@
 import { useEffect, useState } from 'react';
 import { collection, getDocs } from 'firebase/firestore';
 import { db } from '@/lib/firebaseClient';
-
-interface Player {
-  id: string;
-  name: string;
-  team?: string;
-  position?: string;
-}
+import type { Player } from '@/types/players';
+import InjuryAlert from '@/components/InjuryAlert';
+import { useInjuryAlerts } from '@/hooks/useInjuryAlerts';
 
 function PlayerCard({ player }: { player: Player }) {
   return (
@@ -37,7 +33,8 @@ export default function RostersPage() {
           name: docData.name,
           team: docData.team,
           position: docData.position,
-        };
+          injury: docData.injury,
+        } as Player;
       });
       setPlayers(data);
     };
@@ -51,9 +48,18 @@ export default function RostersPage() {
     );
   });
 
+  const { alerts } = useInjuryAlerts(players);
+
   return (
     <main className="p-6">
       <h1 className="text-2xl font-bold mb-4">Rosters</h1>
+      {alerts.map((a) => (
+        <InjuryAlert
+          key={a.injured.id}
+          injured={a.injured}
+          replacements={a.replacements}
+        />
+      ))}
       <div className="flex gap-4 mb-6">
         <input
           type="text"

--- a/src/components/InjuryAlert.tsx
+++ b/src/components/InjuryAlert.tsx
@@ -1,0 +1,25 @@
+import type { Player, RankedPlayer } from '@/types/players';
+
+interface Props {
+  injured: Player;
+  replacements: RankedPlayer[];
+}
+
+export default function InjuryAlert({ injured, replacements }: Props) {
+  if (!injured) return null;
+  return (
+    <div className="p-4 mb-4 border-l-4 border-red-500 bg-red-50">
+      <p className="font-semibold">
+        {injured.name} is out this week—here are 3 players to consider adding
+      </p>
+      <ul className="list-disc ml-6 mt-2">
+        {replacements.map((p) => (
+          <li key={p.id}>
+            {p.name} ({p.team}) - {p.position}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/components/UserDashboard.tsx
+++ b/src/components/UserDashboard.tsx
@@ -1,7 +1,12 @@
 import Link from 'next/link';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { User } from 'firebase/auth';
 import WeekendSummary from './WeekendSummary';
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from '@/lib/firebaseClient';
+import type { Player } from '@/types/players';
+import InjuryAlert from './InjuryAlert';
+import { useInjuryAlerts } from '@/hooks/useInjuryAlerts';
 
 interface UserDashboardProps {
   user: User;
@@ -16,6 +21,28 @@ export default function UserDashboard({ user }: UserDashboardProps) {
     );
   }, [user]);
 
+  const [players, setPlayers] = useState<Player[]>([]);
+
+  useEffect(() => {
+    const fetchPlayers = async () => {
+      const querySnapshot = await getDocs(collection(db, 'players'));
+      const data = querySnapshot.docs.map((doc) => {
+        const docData = doc.data();
+        return {
+          id: doc.id,
+          name: docData.name,
+          team: docData.team,
+          position: docData.position,
+          injury: docData.injury,
+        } as Player;
+      });
+      setPlayers(data);
+    };
+    fetchPlayers();
+  }, []);
+
+  const { alerts } = useInjuryAlerts(players);
+
   return (
     <main className="container mx-auto p-4 sm:p-6 lg:p-8" role="main">
       <header className="mb-8">
@@ -26,6 +53,14 @@ export default function UserDashboard({ user }: UserDashboardProps) {
           Here&apos;s your fantasy dashboard. Good luck this season!
         </p>
       </header>
+
+      {alerts.map((a) => (
+        <InjuryAlert
+          key={a.injured.id}
+          injured={a.injured}
+          replacements={a.replacements}
+        />
+      ))}
 
       <section
         aria-label="Dashboard navigation cards"

--- a/src/hooks/useInjuryAlerts.ts
+++ b/src/hooks/useInjuryAlerts.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import type { Player, RankingsResponse, RankedPlayer } from '@/types/players';
+
+export type InjuryAlert = {
+  injured: Player;
+  replacements: RankedPlayer[];
+};
+
+const fetcher = async (url: string): Promise<RankingsResponse> => {
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) throw new Error(`Rankings API ${res.status} ${res.statusText}`);
+  return res.json();
+};
+
+export function useInjuryAlerts(roster: Player[]) {
+  const injuredPlayers = useMemo(
+    () => roster.filter((p) => p.injury && /out/i.test(p.injury)),
+    [roster]
+  );
+
+  const rosterIds = useMemo(() => new Set(roster.map((p) => String(p.id))), [roster]);
+
+  const { data, error, isLoading, mutate } = useSWR<RankingsResponse>(
+    injuredPlayers.length ? '/api/rankings?perGame=1&winsorP=0.01&includeDE=0' : null,
+    fetcher,
+    { revalidateOnFocus: false, dedupingInterval: 30_000 }
+  );
+
+  const alerts: InjuryAlert[] = useMemo(() => {
+    if (!data) return [];
+    return injuredPlayers
+      .map((injured) => {
+        const candidates = data.players
+          .filter(
+            (p) =>
+              p.position === injured.position && !rosterIds.has(String(p.id))
+          )
+          .sort((a, b) => b.totalValue - a.totalValue)
+          .slice(0, 3);
+        return { injured, replacements: candidates };
+      })
+      .filter((a) => a.replacements.length > 0);
+  }, [data, injuredPlayers, rosterIds]);
+
+  return {
+    alerts,
+    isLoading,
+    error: error ? (error instanceof Error ? error.message : String(error)) : null,
+    refresh: async () => {
+      await mutate();
+    },
+  };
+}
+


### PR DESCRIPTION
## Summary
- add `useInjuryAlerts` hook to recommend replacements for injured players
- display replacement suggestions via new `InjuryAlert` component
- surface injury alerts on roster and dashboard pages

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: Module '"next"' has no exported member 'PageProps'; Cannot find module '@/Hooks/useDebounce'; etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6898aeb8ac54832bb1fa0d50a2a5435a