### PR TITLE
refactor: memoize current member and constantize draft offset

### DIFF
--- a/src/app/api/leagues/join/route.ts
+++ b/src/app/api/leagues/join/route.ts
@@ -8,6 +8,8 @@ import { generateDeterministicMemberId } from '@/utils/firestore';
 
 export const runtime = 'nodejs';
 
+const SEVEN_DAYS_IN_MS = 7 * 24 * 60 * 60 * 1000;
+
 // POST /api/leagues/join - Join league by code
 export async function POST(req: NextRequest) {
   const userId = await getUserIdFromRequest(req);
@@ -43,7 +45,7 @@ export async function POST(req: NextRequest) {
         status: 'preseason',
         categories: ['disposals', 'goals', 'marks', 'tackles', 'inside_50s'],
         createdAt: new Date().toISOString(),
-        draftDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        draftDate: new Date(Date.now() + SEVEN_DAYS_IN_MS).toISOString(),
       };
 
       // Check if user is already a member (simulate check)

--- a/src/app/leagues/[id]/LeaguePageClient.tsx
+++ b/src/app/leagues/[id]/LeaguePageClient.tsx
@@ -5,7 +5,7 @@ import { AppLayout } from '@/components/navigation';
 import { LoadingSpinner, Alert } from '@/components/ui';
 import LeagueOverview from '@/components/league/LeagueOverview';
 import type { League, LeagueMember } from '@/types/leagues';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import OnboardingChecklist from './OnboardingChecklist';
 
 interface Props {
@@ -118,13 +118,16 @@ export default function LeaguePageClient({ league, members, leagueId, errorMsg }
     );
   }
 
-  const currentMember = curMembers.find((m) => m.userId === user?.uid);
+  const currentMember = useMemo(
+    () => curMembers.find((m) => m.userId === user?.uid),
+    [curMembers, user?.uid]
+  );
 
   return (
     <AppLayout>
       <div>
         <h1 className="text-3xl font-bold mb-6">{curLeague.name}</h1>
-        <OnboardingChecklist member={currentMember} />
+        <OnboardingChecklist key={curLeague.id} member={currentMember} />
         {process.env.NODE_ENV === 'development' && (
           <div className="mb-4 p-4 bg-gray-100 rounded text-sm">
             <p><strong>Debug Info:</strong></p>


### PR DESCRIPTION
## Summary
- memoize currentMember lookup and reset onboarding checklist per league
- replace magic number for draftDate with SEVEN_DAYS_IN_MS constant

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b472facff0832b9eaed38db643aa8e