### PR TITLE
refactor: make WeekendSummary server component

### DIFF
--- a/src/components/WeekendSummary.tsx
+++ b/src/components/WeekendSummary.tsx
@@ -1,38 +1,28 @@
-'use client';
+import React from 'react';
+import { fetchFromAPI } from '@/lib/api';
 
-import { useEffect, useState } from 'react';
+export default async function WeekendSummary() {
+  let summary = '';
+  let error: string | null = null;
 
-export default function WeekendSummary() {
-  const [summary, setSummary] = useState<string>('');
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    async function fetchSummary() {
-      try {
-        const res = await fetch('/api/weekend-summary');
-        if (!res.ok) throw new Error('Failed to load');
-        const data = await res.json();
-        setSummary(data.summary || '');
-      } catch (err) {
-        setError((err as Error).message);
-      } finally {
-        setLoading(false);
-      }
-    }
-    fetchSummary();
-  }, []);
+  try {
+    const data = await fetchFromAPI<{ summary?: string }>(
+      '/api/weekend-summary',
+      { cache: 'force-cache' }
+    );
+    summary = data.summary || '';
+  } catch (err) {
+    error = err instanceof Error ? err.message : 'Failed to load';
+  }
 
   return (
     <article className="p-6 bg-card text-card-foreground shadow-md rounded-xl border border-border">
       <h2 className="text-xl font-bold mb-2">Weekend Summary</h2>
-      {loading && <p className="text-muted-foreground">Loading...</p>}
-      {error && (
-        <p className="text-red-500">
-          Error loading summary: {error}
-        </p>
+      {error ? (
+        <p className="text-red-500">Error loading summary: {error}</p>
+      ) : (
+        <p className="text-muted-foreground">{summary}</p>
       )}
-      {!loading && !error && <p className="text-muted-foreground">{summary}</p>}
     </article>
   );
 }


### PR DESCRIPTION
## Summary
- convert WeekendSummary to async server component that prefetches summary with `force-cache`
- fetch weekend summary using absolute base URL via `fetchFromAPI`

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Route "src/app/api/players/[id]/route.ts" has an invalid "GET" export)*

------
https://chatgpt.com/codex/tasks/task_e_6898e84bf288832ba5e388ac43302e98