### PR TITLE
Use team id fallback in draft order bar

### DIFF
--- a/src/components/DraftOrderBar.tsx
+++ b/src/components/DraftOrderBar.tsx
@@ -13,16 +13,17 @@ const DraftOrderBar = ({ teams = [], currentPickIndex, myTeamId }: DraftOrderBar
       {teams.map((team, index) => {
         const isCurrent = index === currentPickIndex;
         const isMyTeam = team.id === myTeamId;
+        const displayName = team.name || team.id; // fall back to id so a label is always shown; aim to provide names consistently
 
         return (
           <div
             key={team.id}
-            title={team.name}
+            title={displayName}
             className={`flex items-center justify-center px-3 py-1 rounded text-xs font-medium border transition
               ${isCurrent ? 'bg-red-500 text-white animate-pulse' : 'bg-white text-gray-700'}
               ${isMyTeam ? 'ring-2 ring-indigo-500' : ''}`}
           >
-            {team.name}
+            {displayName}
           </div>
         );
       })}


### PR DESCRIPTION
## Summary
- fall back to `team.id` when a team's `name` is missing
- document the fallback so maintainers supply names consistently

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_6898e59e834c832bbc116c36bab324b4