### PR TITLE
Add API base URL fallback and friendly error

### DIFF
--- a/src/app/tradecentre/page.tsx
+++ b/src/app/tradecentre/page.tsx
@@ -25,12 +25,13 @@ async function fetchPlayers(): Promise<PlayerLite[]> {
 
 export default async function TradeCentrePage() {
   let players: PlayerLite[] = [];
-  let error: string | null = null;
+  let error = false;
 
   try {
     players = await fetchPlayers();
   } catch (e) {
-    error = e instanceof Error ? e.message : String(e);
+    console.error('Failed to load players', e);
+    error = true;
   }
 
   return (
@@ -48,8 +49,8 @@ export default async function TradeCentrePage() {
 
       {error ? (
         <div className="rounded-md border border-red-300 bg-red-50 p-3 text-red-800" role="alert">
-          <strong className="block">Failed to load players</strong>
-          <pre className="mt-1 whitespace-pre-wrap text-xs">{error}</pre>
+          <strong className="block">Unable to reach rankings service.</strong>
+          <p className="mt-1 text-sm">Check API configuration.</p>
         </div>
       ) : (
         <TradeCentreShellClient players={players} />

--- a/src/components/TradeCentreHeader.tsx
+++ b/src/components/TradeCentreHeader.tsx
@@ -20,15 +20,3 @@ export type TradeCentreHeaderProps = {
   activeTab: 'compare' | 'market';
   onTabChange: (tab: 'compare' | 'market') => void;
 };
-
-function toTeam(x: string | Team): Team {
-  if (typeof x === 'string') {
-    return { id: x, name: x };
-  }
-  return x;
-}
-
-function initials(name: string) {
-  const parts = name.trim().split(/\s+/).slice(0, 2);
-  return parts.map(p => p[0]?.toUpperCase() ?? '').join('');
-}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,28 +2,46 @@
 
 export async function fetchFromAPI<T>(
   path: string,
-  options: (RequestInit & { cache?: RequestCache }) = {}
+  options: (RequestInit & { cache?: RequestCache }) = {},
 ): Promise<T> {
-  const rawBaseUrl = process.env.NEXT_PUBLIC_API_URL;
+  const baseUrls: string[] = [];
+  const envBase = process.env.NEXT_PUBLIC_API_URL;
 
-  if (!rawBaseUrl) {
-    throw new Error('Missing NEXT_PUBLIC_API_URL in environment variables. Please create a .env.local file and add NEXT_PUBLIC_API_URL=http://localhost:3000');
+  if (envBase) {
+    baseUrls.push(envBase);
   }
 
-  const baseUrl = rawBaseUrl.replace(/\/$/, '');
-  const url = `${baseUrl}${path}`;
+  // Try relative path and localhost as fallbacks
+  baseUrls.push('');
+  baseUrls.push(`http://localhost:${process.env.PORT ?? 3000}`);
 
   const { cache, ...rest } = options;
-  const res = await fetch(url, { cache, ...rest });
 
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`API error (${res.status}): ${text}`);
+  for (const rawBase of baseUrls) {
+    const base = rawBase.replace(/\/$/, '');
+    const url = `${base}${path}`;
+
+    let res: Response;
+    try {
+      res = await fetch(url, { cache, ...rest });
+    } catch {
+      continue; // try next base URL
+    }
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`API error (${res.status}): ${text}`);
+    }
+
+    return res.json();
   }
 
-  return res.json();
+  throw new Error(
+    'API base URL is missing or unreachable. Please set NEXT_PUBLIC_API_URL or ensure the API server is running.',
+  );
 }
 
 export function buildQuery(params: Record<string, string>) {
   return '?' + new URLSearchParams(params).toString();
 }
+

--- a/src/lib/snakeDraft.ts
+++ b/src/lib/snakeDraft.ts
@@ -29,7 +29,8 @@ export function generateSnakeDraftOrder(
   benchSize = 0,
 ): number[][] {
   if (teamCount <= 0) throw new Error('teamCount must be positive');
-  if (!Number.isInteger(rosterSize) || rosterSize < 0) throw new Error('rosterSize must be a non-negative integer');
+  if (!Number.isInteger(starterSize) || starterSize < 0)
+    throw new Error('starterSize must be a non-negative integer');
   if (!Number.isInteger(benchSize) || benchSize < 0) throw new Error('benchSize must be a non-negative integer');
   const rounds = starterSize + benchSize;
   const order: number[][] = [];


### PR DESCRIPTION
## Summary
- Use relative or localhost fallback when API base URL is missing or unreachable
- Clarify missing/unreachable API base URL error
- Show friendly message if rankings fetch fails on Trade Centre page

## Testing
- `npm test` *(fails: expected 200 but got 500; ReferenceError: rosterSize is not defined)*
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' in TradeCentreHeader.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6898fd1aa0e4832b8fa4780062fabdfe