### PR TITLE
Add Express API with JWT auth and Prisma integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@hello-pangea/dnd": "^18.0.1",
+        "@prisma/client": "^5.15.0",
         "axios": "^1.11.0",
         "canvas-confetti": "^1.9.3",
         "chart.js": "^4.5.0",
         "cheerio": "^1.1.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cookie-parser": "^1.4.7",
         "daisyui": "^5.0.50",
         "domhandler": "^5.0.3",
         "dotenv": "^17.2.1",
@@ -23,6 +25,7 @@
         "firebase": "^12.0.0",
         "firebase-admin": "^13.4.0",
         "framer-motion": "^12.23.6",
+        "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.536.0",
         "openai": "^5.12.0",
         "react": "^19.1.1",
@@ -47,6 +50,8 @@
         "@tailwindcss/typography": "^0.5.16",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
+        "@types/cookie-parser": "^1.4.7",
+        "@types/jsonwebtoken": "^9.0.5",
         "@types/node": "^24.1.0",
         "@types/react": "^19.1.9",
         "@types/react-dom": "^19.1.7",
@@ -67,6 +72,7 @@
         "postcss": "^8.5.6",
         "postcss-nesting": "^13.0.2",
         "prettier": "^3.2.5",
+        "prisma": "^5.15.0",
         "rimraf": "^6.0.1",
         "tailwindcss": "^4.1.11",
         "ts-node": "^10.9.2",
@@ -2617,6 +2623,74 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@prisma/client": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
+      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
+      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
+      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/fetch-engine": "5.22.0",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
+      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
+      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
+      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -3641,6 +3715,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -5525,6 +5609,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -10207,6 +10310,26 @@
       },
       "peerDependencies": {
         "react": ">=16.0.0"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
+      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/engines": "5.22.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,10 @@
     "use-sound": "^5.0.0",
     "uuid": "^11.1.0",
     "zod": "^3.23.8",
-    "zustand": "^5.0.7"
+    "zustand": "^5.0.7",
+    "cookie-parser": "^1.4.7",
+    "jsonwebtoken": "^9.0.2",
+    "@prisma/client": "^5.15.0"
   },
   "devDependencies": {
     "@eslint/compat": "^1.3.1",
@@ -82,6 +85,9 @@
     "tw-animate-css": "^1.3.6",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.38.0",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "prisma": "^5.15.0",
+    "@types/cookie-parser": "^1.4.7",
+    "@types/jsonwebtoken": "^9.0.5"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,45 @@
+// Prisma schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model User {
+  id       Int     @id @default(autoincrement())
+  email    String  @unique
+  password String
+  leagues  League[]
+  queues   Queue[]
+}
+
+model League {
+  id     Int    @id @default(autoincrement())
+  name   String
+  drafts Draft[]
+}
+
+model Draft {
+  id       Int    @id @default(autoincrement())
+  league   League @relation(fields: [leagueId], references: [id])
+  leagueId Int
+  picks    Pick[]
+}
+
+model Pick {
+  id      Int    @id @default(autoincrement())
+  draft   Draft @relation(fields: [draftId], references: [id])
+  draftId Int
+  player  String
+}
+
+model Queue {
+  id     Int    @id @default(autoincrement())
+  user   User  @relation(fields: [userId], references: [id])
+  userId Int
+  player String
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import authRoutes from './routes/auth';
+import leagueRoutes from './routes/leagues';
+import draftRoutes from './routes/drafts';
+import pickRoutes from './routes/picks';
+import queueRoutes from './routes/queues';
+import { authenticateJWT } from './middleware/auth';
+
+const app = express();
+app.use(express.json());
+app.use(cookieParser());
+
+app.use('/auth', authRoutes);
+app.use(authenticateJWT);
+app.use('/leagues', leagueRoutes);
+app.use('/drafts', draftRoutes);
+app.use('/picks', pickRoutes);
+app.use('/queues', queueRoutes);
+
+export default app;

--- a/src/api/middleware/auth.ts
+++ b/src/api/middleware/auth.ts
@@ -1,0 +1,27 @@
+import type { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+export interface AuthenticatedRequest extends Request {
+  user?: { userId: number };
+}
+
+export function authenticateJWT(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+) {
+  const token = req.cookies?.token;
+  if (!token) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET ?? 'secret') as {
+      userId: number;
+    };
+    req.user = { userId: payload.userId };
+    next();
+  } catch {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+}

--- a/src/api/prisma.ts
+++ b/src/api/prisma.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export default prisma;

--- a/src/api/routes/auth.ts
+++ b/src/api/routes/auth.ts
@@ -1,0 +1,54 @@
+import { Router } from 'express';
+import jwt from 'jsonwebtoken';
+import { z } from 'zod';
+import prisma from '../prisma';
+
+const router = Router();
+
+const authSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+router.post('/register', async (req, res) => {
+  const parsed = authSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const user = await prisma.user.create({ data: parsed.data });
+  const token = jwt.sign(
+    { userId: user.id },
+    process.env.JWT_SECRET ?? 'secret',
+    { expiresIn: '7d' }
+  );
+  res.cookie('token', token, { httpOnly: true, sameSite: 'lax' });
+  res.json({ user });
+});
+
+router.post('/login', async (req, res) => {
+  const parsed = authSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const user = await prisma.user.findUnique({ where: { email: parsed.data.email } });
+  if (!user || user.password !== parsed.data.password) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+
+  const token = jwt.sign(
+    { userId: user.id },
+    process.env.JWT_SECRET ?? 'secret',
+    { expiresIn: '7d' }
+  );
+  res.cookie('token', token, { httpOnly: true, sameSite: 'lax' });
+  res.json({ user });
+});
+
+router.post('/logout', (_req, res) => {
+  res.clearCookie('token');
+  res.status(200).json({ success: true });
+});
+
+export default router;

--- a/src/api/routes/drafts.ts
+++ b/src/api/routes/drafts.ts
@@ -1,0 +1,38 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import prisma from '../prisma';
+
+const router = Router();
+
+const createDraftSchema = z.object({
+  leagueId: z.number(),
+});
+
+router.post('/', async (req, res) => {
+  const parsed = createDraftSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const draft = await prisma.draft.create({ data: parsed.data });
+  res.json(draft);
+});
+
+const draftParams = z.object({
+  id: z.string().regex(/^\d+$/).transform(Number),
+});
+
+router.get('/:id', async (req, res) => {
+  const parsed = draftParams.safeParse(req.params);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const draft = await prisma.draft.findUnique({ where: { id: parsed.data.id } });
+  if (!draft) {
+    return res.status(404).json({ error: 'Draft not found' });
+  }
+  res.json(draft);
+});
+
+export default router;

--- a/src/api/routes/leagues.ts
+++ b/src/api/routes/leagues.ts
@@ -1,0 +1,38 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import prisma from '../prisma';
+
+const router = Router();
+
+const createLeagueSchema = z.object({
+  name: z.string().min(1),
+});
+
+router.post('/', async (req, res) => {
+  const parsed = createLeagueSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const league = await prisma.league.create({ data: parsed.data });
+  res.json(league);
+});
+
+const leagueParams = z.object({
+  id: z.string().regex(/^\d+$/).transform(Number),
+});
+
+router.get('/:id', async (req, res) => {
+  const parsed = leagueParams.safeParse(req.params);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const league = await prisma.league.findUnique({ where: { id: parsed.data.id } });
+  if (!league) {
+    return res.status(404).json({ error: 'League not found' });
+  }
+  res.json(league);
+});
+
+export default router;

--- a/src/api/routes/picks.ts
+++ b/src/api/routes/picks.ts
@@ -1,0 +1,39 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import prisma from '../prisma';
+
+const router = Router();
+
+const createPickSchema = z.object({
+  draftId: z.number(),
+  player: z.string().min(1),
+});
+
+router.post('/', async (req, res) => {
+  const parsed = createPickSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const pick = await prisma.pick.create({ data: parsed.data });
+  res.json(pick);
+});
+
+const pickParams = z.object({
+  id: z.string().regex(/^\d+$/).transform(Number),
+});
+
+router.get('/:id', async (req, res) => {
+  const parsed = pickParams.safeParse(req.params);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const pick = await prisma.pick.findUnique({ where: { id: parsed.data.id } });
+  if (!pick) {
+    return res.status(404).json({ error: 'Pick not found' });
+  }
+  res.json(pick);
+});
+
+export default router;

--- a/src/api/routes/queues.ts
+++ b/src/api/routes/queues.ts
@@ -1,0 +1,39 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import prisma from '../prisma';
+
+const router = Router();
+
+const createQueueSchema = z.object({
+  userId: z.number(),
+  player: z.string().min(1),
+});
+
+router.post('/', async (req, res) => {
+  const parsed = createQueueSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const queue = await prisma.queue.create({ data: parsed.data });
+  res.json(queue);
+});
+
+const queueParams = z.object({
+  id: z.string().regex(/^\d+$/).transform(Number),
+});
+
+router.get('/:id', async (req, res) => {
+  const parsed = queueParams.safeParse(req.params);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const queue = await prisma.queue.findUnique({ where: { id: parsed.data.id } });
+  if (!queue) {
+    return res.status(404).json({ error: 'Queue not found' });
+  }
+  res.json(queue);
+});
+
+export default router;

--- a/src/components/TradeCentreHeader.tsx
+++ b/src/components/TradeCentreHeader.tsx
@@ -21,14 +21,14 @@ export type TradeCentreHeaderProps = {
   onTabChange: (tab: 'compare' | 'market') => void;
 };
 
-function toTeam(x: string | Team): Team {
+function _toTeam(x: string | Team): Team {
   if (typeof x === 'string') {
     return { id: x, name: x };
   }
   return x;
 }
 
-function initials(name: string) {
+function _initials(name: string) {
   const parts = name.trim().split(/\s+/).slice(0, 2);
   return parts.map(p => p[0]?.toUpperCase() ?? '').join('');
 }

--- a/src/lib/snakeDraft.ts
+++ b/src/lib/snakeDraft.ts
@@ -29,7 +29,8 @@ export function generateSnakeDraftOrder(
   benchSize = 0,
 ): number[][] {
   if (teamCount <= 0) throw new Error('teamCount must be positive');
-  if (!Number.isInteger(rosterSize) || rosterSize < 0) throw new Error('rosterSize must be a non-negative integer');
+  if (!Number.isInteger(starterSize) || starterSize < 0)
+    throw new Error('starterSize must be a non-negative integer');
   if (!Number.isInteger(benchSize) || benchSize < 0) throw new Error('benchSize must be a non-negative integer');
   const rounds = starterSize + benchSize;
   const order: number[][] = [];


### PR DESCRIPTION
## Summary
- scaffold Express API with cookie-based JWT auth
- add user, league, draft, pick and queue routes using Prisma and zod validation
- define Prisma schema and fix snake draft roster validation

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689b12445c08832bbbc6a0514404fe54