### PR TITLE
feat: validate player query params

### DIFF
--- a/src/app/api/players/route.test.ts
+++ b/src/app/api/players/route.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+vi.mock('@/lib/data', () => ({
+  getPlayers: vi.fn(async () =>
+    Array.from({ length: 30 }, (_, i) => ({ id: String(i), name: `P${i}` })),
+  ),
+}));
+import { GET } from './route';
+
+describe('GET /api/players', () => {
+  it('returns players for valid query params', async () => {
+    const req = new NextRequest('http://localhost/api/players?search=a&team=b&position=c&page=2&limit=5');
+    const res = await GET(req);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.page).toBe(2);
+    expect(data.limit).toBe(5);
+    expect(data.players).toHaveLength(5);
+  });
+
+  it('returns 400 for invalid page and limit', async () => {
+    const req = new NextRequest('http://localhost/api/players?page=0&limit=101');
+    const res = await GET(req);
+    const data = await res.json();
+    expect(res.status).toBe(400);
+    expect(data.errors.page?.length).toBeGreaterThan(0);
+    expect(data.errors.limit?.length).toBeGreaterThan(0);
+  });
+
+  it('returns 400 for non-numeric page', async () => {
+    const req = new NextRequest('http://localhost/api/players?page=abc');
+    const res = await GET(req);
+    const data = await res.json();
+    expect(res.status).toBe(400);
+    expect(data.errors.page?.length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/api/players/route.ts
+++ b/src/app/api/players/route.ts
@@ -8,8 +8,41 @@ const querySchema = z.object({
   search: z.string().optional(),
   team: z.string().optional(),
   position: z.string().optional(),
-  page: z.coerce.number().int().min(1).default(1),
-  limit: z.coerce.number().int().min(1).max(100).default(20),
+  page: z
+    .string()
+    .transform((val, ctx) => {
+      const num = Number(val);
+      if (!val || val.trim() === "") return 1; // default
+      if (!Number.isFinite(num) || !Number.isInteger(num) || num < 1) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Page must be a positive integer",
+        });
+        return z.NEVER;
+      }
+      return num;
+    })
+    .default("1"),
+  limit: z
+    .string()
+    .transform((val, ctx) => {
+      const num = Number(val);
+      if (!val || val.trim() === "") return 20; // default
+      if (
+        !Number.isFinite(num) ||
+        !Number.isInteger(num) ||
+        num < 1 ||
+        num > 100
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Limit must be an integer between 1 and 100",
+        });
+        return z.NEVER;
+      }
+      return num;
+    })
+    .default("20"),
 });
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/players/route.ts
+++ b/src/app/api/players/route.ts
@@ -1,18 +1,31 @@
 export const runtime = 'nodejs';
 
 import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
 import { getPlayers } from '@/lib/data';
+
+const querySchema = z.object({
+  search: z.string().optional(),
+  team: z.string().optional(),
+  position: z.string().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
 
 export async function GET(request: NextRequest) {
   try {
-    const searchParams = request.nextUrl.searchParams;
-    const search = searchParams.get('search') ?? undefined;
-    const team = searchParams.get('team') ?? undefined;
-    const position = searchParams.get('position') ?? undefined;
-    const pageParam = Number(searchParams.get('page'));
-    const limitParam = Number(searchParams.get('limit'));
-    const page = Number.isFinite(pageParam) && pageParam > 0 ? pageParam : 1;
-    const limit = Number.isFinite(limitParam) && limitParam > 0 ? limitParam : 20;
+    const params = Object.fromEntries(request.nextUrl.searchParams.entries());
+    const parsed = querySchema.safeParse(params);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          message: 'Invalid query parameters',
+          errors: parsed.error.flatten().fieldErrors,
+        },
+        { status: 400 },
+      );
+    }
+    const { search, team, position, page, limit } = parsed.data;
 
     const players = await getPlayers({ search, team, position });
     const total = players.length;


### PR DESCRIPTION
## Summary
- validate `/api/players` query params with a zod schema
- use schema.safeParse and return 400 with error details
- add tests for valid and invalid parameter combinations

## Testing
- `npm test`
- `npm run lint` *(fails: React is defined but never used, toTeam is defined but never used, initials is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_6898f2f1ae9c832bb5e670cb0e25c70c