### PR TITLE
Add round matches banner and dynamic matches page

### DIFF
--- a/src/app/matches/[round]/page.tsx
+++ b/src/app/matches/[round]/page.tsx
@@ -1,0 +1,15 @@
+import RoundMatchesBanner from '@/components/RoundMatchesBanner';
+
+export default function RoundMatchesPage({
+  params,
+}: {
+  params: { round: string };
+}) {
+  const roundNumber = Number(params.round);
+  return (
+    <main className="mx-auto max-w-5xl p-4">
+      <h1 className="mb-4 text-2xl font-semibold">Round {roundNumber} Matches</h1>
+      <RoundMatchesBanner round={roundNumber} />
+    </main>
+  );
+}

--- a/src/components/RoundMatchesBanner.tsx
+++ b/src/components/RoundMatchesBanner.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import teamLogos from '@/lib/teamLogos';
+
+interface Match {
+  homeTeam: string;
+  awayTeam: string;
+  [key: string]: any;
+}
+
+interface Props {
+  round: number;
+}
+
+export default function RoundMatchesBanner({ round }: Props) {
+  const [matches, setMatches] = useState<Match[]>([]);
+
+  useEffect(() => {
+    async function loadMatches() {
+      try {
+        const res = await fetch(`/api/matches?round=${round}`);
+        if (!res.ok) throw new Error('Failed to fetch matches');
+        const data = await res.json();
+        // Support either {matches: Match[]} or Match[]
+        setMatches(Array.isArray(data) ? data : data.matches ?? []);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    loadMatches();
+  }, [round]);
+
+  return (
+    <div className="flex flex-wrap justify-center gap-4">
+      {matches.map((match, idx) => (
+        <div
+          key={`${match.homeTeam}-${match.awayTeam}-${idx}`}
+          className="flex items-center gap-2 rounded-md bg-gray-800/80 px-3 py-2 text-white"
+        >
+          <img
+            src={teamLogos[match.homeTeam]}
+            alt={match.homeTeam}
+            className="h-8 w-8 object-contain"
+          />
+          <span className="font-semibold">{match.homeTeam}</span>
+          <span className="mx-1 text-sm">vs</span>
+          <img
+            src={teamLogos[match.awayTeam]}
+            alt={match.awayTeam}
+            className="h-8 w-8 object-contain"
+          />
+          <span className="font-semibold">{match.awayTeam}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/teamLogos.ts
+++ b/src/lib/teamLogos.ts
@@ -1,0 +1,22 @@
+export const teamLogos: Record<string, string> = {
+  Adelaide: 'https://via.placeholder.com/40?text=ADL',
+  Brisbane: 'https://via.placeholder.com/40?text=BRI',
+  Carlton: 'https://via.placeholder.com/40?text=CAR',
+  Collingwood: 'https://via.placeholder.com/40?text=COL',
+  Essendon: 'https://via.placeholder.com/40?text=ESS',
+  Fremantle: 'https://via.placeholder.com/40?text=FRE',
+  Geelong: 'https://via.placeholder.com/40?text=GEE',
+  'Gold Coast': 'https://via.placeholder.com/40?text=GC',
+  'GWS Giants': 'https://via.placeholder.com/40?text=GWS',
+  Hawthorn: 'https://via.placeholder.com/40?text=HAW',
+  Melbourne: 'https://via.placeholder.com/40?text=MEL',
+  'North Melbourne': 'https://via.placeholder.com/40?text=NM',
+  'Port Adelaide': 'https://via.placeholder.com/40?text=PA',
+  Richmond: 'https://via.placeholder.com/40?text=RIC',
+  'St Kilda': 'https://via.placeholder.com/40?text=STK',
+  Sydney: 'https://via.placeholder.com/40?text=SYD',
+  'West Coast': 'https://via.placeholder.com/40?text=WC',
+  'Western Bulldogs': 'https://via.placeholder.com/40?text=WBD',
+};
+
+export default teamLogos;


### PR DESCRIPTION
## Summary
- create teamLogos mapping for AFL clubs
- add RoundMatchesBanner component that fetches matches for a round and displays team logos and names
- add dynamic `/matches/[round]` page that renders the banner with the route param

## Testing
- `npm test`
- `npm run lint` *(fails: PlayersPageServer.tsx has existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898d857f11c832b82afbc4bcefd98c2