### PR TITLE
feat: centralize player store logic

### DIFF
--- a/src/state/OfferStore.ts
+++ b/src/state/OfferStore.ts
@@ -1,6 +1,7 @@
 'use client';
 import { create } from 'zustand';
 import type { Player } from '@/types/players';
+import { createPlayerStore, type PlayerStore } from './createPlayerStore';
 
 export type OfferSide = 'yours' | 'theirs';
 
@@ -8,33 +9,25 @@ export type OfferPlayer = Pick<Player, 'id' | 'name' | 'team' | 'position'> & {
   stats?: Record<string, number | string>;
 };
 
-type OfferState = {
-  yours: OfferPlayer[];
-  theirs: OfferPlayer[];
+type OfferState = Omit<PlayerStore<OfferSide, OfferPlayer>, 'clear'> & {
   shortlist: OfferPlayer[]; // optional
-  add: (side: OfferSide, p: OfferPlayer) => void;
-  remove: (side: OfferSide, id: string) => void;
   toggleShortlist: (p: OfferPlayer) => void;
   clearOffer: () => void;
 };
 
-export const useOfferStore = create<OfferState>((set) => ({
-  yours: [],
-  theirs: [],
-  shortlist: [],
-  add: (side, p) =>
-    set((s) => {
-      const list = side === 'yours' ? s.yours : s.theirs;
-      if (list.some(x => x.id === p.id)) return s;
-      return { ...s, [side]: [...list, p] };
-    }),
-  remove: (side, id) =>
-    set((s) => ({ ...s, [side]: (side === 'yours' ? s.yours : s.theirs).filter(p => p.id !== id) })),
-  toggleShortlist: (p) =>
-    set((s) =>
-      s.shortlist.some(x => x.id === p.id)
-        ? { ...s, shortlist: s.shortlist.filter(x => x.id !== p.id) }
-        : { ...s, shortlist: [...s.shortlist, p] }
-    ),
-  clearOffer: () => set({ yours: [], theirs: [] }),
-}));
+export const useOfferStore = create<OfferState>()((set) => {
+  const { clear, ...base } =
+    createPlayerStore<OfferSide, OfferPlayer>(['yours', 'theirs'])(set);
+
+  return {
+    ...base,
+    shortlist: [],
+    toggleShortlist: (p) =>
+      set((s) =>
+        s.shortlist.some((x) => x.id === p.id)
+          ? { ...s, shortlist: s.shortlist.filter((x) => x.id !== p.id) }
+          : { ...s, shortlist: [...s.shortlist, p] },
+      ),
+    clearOffer: clear,
+  };
+});

--- a/src/state/createPlayerStore.test.ts
+++ b/src/state/createPlayerStore.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { create } from 'zustand';
+import { createPlayerStore, type PlayerStore } from './createPlayerStore';
+
+type Side = 'left' | 'right';
+interface TestPlayer {
+  id: string;
+  name: string;
+}
+
+const createTestStore = () =>
+  create<PlayerStore<Side, TestPlayer>>(createPlayerStore<Side, TestPlayer>([
+    'left',
+    'right',
+  ]));
+
+describe('createPlayerStore', () => {
+  it('adds and removes players per side without duplicates', () => {
+    const store = createTestStore();
+    const p1 = { id: '1', name: 'A' };
+    const p2 = { id: '2', name: 'B' };
+
+    store.getState().add('left', p1);
+    store.getState().add('left', p1); // duplicate ignored
+    store.getState().add('right', p2);
+
+    expect(store.getState().left).toHaveLength(1);
+    expect(store.getState().right).toHaveLength(1);
+
+    store.getState().remove('left', '1');
+    expect(store.getState().left).toHaveLength(0);
+  });
+
+  it('clears all sides', () => {
+    const store = createTestStore();
+    store.getState().add('left', { id: '1', name: 'A' });
+    store.getState().add('right', { id: '2', name: 'B' });
+
+    store.getState().clear();
+    expect(store.getState().left).toHaveLength(0);
+    expect(store.getState().right).toHaveLength(0);
+  });
+});

--- a/src/state/createPlayerStore.ts
+++ b/src/state/createPlayerStore.ts
@@ -1,0 +1,32 @@
+import type { Player } from '@/types/players';
+import type { StateCreator } from 'zustand';
+
+export type PlayerStore<Side extends string, P extends { id: string } = Player> = {
+  [K in Side]: P[];
+} & {
+  add: (side: Side, p: P) => void;
+  remove: (side: Side, id: string) => void;
+  clear: () => void;
+};
+
+export function createPlayerStore<Side extends string, P extends { id: string } = Player>(
+  sides: readonly Side[],
+): StateCreator<PlayerStore<Side, P>> {
+  return (set) => {
+    const initial = Object.fromEntries(sides.map((s) => [s, [] as P[]])) as {
+      [K in Side]: P[];
+    };
+    return {
+      ...initial,
+      add: (side, p) =>
+        set((state) => {
+          const list = state[side];
+          if (list.some((x) => x.id === p.id)) return state;
+          return { ...state, [side]: [...list, p] };
+        }),
+      remove: (side, id) =>
+        set((state) => ({ ...state, [side]: state[side].filter((x) => x.id !== id) })),
+      clear: () => set(initial),
+    };
+  };
+}

--- a/src/state/tradeStore.tsx
+++ b/src/state/tradeStore.tsx
@@ -1,55 +1,36 @@
 'use client';
 import { create } from 'zustand';
 import type { Player } from '@/types/players';
+import { createPlayerStore, type PlayerStore } from './createPlayerStore';
 
 export type Side = 'incoming' | 'outgoing';
 type RostersMap = Record<string, Player[]>;
 
-type TradeState = {
+type TradeState = Omit<PlayerStore<Side, Player>, 'clear'> & {
   myTeamKey: string | null;
   targetTeamKey: string | null;
   rosters: RostersMap;
-
-  incoming: Player[];
-  outgoing: Player[];
 
   setMyTeam: (teamId: string | null) => void;
   setTargetTeam: (teamId: string | null) => void;
   seedRoster: (teamId: string, players: Player[]) => void;
 
-  add: (side: Side, p: Player) => void;
-  remove: (side: Side, id: string) => void;
   clearAll: () => void;
 };
 
-export const useTradeStore = create<TradeState>((set, _get) => ({
-  myTeamKey: null,
-  targetTeamKey: null,
-  rosters: {},
+export const useTradeStore = create<TradeState>()((set, _get) => {
+  const { clear, ...base } =
+    createPlayerStore<Side, Player>(['incoming', 'outgoing'])(set);
 
-  incoming: [],
-  outgoing: [],
-
-  setMyTeam: (teamId) => set({ myTeamKey: teamId }),
-  setTargetTeam: (teamId) => set({ targetTeamKey: teamId }),
-  seedRoster: (teamId, players) =>
-    set((s) => ({ rosters: { ...s.rosters, [teamId]: players } })),
-
-  add: (side, p) =>
-    set((s) => {
-      const list = side === 'incoming' ? s.incoming : s.outgoing;
-      if (list.some((x) => x.id === p.id)) return s;
-      return side === 'incoming'
-        ? { ...s, incoming: [...s.incoming, p] }
-        : { ...s, outgoing: [...s.outgoing, p] };
-    }),
-
-  remove: (side, id) =>
-    set((s) =>
-      side === 'incoming'
-        ? { ...s, incoming: s.incoming.filter((x) => x.id !== id) }
-        : { ...s, outgoing: s.outgoing.filter((x) => x.id !== id) }
-    ),
-
-  clearAll: () => set({ incoming: [], outgoing: [] }),
-}));
+  return {
+    myTeamKey: null,
+    targetTeamKey: null,
+    rosters: {},
+    ...base,
+    setMyTeam: (teamId) => set({ myTeamKey: teamId }),
+    setTargetTeam: (teamId) => set({ targetTeamKey: teamId }),
+    seedRoster: (teamId, players) =>
+      set((s) => ({ rosters: { ...s.rosters, [teamId]: players } })),
+    clearAll: clear,
+  };
+});


### PR DESCRIPTION
## Summary
- add generic `createPlayerStore` utility for managing player arrays
- refactor `OfferStore` and `tradeStore` to use the shared utility
- cover player store behaviors with new unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898cc19f818832ba65a5b1f880cdbdc