### PR TITLE
docs: note UnifiedDraftRoom replacement

### DIFF
--- a/DRAFT_ERROR_FIX_SUMMARY.md
+++ b/DRAFT_ERROR_FIX_SUMMARY.md
@@ -1,4 +1,6 @@
-# Draft Container "Failed to fetch" Error - RESOLVED
+# [Archived] Draft Container "Failed to fetch" Error - RESOLVED
+
+> **Note**: `DraftContainer` has been replaced by `UnifiedDraftRoom`. This error scenario applied only to the deprecated component and is retained here for historical reference. The current `UnifiedDraftRoom` implementation handles draft lookups without this issue.
 
 ## Problem Summary
 Users were experiencing a recurring "Failed to fetch" error in the DraftContainer component, which was appearing in the browser console every 5 seconds with the following stack trace:

--- a/PRODUCTION_CLEANUP.md
+++ b/PRODUCTION_CLEANUP.md
@@ -18,7 +18,7 @@ grep -r "console\." src/ --include="*.ts" --include="*.tsx"
 
 - Remove development tools from login page
 - Remove mock data creation buttons
-- Remove development bypasses in DraftRoomClient
+- Remove development bypasses in UnifiedDraftRoom (replaces DraftRoomClient)
 - Remove debug statements in all components
 
 ## 3. Replace Alert() Calls
@@ -27,7 +27,7 @@ All alert() calls need to be replaced with proper UI notifications:
 
 - src/app/tradecentre/page.tsx:68
 - src/app/drafts/create/page.tsx:47
-- src/app/drafts/[id]/DraftRoomClient.tsx (multiple instances)
+- src/components/draft/UnifiedDraftRoom.tsx (verify none remain)
 
 ## 4. Environment Configuration
 

--- a/PRODUCTION_CLEANUP.md
+++ b/PRODUCTION_CLEANUP.md
@@ -18,7 +18,7 @@ grep -r "console\." src/ --include="*.ts" --include="*.tsx"
 
 - Remove development tools from login page
 - Remove mock data creation buttons
-- Remove development bypasses in UnifiedDraftRoom (replaces DraftRoomClient)
+- Remove development bypasses in `UnifiedDraftRoom` (replaces `DraftRoomClient`)
 - Remove debug statements in all components
 
 ## 3. Replace Alert() Calls

--- a/PRODUCTION_CLEANUP.md
+++ b/PRODUCTION_CLEANUP.md
@@ -27,7 +27,7 @@ All alert() calls need to be replaced with proper UI notifications:
 
 - src/app/tradecentre/page.tsx:68
 - src/app/drafts/create/page.tsx:47
-- src/components/draft/UnifiedDraftRoom.tsx (verify none remain)
+- `src/components/draft/UnifiedDraftRoom.tsx` (verify none remain)
 
 ## 4. Environment Configuration
 

--- a/SNAKE_DRAFT_REVIEW.md
+++ b/SNAKE_DRAFT_REVIEW.md
@@ -55,7 +55,7 @@ Pick | Round | Direction | Slot | Team
 3. **Draft state management** - Proper round/direction tracking
 
 ### ✅ **Frontend Components**
-1. **`DraftRoomClient.tsx`** - Real-time draft state calculation
+1. **`UnifiedDraftRoom.tsx`** - Real-time draft state calculation
 2. **`LivePickHeader.tsx`** - Current/next turn display
 3. **Draft page** - Pick order visualization
 


### PR DESCRIPTION
## Summary
- clarify that DraftContainer is deprecated and superseded by UnifiedDraftRoom
- update cleanup docs to reference UnifiedDraftRoom instead of DraftRoomClient
- replace legacy DraftRoomClient mention in snake draft review

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e728a568832bbc24e26736cd0881