### PR TITLE
refactor: simplify player sorting state

### DIFF
--- a/src/app/players/PlayersPageClient.tsx
+++ b/src/app/players/PlayersPageClient.tsx
@@ -9,8 +9,7 @@ interface PlayersPageClientProps {
 }
 
 export default function PlayersPageClient({ players }: PlayersPageClientProps) {
-  // Local state retained for future interactive features (filters, search, etc.)
-  const [filteredPlayers] = useState<Player[]>(players);
+  const filteredPlayers = players;
   const [sortKey, setSortKey] = useState<string>('name');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
 
@@ -31,7 +30,7 @@ export default function PlayersPageClient({ players }: PlayersPageClientProps) {
         ? String(aVal).localeCompare(String(bVal))
         : String(bVal).localeCompare(String(aVal));
     });
-  }, [filteredPlayers, sortKey, sortDir]);
+  }, [sortKey, sortDir]);
 
   if (!sortedPlayers.length) {
     return <p className="p-4">No players found.</p>;

--- a/src/app/players/PlayersPageClient.tsx
+++ b/src/app/players/PlayersPageClient.tsx
@@ -30,7 +30,7 @@ export default function PlayersPageClient({ players }: PlayersPageClientProps) {
         ? String(aVal).localeCompare(String(bVal))
         : String(bVal).localeCompare(String(aVal));
     });
-  }, [sortKey, sortDir]);
+  }, [players, sortKey, sortDir]);
 
   if (!sortedPlayers.length) {
     return <p className="p-4">No players found.</p>;


### PR DESCRIPTION
## Summary
- simplify PlayersPageClient by removing unused filteredPlayers state
- adjust player sorting memo dependencies accordingly

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find name 'the' in TradeCentreClient.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6898e840dc08832ba33c4641f431d9b2