### PR TITLE
fix: clean up async calls in LeagueTabs

### DIFF
--- a/src/components/league/LeagueTabs.tsx
+++ b/src/components/league/LeagueTabs.tsx
@@ -25,7 +25,7 @@ interface Tab {
   badge?: number;
 }
 
-export default function LeagueTabs({ league, members, currentUserId }: LeagueTabsProps) {
+export default function LeagueTabs({ league, members, currentUserId }: LeagueTabsProps): JSX.Element {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
@@ -347,7 +347,7 @@ function MyTeamRosterManager({ league, members, currentUserId }: MyTeamRosterMan
       }
     };
 
-    fetchRosterData();
+    void fetchRosterData();
   }, [league?.id, currentUserId]);
 
   // Convert roster data to Team format for MyTeamPanel
@@ -445,7 +445,7 @@ function MyTeamRosterManager({ league, members, currentUserId }: MyTeamRosterMan
               console.error('Failed to refresh roster:', error);
             }
           };
-          refreshRoster();
+          void refreshRoster();
         }, 1000);
       } else {
         const error = await response.json();


### PR DESCRIPTION
## Summary
- annotate LeagueTabs component return type
- mark internal async calls as intentionally unawaited to satisfy lint rules

## Testing
- `npm run lint` *(fails: 16 errors, 647 warnings)*
- `npx eslint src/components/league/LeagueTabs.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b42ea28fe4832bb6c164a9fdee2287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for league tabs to enhance reliability and maintainability.
  * Streamlined internal async calls for roster updates to reduce unnecessary overhead.
  * No user-facing changes in behavior or performance.

* **Chores**
  * General code quality and consistency updates to support future maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->