### PR TITLE
feat: add lobby chat and checklist

### DIFF
--- a/src/components/draft/DraftLobby.tsx
+++ b/src/components/draft/DraftLobby.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Alert } from '@/components/ui';
 import type { LobbyState, WatchlistItem, PreDraftQueueItem } from '@/lib/draftLobby';
+import LobbyChat from './LobbyChat';
+import PreDraftChecklist from './PreDraftChecklist';
 
 // Basic player type for draft lobby
 interface Player {
@@ -379,14 +381,20 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
 
       {/* Main content - Enhanced Layout */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 lg:gap-8">
           {/* Left column - Instructions & Tips */}
           <div className="lg:col-span-1">
             <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 h-fit">
               <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
                 📋 Pre-Draft Setup
               </h2>
-              
+              <PreDraftChecklist
+                draftId={draftId}
+                memberId={memberId}
+                watchlistCount={watchlist.length}
+                queueCount={preDraftQueue.length}
+              />
+
               <div className="space-y-4">
                 {/* Step 1 */}
                 <div className="flex items-start gap-3">
@@ -461,7 +469,7 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
             </div>
           </div>
 
-          {/* Right columns - Interactive Tabs */}
+          {/* Center columns - Interactive Tabs */}
           <div className="lg:col-span-2">
             <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
               {/* Enhanced Tabs */}
@@ -553,6 +561,11 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
                 </AnimatePresence>
               </div>
             </div>
+          </div>
+
+          {/* Chat column */}
+          <div className="lg:col-span-1">
+            <LobbyChat draftId={draftId} memberId={memberId} />
           </div>
         </div>
       </main>

--- a/src/components/draft/LobbyChat.tsx
+++ b/src/components/draft/LobbyChat.tsx
@@ -84,6 +84,9 @@ export default function LobbyChat({ draftId, memberId }: LobbyChatProps) {
           onChange={(e) => setNewMessage(e.target.value)}
           className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm"
           placeholder="Type a message..."
+          aria-label="Message"
+          autoComplete="off"
+          maxLength={1000}
         />
         <button
           type="submit"

--- a/src/components/draft/LobbyChat.tsx
+++ b/src/components/draft/LobbyChat.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useState, useRef, FormEvent } from 'react';
+import { db } from '@/lib/firebaseClient';
+import {
+  collection,
+  addDoc,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  type DocumentData,
+} from 'firebase/firestore';
+
+interface LobbyChatProps {
+  draftId: string;
+  memberId: string;
+}
+
+interface ChatMessage {
+  id: string;
+  text: string;
+  memberId: string;
+  createdAt?: Date;
+}
+
+export default function LobbyChat({ draftId, memberId }: LobbyChatProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [newMessage, setNewMessage] = useState('');
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!db) return; // Firestore not configured
+    const messagesRef = collection(db, 'drafts', draftId, 'chat');
+    const q = query(messagesRef, orderBy('createdAt'));
+    const unsubscribe = onSnapshot(q, (snapshot) => {
+      const data: ChatMessage[] = snapshot.docs.map((doc) => ({
+        id: doc.id,
+        ...(doc.data() as DocumentData),
+        createdAt: doc.data().createdAt?.toDate?.(),
+      }));
+      setMessages(data);
+    });
+    return () => unsubscribe();
+  }, [draftId]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const sendMessage = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!db || !newMessage.trim()) return;
+    try {
+      await addDoc(collection(db, 'drafts', draftId, 'chat'), {
+        text: newMessage.trim(),
+        memberId,
+        createdAt: serverTimestamp(),
+      });
+      setNewMessage('');
+    } catch (err) {
+      console.error('Failed to send message', err);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 flex flex-col h-80">
+      <div className="p-4 border-b">
+        <h2 className="text-lg font-semibold text-gray-900">💬 Lobby Chat</h2>
+      </div>
+      <div className="flex-1 p-4 overflow-y-auto space-y-2">
+        {messages.map((msg) => (
+          <div key={msg.id} className="text-sm">
+            <span className="font-medium text-gray-800">{msg.memberId}:</span>{' '}
+            <span className="text-gray-700 break-words">{msg.text}</span>
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+      <form onSubmit={sendMessage} className="p-4 border-t flex gap-2">
+        <input
+          type="text"
+          value={newMessage}
+          onChange={(e) => setNewMessage(e.target.value)}
+          className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm"
+          placeholder="Type a message..."
+        />
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-700"
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}
+

--- a/src/components/draft/PreDraftChecklist.tsx
+++ b/src/components/draft/PreDraftChecklist.tsx
@@ -48,14 +48,25 @@ export default function PreDraftChecklist({
 
   // Update checklist based on local state
   useEffect(() => {
-    if (!db) return;
+    if (!db || !draftId || !memberId) return;
     const ref = doc(db, 'drafts', draftId, 'checklists', memberId);
-    const payload = {
+    const desired = {
       rankings: queueCount > 0,
       watchlist: watchlistCount > 0,
     };
-    void setDoc(ref, payload, { merge: true });
-  }, [draftId, memberId, queueCount, watchlistCount]);
+    const current = items.reduce((acc, i) => {
+      if (i.id === 'rankings' || i.id === 'watchlist') acc[i.id] = i.completed;
+      return acc;
+    }, {} as Record<'rankings' | 'watchlist', boolean>);
+    if (current.rankings === desired.rankings && current.watchlist === desired.watchlist) return;
+    (async () => {
+      try {
+        await setDoc(ref, desired, { merge: true });
+      } catch (err) {
+        console.error('Failed to update checklist', err);
+      }
+    })();
+  }, [draftId, memberId, queueCount, watchlistCount, items]);
 
   return (
     <div className="mb-4">

--- a/src/components/draft/PreDraftChecklist.tsx
+++ b/src/components/draft/PreDraftChecklist.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { db } from '@/lib/firebaseClient';
+import { doc, onSnapshot, setDoc } from 'firebase/firestore';
+
+interface ChecklistItem {
+  id: string;
+  label: string;
+  completed: boolean;
+}
+
+interface PreDraftChecklistProps {
+  draftId: string;
+  memberId: string;
+  watchlistCount: number;
+  queueCount: number;
+}
+
+const defaultItems: ChecklistItem[] = [
+  { id: 'rankings', label: 'Rankings set', completed: false },
+  { id: 'watchlist', label: 'Watchlist updated', completed: false },
+];
+
+export default function PreDraftChecklist({
+  draftId,
+  memberId,
+  watchlistCount,
+  queueCount,
+}: PreDraftChecklistProps) {
+  const [items, setItems] = useState<ChecklistItem[]>(defaultItems);
+
+  // Subscribe to stored checklist
+  useEffect(() => {
+    if (!db) return;
+    const ref = doc(db, 'drafts', draftId, 'checklists', memberId);
+    const unsubscribe = onSnapshot(ref, (snap) => {
+      const data = snap.data() as Record<string, boolean> | undefined;
+      setItems(
+        defaultItems.map((item) => ({
+          ...item,
+          completed: data ? Boolean(data[item.id]) : false,
+        }))
+      );
+    });
+    return () => unsubscribe();
+  }, [draftId, memberId]);
+
+  // Update checklist based on local state
+  useEffect(() => {
+    if (!db) return;
+    const ref = doc(db, 'drafts', draftId, 'checklists', memberId);
+    const payload = {
+      rankings: queueCount > 0,
+      watchlist: watchlistCount > 0,
+    };
+    void setDoc(ref, payload, { merge: true });
+  }, [draftId, memberId, queueCount, watchlistCount]);
+
+  return (
+    <div className="mb-4">
+      <h3 className="text-sm font-medium text-gray-900 mb-2">Your Checklist</h3>
+      <ul className="space-y-1">
+        {items.map((item) => (
+          <li key={item.id} className="flex items-center text-sm text-gray-700">
+            <span className="mr-2">
+              {item.completed ? '✅' : '⬜'}
+            </span>
+            {item.label}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/components/draft/PreDraftChecklist.tsx
+++ b/src/components/draft/PreDraftChecklist.tsx
@@ -32,17 +32,23 @@ export default function PreDraftChecklist({
 
   // Subscribe to stored checklist
   useEffect(() => {
-    if (!db) return;
+    if (!db || !draftId || !memberId) return;
     const ref = doc(db, 'drafts', draftId, 'checklists', memberId);
-    const unsubscribe = onSnapshot(ref, (snap) => {
-      const data = snap.data() as Record<string, boolean> | undefined;
-      setItems(
-        defaultItems.map((item) => ({
-          ...item,
-          completed: data ? Boolean(data[item.id]) : false,
-        }))
-      );
-    });
+    const unsubscribe = onSnapshot(
+      ref,
+      (snap) => {
+        const data = snap.data() as Record<string, boolean> | undefined;
+        setItems(
+          defaultItems.map((item) => ({
+            ...item,
+            completed: data ? Boolean(data[item.id]) : false,
+          }))
+        );
+      },
+      (error) => {
+        console.error('Checklist snapshot error', error);
+      }
+    );
     return () => unsubscribe();
   }, [draftId, memberId]);
 


### PR DESCRIPTION
## Summary
- add Firestore-powered LobbyChat and mount in DraftLobby
- track user preparation via PreDraftChecklist

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b40390ca64832bb69db559e8230fda

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Real-time lobby chat per draft with auto-scrolling and message compose.
  - Pre-draft checklist showing readiness based on your watchlist and queue counts.
  - Manage pre-draft queue (reorder) and watchlist (remove items); changes are saved and surface basic error feedback.

- Refactor
  - Lobby layout expanded to a 4-column grid with a dedicated chat column and centralized tabs; left column surfaces checklist and counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->