### PR TITLE
Add Docker Compose setup for web, API, Postgres, and Redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+version: "3.9"
+
+services:
+  web:
+    image: node:18
+    working_dir: /app
+    command: sh -c "npm install && npm run dev"
+    volumes:
+      - .:/app
+      - /app/node_modules
+    ports:
+      - "${WEB_PORT:-3000}:3000"
+    env_file: .env
+    depends_on:
+      - api
+
+  api:
+    image: node:18
+    working_dir: /app
+    command: sh -c "npm install && npm run migrate && npx ts-node src/server/index.ts"
+    volumes:
+      - .:/app
+      - /app/node_modules
+    ports:
+      - "${API_PORT:-3001}:3001"
+    env_file: .env
+    environment:
+      DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-postgres}
+      REDIS_URL: redis://redis:6379
+    depends_on:
+      - postgres
+      - redis
+
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+
+  redis:
+    image: redis:7
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redisdata:/data
+
+volumes:
+  pgdata:
+  redisdata:


### PR DESCRIPTION
## Summary
- add docker-compose with web, api, postgres, and redis services
- mount source code and load env vars from `.env`
- start API after running migrations and waiting for postgres and redis

## Testing
- `npm test` *(fails: rosterSize is not defined; expected 500 to be 200)*

------
https://chatgpt.com/codex/tasks/task_e_689b123ee97c832bae8b684b968ccb22