### PR TITLE
fix: isolate onboarding checklist storage per user

### DIFF
--- a/src/app/leagues/[id]/OnboardingChecklist.tsx
+++ b/src/app/leagues/[id]/OnboardingChecklist.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { LeagueMember } from '@/types/leagues';
 
 interface Task {
@@ -15,6 +15,11 @@ interface Props {
 
 export default function OnboardingChecklist({ member }: Props) {
   const [tasks, setTasks] = useState<Task[]>([]);
+  const latestMemberRef = useRef<LeagueMember | undefined>(member);
+
+  useEffect(() => {
+    latestMemberRef.current = member;
+  }, [member]);
 
   useEffect(() => {
     const initial: Task[] = [
@@ -29,28 +34,31 @@ export default function OnboardingChecklist({ member }: Props) {
         completed: false,
       },
     ];
-    const saved = localStorage.getItem('league-onboarding');
-    if (saved) {
+    if (member) {
+      const storageKey = `league-onboarding:${member.leagueId}:${member.userId}`;
       try {
-        const parsed = JSON.parse(saved) as Record<string, Task[]>;
-        setTasks(parsed[member?.leagueId ?? ''] ?? initial);
-        return;
-      } catch {
-        // ignore
+        const saved = localStorage.getItem(storageKey);
+        if (saved) {
+          setTasks(JSON.parse(saved) as Task[]);
+          return;
+        }
+      } catch (error) {
+        console.error('Failed to parse onboarding tasks from localStorage:', error);
       }
     }
     setTasks(initial);
   }, [member]);
 
   useEffect(() => {
-    if (!member) return;
-    const storageKey = `league-onboarding:${member.leagueId}:${member.userId}`;
+    const m = latestMemberRef.current;
+    if (!m) return;
+    const storageKey = `league-onboarding:${m.leagueId}:${m.userId}`;
     try {
       localStorage.setItem(storageKey, JSON.stringify(tasks));
-    } catch {
-      // ignore quota errors
+    } catch (error) {
+      console.warn('Failed to save onboarding tasks to localStorage:', error);
     }
-  }, [tasks, member]);
+  }, [tasks]);
 
   const toggle = (id: string) => {
     setTasks((prev) =>
@@ -67,14 +75,14 @@ export default function OnboardingChecklist({ member }: Props) {
         {tasks.map((task) => (
           <li key={task.id} className="flex items-center">
             <input
-              id={task.id}
+              id={`${member.leagueId}-${task.id}`}
               type="checkbox"
               checked={task.completed}
               onChange={() => toggle(task.id)}
               className="mr-2 h-4 w-4"
             />
             <label
-              htmlFor={task.id}
+              htmlFor={`${member.leagueId}-${task.id}`}
               className={task.completed ? 'line-through text-gray-500' : ''}
             >
               {task.label}


### PR DESCRIPTION
## Summary
- key onboarding checklist state by league and user with safe parsing
- fix race condition when saving tasks and log errors
- ensure checklist checkbox ids are unique per league

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b47380da54832b95d2461c428ea7a0