### PR TITLE
Add auth, league, and draft routes with shared components

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import AuthForm from '@/components/AuthForm';
+import Button from '@/components/Button';
+
+export default function LoginPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-sm space-y-4">
+        <AuthForm initialMode="login" />
+        <div className="text-center">
+          <Link href="/register">
+            <Button type="button" variant="secondary">
+              Create account
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import AuthForm from '@/components/AuthForm';
+import Button from '@/components/Button';
+
+export default function RegisterPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-sm space-y-4">
+        <AuthForm initialMode="signup" />
+        <div className="text-center">
+          <Link href="/login">
+            <Button type="button" variant="secondary">
+              Have an account? Log in
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/drafts/[id]/page.tsx
+++ b/src/app/drafts/[id]/page.tsx
@@ -1,0 +1,87 @@
+import Tabs from '@/components/Tabs';
+import Table from '@/components/Table';
+import Modal from '@/components/Modal';
+import CountdownTimer from '@/components/CountdownTimer';
+import Button from '@/components/Button';
+import { fetchFromAPI } from '@/lib/api';
+import { notFound } from 'next/navigation';
+import { Suspense, useState } from 'react';
+
+interface DraftPlayer {
+  id: string;
+  name: string;
+  position: string;
+}
+
+interface Draft {
+  id: string;
+  players: DraftPlayer[];
+}
+
+function DraftRoom({ players }: { players: DraftPlayer[] }) {
+  'use client';
+  const [tab, setTab] = useState('players');
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="space-y-4">
+      <CountdownTimer initialSeconds={60} onExpire={() => setOpen(true)} />
+      <Tabs
+        tabs={[
+          { value: 'players', label: 'Players' },
+          { value: 'my-team', label: 'My Team' },
+        ]}
+        active={tab}
+        onChange={setTab}
+      />
+      {tab === 'players' && (
+        <Table className="text-left">
+          <thead>
+            <tr>
+              <th className="px-2 py-1">Name</th>
+              <th className="px-2 py-1">Pos</th>
+            </tr>
+          </thead>
+          <tbody>
+            {players.map((p) => (
+              <tr key={p.id} className="odd:bg-neutral-50">
+                <td className="px-2 py-1">{p.name}</td>
+                <td className="px-2 py-1">{p.position}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      )}
+      {tab === 'my-team' && (
+        <Table>
+          <tbody>
+            <tr>
+              <td className="px-2 py-1">No players yet</td>
+            </tr>
+          </tbody>
+        </Table>
+      )}
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <p className="mb-4">Time is up!</p>
+        <Button onClick={() => setOpen(false)}>Close</Button>
+      </Modal>
+    </div>
+  );
+}
+
+export default async function DraftPage({ params }: { params: { id: string } }) {
+  let draft: Draft | null = null;
+  try {
+    draft = await fetchFromAPI<Draft>(`/api/drafts/${params.id}`);
+  } catch {
+    // ignore
+  }
+  if (!draft) notFound();
+  return (
+    <main className="mx-auto max-w-3xl p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Draft Room</h1>
+      <Suspense fallback={<div>Loading...</div>}>
+        <DraftRoom players={draft.players} />
+      </Suspense>
+    </main>
+  );
+}

--- a/src/app/leagues/[id]/page.tsx
+++ b/src/app/leagues/[id]/page.tsx
@@ -1,0 +1,46 @@
+import { notFound } from 'next/navigation';
+import Table from '@/components/Table';
+import { fetchFromAPI } from '@/lib/api';
+
+interface LeagueTeam {
+  id: string;
+  name: string;
+  manager: string;
+}
+
+interface League {
+  id: string;
+  name: string;
+  teams: LeagueTeam[];
+}
+
+export default async function LeaguePage({ params }: { params: { id: string } }) {
+  let league: League | null = null;
+  try {
+    league = await fetchFromAPI<League>(`/api/leagues/${params.id}`);
+  } catch {
+    // ignore
+  }
+  if (!league) notFound();
+  return (
+    <main className="mx-auto max-w-2xl p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">{league.name}</h1>
+      <Table className="text-left">
+        <thead>
+          <tr>
+            <th className="px-2 py-1">Team</th>
+            <th className="px-2 py-1">Manager</th>
+          </tr>
+        </thead>
+        <tbody>
+          {league.teams.map((team) => (
+            <tr key={team.id} className="odd:bg-neutral-50">
+              <td className="px-2 py-1">{team.name}</td>
+              <td className="px-2 py-1">{team.manager}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </main>
+  );
+}

--- a/src/app/leagues/new/page.tsx
+++ b/src/app/leagues/new/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Form from '@/components/Form';
+import FormField from '@/components/FormField';
+import Button from '@/components/Button';
+import { fetchFromAPI } from '@/lib/api';
+
+export default function NewLeaguePage() {
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const league = await fetchFromAPI<{ id: string }>(
+        '/api/leagues',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name }),
+        },
+      );
+      router.push(`/leagues/${league.id}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to create league';
+      setError(message);
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-md p-4">
+      <h1 className="mb-4 text-2xl font-semibold">Create League</h1>
+      <Form onSubmit={handleSubmit}>
+        <FormField label="League Name">
+          <input
+            className="w-full rounded border px-2 py-1"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </FormField>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <Button type="submit">Create</Button>
+      </Form>
+    </main>
+  );
+}

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -3,9 +3,13 @@
 import React, { useState } from 'react';
 import { useAuth } from '@/AuthContext';
 
-const AuthForm = () => {
+interface AuthFormProps {
+  initialMode?: 'login' | 'signup';
+}
+
+const AuthForm = ({ initialMode = 'login' }: AuthFormProps) => {
   const { login, signup, user, logout, loginWithGoogle } = useAuth();
-  const [isSignup, setIsSignup] = useState(false);
+  const [isSignup, setIsSignup] = useState(initialMode === 'signup');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,21 @@
+import clsx from 'clsx';
+import type { ButtonHTMLAttributes } from 'react';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+
+export default function Button({
+  variant = 'primary',
+  className,
+  ...props
+}: ButtonProps) {
+  const base = 'px-4 py-2 rounded text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2';
+  const styles =
+    variant === 'primary'
+      ? 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500'
+      : 'bg-neutral-200 text-neutral-900 hover:bg-neutral-300 focus:ring-neutral-400';
+
+  return <button className={clsx(base, styles, className)} {...props} />;
+}
+

--- a/src/components/CountdownTimer.tsx
+++ b/src/components/CountdownTimer.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface CountdownTimerProps {
+  initialSeconds: number;
+  onExpire?: () => void;
+}
+
+export default function CountdownTimer({ initialSeconds, onExpire }: CountdownTimerProps) {
+  const [seconds, setSeconds] = useState(initialSeconds);
+
+  useEffect(() => {
+    setSeconds(initialSeconds);
+  }, [initialSeconds]);
+
+  useEffect(() => {
+    if (seconds <= 0) {
+      onExpire?.();
+      return;
+    }
+    const id = setInterval(() => setSeconds((s) => s - 1), 1000);
+    return () => clearInterval(id);
+  }, [seconds, onExpire]);
+
+  return <span>{seconds}s</span>;
+}

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,0 +1,6 @@
+import clsx from 'clsx';
+import type { FormHTMLAttributes } from 'react';
+
+export default function Form({ className, ...props }: FormHTMLAttributes<HTMLFormElement>) {
+  return <form className={clsx('space-y-4', className)} {...props} />;
+}

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -1,0 +1,17 @@
+import clsx from 'clsx';
+import type { ReactNode } from 'react';
+
+interface FormFieldProps {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export default function FormField({ label, children, className }: FormFieldProps) {
+  return (
+    <div className={clsx('space-y-1', className)}>
+      <label className="block text-sm font-medium">{label}</label>
+      {children}
+    </div>
+  );
+}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export default function Modal({ open, onClose, children }: ModalProps) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="bg-white p-4 rounded shadow max-w-sm w-full"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,0 +1,6 @@
+import clsx from 'clsx';
+import type { HTMLAttributes } from 'react';
+
+export default function Table({ className, ...props }: HTMLAttributes<HTMLTableElement>) {
+  return <table className={clsx('min-w-full divide-y divide-neutral-200', className)} {...props} />;
+}

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import clsx from 'clsx';
+
+export interface TabItem {
+  value: string;
+  label: string;
+}
+
+interface TabsProps {
+  tabs: TabItem[];
+  active: string;
+  onChange: (value: string) => void;
+}
+
+export default function Tabs({ tabs, active, onChange }: TabsProps) {
+  return (
+    <div className="flex space-x-2 border-b border-neutral-200">
+      {tabs.map((t) => (
+        <button
+          key={t.value}
+          className={clsx(
+            'px-3 py-2 text-sm',
+            active === t.value
+              ? 'border-b-2 border-blue-600 text-blue-600'
+              : 'text-neutral-600 hover:text-neutral-900',
+          )}
+          onClick={() => onChange(t.value)}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `Button`, `Modal`, `Tabs`, `Table`, `Form` helpers, and `CountdownTimer` shared components
- Enhance `AuthForm` with mode control and create `/login` and `/register` routes
- Introduce league creation, league details, and draft room pages wired to the API client

## Testing
- `npm test` *(fails: rosterSize is not defined; expected 500 to be 200)*

------
https://chatgpt.com/codex/tasks/task_e_689b12410514832ba32f3ffcf0a44581