### PR TITLE
refactor: type player store helpers

### DIFF
--- a/src/state/OfferStore.ts
+++ b/src/state/OfferStore.ts
@@ -17,11 +17,7 @@ type OfferState = Omit<PlayerStore<OfferSide, OfferPlayer>, 'clear'> & {
 
 export const useOfferStore = create<OfferState>()((set, get, api) => {
   const { clear, ...base } =
-    createPlayerStore<OfferSide, OfferPlayer>(['yours', 'theirs'])(
-      set as any,
-      get as any,
-      api as any,
-    );
+    createPlayerStore<OfferSide, OfferPlayer>(['yours', 'theirs'])(set, get, api);
 
   return {
     ...base,

--- a/src/state/createPlayerStore.ts
+++ b/src/state/createPlayerStore.ts
@@ -1,5 +1,5 @@
 import type { Player } from '@/types/players';
-import type { StateCreator } from 'zustand';
+import type { StoreApi } from 'zustand';
 
 export type PlayerStore<Side extends string, P extends { id: string } = Player> = {
   [K in Side]: P[];
@@ -11,8 +11,12 @@ export type PlayerStore<Side extends string, P extends { id: string } = Player> 
 
 export function createPlayerStore<Side extends string, P extends { id: string } = Player>(
   sides: readonly Side[],
-): StateCreator<PlayerStore<Side, P>> {
-  return (set) => {
+) {
+  return <T extends PlayerStore<Side, P>>(
+    set: StoreApi<T>['setState'],
+    _get: StoreApi<T>['getState'],
+    _api: StoreApi<T>,
+  ): PlayerStore<Side, P> => {
     const initial = Object.fromEntries(sides.map((s) => [s, [] as P[]])) as {
       [K in Side]: P[];
     };
@@ -26,7 +30,7 @@ export function createPlayerStore<Side extends string, P extends { id: string } 
         }),
       remove: (side, id) =>
         set((state) => ({ ...state, [side]: state[side].filter((x) => x.id !== id) })),
-      clear: () => set(initial as Partial<PlayerStore<Side, P>>),
+      clear: () => set(initial as Partial<T>),
     };
   };
 }

--- a/src/state/tradeStore.tsx
+++ b/src/state/tradeStore.tsx
@@ -20,11 +20,7 @@ type TradeState = Omit<PlayerStore<Side, Player>, 'clear'> & {
 
 export const useTradeStore = create<TradeState>()((set, get, api) => {
   const { clear, ...base } =
-    createPlayerStore<Side, Player>(['incoming', 'outgoing'])(
-      set as any,
-      get as any,
-      api as any,
-    );
+    createPlayerStore<Side, Player>(['incoming', 'outgoing'])(set, get, api);
 
   return {
     myTeamKey: null,


### PR DESCRIPTION
## Summary
- support typed setters/getters in `createPlayerStore`
- remove `as any` casts when composing player stores in `tradeStore` and `OfferStore`

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars in unrelated files)*
- `npm test` *(fails: rosterSize is not defined; POST /api/draft/order returns 500)*

------
https://chatgpt.com/codex/tasks/task_e_6898fa8d7b60832bba0ec088a66006ec