### PR TITLE
refactor: reuse draft id in lobby logging

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -108,6 +108,7 @@ export default [
     },
     plugins: {
       '@typescript-eslint': tsPlugin,
+      'jsx-a11y': a11yPlugin,
     },
     rules: {
       // TS recommended (type-aware)
@@ -127,24 +128,7 @@ export default [
       '@typescript-eslint/consistent-type-imports': 'warn',
       '@typescript-eslint/explicit-module-boundary-types': 'warn',
       '@typescript-eslint/no-floating-promises': ['warn', { ignoreVoid: true }],
-     plugins: {
-       '@typescript-eslint': tsPlugin,
-      'jsx-a11y': a11yPlugin,
-     },
-     rules: {
-       // TS recommended (type-aware)
-       ...tsPlugin.configs.recommended.rules,
- 
-       // Use TS instead of prop-types
-       'react/prop-types': 'off',
- 
-       // TS handles undefined vars; disabling avoids noise with types
-       'no-undef': 'off',
- 
-       // Hygiene
-       // Enable accessibility rule for table headers: ensure headers have valid scope
-       'jsx-a11y/scope': 'error',
-     },
+      
       // Keep velocity but still nudge away from `any`
       '@typescript-eslint/no-explicit-any': 'warn',
 
@@ -153,6 +137,9 @@ export default [
         'warn',
         { checksVoidReturn: { attributes: false } },
       ],
+
+      // Enable accessibility rule for table headers: ensure headers have valid scope
+      'jsx-a11y/scope': 'error',
     },
   },
 

--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -11,8 +11,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  let draftId: string | undefined;
   try {
-    const { id: draftId } = params;
+    ({ id: draftId } = params);
     if (!draftId) {
       logger.warn('Missing draft id in route params');
       return errorResponse('Missing draft id', 400);
@@ -31,15 +32,8 @@ export async function GET(
 
     return successResponse(lobbyState);
   } catch (error) {
-    logger.error('Failed to get lobby state', {
-      draftId: params.id,
-      error: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    });
+    logger.error('Failed to get lobby state', error, { draftId });
 
-    return errorResponse(
-      `Failed to get lobby state: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      500
-    );
+    return errorResponse('Failed to get lobby state', 500);
   }
 }

--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -9,15 +9,14 @@ import { ensureLobbyColumns } from '@/lib/ensureLobbyColumns';
  */
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  let draftId: string | undefined;
+  { params }: { params: { id?: string } }
+): Promise<Response> {
+  const draftId = params?.id;
+  if (!draftId) {
+    logger.warn('Missing draft id in route params');
+    return errorResponse('Missing draft id', 400);
+  }
   try {
-    ({ id: draftId } = params);
-    if (!draftId) {
-      logger.warn('Missing draft id in route params');
-      return errorResponse('Missing draft id', 400);
-    }
     logger.info('Lobby API called', { draftId });
 
     // Ensure lobby columns exist before querying
@@ -31,7 +30,7 @@ export async function GET(
     logger.info('Lobby state retrieved', { draftId, status: lobbyState.status });
 
     return successResponse(lobbyState);
-  } catch (error) {
+  } catch (error: unknown) {
     logger.error('Failed to get lobby state', error, { draftId });
 
     return errorResponse('Failed to get lobby state', 500);


### PR DESCRIPTION
## Summary
- reuse `draftId` across lobby route to avoid re-reading params
- log errors with structured `Error` argument and generic client message

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b4654e636c832bab76f141cfa8e5fd