### PR TITLE
refactor: remove React imports from components

### DIFF
--- a/src/components/CompletionBanner.tsx
+++ b/src/components/CompletionBanner.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 type CompletionBannerProps = {
   isComplete: boolean;
   onReset?: () => void;

--- a/src/components/DraftOrderBar.tsx
+++ b/src/components/DraftOrderBar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Team } from '../types/players';
 
 interface DraftOrderBarProps {

--- a/src/components/MatchLogTable.tsx
+++ b/src/components/MatchLogTable.tsx
@@ -1,5 +1,4 @@
 // src/Components/MatchLogTable.tsx
-import React from 'react';
 
 type MatchLog = {
   round: number;

--- a/src/components/MyTeamPanel.tsx
+++ b/src/components/MyTeamPanel.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import React from 'react';
 import type { Player, Team } from '../types/players';
 import { useRankings } from '@/app/tradecentre/RankingsContext';
 import { ValueChip } from './ValueChip';

--- a/src/components/PlayerList.tsx
+++ b/src/components/PlayerList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Player } from '../types/players';
 
 interface PlayerListProps {

--- a/src/components/TeamSelectorPanel.tsx
+++ b/src/components/TeamSelectorPanel.tsx
@@ -1,8 +1,6 @@
 // src/components/TeamSelectorPanel.tsx
 'use client';
 
-import React from 'react';
-
 export interface TeamSelectorPanelProps {
   id?: string;                       // <-- add this
   teams: string[];

--- a/src/components/TradeCentreHeader.tsx
+++ b/src/components/TradeCentreHeader.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import React from 'react';
 import type { Team as BaseTeam } from '@/types';
 
 interface Team extends BaseTeam {

--- a/src/components/WatchList.tsx
+++ b/src/components/WatchList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Player } from '../types/players';
 
 interface WatchListProps {


### PR DESCRIPTION
## Summary
- remove unused `React` imports from eight component files

## Testing
- `npm run lint` *(fails: react-hooks/exhaustive-deps, consistent-type-imports, no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_6898fa962634832b8fa0ce04bf5c7677