### PR TITLE
fix: paginate player fetch and debounce autosave

### DIFF
--- a/src/components/draft/DraftLobby.tsx
+++ b/src/components/draft/DraftLobby.tsx
@@ -58,8 +58,10 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draftId, memberId, forcedLobbyState]);
 
-  // Fetch all players on component mount
+  // Fetch all players and preferences when draft or member changes
   useEffect(() => {
+    setPreferencesLoaded(false);
+    initialSave.current = true;
     fetchAllPlayers();
     void loadSavedPreferences();
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -115,16 +117,27 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
 
   const fetchAllPlayers = useCallback(async () => {
     try {
-      // Request a large limit to ensure we receive the full player list
-      const response = await fetch('/api/players?limit=1000');
-      if (response.ok) {
-        const data = await response.json();
-        setAllPlayers(data.players || []);
-
-        // Initialize player order if not already set
-        if (playerOrder.length === 0) {
-          setPlayerOrder(data.players?.map((p: Player) => p.id) || []);
+      const players: Player[] = [];
+      let page = 1;
+      let total = Infinity;
+      while (players.length < total) {
+        const response = await fetch(`/api/players?limit=1000&page=${page}`);
+        if (!response.ok) {
+          console.error('Failed to fetch players:', response.statusText);
+          break;
         }
+        const data = await response.json();
+        const fetched = data.players || [];
+        players.push(...fetched);
+        total = data.total ?? players.length;
+        if (players.length >= total || fetched.length === 0) break;
+        page++;
+      }
+      setAllPlayers(players);
+
+      // Initialize player order if not already set
+      if (playerOrder.length === 0) {
+        setPlayerOrder(players.map((p: Player) => p.id));
       }
     } catch (err) {
       console.error('Failed to fetch players:', err);
@@ -235,7 +248,12 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
       initialSave.current = false;
       return;
     }
-    savePreferences();
+    const timer = setTimeout(() => {
+      savePreferences();
+    }, 1000);
+    return () => {
+      clearTimeout(timer);
+    };
   }, [savePreferences, preferencesLoaded]);
 
   const formatTime = (seconds: number): string => {


### PR DESCRIPTION
## Summary
- fetch players with pagination instead of hard limit
- reset and debounce autosave when draft or member changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b471de43c0832b8d5ebaf7ff0b18c8