### PR TITLE
refactor: normalize API route params and logging

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -108,6 +108,7 @@ export default [
     },
     plugins: {
       '@typescript-eslint': tsPlugin,
+      'jsx-a11y': a11yPlugin,
     },
     rules: {
       // TS recommended (type-aware)
@@ -127,24 +128,6 @@ export default [
       '@typescript-eslint/consistent-type-imports': 'warn',
       '@typescript-eslint/explicit-module-boundary-types': 'warn',
       '@typescript-eslint/no-floating-promises': ['warn', { ignoreVoid: true }],
-     plugins: {
-       '@typescript-eslint': tsPlugin,
-      'jsx-a11y': a11yPlugin,
-     },
-     rules: {
-       // TS recommended (type-aware)
-       ...tsPlugin.configs.recommended.rules,
- 
-       // Use TS instead of prop-types
-       'react/prop-types': 'off',
- 
-       // TS handles undefined vars; disabling avoids noise with types
-       'no-undef': 'off',
- 
-       // Hygiene
-       // Enable accessibility rule for table headers: ensure headers have valid scope
-       'jsx-a11y/scope': 'error',
-     },
       // Keep velocity but still nudge away from `any`
       '@typescript-eslint/no-explicit-any': 'warn',
 
@@ -153,6 +136,9 @@ export default [
         'warn',
         { checksVoidReturn: { attributes: false } },
       ],
+
+      // Enable accessibility rule for table headers: ensure headers have valid scope
+      'jsx-a11y/scope': 'error',
     },
   },
 

--- a/src/app/api/draft/[id]/roster/[userId]/route.ts
+++ b/src/app/api/draft/[id]/roster/[userId]/route.ts
@@ -3,10 +3,10 @@ import { NextResponse } from 'next/server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string; userId: string }> }
+  { params }: { params: { id: string; userId: string } }
 ) {
   try {
-    const { id: leagueId, userId } = await params;
+    const { id: leagueId, userId } = params;
     
     if (!leagueId || !userId) {
       return NextResponse.json(

--- a/src/app/api/drafts/[id]/debug/route.ts
+++ b/src/app/api/drafts/[id]/debug/route.ts
@@ -8,10 +8,11 @@ import { prisma } from '@/lib/prisma';
  */
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let draftId: string | undefined;
   try {
-    const { id: draftId } = await params;
+    ({ id: draftId } = params);
 
     // First, check if draft exists at all
     const draft = await prisma.draft.findUnique({
@@ -79,12 +80,7 @@ export async function GET(
 
     return successResponse(debugInfo);
   } catch (error) {
-    logger.error('Failed to get debug info', {
-      draftId: (await params).id,
-      error: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    });
-
-    return errorResponse(`Debug failed: ${error instanceof Error ? error.message : 'Unknown error'}`, 500);
+    logger.error('Failed to get debug info', error, { draftId });
+    return errorResponse('Debug failed', 500);
   }
 }

--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -11,8 +11,13 @@ export async function GET(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  let draftId: string | undefined;
   try {
-    const { id: draftId } = params;
+    ({ id: draftId } = params);
+    if (!draftId) {
+      logger.warn('Missing draft id in route params');
+      return errorResponse('Missing draft id', 400);
+    }
 
     logger.info('Lobby API called', { draftId });
 
@@ -28,15 +33,7 @@ export async function GET(
 
     return successResponse(lobbyState);
   } catch (error) {
-    logger.error('Failed to get lobby state', {
-      draftId: params.id,
-      error: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    });
-
-    return errorResponse(
-      `Failed to get lobby state: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      500
-    );
+    logger.error('Failed to get lobby state', error, { draftId });
+    return errorResponse('Failed to get lobby state', 500);
   }
 }

--- a/src/app/api/drafts/[id]/participants/route.ts
+++ b/src/app/api/drafts/[id]/participants/route.ts
@@ -18,9 +18,9 @@ const UpdateParticipantSchema = z.object({
 // PUT /api/drafts/[id]/participants - Update participant status
 export async function PUT(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const { id: draftId } = await params;
+  const { id: draftId } = params;
   
   try {
     const body = await request.json();
@@ -52,10 +52,7 @@ export async function PUT(
     });
 
   } catch (error) {
-    logger.error('Failed to update participant status via API', { 
-      draftId, 
-      error: error instanceof Error ? error.message : 'Unknown error'
-    });
+    logger.error('Failed to update participant status via API', error, { draftId });
     
     const errorMessage = error instanceof Error ? error.message : 'Failed to update participant status';
     const statusCode = errorMessage.includes('not found') ? 404 : 500;

--- a/src/app/api/drafts/[id]/players/route.ts
+++ b/src/app/api/drafts/[id]/players/route.ts
@@ -14,9 +14,10 @@ const VALID_POSITIONS = ['DEF', 'MID', 'FWD', 'RUC'] as const;
 
 // GET /api/drafts/[id]/players
 // Paginated available players for a draft with filtering
-export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  let id: string | undefined;
   try {
-    const { id } = await params;
+    ({ id } = params);
 
     if (!id || typeof id !== 'string' || id.length < 10) {
       return errorResponse('Invalid draft id', 400);
@@ -147,13 +148,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     logger.info('Draft players retrieved', { draftId: id, page, pageSize, count: players.length });
     return response;
   } catch (error) {
-    logger.error('Failed to retrieve draft players', {
-      error: {
-        name: error instanceof Error ? error.name : 'Unknown',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-    });
+    logger.error('Failed to retrieve draft players', error, { draftId: id });
     return errorResponse('Failed to retrieve draft players', 500);
   }
 }

--- a/src/app/api/drafts/[id]/pre-queue/route.ts
+++ b/src/app/api/drafts/[id]/pre-queue/route.ts
@@ -17,10 +17,11 @@ interface PreQueueRequest {
  */
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let draftId: string | undefined;
   try {
-    const { id: draftId } = await params;
+    ({ id: draftId } = params);
     const url = new URL(request.url);
     const memberId = url.searchParams.get('memberId');
 
@@ -32,11 +33,7 @@ export async function GET(
 
     return successResponse({ queue });
   } catch (error) {
-    logger.error('Failed to get pre-draft queue', {
-      draftId: (await params).id,
-      error: error instanceof Error ? error.message : String(error),
-    });
-
+    logger.error('Failed to get pre-draft queue', error, { draftId });
     return errorResponse('Failed to get pre-draft queue', 500);
   }
 }
@@ -46,10 +43,11 @@ export async function GET(
  */
 export async function PUT(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let draftId: string | undefined;
   try {
-    const { id: draftId } = await params;
+    ({ id: draftId } = params);
     const body: PreQueueRequest = await request.json();
 
     if (!body.memberId || !Array.isArray(body.queue)) {
@@ -67,11 +65,7 @@ export async function PUT(
 
     return successResponse({ queue: updatedQueue });
   } catch (error) {
-    logger.error('Failed to update pre-draft queue', {
-      draftId: (await params).id,
-      error: error instanceof Error ? error.message : String(error),
-    });
-
+    logger.error('Failed to update pre-draft queue', error, { draftId });
     return errorResponse('Failed to update pre-draft queue', 500);
   }
 }

--- a/src/app/api/drafts/[id]/queue/route.ts
+++ b/src/app/api/drafts/[id]/queue/route.ts
@@ -10,11 +10,12 @@ interface QueueRequest {
 }
 
 export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  let draftId: string | undefined;
   try {
-  const { id: draftId } = params;
-  if (typeof draftId !== 'string' || draftId.trim().length === 0) {
-    return errorResponse('Missing or invalid draftId', 400);
-  }
+    ({ id: draftId } = params);
+    if (typeof draftId !== 'string' || draftId.trim().length === 0) {
+      return errorResponse('Missing or invalid draftId', 400);
+    }
     const body: QueueRequest = await request.json();
     const { playerId, memberId, rank } = body;
 
@@ -92,24 +93,18 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
 
     return successResponse(queueItem);
   } catch (error) {
-    logger.error('Failed to add player to queue', {
-      error: {
-        name: error instanceof Error ? error.name : 'Unknown',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-    });
-
+    logger.error('Failed to add player to queue', error, { draftId });
     return errorResponse('Failed to add player to queue', 500);
   }
 }
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let draftId: string | undefined;
   try {
-    const { id: draftId } = await params;
+    ({ id: draftId } = params);
     const url = new URL(request.url);
     const playerId = url.searchParams.get('playerId');
     const memberId = url.searchParams.get('memberId');
@@ -164,24 +159,18 @@ export async function DELETE(
 
     return successResponse({ message: 'Player removed from queue' });
   } catch (error) {
-    logger.error('Failed to remove player from queue', {
-      error: {
-        name: error instanceof Error ? error.name : 'Unknown',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-    });
-
+    logger.error('Failed to remove player from queue', error, { draftId });
     return errorResponse('Failed to remove player from queue', 500);
   }
 }
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  let draftId: string | undefined;
   try {
-  const { id: draftId } = params;
-  if (typeof draftId !== 'string' || draftId.trim().length === 0) {
-    return errorResponse('Missing or invalid draftId', 400);
-  }
+    ({ id: draftId } = params);
+    if (typeof draftId !== 'string' || draftId.trim().length === 0) {
+      return errorResponse('Missing or invalid draftId', 400);
+    }
     const url = new URL(request.url);
     const memberId = url.searchParams.get('memberId');
 
@@ -216,14 +205,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
 
     return successResponse(queueWithPlayers);
   } catch (error) {
-    logger.error('Failed to get queue', {
-      error: {
-        name: error instanceof Error ? error.name : 'Unknown',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-    });
-
+    logger.error('Failed to get queue', error, { draftId });
     return errorResponse('Failed to get queue', 500);
   }
 }

--- a/src/app/api/drafts/[id]/route.ts
+++ b/src/app/api/drafts/[id]/route.ts
@@ -9,9 +9,10 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  let id: string | undefined;
   try {
-    const { id } = await params;
+    ({ id } = params);
 
     // Strict id validation (Draft IDs are CUIDs per Prisma schema)
     if (!z.string().cuid().safeParse(id).success) {
@@ -177,14 +178,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     return response;
   } catch (error) {
-    logger.error('Failed to retrieve draft', {
-      error: {
-        name: error instanceof Error ? error.name : 'Unknown',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-    });
-
+    logger.error('Failed to retrieve draft', error, { draftId: id });
     return errorResponse('Failed to retrieve draft', 500);
   }
 }

--- a/src/app/api/drafts/[id]/schedule/route.ts
+++ b/src/app/api/drafts/[id]/schedule/route.ts
@@ -16,11 +16,13 @@ interface UpdateScheduleRequest {
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let draftId: string | undefined;
+  let body: UpdateScheduleRequest;
   try {
-    const { id: draftId } = await params;
-    const body: UpdateScheduleRequest = await request.json();
+    ({ id: draftId } = params);
+    body = await request.json();
 
     // Validation
     if (!body.scheduledTime) {
@@ -117,11 +119,10 @@ export async function PUT(
         remindersEnabled: body.enableReminders !== false,
       });
     } catch (error) {
-      logger.error('Failed to schedule draft start', {
+      logger.error('Failed to schedule draft start', error, {
         draftId,
         leagueId: draft.leagueId,
         scheduledTime: body.scheduledTime,
-        error: error instanceof Error ? error.message : String(error),
       });
       return errorResponse('Failed to schedule draft', 500);
     }
@@ -134,21 +135,18 @@ export async function PUT(
       message: 'Draft rescheduled successfully',
     });
   } catch (error) {
-    logger.error('Failed to update draft schedule', {
-      draftId: (await params).id,
-      error: error instanceof Error ? error.message : String(error),
-    });
-
+    logger.error('Failed to update draft schedule', error, { draftId });
     return errorResponse('Failed to update draft schedule', 500);
   }
 }
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let draftId: string | undefined;
   try {
-    const { id: draftId } = await params;
+    ({ id: draftId } = params);
 
     // Find the draft
     const draft = await prisma.draft.findUnique({
@@ -203,11 +201,7 @@ export async function DELETE(
       message: 'Draft schedule cancelled, draft started immediately',
     });
   } catch (error) {
-    logger.error('Failed to cancel draft schedule', {
-      draftId: (await params).id,
-      error: error instanceof Error ? error.message : String(error),
-    });
-
+    logger.error('Failed to cancel draft schedule', error, { draftId });
     return errorResponse('Failed to cancel draft schedule', 500);
   }
 }

--- a/src/app/api/drafts/[id]/start/route.ts
+++ b/src/app/api/drafts/[id]/start/route.ts
@@ -13,9 +13,9 @@ import { logger } from '@/lib/logger';
 // POST /api/drafts/[draftId]/start - Start a draft
 export async function POST(
   request: NextRequest,
-  context: { params: Promise<{ id: string }> }
+  context: { params: { id: string } }
 ) {
-  const { id: draftId } = await context.params;
+  const { id: draftId } = context.params;
   
   try {
     logger.info('Starting draft via API', { draftId });
@@ -56,10 +56,7 @@ export async function POST(
     });
 
   } catch (error) {
-    logger.error('Failed to start draft via API', { 
-      draftId, 
-      error: error instanceof Error ? error.message : 'Unknown error'
-    });
+    logger.error('Failed to start draft via API', error, { draftId });
     
     const errorMessage = error instanceof Error ? error.message : 'Failed to start draft';
     const statusCode = errorMessage.includes('not found') ? 404 : 

--- a/src/app/api/drafts/[id]/watchlist/route.ts
+++ b/src/app/api/drafts/[id]/watchlist/route.ts
@@ -15,10 +15,11 @@ interface WatchlistRequest {
  */
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let draftId: string | undefined;
   try {
-    const { id: draftId } = await params;
+    ({ id: draftId } = params);
     const url = new URL(request.url);
     const memberId = url.searchParams.get('memberId');
 
@@ -30,11 +31,7 @@ export async function GET(
 
     return successResponse({ watchlist });
   } catch (error) {
-    logger.error('Failed to get watchlist', {
-      draftId: (await params).id,
-      error: error instanceof Error ? error.message : String(error),
-    });
-
+    logger.error('Failed to get watchlist', error, { draftId });
     return errorResponse('Failed to get watchlist', 500);
   }
 }
@@ -44,10 +41,11 @@ export async function GET(
  */
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let draftId: string | undefined;
   try {
-    const { id: draftId } = await params;
+    ({ id: draftId } = params);
     const body: WatchlistRequest = await request.json();
 
     if (!body.playerId || !body.memberId) {
@@ -64,11 +62,7 @@ export async function POST(
 
     return successResponse({ watchlistItem });
   } catch (error) {
-    logger.error('Failed to add to watchlist', {
-      draftId: (await params).id,
-      error: error instanceof Error ? error.message : String(error),
-    });
-
+    logger.error('Failed to add to watchlist', error, { draftId });
     return errorResponse('Failed to add to watchlist', 500);
   }
 }
@@ -78,10 +72,11 @@ export async function POST(
  */
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let draftId: string | undefined;
   try {
-    const { id: draftId } = await params;
+    ({ id: draftId } = params);
     const url = new URL(request.url);
     const memberId = url.searchParams.get('memberId');
     const playerId = url.searchParams.get('playerId');
@@ -94,11 +89,7 @@ export async function DELETE(
 
     return successResponse({ message: 'Player removed from watchlist' });
   } catch (error) {
-    logger.error('Failed to remove from watchlist', {
-      draftId: (await params).id,
-      error: error instanceof Error ? error.message : String(error),
-    });
-
+    logger.error('Failed to remove from watchlist', error, { draftId });
     return errorResponse('Failed to remove from watchlist', 500);
   }
 }

--- a/src/app/api/leagues/[id]/[id2]/roster/[userId]/route.ts
+++ b/src/app/api/leagues/[id]/[id2]/roster/[userId]/route.ts
@@ -5,8 +5,8 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string; id2: string; userId: string }> }) {
-  const { id, id2, userId } = await params;
+export async function GET(_req: NextRequest, { params }: { params: { id: string; id2: string; userId: string } }) {
+  const { id, id2, userId } = params;
   return NextResponse.json(
     { success: false, error: 'Not implemented', route: { id, id2, userId } },
     { status: 501 }

--- a/src/app/api/leagues/[id]/actions/[userId]/route.ts
+++ b/src/app/api/leagues/[id]/actions/[userId]/route.ts
@@ -7,10 +7,12 @@ import { ensureRosterTables } from '@/lib/ensureLobbyColumns';
 // GET /api/leagues/[id]/actions/[userId] - Get user's team actions
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string; userId: string }> }
+  { params }: { params: { id: string; userId: string } }
 ) {
+  let leagueId: string | undefined;
+  let userId: string | undefined;
   try {
-    const { id: leagueId, userId } = await params;
+    ({ id: leagueId, userId } = params);
 
     if (!leagueId || !userId) {
       return errorResponse('League ID and User ID are required', 400);
@@ -55,9 +57,7 @@ export async function GET(
     });
 
   } catch (error) {
-    logger.error('Failed to get team actions', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+    logger.error('Failed to get team actions', error, { leagueId, userId });
     return errorResponse('Failed to retrieve team actions', 500);
   }
 }
@@ -65,10 +65,12 @@ export async function GET(
 // POST /api/leagues/[id]/actions/[userId] - Create new team action
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string; userId: string }> }
+  { params }: { params: { id: string; userId: string } }
 ) {
+  let leagueId: string | undefined;
+  let userId: string | undefined;
   try {
-    const { id: leagueId, userId } = await params;
+    ({ id: leagueId, userId } = params);
     const body = await request.json();
 
     if (!leagueId || !userId) {
@@ -156,9 +158,7 @@ export async function POST(
     });
 
   } catch (error) {
-    logger.error('Failed to create team action', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+    logger.error('Failed to create team action', error, { leagueId, userId });
     return errorResponse('Failed to create team action', 500);
   }
 }

--- a/src/app/api/leagues/[id]/draft-settings/route.ts
+++ b/src/app/api/leagues/[id]/draft-settings/route.ts
@@ -5,10 +5,11 @@ import { logger } from '@/lib/logger';
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let id: string | undefined;
   try {
-    const { id } = await params;
+    ({ id } = params);
     const body = await request.json();
     
     if (!id) {
@@ -50,17 +51,18 @@ export async function PUT(
       data: body
     });
   } catch (error) {
-    logger.error('Error updating draft settings:', error);
+    logger.error('Error updating draft settings:', error, { leagueId: id });
     return NextResponse.json({ error: 'Failed to update draft settings' }, { status: 500 });
   }
 }
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let id: string | undefined;
   try {
-    const { id } = await params;
+    ({ id } = params);
     
     if (!id) {
       return NextResponse.json({ error: 'League ID is required' }, { status: 400 });
@@ -100,7 +102,7 @@ export async function GET(
       data: draftSettings
     });
   } catch (error) {
-    logger.error('Error fetching draft settings:', error);
+    logger.error('Error fetching draft settings:', error, { leagueId: id });
     return NextResponse.json({ error: 'Failed to fetch draft settings' }, { status: 500 });
   }
 }

--- a/src/app/api/leagues/[id]/draft/route.ts
+++ b/src/app/api/leagues/[id]/draft/route.ts
@@ -4,13 +4,13 @@ import { adminDb } from '@/lib/firebaseAdmin';
 import { FieldValue } from 'firebase-admin/firestore';
 
 interface DraftPageProps {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 // GET /api/leagues/[id]/draft - Get or create draft for league
 export async function GET(_req: NextRequest, { params }: DraftPageProps): Promise<NextResponse> {
   try {
-    const { id: leagueId } = await params;
+    const { id: leagueId } = params;
 
     // Development shortcut: support test league without requiring Firestore
     if (leagueId === 'test-league-id') {
@@ -93,7 +93,7 @@ export async function GET(_req: NextRequest, { params }: DraftPageProps): Promis
 // POST /api/leagues/[id]/draft - Create draft for league
 export async function POST(req: NextRequest, { params }: DraftPageProps): Promise<NextResponse> {
   try {
-    const { id: leagueId } = await params;
+    const { id: leagueId } = params;
     
     let body: Partial<{
       name: string;

--- a/src/app/api/leagues/[id]/link-draft/route.ts
+++ b/src/app/api/leagues/[id]/link-draft/route.ts
@@ -10,10 +10,11 @@ interface LinkDraftRequest {
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let leagueId: string | undefined;
   try {
-    const { id: leagueId } = await params;
+    ({ id: leagueId } = params);
     const body: LinkDraftRequest = await request.json();
 
     // Dev shortcut for test league: accept link without DB writes
@@ -88,14 +89,7 @@ export async function POST(
     });
 
   } catch (error) {
-    logger.error('Failed to link league to draft', {
-      leagueId: (await params).id,
-      error: error instanceof Error ? error.message : 'Unknown error',
-    });
-
-    return errorResponse(
-      'Failed to link league to draft',
-      500
-    );
+    logger.error('Failed to link league to draft', error, { leagueId });
+    return errorResponse('Failed to link league to draft', 500);
   }
 }

--- a/src/app/api/leagues/[id]/members/route.ts
+++ b/src/app/api/leagues/[id]/members/route.ts
@@ -8,8 +8,8 @@ import { Timestamp } from 'firebase-admin/firestore';
 import { getUserIdFromRequest } from '@/lib/serverAuth';
 
 // GET /api/leagues/[id]/members - Get league members
-export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const { id: leagueId } = await params;
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const { id: leagueId } = params;
   const tracer = withRequestTracing(req, { endpoint: 'league-members', leagueId });
 
   try {
@@ -208,8 +208,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
 }
 
 // POST /api/leagues/[id]/members - Add member or update member settings
-export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const { id: leagueId } = await params;
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const { id: leagueId } = params;
   const tracer = withRequestTracing(req, { endpoint: 'league-member-action', leagueId });
 
   try {

--- a/src/app/api/leagues/[id]/players/route.ts
+++ b/src/app/api/leagues/[id]/players/route.ts
@@ -22,8 +22,8 @@ interface AvailableIndexDoc {
 }
 
 // GET /api/leagues/[id]/players?limit=100&cursor=<lastId>&team=XXX&position=YYY&owned=true|false
-export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const { id: leagueId } = await params;
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const { id: leagueId } = params;
 
   // AuthN + AuthZ: require authenticated user and league membership
   const userId = await getAuthenticatedUserId(req);

--- a/src/app/api/leagues/[id]/route.ts
+++ b/src/app/api/leagues/[id]/route.ts
@@ -7,9 +7,10 @@ import { logger } from '@/lib/logger';
 import type { League, LeagueMember } from '@/types/leagues';
 
 // GET /api/leagues/[id] - Get specific league details
-export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  let leagueId: string | undefined;
   try {
-    const { id: leagueId } = await params;
+    ({ id: leagueId } = params);
 
     // First try to get from Prisma database
     const prismaLeague = await prisma.league.findUnique({
@@ -255,13 +256,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       { headers: { 'Cache-Control': 'public, max-age=0, s-maxage=120, stale-while-revalidate=60' } }
     );
   } catch (error) {
-    logger.error('Failed to fetch league', {
-      error: {
-        name: error instanceof Error ? error.name : 'Unknown',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-    });
+    logger.error('Failed to fetch league', error, { leagueId });
     return NextResponse.json(
       { success: false, error: 'Failed to fetch league details' },
       { status: 500 }

--- a/src/app/api/leagues/[id]/sync-draft-results/route.ts
+++ b/src/app/api/leagues/[id]/sync-draft-results/route.ts
@@ -29,11 +29,13 @@ interface SyncDraftResultsRequest {
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let leagueId: string | undefined;
+  let body: SyncDraftResultsRequest | undefined;
   try {
-    const { id: leagueId } = await params;
-    const body: SyncDraftResultsRequest = await request.json();
+    ({ id: leagueId } = params);
+    body = await request.json();
 
     if (!body.draftId?.trim()) {
       return errorResponse('Draft ID is required', 400);
@@ -195,15 +197,10 @@ export async function POST(
     });
 
   } catch (error) {
-    logger.error('Failed to sync draft results to league', {
-      leagueId: (await params).id,
-      draftId: (await request.json()).draftId,
-      error: error instanceof Error ? error.message : 'Unknown error',
+    logger.error('Failed to sync draft results to league', error, {
+      leagueId,
+      draftId: body?.draftId,
     });
-
-    return errorResponse(
-      'Failed to sync draft results',
-      500
-    );
+    return errorResponse('Failed to sync draft results', 500);
   }
 }

--- a/src/app/api/leagues/[id]/waivers/cancel/route.ts
+++ b/src/app/api/leagues/[id]/waivers/cancel/route.ts
@@ -23,10 +23,11 @@ interface WaiverClaimData {
 
 export const POST = withMetrics(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) => {
+  let leagueId: string | undefined;
   try {
-    const { id: leagueId } = await params;
+    ({ id: leagueId } = params);
 
     // AuthN
     const callerId = await getAuthenticatedUserId(req);

--- a/src/app/api/leagues/[id]/waivers/process/route.ts
+++ b/src/app/api/leagues/[id]/waivers/process/route.ts
@@ -41,8 +41,8 @@ interface RosterDoc {
   updatedAt?: FirebaseFirestore.Timestamp | Date;
 }
 
-export const POST = withMetrics(async (req: NextRequest, { params }: { params: Promise<{ id: string }> }) => {
-  const { id: leagueId } = await params;
+export const POST = withMetrics(async (req: NextRequest, { params }: { params: { id: string } }) => {
+  const { id: leagueId } = params;
   try {
     // Stronger auth: verify Firebase ID token from Authorization header or session
     const userId = await getAuthenticatedUserId(req);

--- a/src/app/api/leagues/[id]/waivers/submit/route.ts
+++ b/src/app/api/leagues/[id]/waivers/submit/route.ts
@@ -17,9 +17,9 @@ interface WaiverSettings {
   minimumBid?: number;
 }
 
-export const POST = withMetrics(async (req: NextRequest, context: { params: Promise<{ id: string }> }) => {
+export const POST = withMetrics(async (req: NextRequest, context: { params: { id: string } }) => {
   try {
-    const { id: leagueId } = await context.params;
+    const { id: leagueId } = context.params;
     if (!leagueId) return NextResponse.json({ error: 'Missing leagueId' }, { status: 400 });
 
     const userId = await getAuthenticatedUserId(req);

--- a/src/app/api/leagues/user/[userId]/route.ts
+++ b/src/app/api/leagues/user/[userId]/route.ts
@@ -6,10 +6,11 @@ import { logger } from '@/lib/logger';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ userId: string }> }
+  { params }: { params: { userId: string } }
 ) {
+  let userId: string | undefined;
   try {
-    const { userId } = await params;
+    ({ userId } = params);
 
     if (!userId) {
       return NextResponse.json({ 
@@ -130,11 +131,11 @@ export async function GET(
       leagues: leagues
     });
   } catch (error) {
-    logger.error('Error fetching user league memberships:', error);
-    return NextResponse.json({ 
-      success: false, 
-      leagues: [], 
-      error: 'Failed to fetch user league memberships' 
+    logger.error('Error fetching user league memberships:', error, { userId });
+    return NextResponse.json({
+      success: false,
+      leagues: [],
+      error: 'Failed to fetch user league memberships'
     }, { status: 500 });
   }
 }

--- a/src/app/api/players/[id]/matches/route.ts
+++ b/src/app/api/players/[id]/matches/route.ts
@@ -6,9 +6,10 @@ import { logger } from '@/lib/logger';
 import { commonErrors, successResponse } from '@/lib/apiResponse';
 import { calculateTotalValue, type PlayerStats } from '@/types/fantasyCategories';
 
-export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  let id: string | undefined;
   try {
-    const { id } = await params;
+    ({ id } = params);
     
     console.log(`🔍 Fetching matches for player: ${id}`);
     
@@ -105,7 +106,6 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     console.log(`✅ Returning ${matches.length} matches for ${id}`);
     return successResponse(matches);
   } catch (error) {
-    const { id } = await params;
     logger.error('Failed to fetch player matches', error, { playerId: id });
     return commonErrors.internalServerError('Failed to fetch player matches');
   }

--- a/src/app/api/players/[id]/stats/route.ts
+++ b/src/app/api/players/[id]/stats/route.ts
@@ -7,8 +7,9 @@ import { commonErrors, successResponse } from '@/lib/apiResponse';
 import { calculateTotalValue, type PlayerStats } from '@/types/fantasyCategories';
 
 export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  let id: string | undefined;
   try {
-    const { id } = params;
+    ({ id } = params);
     
     console.log(`🔍 Fetching stats for player: ${id}`);
     
@@ -179,7 +180,6 @@ export async function GET(_request: NextRequest, { params }: { params: { id: str
     console.log(`✅ Returning aggregated stats for ${id}: ${totalGames} games, avg score ${playerStats.averageScore}`);
     return successResponse(playerStats);
   } catch (error) {
-    const { id } = await params;
     logger.error('Failed to fetch player stats', error, { playerId: id });
     return commonErrors.internalServerError('Failed to fetch player stats');
   }

--- a/src/app/api/user/leagues/[id]/settings/route.ts
+++ b/src/app/api/user/leagues/[id]/settings/route.ts
@@ -14,10 +14,11 @@ import { logger } from '@/lib/logger';
  */
 export async function PUT(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let leagueId: string | undefined;
   try {
-    const { id: leagueId } = await params;
+    ({ id: leagueId } = params);
     const body = await request.json();
     const { userId, settings } = body;
     
@@ -49,7 +50,7 @@ export async function PUT(
 
     return NextResponse.json({ settings: updatedSettings }, { status: 200 });
   } catch (error) {
-    logger.error('API: Failed to update league settings', { error });
+    logger.error('API: Failed to update league settings', error, { leagueId });
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }
@@ -63,10 +64,11 @@ export async function PUT(
  */
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
+  let leagueId: string | undefined;
   try {
-    const { id: leagueId } = await params;
+    ({ id: leagueId } = params);
     const { searchParams } = new URL(request.url);
     const userId = searchParams.get('userId');
     
@@ -107,7 +109,7 @@ export async function GET(
       }
     }, { status: 200 });
   } catch (error) {
-    logger.error('API: Failed to get league settings', { error });
+    logger.error('API: Failed to get league settings', error, { leagueId });
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/src/app/api/user/profile/[userId]/route.ts
+++ b/src/app/api/user/profile/[userId]/route.ts
@@ -14,10 +14,11 @@ import { logger } from '@/lib/logger';
  */
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ userId: string }> }
+  { params }: { params: { userId: string } }
 ) {
+  let userId: string | undefined;
   try {
-    const { userId } = await params;
+    ({ userId } = params);
     
     if (!userId) {
       return NextResponse.json(
@@ -39,7 +40,7 @@ export async function GET(
 
     return NextResponse.json({ profile }, { status: 200 });
   } catch (error) {
-    logger.error('API: Failed to get user profile', { error });
+    logger.error('API: Failed to get user profile', error, { userId });
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }
@@ -53,10 +54,11 @@ export async function GET(
  */
 export async function PUT(
   request: NextRequest,
-  { params }: { params: Promise<{ userId: string }> }
+  { params }: { params: { userId: string } }
 ) {
+  let userId: string | undefined;
   try {
-    const { userId } = await params;
+    ({ userId } = params);
     const updates = await request.json();
     
     if (!userId) {
@@ -72,7 +74,7 @@ export async function PUT(
 
     return NextResponse.json({ profile: updatedProfile }, { status: 200 });
   } catch (error) {
-    logger.error('API: Failed to update user profile', { error });
+    logger.error('API: Failed to update user profile', error, { userId });
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/src/app/api/user/watchlists/route.ts
+++ b/src/app/api/user/watchlists/route.ts
@@ -56,10 +56,11 @@ export async function POST(request: NextRequest) {
  */
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ userId: string }> }
+  { params }: { params: { userId: string } }
 ) {
+  let userId: string | undefined;
   try {
-    const { userId } = await params;
+    ({ userId } = params);
     const { searchParams } = new URL(request.url);
     const leagueId = searchParams.get('leagueId');
     
@@ -89,7 +90,7 @@ export async function GET(
 
     return NextResponse.json({ watchlists }, { status: 200 });
   } catch (error) {
-    logger.error('API: Failed to get user watchlists', { error });
+    logger.error('API: Failed to get user watchlists', error, { userId });
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }


### PR DESCRIPTION
## Summary
- refactor lobby route with param validation and structured error logging
- standardize params handling and logger usage across API routes
- fix ESLint flat config by removing nested plugin/rules block

## Testing
- `npm test`
- `npm run lint` *(fails: 67 errors, 661 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68b4653f2fbc832b81f17269fe006c80