### PR TITLE
Persist draft rankings and optimize mock draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ buildinfo
 Statly.worktrees/**
 lint.config.js
 .eslintrc.js
+data/user-rankings.json

--- a/src/app/api/user/rankings/route.ts
+++ b/src/app/api/user/rankings/route.ts
@@ -1,25 +1,61 @@
 import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs/promises';
+import path from 'path';
 
-// In-memory store for player ranking preferences
-// Keyed by `${draftId}:${memberId}`
-const rankingStore = new Map<string, any>();
+interface RankingPreferences {
+  draftId: string;
+  memberId: string;
+  excludedPlayers: string[];
+  playerOrder: string[];
+  watchlist: unknown[];
+  preDraftQueue: unknown[];
+  timestamp: number;
+}
+
+const DATA_PATH = path.join(process.cwd(), 'data', 'user-rankings.json');
+let rankingStore: Map<string, RankingPreferences> | null = null;
+
+async function loadStore() {
+  if (rankingStore) return rankingStore;
+  try {
+    const file = await fs.readFile(DATA_PATH, 'utf-8');
+    const json = JSON.parse(file) as Record<string, RankingPreferences>;
+    rankingStore = new Map(Object.entries(json));
+  } catch {
+    rankingStore = new Map();
+  }
+  return rankingStore;
+}
+
+async function saveStore() {
+  if (!rankingStore) return;
+  const obj = Object.fromEntries(rankingStore);
+  await fs.mkdir(path.dirname(DATA_PATH), { recursive: true });
+  await fs.writeFile(DATA_PATH, JSON.stringify(obj, null, 2), 'utf-8');
+}
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
-  const draftId = searchParams.get('draftId') || '';
-  const memberId = searchParams.get('memberId') || '';
+  const draftId = searchParams.get('draftId');
+  const memberId = searchParams.get('memberId');
+  if (!draftId || !memberId) {
+    return NextResponse.json({ error: 'draftId and memberId required' }, { status: 400 });
+  }
   const key = `${draftId}:${memberId}`;
-  const data = rankingStore.get(key) || {};
+  const store = await loadStore();
+  const data = store.get(key) || {};
   return NextResponse.json(data);
 }
 
 export async function POST(req: NextRequest) {
-  const body = await req.json();
+  const body = (await req.json()) as RankingPreferences;
   const { draftId, memberId } = body;
   if (!draftId || !memberId) {
     return NextResponse.json({ error: 'draftId and memberId required' }, { status: 400 });
   }
   const key = `${draftId}:${memberId}`;
-  rankingStore.set(key, body);
+  const store = await loadStore();
+  store.set(key, body);
+  await saveStore();
   return NextResponse.json({ success: true });
 }

--- a/src/components/draft/DraftLobby.tsx
+++ b/src/components/draft/DraftLobby.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Alert } from '@/components/ui';
 import type { LobbyState, WatchlistItem, PreDraftQueueItem } from '@/lib/draftLobby';
@@ -37,6 +37,8 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
   const [draftStartCalled, setDraftStartCalled] = useState(false);
   const [mockDraftPicks, setMockDraftPicks] = useState<Player[]>([]);
   const [aiLoading, setAiLoading] = useState(false);
+  const [preferencesLoaded, setPreferencesLoaded] = useState(false);
+  const initialSave = useRef(true);
 
   // Countdown timer
   const [timeRemaining, setTimeRemaining] = useState(0);
@@ -113,7 +115,7 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
 
   const fetchAllPlayers = useCallback(async () => {
     try {
-      const response = await fetch('/api/players');
+      const response = await fetch('/api/players?limit=1000');
       if (response.ok) {
         const data = await response.json();
         setAllPlayers(data.players || []);
@@ -157,6 +159,8 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
       }
     } catch (err) {
       console.error('Failed to load saved preferences:', err);
+    } finally {
+      setPreferencesLoaded(true);
     }
   }, [draftId, memberId]);
 
@@ -209,20 +213,26 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
     }
   }, [allPlayers]);
 
+  const allPlayersById = useMemo(() => new Map(allPlayers.map(p => [p.id, p])), [allPlayers]);
+
   const runMockDraft = useCallback(() => {
     const availableIds = playerOrder.filter(id => !excludedPlayers.has(id));
-    const picks: Player[] = [];
-    for (const id of availableIds.slice(0, 10)) {
-      const p = allPlayers.find(pl => pl.id === id);
-      if (p) picks.push(p);
-    }
+    const picks = availableIds
+      .slice(0, 10)
+      .map(id => allPlayersById.get(id))
+      .filter((p): p is Player => !!p);
     setMockDraftPicks(picks);
-  }, [playerOrder, excludedPlayers, allPlayers]);
+  }, [playerOrder, excludedPlayers, allPlayersById]);
 
   // Auto-save preferences when they change
   useEffect(() => {
+    if (!preferencesLoaded) return;
+    if (initialSave.current) {
+      initialSave.current = false;
+      return;
+    }
     savePreferences();
-  }, [savePreferences]);
+  }, [savePreferences, preferencesLoaded]);
 
   const formatTime = (seconds: number): string => {
     const minutes = Math.floor(seconds / 60);


### PR DESCRIPTION
## Summary
- persist user rankings to a JSON file with type-safe interface and required query parameters
- fetch full player list and memoize lookups for faster mock draft
- delay auto-save until preferences load to avoid overwriting saved rankings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b432418494832b8c9407f5d28dfaba