### PR TITLE
Fix starter size validation and expand draft tests

### DIFF
--- a/src/lib/snakeDraft.test.ts
+++ b/src/lib/snakeDraft.test.ts
@@ -2,12 +2,17 @@ import { describe, it, expect } from 'vitest';
 import { computeSnakeState, generateSnakeDraftOrder } from './snakeDraft';
 
 describe('computeSnakeState', () => {
-  it('computes round, direction and slot correctly', () => {
+  it('handles odd and even rounds correctly', () => {
     expect(computeSnakeState(1, 3)).toEqual({ round: 1, direction: 'FORWARD', slot: 1 });
     expect(computeSnakeState(3, 3)).toEqual({ round: 1, direction: 'FORWARD', slot: 3 });
     expect(computeSnakeState(4, 3)).toEqual({ round: 2, direction: 'REVERSE', slot: 3 });
     expect(computeSnakeState(6, 3)).toEqual({ round: 2, direction: 'REVERSE', slot: 1 });
     expect(computeSnakeState(7, 3)).toEqual({ round: 3, direction: 'FORWARD', slot: 1 });
+  });
+
+  it('validates input', () => {
+    expect(() => computeSnakeState(0, 3)).toThrow();
+    expect(() => computeSnakeState(1, 0)).toThrow();
   });
 });
 
@@ -18,5 +23,20 @@ describe('generateSnakeDraftOrder', () => {
       [1, 2, 3],
       [3, 2, 1],
     ]);
+  });
+
+  it('includes bench rounds', () => {
+    const order = generateSnakeDraftOrder(3, 2, 1);
+    expect(order).toEqual([
+      [1, 2, 3],
+      [3, 2, 1],
+      [1, 2, 3],
+    ]);
+  });
+
+  it('validates input', () => {
+    expect(() => generateSnakeDraftOrder(0, 1)).toThrow('teamCount must be positive');
+    expect(() => generateSnakeDraftOrder(2, -1)).toThrow('starterSize must be a non-negative integer');
+    expect(() => generateSnakeDraftOrder(2, 1, -1)).toThrow('benchSize must be a non-negative integer');
   });
 });

--- a/src/lib/snakeDraft.ts
+++ b/src/lib/snakeDraft.ts
@@ -29,7 +29,8 @@ export function generateSnakeDraftOrder(
   benchSize = 0,
 ): number[][] {
   if (teamCount <= 0) throw new Error('teamCount must be positive');
-  if (!Number.isInteger(rosterSize) || rosterSize < 0) throw new Error('rosterSize must be a non-negative integer');
+  if (!Number.isInteger(starterSize) || starterSize < 0)
+    throw new Error('starterSize must be a non-negative integer');
   if (!Number.isInteger(benchSize) || benchSize < 0) throw new Error('benchSize must be a non-negative integer');
   const rounds = starterSize + benchSize;
   const order: number[][] = [];

--- a/src/server/app.test.ts
+++ b/src/server/app.test.ts
@@ -19,26 +19,34 @@ afterAll(() => {
 });
 
 describe('POST /api/draft/order', () => {
-  it('returns generated snake draft order', async () => {
+  it('returns generated snake draft order including bench', async () => {
     const res = await fetch(`${url}/api/draft/order`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ teams: 3, rosterSize: 2 })
+      body: JSON.stringify({ teams: 3, rosterSize: 2, benchSize: 1 })
     });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.order).toEqual([
       [1, 2, 3],
-      [3, 2, 1]
+      [3, 2, 1],
+      [1, 2, 3]
     ]);
   });
 
   it('validates input', async () => {
-    const res = await fetch(`${url}/api/draft/order`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ teams: 0, rosterSize: 1 })
-    });
-    expect(res.status).toBe(400);
+    const invalidBodies = [
+      { teams: 0, rosterSize: 1 },
+      { teams: 3, rosterSize: 0 },
+      { teams: 3, rosterSize: 1, benchSize: -1 }
+    ];
+    for (const body of invalidBodies) {
+      const res = await fetch(`${url}/api/draft/order`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      expect(res.status).toBe(400);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- use `starterSize` rather than `rosterSize` for draft order validation
- cover odd/even rounds, bench sizes, and invalid inputs in unit tests
- extend API tests for bench rounds and validation errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b123f6c00832b9c5b5998775e0e02