### PR TITLE
feat: add team logo assets and helper

### DIFF
--- a/public/logos/Adelaide.svg
+++ b/public/logos/Adelaide.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Adelaide</text></svg>

--- a/public/logos/Brisbane.svg
+++ b/public/logos/Brisbane.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Brisbane</text></svg>

--- a/public/logos/Carlton.svg
+++ b/public/logos/Carlton.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Carlton</text></svg>

--- a/public/logos/Collingwood.svg
+++ b/public/logos/Collingwood.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Collingwood</text></svg>

--- a/public/logos/Essendon.svg
+++ b/public/logos/Essendon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Essendon</text></svg>

--- a/public/logos/Fremantle.svg
+++ b/public/logos/Fremantle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Fremantle</text></svg>

--- a/public/logos/GWS.svg
+++ b/public/logos/GWS.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">GWS</text></svg>

--- a/public/logos/Geelong.svg
+++ b/public/logos/Geelong.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Geelong</text></svg>

--- a/public/logos/Gold Coast.svg
+++ b/public/logos/Gold Coast.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Gold Coast</text></svg>

--- a/public/logos/Hawthorn.svg
+++ b/public/logos/Hawthorn.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Hawthorn</text></svg>

--- a/public/logos/Melbourne.svg
+++ b/public/logos/Melbourne.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Melbourne</text></svg>

--- a/public/logos/North Melbourne.svg
+++ b/public/logos/North Melbourne.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">North Melbourne</text></svg>

--- a/public/logos/Port Adelaide.svg
+++ b/public/logos/Port Adelaide.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Port Adelaide</text></svg>

--- a/public/logos/Richmond.svg
+++ b/public/logos/Richmond.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Richmond</text></svg>

--- a/public/logos/St Kilda.svg
+++ b/public/logos/St Kilda.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">St Kilda</text></svg>

--- a/public/logos/Sydney.svg
+++ b/public/logos/Sydney.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Sydney</text></svg>

--- a/public/logos/West Coast.svg
+++ b/public/logos/West Coast.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">West Coast</text></svg>

--- a/public/logos/Western Bulldogs.svg
+++ b/public/logos/Western Bulldogs.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#ccc"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Western Bulldogs</text></svg>

--- a/public/logos/fallback.svg
+++ b/public/logos/fallback.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" fill="#eee"/><text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">Unknown</text></svg>

--- a/src/utils/teamLogos.ts
+++ b/src/utils/teamLogos.ts
@@ -1,0 +1,28 @@
+export const teamLogos: Record<string, string> = {
+  Adelaide: '/logos/Adelaide.svg',
+  Brisbane: '/logos/Brisbane.svg',
+  Carlton: '/logos/Carlton.svg',
+  Collingwood: '/logos/Collingwood.svg',
+  Essendon: '/logos/Essendon.svg',
+  Fremantle: '/logos/Fremantle.svg',
+  GWS: '/logos/GWS.svg',
+  Geelong: '/logos/Geelong.svg',
+  'Gold Coast': '/logos/Gold Coast.svg',
+  Hawthorn: '/logos/Hawthorn.svg',
+  Melbourne: '/logos/Melbourne.svg',
+  'North Melbourne': '/logos/North Melbourne.svg',
+  'Port Adelaide': '/logos/Port Adelaide.svg',
+  Richmond: '/logos/Richmond.svg',
+  'St Kilda': '/logos/St Kilda.svg',
+  Sydney: '/logos/Sydney.svg',
+  'West Coast': '/logos/West Coast.svg',
+  'Western Bulldogs': '/logos/Western Bulldogs.svg',
+};
+
+export const fallbackLogo = '/logos/fallback.svg';
+
+export const getTeamLogo = (team: string): string => {
+  return teamLogos[team] || fallbackLogo;
+};
+
+export default teamLogos;


### PR DESCRIPTION
## Summary
- add placeholder logos for all AFL teams and a fallback image
- expose `getTeamLogo` helper mapping team names to logo paths

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-unused-expressions in PlayersPageServer.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6898d8566788832ba535130ead31432b