### PR TITLE
Persist draft rankings and add mock draft mode

### DIFF
--- a/src/components/draft/DraftLobby.tsx
+++ b/src/components/draft/DraftLobby.tsx
@@ -58,8 +58,12 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draftId, memberId, forcedLobbyState]);
 
-  // Fetch all players on component mount
+  // Fetch all players and load preferences when draft or member changes
   useEffect(() => {
+    // Reset autosave guard so we don't save previous draft's preferences
+    setPreferencesLoaded(false);
+    initialSave.current = true;
+
     fetchAllPlayers();
     void loadSavedPreferences();
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -115,16 +119,30 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
 
   const fetchAllPlayers = useCallback(async () => {
     try {
-      // Request a large limit to ensure we receive the full player list
-      const response = await fetch('/api/players?limit=1000');
-      if (response.ok) {
-        const data = await response.json();
-        setAllPlayers(data.players || []);
-
-        // Initialize player order if not already set
-        if (playerOrder.length === 0) {
-          setPlayerOrder(data.players?.map((p: Player) => p.id) || []);
+      const players: Player[] = [];
+      let page = 1;
+      let hasMore = true;
+      while (hasMore) {
+        const response = await fetch(`/api/players?limit=1000&page=${page}`);
+        if (response.ok) {
+          const data = await response.json();
+          const fetchedPlayers = data.players || [];
+          players.push(...fetchedPlayers);
+          if (players.length >= data.total || fetchedPlayers.length === 0) {
+            hasMore = false;
+          } else {
+            page++;
+          }
+        } else {
+          console.error('Failed to fetch players:', response.statusText);
+          hasMore = false;
         }
+      }
+      setAllPlayers(players);
+
+      // Initialize player order if not already set
+      if (playerOrder.length === 0) {
+        setPlayerOrder(players.map((p: Player) => p.id));
       }
     } catch (err) {
       console.error('Failed to fetch players:', err);
@@ -228,14 +246,21 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
     setMockDraftPicks(picks);
   }, [playerOrder, excludedPlayers, allPlayersById]);
 
-  // Auto-save preferences when they change (skip initial load)
+  // Auto-save preferences when they change (skip initial load and debounce saves)
   useEffect(() => {
     if (!preferencesLoaded) return;
     if (initialSave.current) {
       initialSave.current = false;
       return;
     }
-    savePreferences();
+
+    const timer = setTimeout(() => {
+      savePreferences();
+    }, 1000);
+
+    return () => {
+      clearTimeout(timer);
+    };
   }, [savePreferences, preferencesLoaded]);
 
   const formatTime = (seconds: number): string => {

--- a/src/components/draft/DraftLobby.tsx
+++ b/src/components/draft/DraftLobby.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Alert } from '@/components/ui';
 import type { LobbyState, WatchlistItem, PreDraftQueueItem } from '@/lib/draftLobby';
@@ -37,6 +37,8 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
   const [draftStartCalled, setDraftStartCalled] = useState(false);
   const [mockDraftPicks, setMockDraftPicks] = useState<Player[]>([]);
   const [aiLoading, setAiLoading] = useState(false);
+  const [preferencesLoaded, setPreferencesLoaded] = useState(false);
+  const initialSave = useRef(true);
 
   // Countdown timer
   const [timeRemaining, setTimeRemaining] = useState(0);
@@ -113,7 +115,8 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
 
   const fetchAllPlayers = useCallback(async () => {
     try {
-      const response = await fetch('/api/players');
+      // Request a large limit to ensure we receive the full player list
+      const response = await fetch('/api/players?limit=1000');
       if (response.ok) {
         const data = await response.json();
         setAllPlayers(data.players || []);
@@ -140,6 +143,7 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
         setPlayerOrder(data.playerOrder || []);
         setWatchlist(data.watchlist || []);
         setPreDraftQueue(data.preDraftQueue || []);
+        setPreferencesLoaded(true);
         return;
       }
     } catch (err) {
@@ -158,6 +162,7 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
     } catch (err) {
       console.error('Failed to load saved preferences:', err);
     }
+    setPreferencesLoaded(true);
   }, [draftId, memberId]);
 
   const savePreferences = useCallback(() => {
@@ -209,20 +214,29 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
     }
   }, [allPlayers]);
 
+  const allPlayersById = useMemo(
+    () => new Map(allPlayers.map(p => [p.id, p])),
+    [allPlayers]
+  );
+
   const runMockDraft = useCallback(() => {
     const availableIds = playerOrder.filter(id => !excludedPlayers.has(id));
-    const picks: Player[] = [];
-    for (const id of availableIds.slice(0, 10)) {
-      const p = allPlayers.find(pl => pl.id === id);
-      if (p) picks.push(p);
-    }
+    const picks = availableIds
+      .slice(0, 10)
+      .map(id => allPlayersById.get(id))
+      .filter((p): p is Player => !!p);
     setMockDraftPicks(picks);
-  }, [playerOrder, excludedPlayers, allPlayers]);
+  }, [playerOrder, excludedPlayers, allPlayersById]);
 
-  // Auto-save preferences when they change
+  // Auto-save preferences when they change (skip initial load)
   useEffect(() => {
+    if (!preferencesLoaded) return;
+    if (initialSave.current) {
+      initialSave.current = false;
+      return;
+    }
     savePreferences();
-  }, [savePreferences]);
+  }, [savePreferences, preferencesLoaded]);
 
   const formatTime = (seconds: number): string => {
     const minutes = Math.floor(seconds / 60);


### PR DESCRIPTION
## Summary
- fetch complete player list when loading draft lobby
- memoize allPlayers for O(1) mock draft lookups
- delay autosave until initial preferences load to avoid overwrites

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4322f5ac8832b9ba86aed4beb56e5