### PR TITLE
test: add backend and e2e test suites

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,6 +18,9 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run lint
+      - run: npm test
+      - run: npx playwright install --with-deps
+      - run: npm run test:e2e
 
   deploy:
     # needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
       - name: Format check
         run: npm run format:check
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
       "devDependencies": {
         "@eslint/compat": "^1.3.1",
         "@eslint/js": "^9.32.0",
+        "@playwright/test": "^1.54.2",
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/postcss": "^4.1.11",
         "@tailwindcss/typography": "^0.5.16",
@@ -2608,6 +2609,22 @@
       "optional": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -9990,6 +10007,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
+    "test:e2e": "playwright test --config=playwright/playwright.config.ts",
     "update:check": "npx npm-check-updates",
     "update:interactive": "npx npm-check-updates -u"
   },
@@ -51,6 +52,7 @@
   "devDependencies": {
     "@eslint/compat": "^1.3.1",
     "@eslint/js": "^9.32.0",
+    "@playwright/test": "^1.54.2",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/postcss": "^4.1.11",
     "@tailwindcss/typography": "^0.5.16",

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    baseURL: 'http://localhost:3000'
+  }
+});

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './tests',
   use: {
-    baseURL: 'http://localhost:3000'
+    baseURL: process.env.BASE_URL || 'http://localhost:3000'
   }
 });

--- a/playwright/tests/auth.spec.ts
+++ b/playwright/tests/auth.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Authentication flow', () => {
+  test('placeholder sign in', async () => {
+    expect(true).toBe(true);
+  });
+});

--- a/playwright/tests/auth.spec.ts
+++ b/playwright/tests/auth.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Authentication flow', () => {
-  test('placeholder sign in', async () => {
-    expect(true).toBe(true);
+  test.skip('placeholder sign in', async () => {
+    // TODO: Implement authentication flow test
   });
 });

--- a/playwright/tests/draft-room.spec.ts
+++ b/playwright/tests/draft-room.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Live draft room', () => {
+  test('placeholder draft interaction', async () => {
+    expect(true).toBe(true);
+  });
+});

--- a/playwright/tests/league.spec.ts
+++ b/playwright/tests/league.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('League creation', () => {
+  test('placeholder league creation', async () => {
+    expect(true).toBe(true);
+  });
+});

--- a/playwright/tests/league.spec.ts
+++ b/playwright/tests/league.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('League creation', () => {
-  test('placeholder league creation', async () => {
-    expect(true).toBe(true);
+  test.skip('placeholder league creation', async () => {
+    // TODO: Implement league creation test
   });
 });

--- a/src/api/__tests__/ping.test.ts
+++ b/src/api/__tests__/ping.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { GET } from '../../app/api/ping/route';
+
+describe('GET /api/ping', () => {
+  it('returns ok status', async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(typeof body.time).toBe('string');
+  });
+});

--- a/src/lib/__tests__/snakeDraft.test.ts
+++ b/src/lib/__tests__/snakeDraft.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { computeSnakeState } from '../snakeDraft';
+
+describe('computeSnakeState', () => {
+  it('calculates round, direction and slot', () => {
+    expect(computeSnakeState(1, 3)).toEqual({ round: 1, direction: 'FORWARD', slot: 1 });
+    expect(computeSnakeState(3, 3)).toEqual({ round: 1, direction: 'FORWARD', slot: 3 });
+    expect(computeSnakeState(4, 3)).toEqual({ round: 2, direction: 'REVERSE', slot: 3 });
+  });
+
+  it('throws on invalid input', () => {
+    expect(() => computeSnakeState(0, 3)).toThrow();
+    expect(() => computeSnakeState(1, 0)).toThrow();
+  });
+});

--- a/src/lib/snakeDraft.ts
+++ b/src/lib/snakeDraft.ts
@@ -29,8 +29,10 @@ export function generateSnakeDraftOrder(
   benchSize = 0,
 ): number[][] {
   if (teamCount <= 0) throw new Error('teamCount must be positive');
-  if (!Number.isInteger(rosterSize) || rosterSize < 0) throw new Error('rosterSize must be a non-negative integer');
-  if (!Number.isInteger(benchSize) || benchSize < 0) throw new Error('benchSize must be a non-negative integer');
+  if (!Number.isInteger(starterSize) || starterSize < 0)
+    throw new Error('starterSize must be a non-negative integer');
+  if (!Number.isInteger(benchSize) || benchSize < 0)
+    throw new Error('benchSize must be a non-negative integer');
   const rounds = starterSize + benchSize;
   const order: number[][] = [];
   for (let r = 1; r <= rounds; r++) {

--- a/src/server/__tests__/socketEvents.test.ts
+++ b/src/server/__tests__/socketEvents.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { draftSocket, emitDraftPick, type DraftPick } from '../socketEvents';
+
+afterEach(() => {
+  draftSocket.removeAllListeners();
+});
+
+describe('draft socket events', () => {
+  it('emits draftPick events with payload', () => {
+    const received: DraftPick[] = [];
+    draftSocket.on('draftPick', (pick) => received.push(pick));
+
+    const pick = { team: 1, player: 'PlayerA' };
+    emitDraftPick(pick);
+
+    expect(received).toEqual([pick]);
+  });
+});

--- a/src/server/socketEvents.ts
+++ b/src/server/socketEvents.ts
@@ -1,0 +1,12 @@
+import { EventEmitter } from 'events';
+
+export interface DraftPick {
+  team: number;
+  player: string;
+}
+
+export const draftSocket = new EventEmitter();
+
+export function emitDraftPick(pick: DraftPick) {
+  draftSocket.emit('draftPick', pick);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig, configDefaults } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, 'playwright/**']
+  }
+});


### PR DESCRIPTION
## Summary
- add Vitest tests for API ping route, draft scheduling, and socket events
- configure Playwright with placeholder auth, league, and draft room tests
- update CI workflows to run unit and E2E suites

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b123e8a44832bb1940763b73c9167