### PR TITLE
feat: add player detail API and update player page

### DIFF
--- a/src/app/api/players/[id]/route.ts
+++ b/src/app/api/players/[id]/route.ts
@@ -1,0 +1,23 @@
+export const runtime = 'nodejs';
+
+import { NextResponse, type NextRequest } from 'next/server';
+import { getPlayer } from '@/lib/data';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const player = await getPlayer(params.id);
+    if (!player) {
+      return NextResponse.json({ message: 'Player not found' }, { status: 404 });
+    }
+    return NextResponse.json(player);
+  } catch (error) {
+    console.error('API Error fetching player:', error);
+    return NextResponse.json(
+      { message: 'Failed to fetch player' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/players/[id]/page.tsx
+++ b/src/app/players/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import type { Player } from '@/types/players';
-import { getPlayerIds, getPlayer } from '@/lib/data';
+import { getPlayerIds } from '@/lib/data';
+import { fetchFromAPI } from '@/lib/api';
 import PlayerDetail from '@/components/PlayerDetail';
 
 // Build all player pages at build time
@@ -16,13 +17,15 @@ export async function generateMetadata({
   params: { id: string };
 }) {
   const { id } = params;
-  const player = await getPlayer(id);
-  if (!player) return { title: 'Player Not Found' };
-
-  return {
-    title: `${player.name} | Player Stats | Statly`,
-    description: `View detailed stats for ${player.name} of ${player.team}.`,
-  };
+  try {
+    const player = await fetchFromAPI<Player>(`/api/players/${id}`);
+    return {
+      title: `${player.name} | Player Stats | Statly`,
+      description: `View detailed stats for ${player.name} of ${player.team}.`,
+    };
+  } catch {
+    return { title: 'Player Not Found' };
+  }
 }
 
 export default async function PlayerPage({
@@ -31,8 +34,12 @@ export default async function PlayerPage({
   params: { id: string };
 }) {
   const { id } = params;
-  const player: Player | null = await getPlayer(id);
-  if (!player) notFound();
+  let player: Player;
+  try {
+    player = await fetchFromAPI<Player>(`/api/players/${id}`);
+  } catch {
+    notFound();
+  }
 
   return (
     <main className="mx-auto max-w-5xl p-4">


### PR DESCRIPTION
## Summary
- add `/api/players/[id]` endpoint to return a single player or 404
- update player detail page to fetch player data via the new endpoint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e5f85010832b88b6e4860c15f93d