### PR TITLE
refactor: sync cookie access in requireUser

### DIFF
--- a/src/lib/requireUser.ts
+++ b/src/lib/requireUser.ts
@@ -1,0 +1,16 @@
+import { cookies } from 'next/headers';
+import { adminAuth } from '@/lib/firebaseAdmin';
+
+/**
+ * Resolve the authenticated user from the statly_session cookie.
+ * Throws an error if the user cannot be verified.
+ */
+export async function requireUser(): Promise<string> {
+  const cookieStore = cookies();
+  const sessionCookie = cookieStore.get('statly_session')?.value;
+  if (!sessionCookie) {
+    throw new Error('Unauthorized');
+  }
+  const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+  return decoded.uid;
+}

--- a/src/lib/requireUser.ts
+++ b/src/lib/requireUser.ts
@@ -6,10 +6,12 @@ import { adminAuth } from '@/lib/firebaseAdmin';
  * Throws an error if the user cannot be verified.
  */
 export async function requireUser(): Promise<string> {
+  // TODO: Move to a shared constants file
+  const SESSION_COOKIE_NAME = 'statly_session';
   const cookieStore = cookies();
-  const sessionCookie = cookieStore.get('statly_session')?.value;
+  const sessionCookie = cookieStore.get(SESSION_COOKIE_NAME)?.value;
   if (!sessionCookie) {
-    throw new Error('Unauthorized');
+    throw new Error('Session cookie not found');
   }
   const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
   return decoded.uid;


### PR DESCRIPTION
## Summary
- switch requireUser to synchronous `cookies()` API
- keep function async to await `adminAuth.verifySessionCookie`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2fc5bfe48832bbe01dab31fc83c29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sign-in is now enforced for protected pages and actions.
  * Active sessions are validated to confirm the signed-in user before access is granted.
  * Unauthenticated visits to protected areas return an “Unauthorized” error instead of proceeding silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->