### PR TITLE
feat: add invite link improvements and onboarding

### DIFF
--- a/src/app/api/leagues/join/route.ts
+++ b/src/app/api/leagues/join/route.ts
@@ -3,7 +3,12 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { adminDb } from '@/lib/firebaseAdmin';
 import { commonErrors } from '@/lib/apiResponse';
-import type { JoinLeagueRequest, League, LeagueMember } from '@/types/leagues';
+import type {
+  JoinLeagueRequest,
+  League,
+  LeagueMember,
+  JoinedLeagueSummary,
+} from '@/types/leagues';
 import { generateDeterministicMemberId } from '@/utils/firestore';
 
 export const runtime = 'nodejs';
@@ -33,16 +38,12 @@ export async function POST(req: NextRequest) {
       console.log('🧪 Using test mode for code 123ABC');
       
       // Create a mock league for testing
-      const testLeague = {
+      const testLeague: JoinedLeagueSummary = {
         id: 'test-league-id',
         name: 'Test AFL Champions League',
         code: '123ABC',
         type: 'public',
-        ownerId: 'test-owner',
-        maxTeams: 12,
         status: 'preseason',
-        categories: ['disposals', 'goals', 'marks', 'tackles', 'inside_50s'],
-        createdAt: new Date().toISOString(),
         draftDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
       };
 
@@ -174,19 +175,21 @@ export async function POST(req: NextRequest) {
       ...newMember,
     };
 
+    const leagueSummary: JoinedLeagueSummary = {
+      id: league.id,
+      name: league.name,
+      code: league.code,
+      type: league.type,
+      status: league.status,
+      draftDate: league.draftDate,
+    };
+
     return NextResponse.json(
       {
         success: true,
         data: {
           member: createdMember,
-          league: {
-            id: league.id,
-            name: league.name,
-            code: league.code,
-            type: league.type,
-            status: league.status,
-            draftDate: league.draftDate,
-          },
+          league: leagueSummary,
         },
       },
       { status: 201 }

--- a/src/app/leagues/join/page.tsx
+++ b/src/app/leagues/join/page.tsx
@@ -8,17 +8,14 @@ import Button from '@/components/Button';
 import { LoadingSpinner } from '@/components/ui';
 import Link from 'next/link';
 import { AppLayout } from '@/components/navigation';
+import type { JoinedLeagueSummary } from '@/types/leagues';
 
 export default function JoinLeaguePage() {
   const [code, setCode] = useState('');
   const [teamName, setTeamName] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const [joinedLeague, setJoinedLeague] = useState<{
-    id: string;
-    name: string;
-    draftDate?: string;
-  } | null>(null);
+  const [joinedLeague, setJoinedLeague] = useState<JoinedLeagueSummary | null>(null);
   const { user } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/src/types/leagues.ts
+++ b/src/types/leagues.ts
@@ -81,6 +81,16 @@ export interface JoinLeagueRequest {
   teamName: string;
 }
 
+// League summary returned after joining
+export interface JoinedLeagueSummary {
+  id: string;
+  name: string;
+  code: string;
+  type: LeagueType;
+  status: LeagueStatus;
+  draftDate?: string;
+}
+
 // League Update Request (only editable fields)
 export interface UpdateLeagueRequest {
   name?: string;


### PR DESCRIPTION
## Summary
- extract JoinedLeagueSummary type for join flow
- use shared type in join page and join API response

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b473790eb8832b8ec6c8e2d4cd6d08