### PR TITLE
feat: add invite link improvements and onboarding

### DIFF
--- a/src/app/api/leagues/join/route.ts
+++ b/src/app/api/leagues/join/route.ts
@@ -5,6 +5,7 @@ import { adminDb } from '@/lib/firebaseAdmin';
 import { commonErrors } from '@/lib/apiResponse';
 import type { JoinLeagueRequest, League, LeagueMember } from '@/types/leagues';
 import { generateDeterministicMemberId } from '@/utils/firestore';
+import { Timestamp } from 'firebase-admin/firestore';
 
 export const runtime = 'nodejs';
 
@@ -33,18 +34,19 @@ export async function POST(req: NextRequest) {
       console.log('🧪 Using test mode for code 123ABC');
       
       // Create a mock league for testing
-      const testLeague = {
-        id: 'test-league-id',
-        name: 'Test AFL Champions League',
-        code: '123ABC',
-        type: 'public',
-        ownerId: 'test-owner',
-        maxTeams: 12,
-        status: 'preseason',
-        categories: ['disposals', 'goals', 'marks', 'tackles', 'inside_50s'],
-        createdAt: new Date().toISOString(),
-        draftDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
-      };
+        const SEVEN_DAYS_IN_MS = 7 * 24 * 60 * 60 * 1000;
+        const testLeague = {
+          id: 'test-league-id',
+          name: 'Test AFL Champions League',
+          code: '123ABC',
+          type: 'public',
+          ownerId: 'test-owner',
+          maxTeams: 12,
+          status: 'preseason',
+          categories: ['disposals', 'goals', 'marks', 'tackles', 'inside_50s'],
+          createdAt: Timestamp.now(),
+          draftDate: new Date(Date.now() + SEVEN_DAYS_IN_MS).toISOString(),
+        };
 
       // Check if user is already a member (simulate check)
       console.log('✅ Test league found, proceeding with join...');

--- a/src/app/leagues/[id]/LeaguePageClient.tsx
+++ b/src/app/leagues/[id]/LeaguePageClient.tsx
@@ -5,7 +5,7 @@ import { AppLayout } from '@/components/navigation';
 import { LoadingSpinner, Alert } from '@/components/ui';
 import LeagueOverview from '@/components/league/LeagueOverview';
 import type { League, LeagueMember } from '@/types/leagues';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import OnboardingChecklist from './OnboardingChecklist';
 
 interface Props {
@@ -118,13 +118,16 @@ export default function LeaguePageClient({ league, members, leagueId, errorMsg }
     );
   }
 
-  const currentMember = curMembers.find((m) => m.userId === user?.uid);
+  const currentMember = useMemo(
+    () => curMembers.find((m) => m.userId === user?.uid),
+    [curMembers, user?.uid],
+  );
 
   return (
     <AppLayout>
       <div>
         <h1 className="text-3xl font-bold mb-6">{curLeague.name}</h1>
-        <OnboardingChecklist member={currentMember} />
+        <OnboardingChecklist key={curLeague.id} member={currentMember} />
         {process.env.NODE_ENV === 'development' && (
           <div className="mb-4 p-4 bg-gray-100 rounded text-sm">
             <p><strong>Debug Info:</strong></p>

--- a/src/app/leagues/[id]/OnboardingChecklist.tsx
+++ b/src/app/leagues/[id]/OnboardingChecklist.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import type { LeagueMember } from '@/types/leagues';
 
 interface Task {
@@ -15,6 +15,10 @@ interface Props {
 
 export default function OnboardingChecklist({ member }: Props) {
   const [tasks, setTasks] = useState<Task[]>([]);
+  const memberRef = useRef(member);
+  useEffect(() => {
+    memberRef.current = member;
+  }, [member]);
 
   useEffect(() => {
     const initial: Task[] = [
@@ -29,28 +33,35 @@ export default function OnboardingChecklist({ member }: Props) {
         completed: false,
       },
     ];
-    const saved = localStorage.getItem('league-onboarding');
-    if (saved) {
-      try {
-        const parsed = JSON.parse(saved) as Record<string, Task[]>;
-        setTasks(parsed[member?.leagueId ?? ''] ?? initial);
+    if (!member) {
+      setTasks(initial);
+      return;
+    }
+    const leagueId = member.leagueId;
+    const userId = member.userId || 'anon';
+    const storageKey = `league-onboarding:${leagueId}:${userId}`;
+    try {
+      const saved = localStorage.getItem(storageKey);
+      if (saved) {
+        setTasks(JSON.parse(saved) as Task[]);
         return;
-      } catch {
-        // ignore
       }
+    } catch (error) {
+      console.error('Failed to parse onboarding tasks from localStorage:', error);
     }
     setTasks(initial);
   }, [member]);
 
   useEffect(() => {
-    if (!member) return;
-    const storageKey = `league-onboarding:${member.leagueId}:${member.userId}`;
+    const m = memberRef.current;
+    if (!m) return;
+    const storageKey = `league-onboarding:${m.leagueId}:${m.userId}`;
     try {
       localStorage.setItem(storageKey, JSON.stringify(tasks));
     } catch {
       // ignore quota errors
     }
-  }, [tasks, member]);
+  }, [tasks]);
 
   const toggle = (id: string) => {
     setTasks((prev) =>
@@ -67,14 +78,14 @@ export default function OnboardingChecklist({ member }: Props) {
         {tasks.map((task) => (
           <li key={task.id} className="flex items-center">
             <input
-              id={task.id}
+              id={`${member.leagueId}-${task.id}`}
               type="checkbox"
               checked={task.completed}
               onChange={() => toggle(task.id)}
               className="mr-2 h-4 w-4"
             />
             <label
-              htmlFor={task.id}
+              htmlFor={`${member.leagueId}-${task.id}`}
               className={task.completed ? 'line-through text-gray-500' : ''}
             >
               {task.label}

--- a/src/app/leagues/join/page.tsx
+++ b/src/app/leagues/join/page.tsx
@@ -56,14 +56,18 @@ export default function JoinLeaguePage() {
         method: 'POST',
         body: JSON.stringify({
           code: code.trim().toUpperCase(),
-          teamName: teamName.trim() || undefined
+          teamName: teamName.trim() || undefined,
         }),
         headers: {
           'Content-Type': 'application/json',
-        }
+        },
       });
 
-      setJoinedLeague(result.data.league);
+      if (result?.success && result?.data?.league?.id && result?.data?.league?.name) {
+        setJoinedLeague(result.data.league);
+      } else {
+        throw new Error(result?.error || 'Unexpected response');
+      }
 
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to join league');
@@ -90,8 +94,28 @@ export default function JoinLeaguePage() {
 
   const handleAddToCalendar = () => {
     if (!joinedLeague?.draftDate) return;
-    const format = (date: string) => date.replace(/[-:]/g, '').split('.')[0] + 'Z';
-    const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Statly//EN\nBEGIN:VEVENT\nUID:${joinedLeague.id}-draft@statly\nDTSTAMP:${format(new Date().toISOString())}\nDTSTART:${format(joinedLeague.draftDate)}\nSUMMARY:${joinedLeague.name} Draft\nDESCRIPTION:Draft for ${joinedLeague.name}\nEND:VEVENT\nEND:VCALENDAR`;
+    const esc = (s: string) =>
+      s.replace(/([,;\\])/g, '\\$1').replace(/\r?\n/g, '\\n');
+    const format = (date: string) =>
+      date.replace(/[-:]/g, '').split('.')[0] + 'Z';
+    const start = format(joinedLeague.draftDate);
+    const dtstamp = format(new Date().toISOString());
+    const summary = `${esc(joinedLeague.name)} Draft`;
+    const description = `Draft for ${esc(joinedLeague.name)}`;
+    const lines = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//Statly//EN',
+      'BEGIN:VEVENT',
+      `UID:${joinedLeague.id}-draft@statly`,
+      `DTSTAMP:${dtstamp}`,
+      `DTSTART:${start}`,
+      `SUMMARY:${summary}`,
+      `DESCRIPTION:${description}`,
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ];
+    const ics = lines.join('\r\n');
     const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');

--- a/src/components/league/InviteModal.tsx
+++ b/src/components/league/InviteModal.tsx
@@ -13,8 +13,11 @@ export default function InviteModal({ league, isOpen, onClose }: InviteModalProp
   const [copied, setCopied] = useState(false);
   
   const joinUrl = useMemo(() => {
-    const base = typeof window !== 'undefined' ? window.location.origin : '';
-    return `${base}/leagues/join?code=${encodeURIComponent(league.code)}`;
+    if (typeof window === 'undefined') return '';
+    return new URL(
+      `/leagues/join?code=${encodeURIComponent(league.code)}`,
+      window.location.origin,
+    ).toString();
   }, [league.code]);
   
   const handleCopyCode = async () => {


### PR DESCRIPTION
## Summary
- validate join API response before updating UI and enhance ICS export
- align test league timestamps and improve invite URL construction
- memoize league member lookup and persist onboarding per user

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b47366400c832b90ccfe79d5f1b0d3