### PR TITLE
fix: isolate onboarding storage per user

### DIFF
--- a/src/app/leagues/[id]/OnboardingChecklist.tsx
+++ b/src/app/leagues/[id]/OnboardingChecklist.tsx
@@ -29,16 +29,26 @@ export default function OnboardingChecklist({ member }: Props) {
         completed: false,
       },
     ];
-    const saved = localStorage.getItem('league-onboarding');
-    if (saved) {
+
+    const leagueId = member?.leagueId;
+    const userId = member?.userId ?? 'anon';
+    if (leagueId) {
+      const storageKey = `league-onboarding:${leagueId}:${userId}`;
       try {
-        const parsed = JSON.parse(saved) as Record<string, Task[]>;
-        setTasks(parsed[member?.leagueId ?? ''] ?? initial);
-        return;
-      } catch {
-        // ignore
+        const saved = localStorage.getItem(storageKey);
+        if (saved) {
+          setTasks(JSON.parse(saved) as Task[]);
+          return;
+        }
+      } catch (err) {
+        console.warn(
+          'Failed to parse onboarding tasks from localStorage',
+          err
+        );
+        localStorage.removeItem(storageKey);
       }
     }
+
     setTasks(initial);
   }, [member]);
 
@@ -67,14 +77,14 @@ export default function OnboardingChecklist({ member }: Props) {
         {tasks.map((task) => (
           <li key={task.id} className="flex items-center">
             <input
-              id={task.id}
+              id={`${member.leagueId}-${task.id}`}
               type="checkbox"
               checked={task.completed}
               onChange={() => toggle(task.id)}
               className="mr-2 h-4 w-4"
             />
             <label
-              htmlFor={task.id}
+              htmlFor={`${member.leagueId}-${task.id}`}
               className={task.completed ? 'line-through text-gray-500' : ''}
             >
               {task.label}


### PR DESCRIPTION
## Summary
- scope onboarding checklist localStorage per league and user
- warn and reset when stored data can't be parsed
- ensure checklist checkbox IDs are unique per league

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b4731d27b4832bb7b1ef5a596eb4d5