### PR TITLE
feat: add helper for top fantasy players

### DIFF
--- a/src/app/api/weekend-summary/route.ts
+++ b/src/app/api/weekend-summary/route.ts
@@ -3,6 +3,7 @@ export const runtime = 'nodejs';
 import { NextResponse } from 'next/server';
 import OpenAI from 'openai';
 import { getPlayers } from '@/lib/data';
+import { getTopPlayersByFantasy } from '@/lib/getTopPlayersByFantasy';
 
 interface CachedSummary {
   summary: string;
@@ -19,19 +20,12 @@ export async function GET() {
     }
 
     const players = await getPlayers();
-    const top = players
-      .sort(
-        (a, b) =>
-          (Number(b.stats?.aflFantasy) || 0) -
-          (Number(a.stats?.aflFantasy) || 0)
-      )
-      .slice(0, 5)
-      .map((p) => ({
-        name: p.name,
-        team: p.team,
-        goals: p.stats?.goals,
-        aflFantasy: p.stats?.aflFantasy,
-      }));
+    const top = getTopPlayersByFantasy(players, 5).map((p) => ({
+      name: p.name,
+      team: p.team,
+      goals: p.stats?.goals,
+      aflFantasy: p.stats?.aflFantasy,
+    }));
 
     const client = new OpenAI({
       apiKey: process.env.GITHUB_TOKEN,

--- a/src/lib/getTopPlayersByFantasy.test.ts
+++ b/src/lib/getTopPlayersByFantasy.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import type { Player } from '@/types/players';
+import { getTopPlayersByFantasy } from './getTopPlayersByFantasy';
+
+describe('getTopPlayersByFantasy', () => {
+  const players: Player[] = [
+    { id: '1', name: 'A', stats: { aflFantasy: 10 } },
+    { id: '2', name: 'B', stats: { aflFantasy: 50 } },
+    { id: '3', name: 'C', stats: { aflFantasy: 30 } },
+    { id: '4', name: 'D', stats: { aflFantasy: 70 } },
+    { id: '5', name: 'E', stats: { aflFantasy: 20 } },
+    { id: '6', name: 'F', stats: { aflFantasy: 90 } },
+  ];
+
+  it('returns top n players by aflFantasy in descending order', () => {
+    const top = getTopPlayersByFantasy(players, 3);
+    expect(top.map((p) => p.name)).toEqual(['F', 'D', 'B']);
+  });
+
+  it('defaults to top 5 players', () => {
+    const top = getTopPlayersByFantasy(players);
+    expect(top).toHaveLength(5);
+    expect(top.map((p) => p.name)).toEqual(['F', 'D', 'B', 'C', 'E']);
+  });
+});

--- a/src/lib/getTopPlayersByFantasy.ts
+++ b/src/lib/getTopPlayersByFantasy.ts
@@ -1,0 +1,30 @@
+import type { Player } from '@/types/players';
+
+/**
+ * Return the top `count` players sorted by `stats.aflFantasy` without sorting
+ * the entire input list. Uses an insertion approach with a fixed-size array.
+ */
+export function getTopPlayersByFantasy(
+  players: Player[],
+  count = 5,
+): Player[] {
+  const top: Player[] = [];
+
+  for (const p of players) {
+    const fantasy = Number(p.stats?.aflFantasy) || 0;
+
+    let inserted = false;
+    for (let i = 0; i < top.length; i++) {
+      const cur = Number(top[i].stats?.aflFantasy) || 0;
+      if (fantasy > cur) {
+        top.splice(i, 0, p);
+        inserted = true;
+        break;
+      }
+    }
+    if (!inserted) top.push(p);
+    if (top.length > count) top.pop();
+  }
+
+  return top.slice(0, count);
+}


### PR DESCRIPTION
## Summary
- add `getTopPlayersByFantasy` to pull top players without sorting entire list
- use helper in weekend summary route
- cover helper with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898e8625314832bbaae5de4a3eb7e7d