### PR TITLE
feat: add snake draft order utilities

### DIFF
--- a/src/lib/snakeDraft.test.ts
+++ b/src/lib/snakeDraft.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { computeSnakeState, generateSnakeDraftOrder } from './snakeDraft';
+
+describe('computeSnakeState', () => {
+  it('computes round, direction and slot correctly', () => {
+    expect(computeSnakeState(1, 3)).toEqual({ round: 1, direction: 'FORWARD', slot: 1 });
+    expect(computeSnakeState(3, 3)).toEqual({ round: 1, direction: 'FORWARD', slot: 3 });
+    expect(computeSnakeState(4, 3)).toEqual({ round: 2, direction: 'REVERSE', slot: 3 });
+    expect(computeSnakeState(6, 3)).toEqual({ round: 2, direction: 'REVERSE', slot: 1 });
+    expect(computeSnakeState(7, 3)).toEqual({ round: 3, direction: 'FORWARD', slot: 1 });
+  });
+});
+
+describe('generateSnakeDraftOrder', () => {
+  it('generates order for given teams and roster size', () => {
+    const order = generateSnakeDraftOrder(3, 2);
+    expect(order).toEqual([
+      [1, 2, 3],
+      [3, 2, 1],
+    ]);
+  });
+});

--- a/src/lib/snakeDraft.ts
+++ b/src/lib/snakeDraft.ts
@@ -29,6 +29,8 @@ export function generateSnakeDraftOrder(
   benchSize = 0,
 ): number[][] {
   if (teamCount <= 0) throw new Error('teamCount must be positive');
+  if (!Number.isInteger(rosterSize) || rosterSize < 0) throw new Error('rosterSize must be a non-negative integer');
+  if (!Number.isInteger(benchSize) || benchSize < 0) throw new Error('benchSize must be a non-negative integer');
   const rounds = starterSize + benchSize;
   const order: number[][] = [];
   for (let r = 1; r <= rounds; r++) {

--- a/src/lib/snakeDraft.ts
+++ b/src/lib/snakeDraft.ts
@@ -20,16 +20,16 @@ export function computeSnakeState(
 }
 
 /**
- * Generates the full snake draft order given a number of teams and roster size.
+ * Generates the full snake draft order given a number of teams and starter size (active roster spots).
  * Returns an array of rounds, each round being an array of team slots in pick order.
  */
 export function generateSnakeDraftOrder(
   teamCount: number,
-  rosterSize: number,
+  starterSize: number,
   benchSize = 0,
 ): number[][] {
   if (teamCount <= 0) throw new Error('teamCount must be positive');
-  const rounds = rosterSize + benchSize;
+  const rounds = starterSize + benchSize;
   const order: number[][] = [];
   for (let r = 1; r <= rounds; r++) {
     const roundOrder: number[] = [];

--- a/src/lib/snakeDraft.ts
+++ b/src/lib/snakeDraft.ts
@@ -1,0 +1,44 @@
+export type DraftDirection = 'FORWARD' | 'REVERSE';
+
+/**
+ * Calculates round, direction and slot for a given pick in a snake draft.
+ * @param currentPick global pick number starting at 1
+ * @param teamCount number of teams participating
+ */
+export function computeSnakeState(
+  currentPick: number,
+  teamCount: number,
+): { round: number; direction: DraftDirection; slot: number } {
+  if (teamCount <= 0) throw new Error('teamCount must be positive');
+  if (currentPick <= 0) throw new Error('currentPick must be positive');
+
+  const round = Math.ceil(currentPick / teamCount);
+  const direction: DraftDirection = round % 2 === 1 ? 'FORWARD' : 'REVERSE';
+  const indexInRound = (currentPick - 1) % teamCount;
+  const slot = direction === 'FORWARD' ? indexInRound + 1 : teamCount - indexInRound;
+  return { round, direction, slot };
+}
+
+/**
+ * Generates the full snake draft order given a number of teams and roster size.
+ * Returns an array of rounds, each round being an array of team slots in pick order.
+ */
+export function generateSnakeDraftOrder(
+  teamCount: number,
+  rosterSize: number,
+  benchSize = 0,
+): number[][] {
+  if (teamCount <= 0) throw new Error('teamCount must be positive');
+  const rounds = rosterSize + benchSize;
+  const order: number[][] = [];
+  for (let r = 1; r <= rounds; r++) {
+    const roundOrder: number[] = [];
+    if (r % 2 === 1) {
+      for (let i = 1; i <= teamCount; i++) roundOrder.push(i);
+    } else {
+      for (let i = teamCount; i >= 1; i--) roundOrder.push(i);
+    }
+    order.push(roundOrder);
+  }
+  return order;
+}

--- a/src/server/app.test.ts
+++ b/src/server/app.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer, Server } from 'http';
+import app from './app';
+
+let server: Server;
+let url: string;
+
+beforeAll(async () => {
+  server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  if (typeof address === 'object' && address) {
+    url = `http://127.0.0.1:${address.port}`;
+  }
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('POST /api/draft/order', () => {
+  it('returns generated snake draft order', async () => {
+    const res = await fetch(`${url}/api/draft/order`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ teams: 3, rosterSize: 2 })
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.order).toEqual([
+      [1, 2, 3],
+      [3, 2, 1]
+    ]);
+  });
+
+  it('validates input', async () => {
+    const res = await fetch(`${url}/api/draft/order`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ teams: 0, rosterSize: 1 })
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,0 +1,23 @@
+import express from 'express';
+import { generateSnakeDraftOrder } from '../lib/snakeDraft';
+
+const app = express();
+app.use(express.json());
+
+app.post('/api/draft/order', (req, res) => {
+  const { teams, rosterSize } = req.body ?? {};
+  if (
+    !Number.isInteger(teams) ||
+    teams <= 0 ||
+    !Number.isInteger(rosterSize) ||
+    rosterSize <= 0
+  ) {
+    return res
+      .status(400)
+      .json({ error: 'teams and rosterSize must be positive integers' });
+  }
+  const order = generateSnakeDraftOrder(teams, rosterSize);
+  return res.json({ order });
+});
+
+export default app;

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -5,18 +5,19 @@ const app = express();
 app.use(express.json());
 
 app.post('/api/draft/order', (req, res) => {
-  const { teams, rosterSize } = req.body ?? {};
+  const { teams, rosterSize, benchSize } = req.body ?? {};
   if (
     !Number.isInteger(teams) ||
     teams <= 0 ||
     !Number.isInteger(rosterSize) ||
-    rosterSize <= 0
+    rosterSize <= 0 ||
+    (benchSize !== undefined && (!Number.isInteger(benchSize) || benchSize < 0))
   ) {
     return res
       .status(400)
-      .json({ error: 'teams and rosterSize must be positive integers' });
+      .json({ error: 'teams and rosterSize must be positive integers, benchSize (if provided) must be a non-negative integer' });
   }
-  const order = generateSnakeDraftOrder(teams, rosterSize);
+  const order = generateSnakeDraftOrder(teams, rosterSize, benchSize);
   return res.json({ order });
 });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,6 @@
+import app from './app';
+
+const port = Number(process.env.PORT) || 3001;
+app.listen(port, () => {
+  console.log(`API server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- implement generic snake draft algorithm utilities to compute pick slot and round
- generate full snake draft order given team count and roster size
- cover logic with Vitest unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898f2d64f94832ba3f09a11c2af1ba6