### PR TITLE
feat: centralize environment configuration

### DIFF
--- a/src/app/api/weekend-summary/route.ts
+++ b/src/app/api/weekend-summary/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 import OpenAI from 'openai';
 import { getPlayers } from '@/lib/data';
 import { getTopPlayersByFantasy } from '@/lib/getTopPlayersByFantasy';
+import { env } from '@/lib/env';
 
 interface CachedSummary {
   summary: string;
@@ -28,8 +29,8 @@ export async function GET() {
     }));
 
     const client = new OpenAI({
-      apiKey: process.env.GITHUB_TOKEN,
-      baseURL: process.env.OPENAI_BASE_URL || 'https://models.inference.ai.azure.com',
+      apiKey: env.OPENAI_API_KEY ?? env.GITHUB_TOKEN,
+      baseURL: env.OPENAI_BASE_URL,
     });
 
     const prompt = `Provide a concise 2-3 sentence summary of the AFL weekend based on these top player stats: ${JSON.stringify(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,13 +1,12 @@
 // src/lib/api.ts
 
-export async function fetchFromAPI<T>(path: string, options?: RequestInit): Promise<T> {
-  const rawBaseUrl = process.env.NEXT_PUBLIC_API_URL;
+import { env } from '@/lib/env';
 
-  if (!rawBaseUrl) {
-    throw new Error('Missing NEXT_PUBLIC_API_URL in environment variables. Please create a .env.local file and add NEXT_PUBLIC_API_URL=http://localhost:3000');
-  }
-
-  const baseUrl = rawBaseUrl.replace(/\/$/, '');
+export async function fetchFromAPI<T>(
+  path: string,
+  options?: RequestInit
+): Promise<T> {
+  const baseUrl = env.NEXT_PUBLIC_API_URL.replace(/\/$/, '');
   const url = `${baseUrl}${path}`;
 
   const res = await fetch(url, options);

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+const envSchema = z
+  .object({
+    FIREBASE_SERVICE_ACCOUNT_JSON_BASE64: z
+      .string()
+      .min(1, 'FIREBASE_SERVICE_ACCOUNT_JSON_BASE64 is required')
+      .superRefine((val, ctx) => {
+        try {
+          const json = Buffer.from(val, 'base64').toString('utf-8');
+          JSON.parse(json);
+        } catch {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message:
+              'FIREBASE_SERVICE_ACCOUNT_JSON_BASE64 must be valid base64-encoded JSON',
+          });
+        }
+      }),
+    NEXT_PUBLIC_API_URL: z
+      .string()
+      .url('NEXT_PUBLIC_API_URL must be a valid URL'),
+    GITHUB_TOKEN: z.string().min(1, 'GITHUB_TOKEN is required').optional(),
+    OPENAI_API_KEY: z
+      .string()
+      .min(1, 'OPENAI_API_KEY is required')
+      .optional(),
+    OPENAI_BASE_URL: z
+      .string()
+      .url('OPENAI_BASE_URL must be a valid URL')
+      .optional()
+      .default('https://models.inference.ai.azure.com'),
+  })
+  .refine(
+    (data) => data.GITHUB_TOKEN || data.OPENAI_API_KEY,
+    {
+      message: 'Either GITHUB_TOKEN or OPENAI_API_KEY must be provided',
+      path: ['GITHUB_TOKEN'],
+    }
+  );
+
+export const env = envSchema.parse(process.env);

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -1,13 +1,16 @@
 import 'server-only';
 import admin from 'firebase-admin';
+import { env } from '@/lib/env';
 
 if (!admin.apps.length) {
-  const b64 = process.env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64;
-  if (!b64) throw new Error('Missing FIREBASE_SERVICE_ACCOUNT_JSON_BASE64');
-
-  const json = Buffer.from(b64, 'base64').toString('utf-8');
+  const json = Buffer.from(
+    env.FIREBASE_SERVICE_ACCOUNT_JSON_BASE64,
+    'base64'
+  ).toString('utf-8');
   const sa = JSON.parse(json) as {
-    project_id: string; client_email: string; private_key: string;
+    project_id: string;
+    client_email: string;
+    private_key: string;
   };
 
   admin.initializeApp({


### PR DESCRIPTION
## Summary
- add zod-based environment parser to validate required variables
- use typed `env` helper instead of `process.env` in Firebase, API helpers, and weekend summary route

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint` *(fails: React unused var and no-explicit-any warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6898f2ebf0bc832bb794d9d245b74d97