### PR TITLE
fix: correct state variable declaration

### DIFF
--- a/src/components/TradeCentreClient.tsx
+++ b/src/components/TradeCentreClient.tsx
@@ -74,7 +74,7 @@ export default function TradeCentreClient({ initialPlayers }: TradeCentreClientP
   const [panelOpen, setPanelOpen] = useState(true);
 
   const [pending, setPending] = useState<Filters>({});
-  the [applied, setApplied] = useState<Filters>({});
+  const [applied, setApplied] = useState<Filters>({});
 
   const appliedCount = useMemo(
     () => Object.values(applied).filter((v) => v !== '').length,


### PR DESCRIPTION
## Summary
- fix typo in TradeCentreClient state declaration

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6898eb9fe630832ba9a94b194a80f5b5