### PR TITLE
feat: add invite link improvements and onboarding

### DIFF
--- a/src/app/api/leagues/join/route.ts
+++ b/src/app/api/leagues/join/route.ts
@@ -32,6 +32,7 @@ export async function POST(req: NextRequest) {
     if (code.toUpperCase() === '123ABC') {
       console.log('🧪 Using test mode for code 123ABC');
       
+      const SEVEN_DAYS_IN_MS = 7 * 24 * 60 * 60 * 1000;
       // Create a mock league for testing
       const testLeague = {
         id: 'test-league-id',
@@ -43,7 +44,7 @@ export async function POST(req: NextRequest) {
         status: 'preseason',
         categories: ['disposals', 'goals', 'marks', 'tackles', 'inside_50s'],
         createdAt: new Date().toISOString(),
-        draftDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        draftDate: new Date(Date.now() + SEVEN_DAYS_IN_MS).toISOString(),
       };
 
       // Check if user is already a member (simulate check)

--- a/src/app/leagues/[id]/LeaguePageClient.tsx
+++ b/src/app/leagues/[id]/LeaguePageClient.tsx
@@ -5,7 +5,7 @@ import { AppLayout } from '@/components/navigation';
 import { LoadingSpinner, Alert } from '@/components/ui';
 import LeagueOverview from '@/components/league/LeagueOverview';
 import type { League, LeagueMember } from '@/types/leagues';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import OnboardingChecklist from './OnboardingChecklist';
 
 interface Props {
@@ -118,13 +118,16 @@ export default function LeaguePageClient({ league, members, leagueId, errorMsg }
     );
   }
 
-  const currentMember = curMembers.find((m) => m.userId === user?.uid);
+  const currentMember = useMemo(
+    () => curMembers.find((m) => m.userId === user?.uid),
+    [curMembers, user?.uid]
+  );
 
   return (
     <AppLayout>
       <div>
         <h1 className="text-3xl font-bold mb-6">{curLeague.name}</h1>
-        <OnboardingChecklist member={currentMember} />
+        <OnboardingChecklist key={curLeague.id} member={currentMember} />
         {process.env.NODE_ENV === 'development' && (
           <div className="mb-4 p-4 bg-gray-100 rounded text-sm">
             <p><strong>Debug Info:</strong></p>

--- a/src/app/leagues/[id]/OnboardingChecklist.tsx
+++ b/src/app/leagues/[id]/OnboardingChecklist.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import type { LeagueMember } from '@/types/leagues';
 
 interface Task {
@@ -15,6 +15,11 @@ interface Props {
 
 export default function OnboardingChecklist({ member }: Props) {
   const [tasks, setTasks] = useState<Task[]>([]);
+  const memberRef = useRef<LeagueMember | undefined>(member);
+
+  useEffect(() => {
+    memberRef.current = member;
+  }, [member]);
 
   useEffect(() => {
     const initial: Task[] = [
@@ -29,28 +34,33 @@ export default function OnboardingChecklist({ member }: Props) {
         completed: false,
       },
     ];
-    const saved = localStorage.getItem('league-onboarding');
-    if (saved) {
+    const leagueId = member?.leagueId;
+    const userId = member?.userId;
+    const storageKey = leagueId && userId ? `league-onboarding:${leagueId}:${userId}` : null;
+    if (storageKey) {
       try {
-        const parsed = JSON.parse(saved) as Record<string, Task[]>;
-        setTasks(parsed[member?.leagueId ?? ''] ?? initial);
-        return;
-      } catch {
-        // ignore
+        const saved = localStorage.getItem(storageKey);
+        if (saved) {
+          setTasks(JSON.parse(saved) as Task[]);
+          return;
+        }
+      } catch (error) {
+        console.error('Failed to parse onboarding tasks from localStorage:', error);
       }
     }
     setTasks(initial);
   }, [member]);
 
   useEffect(() => {
-    if (!member) return;
-    const storageKey = `league-onboarding:${member.leagueId}:${member.userId}`;
+    const m = memberRef.current;
+    if (!m) return;
+    const storageKey = `league-onboarding:${m.leagueId}:${m.userId}`;
     try {
       localStorage.setItem(storageKey, JSON.stringify(tasks));
     } catch {
       // ignore quota errors
     }
-  }, [tasks, member]);
+  }, [tasks]);
 
   const toggle = (id: string) => {
     setTasks((prev) =>
@@ -67,14 +77,14 @@ export default function OnboardingChecklist({ member }: Props) {
         {tasks.map((task) => (
           <li key={task.id} className="flex items-center">
             <input
-              id={task.id}
+              id={`${member.leagueId}-${task.id}`}
               type="checkbox"
               checked={task.completed}
               onChange={() => toggle(task.id)}
               className="mr-2 h-4 w-4"
             />
             <label
-              htmlFor={task.id}
+              htmlFor={`${member.leagueId}-${task.id}`}
               className={task.completed ? 'line-through text-gray-500' : ''}
             >
               {task.label}

--- a/src/app/leagues/join/page.tsx
+++ b/src/app/leagues/join/page.tsx
@@ -90,13 +90,38 @@ export default function JoinLeaguePage() {
 
   const handleAddToCalendar = () => {
     if (!joinedLeague?.draftDate) return;
-    const format = (date: string) => date.replace(/[-:]/g, '').split('.')[0] + 'Z';
-    const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Statly//EN\nBEGIN:VEVENT\nUID:${joinedLeague.id}-draft@statly\nDTSTAMP:${format(new Date().toISOString())}\nDTSTART:${format(joinedLeague.draftDate)}\nSUMMARY:${joinedLeague.name} Draft\nDESCRIPTION:Draft for ${joinedLeague.name}\nEND:VEVENT\nEND:VCALENDAR`;
+    const esc = (s: string) =>
+      s.replace(/([,;\\])/g, '\\$1').replace(/\r?\n/g, '\\n');
+    const format = (date: string) =>
+      date.replace(/[-:]/g, '').split('.')[0] + 'Z';
+    const start = format(joinedLeague.draftDate);
+    const end = format(
+      new Date(new Date(joinedLeague.draftDate).getTime() + 60 * 60 * 1000).toISOString()
+    );
+    const dtstamp = format(new Date().toISOString());
+    const summary = `${esc(joinedLeague.name)} Draft`;
+    const description = `Draft for ${esc(joinedLeague.name)}`;
+    const lines = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//Statly//EN',
+      'BEGIN:VEVENT',
+      `UID:${joinedLeague.id}-draft@statly`,
+      `DTSTAMP:${dtstamp}`,
+      `DTSTART:${start}`,
+      `DTEND:${end}`,
+      `SUMMARY:${summary}`,
+      `DESCRIPTION:${description}`,
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ];
+    const ics = lines.join('\r\n');
     const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = `${joinedLeague.name.replace(/\s+/g, '_')}_draft.ics`;
+    const filename = `${joinedLeague.name.replace(/[^a-zA-Z0-9_]/g, '_')}_draft.ics`;
+    link.download = filename;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);

--- a/src/components/league/InviteModal.tsx
+++ b/src/components/league/InviteModal.tsx
@@ -13,8 +13,15 @@ export default function InviteModal({ league, isOpen, onClose }: InviteModalProp
   const [copied, setCopied] = useState(false);
   
   const joinUrl = useMemo(() => {
-    const base = typeof window !== 'undefined' ? window.location.origin : '';
-    return `${base}/leagues/join?code=${encodeURIComponent(league.code)}`;
+    if (typeof window === 'undefined') return '';
+    try {
+      return new URL(
+        `/leagues/join?code=${encodeURIComponent(league.code)}`,
+        window.location.origin
+      ).toString();
+    } catch {
+      return '';
+    }
   }, [league.code]);
   
   const handleCopyCode = async () => {


### PR DESCRIPTION
## Summary
- escape calendar ICS fields and include DTEND for draft exports
- store onboarding tasks per-league/user with safer localStorage writes
- memoize member lookup and generate absolute invite links

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b4734eb3c8832bb76c9fedd693efb1