### PR TITLE
feat: add commissioner setup wizard and join status

### DIFF
--- a/src/components/commissioner/CommissionerTools.tsx
+++ b/src/components/commissioner/CommissionerTools.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   CogIcon,
@@ -10,6 +10,9 @@ import {
   EnvelopeIcon,
   ChartBarIcon,
 } from '@heroicons/react/24/outline';
+import { fetchApi } from '@/lib/api';
+import { LoadingSpinner } from '@/components/ui';
+import CommissionerWizard from './CommissionerWizard';
 import type { League } from '@/types/leagues';
 
 // Types
@@ -87,50 +90,6 @@ interface CommissionerToolsProps {
   isCommissioner?: boolean;
 }
 
-// Mock data
-const mockSettings: LeagueSettings = {
-  scoring: {
-    disposal: 1,
-    kick: 3,
-    handball: 2,
-    mark: 3,
-    tackle: 4,
-    goal: 6,
-    behind: 1,
-    hitout: 1,
-    freeFor: 1,
-    freeAgainst: -1,
-  },
-  roster: {
-    totalPlayers: 30,
-    forwards: 8,
-    midfielders: 10,
-    defenders: 8,
-    rucks: 4,
-    bench: 6,
-    emergencies: 4,
-  },
-  waivers: {
-    enabled: true,
-    processingDay: 'Wednesday',
-    processingTime: '09:00',
-    fAABBudget: 100,
-    minimumBid: 1,
-  },
-  playoffs: {
-    enabled: true,
-    teams: 8,
-    startWeek: 20,
-    format: 'single',
-  },
-  trades: {
-    enabled: true,
-    deadline: '2025-08-15',
-    reviewPeriod: 48,
-    vetoVotes: 4,
-  },
-};
-
 const mockMembers: Member[] = [
   {
     id: '1',
@@ -166,7 +125,7 @@ const mockMembers: Member[] = [
 
 export default function CommissionerTools({
   league,
-  leagueSettings = mockSettings,
+  leagueSettings,
   members = mockMembers,
   invitations = [],
   onUpdateSettings,
@@ -178,17 +137,48 @@ export default function CommissionerTools({
   const [activeTab, setActiveTab] = useState<'settings' | 'members' | 'invites' | 'advanced'>(
     'settings'
   );
-  const [settings, setSettings] = useState(leagueSettings);
+  const [settings, setSettings] = useState<LeagueSettings | null>(leagueSettings || null);
+  const [settingsLoading, setSettingsLoading] = useState(false);
   const [newInviteEmail, setNewInviteEmail] = useState('');
   const [showConfirmation, setShowConfirmation] = useState<string | null>(null);
 
+  useEffect(() => {
+    const loadSettings = async () => {
+      if (!league) return;
+      try {
+        setSettingsLoading(true);
+        const res = await fetchApi(`leagues/${league.id}/settings`);
+        const fetched = res?.settings || res?.data || res;
+        setSettings(fetched as LeagueSettings);
+      } catch (err) {
+        console.error('Failed to fetch league settings', err);
+      } finally {
+        setSettingsLoading(false);
+      }
+    };
+    loadSettings();
+  }, [league]);
+
   // Use actual league data if available
   const displayName = league?.name || 'League';
-  // const displayMembers = league ? [] : members; // TODO: Fetch actual members
   const displayCategories = league?.categories || [];
   const leagueCode = league?.code || 'N/A';
   const maxTeams = league?.maxTeams || 12;
   const currentTeams = league?.currentTeams || 0;
+
+  if (settingsLoading) {
+    return (
+      <div className="flex justify-center items-center p-6">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (!settings) {
+    return (
+      <div className="p-6 text-center text-gray-600">Failed to load league settings.</div>
+    );
+  }
 
   if (!isCommissioner) {
     return (
@@ -297,6 +287,10 @@ export default function CommissionerTools({
             exit={{ opacity: 0, y: -20 }}
             className="space-y-6"
           >
+            {league && settings && (
+              <CommissionerWizard leagueId={league.id} settings={settings} />
+            )}
+
             {/* League Information */}
             {league && (
               <div className="bg-white rounded-xl shadow-lg p-6">

--- a/src/components/commissioner/CommissionerWizard.tsx
+++ b/src/components/commissioner/CommissionerWizard.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { fetchApi } from '@/lib/api';
+
+interface LeagueSettings {
+  scoring?: Record<string, number>;
+  roster?: Record<string, number>;
+  draft?: Record<string, unknown>;
+  waivers?: Record<string, unknown>;
+}
+
+interface JoinStatus {
+  joined: number;
+  total: number;
+}
+
+interface CommissionerWizardProps {
+  leagueId: string;
+  settings: LeagueSettings | null;
+}
+
+const steps = ['Scoring', 'Roster', 'Draft', 'Waivers'] as const;
+
+type Step = typeof steps[number];
+
+export default function CommissionerWizard({ leagueId, settings }: CommissionerWizardProps) {
+  const [stepIndex, setStepIndex] = useState(0);
+  const [joinStatus, setJoinStatus] = useState<JoinStatus | null>(null);
+
+  useEffect(() => {
+    const loadStatus = async () => {
+      try {
+        const data = await fetchApi(`leagues/${leagueId}/join-status`);
+        setJoinStatus(data);
+      } catch (err) {
+        console.error('Failed to fetch join status', err);
+      }
+    };
+    loadStatus();
+  }, [leagueId]);
+
+  const next = () => setStepIndex((i) => Math.min(i + 1, steps.length - 1));
+  const prev = () => setStepIndex((i) => Math.max(i - 1, 0));
+
+  const currentStep = steps[stepIndex];
+
+  const renderStep = (step: Step) => {
+    switch (step) {
+      case 'Scoring':
+        return <pre className="text-sm bg-gray-50 p-4 rounded">{JSON.stringify(settings?.scoring, null, 2)}</pre>;
+      case 'Roster':
+        return <pre className="text-sm bg-gray-50 p-4 rounded">{JSON.stringify(settings?.roster, null, 2)}</pre>;
+      case 'Draft':
+        return <pre className="text-sm bg-gray-50 p-4 rounded">{JSON.stringify(settings?.draft, null, 2)}</pre>;
+      case 'Waivers':
+        return <pre className="text-sm bg-gray-50 p-4 rounded">{JSON.stringify(settings?.waivers, null, 2)}</pre>;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-xl shadow p-6 space-y-4">
+      {joinStatus && (
+        <div className="text-sm text-gray-600">
+          Teams joined: {joinStatus.joined} / {joinStatus.total}
+        </div>
+      )}
+      <div className="font-semibold text-lg">{currentStep} Settings</div>
+      {renderStep(currentStep)}
+      <div className="flex justify-between pt-4">
+        <button
+          onClick={prev}
+          disabled={stepIndex === 0}
+          className="px-4 py-2 rounded bg-gray-200 disabled:opacity-50"
+        >
+          Previous
+        </button>
+        <button
+          onClick={next}
+          disabled={stepIndex === steps.length - 1}
+          className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/api/leagues/[leagueId]/join-status.ts
+++ b/src/pages/api/leagues/[leagueId]/join-status.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { adminDb } from '@/lib/firebaseAdmin';
+import { getLeagueMeta } from '@/lib/data/leagueApi';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { leagueId } = req.query;
+
+  if (typeof leagueId !== 'string') {
+    res.status(400).json({ error: 'leagueId is required' });
+    return;
+  }
+
+  try {
+    const meta = await getLeagueMeta(adminDb, leagueId);
+    res.status(200).json({ joined: meta.memberCount, total: meta.maxTeams });
+  } catch (err) {
+    console.error('Failed to load join status', err);
+    res.status(500).json({ error: 'Failed to load join status' });
+  }
+}


### PR DESCRIPTION
## Summary
- add commissioner setup wizard for scoring, roster, draft and waivers
- expose join status endpoint returning joined and total team counts
- fetch real league settings instead of mock data in commissioner tools

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4036da0ec832b90207d8cfecf262a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Commissioner Wizard to step through and preview league settings (Scoring, Roster, Draft, Waivers).
  - League settings now load from the server with a loading spinner and clear error messaging.
  - Display league join status (teams joined vs total) within the wizard.

- Bug Fixes
  - Improved Members tab feedback to distinguish between loading and no-members states.

- Refactor
  - Removed reliance on mock settings; initialization now reflects real data availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->