### PR TITLE
fix: use structured error logging in draft lobby route

### DIFF
--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -11,9 +11,13 @@ export async function GET(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  try {
-    const { id: draftId } = params;
+  const { id: draftId } = params;
+  if (!draftId) {
+    logger.warn('Missing draft id in route params');
+    return errorResponse('Missing draft id', 400);
+  }
 
+  try {
     logger.info('Lobby API called', { draftId });
 
     // Ensure lobby columns exist before querying
@@ -28,15 +32,7 @@ export async function GET(
 
     return successResponse(lobbyState);
   } catch (error) {
-    logger.error('Failed to get lobby state', {
-      draftId: params.id,
-      error: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    });
-
-    return errorResponse(
-      `Failed to get lobby state: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      500
-    );
+    logger.error('Failed to get lobby state', error as Error, { draftId });
+    return errorResponse('Failed to get lobby state', 500);
   }
 }


### PR DESCRIPTION
## Summary
- guard against missing draftId and return 400
- log errors via logger.error with Error object and structured context
- avoid exposing error details in API response

## Testing
- `npm test`
- `npm run lint` *(fails: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*


------
https://chatgpt.com/codex/tasks/task_e_68b465249c44832b8b5a4b3c31a39bf8