### PR TITLE
refine match type in RoundMatchesBanner

### DIFF
--- a/src/components/RoundMatchesBanner.tsx
+++ b/src/components/RoundMatchesBanner.tsx
@@ -5,7 +5,7 @@ import teamLogos from '@/lib/teamLogos';
 import { fetchFromAPI } from '@/lib/api';
 
 interface Match {
-  matchDate?: string | null;
+  matchDate?: string;
   homeTeam: string;
   awayTeam: string;
   scoreHome?: number | null;

--- a/src/components/RoundMatchesBanner.tsx
+++ b/src/components/RoundMatchesBanner.tsx
@@ -5,9 +5,12 @@ import teamLogos from '@/lib/teamLogos';
 import { fetchFromAPI } from '@/lib/api';
 
 interface Match {
+  matchDate?: string | null;
   homeTeam: string;
   awayTeam: string;
-  [key: string]: any;
+  scoreHome?: number | null;
+  scoreAway?: number | null;
+  round?: number;
 }
 
 interface Props {

--- a/src/components/RoundMatchesBanner.tsx
+++ b/src/components/RoundMatchesBanner.tsx
@@ -8,8 +8,8 @@ interface Match {
   matchDate?: string;
   homeTeam: string;
   awayTeam: string;
-  scoreHome?: number | null;
-  scoreAway?: number | null;
+  scoreHome: number | null;
+  scoreAway: number | null;
   round?: number;
 }
 


### PR DESCRIPTION
## Summary
- define explicit fields for Match type in RoundMatchesBanner to avoid `any`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6898fa8eb908832bb3be08f6f941dd67