### PR TITLE
Use live draft data on dashboard

### DIFF
--- a/src/components/dashboard/LiveDraftModule.tsx
+++ b/src/components/dashboard/LiveDraftModule.tsx
@@ -38,7 +38,7 @@ export default function LiveDraftModule({ refreshTrigger, user }: LiveDraftModul
       try {
         const listRes = await fetchApi('drafts/list');
         const drafts = listRes.data?.drafts ?? [];
-        const activeDraft = drafts.find((d: any) => d.status !== 'COMPLETED');
+        const activeDraft = drafts.find((d: { id: string; status: string }) => d.status !== 'COMPLETED');
         if (!activeDraft) {
           if (isMounted) setDraft(null);
           return;

--- a/src/components/dashboard/LiveDraftModule.tsx
+++ b/src/components/dashboard/LiveDraftModule.tsx
@@ -1,98 +1,184 @@
+"use client";
+
 import Link from 'next/link';
 import { motion } from 'framer-motion';
+import { useEffect, useState } from 'react';
+import type { User } from 'firebase/auth';
+import { fetchApi } from '@/lib/api';
 
 interface LiveDraftModuleProps {
   refreshTrigger: number;
+  user: User;
 }
 
-export default function LiveDraftModule({ refreshTrigger: _refreshTrigger }: LiveDraftModuleProps) {
-  // Mock draft status - in real app, fetch from API
-  const draftStatus = {
-    isLive: true,
-    currentPick: 15,
-    totalPicks: 180,
-    yourTurn: false,
-    nextTurn: 3,
-    timeRemaining: 87,
-  };
+interface DraftMeta {
+  id: string;
+  status: string;
+  currentPick: number;
+  totalPicks: number;
+  round: number;
+  direction: string;
+  timePerPick: number;
+  participants: Array<{
+    slot: number;
+    member: { userId: string; displayName: string };
+  }>;
+}
+
+export default function LiveDraftModule({ refreshTrigger, user }: LiveDraftModuleProps) {
+  const [draft, setDraft] = useState<DraftMeta | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const loadDraft = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const listRes = await fetchApi('drafts/list');
+        const drafts = listRes.data?.drafts ?? [];
+        const activeDraft = drafts.find((d: any) => d.status !== 'COMPLETED');
+        if (!activeDraft) {
+          if (isMounted) setDraft(null);
+          return;
+        }
+
+        const detailRes = await fetchApi(`drafts/${activeDraft.id}`);
+        const d = detailRes.data;
+        const meta: DraftMeta = {
+          id: d.id,
+          status: d.status,
+          currentPick: d.currentPick,
+          totalPicks: d.totalPicks,
+          round: d.round,
+          direction: d.direction,
+          timePerPick: d.timePerPick,
+          participants: d.participants,
+        };
+        if (isMounted) setDraft(meta);
+      } catch (e) {
+        if (isMounted) setError(e instanceof Error ? e.message : 'Failed to load draft');
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    };
+
+    loadDraft();
+    return () => {
+      isMounted = false;
+    };
+  }, [refreshTrigger]);
+
+  // Determine turn information
+  const teamCount = draft?.participants.length ?? 0;
+  let isYourTurn = false;
+  let picksUntilYourTurn = 0;
+
+  if (draft && teamCount > 0) {
+    const round = Math.ceil(draft.currentPick / teamCount);
+    const directionForward = round % 2 === 1;
+    const currentSlot = directionForward
+      ? ((draft.currentPick - 1) % teamCount) + 1
+      : teamCount - ((draft.currentPick - 1) % teamCount);
+    const mySlot = draft.participants.find((p) => p.member.userId === user.uid)?.slot;
+    isYourTurn = mySlot === currentSlot;
+
+    if (!isYourTurn && mySlot) {
+      let nextPickNumber = draft.currentPick + 1;
+      while (nextPickNumber <= draft.totalPicks) {
+        const nextRound = Math.ceil(nextPickNumber / teamCount);
+        const nextDirectionForward = nextRound % 2 === 1;
+        const nextSlot = nextDirectionForward
+          ? ((nextPickNumber - 1) % teamCount) + 1
+          : teamCount - ((nextPickNumber - 1) % teamCount);
+        picksUntilYourTurn++;
+        if (nextSlot === mySlot) break;
+        nextPickNumber++;
+      }
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-slate-500">Loading draft...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-red-600">{error}</p>
+      </div>
+    );
+  }
+
+  if (!draft || draft.status === 'COMPLETED') {
+    return (
+      <div className="text-center py-6">
+        <div className="w-16 h-16 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-3">
+          <svg
+            className="w-8 h-8 text-slate-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+            />
+          </svg>
+        </div>
+        <h4 className="font-medium text-slate-900 mb-1">No Active Draft</h4>
+        <p className="text-sm text-slate-600 mb-3">Create or join a draft to get started</p>
+        <Link
+          href="/drafts/create"
+          className="inline-flex items-center px-3 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
+        >
+          Create Draft
+        </Link>
+      </div>
+    );
+  }
+
+  const joinHref = `/drafts/${draft.id}`;
 
   return (
     <div className="space-y-4">
-      {draftStatus.isLive ? (
-        <>
-          {/* Live Indicator */}
+      {/* Live Indicator */}
+      <div className="flex items-center space-x-2">
+        <div className="w-3 h-3 bg-red-500 rounded-full animate-pulse"></div>
+        <span className="text-sm font-medium text-red-600">DRAFT LIVE</span>
+      </div>
+
+      {/* Draft Progress */}
+      <div className="space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-slate-600">Pick Progress</span>
+          <span className="font-medium">
+            {draft.currentPick}/{draft.totalPicks}
+          </span>
+        </div>
+        <div className="w-full bg-slate-200 rounded-full h-2">
+          <motion.div
+            className="bg-blue-600 h-2 rounded-full"
+            initial={{ width: 0 }}
+            animate={{ width: `${(draft.currentPick / draft.totalPicks) * 100}%` }}
+            transition={{ duration: 0.5 }}
+          />
+        </div>
+      </div>
+
+      {/* Turn Status */}
+      {isYourTurn ? (
+        <div className="p-3 bg-green-50 border border-green-200 rounded-lg">
           <div className="flex items-center space-x-2">
-            <div className="w-3 h-3 bg-red-500 rounded-full animate-pulse"></div>
-            <span className="text-sm font-medium text-red-600">DRAFT LIVE</span>
-          </div>
-
-          {/* Draft Progress */}
-          <div className="space-y-2">
-            <div className="flex justify-between text-sm">
-              <span className="text-slate-600">Pick Progress</span>
-              <span className="font-medium">
-                {draftStatus.currentPick}/{draftStatus.totalPicks}
-              </span>
-            </div>
-            <div className="w-full bg-slate-200 rounded-full h-2">
-              <motion.div
-                className="bg-blue-600 h-2 rounded-full"
-                initial={{ width: 0 }}
-                animate={{ width: `${(draftStatus.currentPick / draftStatus.totalPicks) * 100}%` }}
-                transition={{ duration: 0.5 }}
-              />
-            </div>
-          </div>
-
-          {/* Turn Status */}
-          {draftStatus.yourTurn ? (
-            <div className="p-3 bg-green-50 border border-green-200 rounded-lg">
-              <div className="flex items-center space-x-2">
-                <svg
-                  className="w-5 h-5 text-green-600"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-                <span className="font-medium text-green-800">Your Turn!</span>
-              </div>
-              <p className="text-sm text-green-700 mt-1">
-                Time remaining: {draftStatus.timeRemaining}s
-              </p>
-            </div>
-          ) : (
-            <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
-              <p className="text-sm text-blue-800">
-                <span className="font-medium">{draftStatus.nextTurn} picks</span> until your turn
-              </p>
-            </div>
-          )}
-
-          {/* Actions */}
-          <div className="grid grid-cols-2 gap-2">
-            <Link
-              href="/drafts"
-              className="px-3 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors text-center"
-            >
-              Join Draft
-            </Link>
-            <button className="px-3 py-2 bg-slate-100 text-slate-700 text-sm font-medium rounded-lg hover:bg-slate-200 transition-colors">
-              Watch Only
-            </button>
-          </div>
-        </>
-      ) : (
-        <div className="text-center py-6">
-          <div className="w-16 h-16 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-3">
             <svg
-              className="w-8 h-8 text-slate-400"
+              className="w-5 h-5 text-green-600"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -101,20 +187,34 @@ export default function LiveDraftModule({ refreshTrigger: _refreshTrigger }: Liv
                 strokeLinecap="round"
                 strokeLinejoin="round"
                 strokeWidth={2}
-                d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
               />
             </svg>
+            <span className="font-medium text-green-800">Your Turn!</span>
           </div>
-          <h4 className="font-medium text-slate-900 mb-1">No Active Draft</h4>
-          <p className="text-sm text-slate-600 mb-3">Create or join a draft to get started</p>
-          <Link
-            href="/drafts/create"
-            className="inline-flex items-center px-3 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
-          >
-            Create Draft
-          </Link>
+          <p className="text-sm text-green-700 mt-1">Time per pick: {draft.timePerPick}s</p>
+        </div>
+      ) : (
+        <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
+          <p className="text-sm text-blue-800">
+            <span className="font-medium">{picksUntilYourTurn} picks</span> until your turn
+          </p>
         </div>
       )}
+
+      {/* Actions */}
+      <div className="grid grid-cols-2 gap-2">
+        <Link
+          href={joinHref}
+          className="px-3 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors text-center"
+        >
+          Join Draft
+        </Link>
+        <button className="px-3 py-2 bg-slate-100 text-slate-700 text-sm font-medium rounded-lg hover:bg-slate-200 transition-colors">
+          Watch Only
+        </button>
+      </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- load draft status via API and show progress for active draft
- handle loading and error states for draft info
- link Join Draft to the current draft id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d7b18378832bb43a6e6828221447