### PR TITLE
Persist draft rankings and add mock draft mode

### DIFF
--- a/src/components/draft/DraftLobby.tsx
+++ b/src/components/draft/DraftLobby.tsx
@@ -58,8 +58,11 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draftId, memberId, forcedLobbyState]);
 
-  // Fetch all players on component mount
+  // Fetch all players and preferences when draft/member change
   useEffect(() => {
+    // Reset autosave guard for new drafts/members
+    setPreferencesLoaded(false);
+    initialSave.current = true;
     fetchAllPlayers();
     void loadSavedPreferences();
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -115,16 +118,30 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
 
   const fetchAllPlayers = useCallback(async () => {
     try {
-      // Request a large limit to ensure we receive the full player list
-      const response = await fetch('/api/players?limit=1000');
-      if (response.ok) {
-        const data = await response.json();
-        setAllPlayers(data.players || []);
+      const players: Player[] = [];
+      let page = 1;
+      let hasMore = true;
 
-        // Initialize player order if not already set
-        if (playerOrder.length === 0) {
-          setPlayerOrder(data.players?.map((p: Player) => p.id) || []);
+      while (hasMore) {
+        const response = await fetch(`/api/players?limit=1000&page=${page}`);
+        if (!response.ok) break;
+
+        const data = await response.json();
+        const fetched = data.players || [];
+        players.push(...fetched);
+
+        if (players.length >= data.total || fetched.length === 0) {
+          hasMore = false;
+        } else {
+          page++;
         }
+      }
+
+      setAllPlayers(players);
+
+      // Initialize player order if not already set
+      if (playerOrder.length === 0) {
+        setPlayerOrder(players.map((p: Player) => p.id));
       }
     } catch (err) {
       console.error('Failed to fetch players:', err);
@@ -228,14 +245,17 @@ export default function DraftLobby({ draftId, memberId, onDraftStart, forcedLobb
     setMockDraftPicks(picks);
   }, [playerOrder, excludedPlayers, allPlayersById]);
 
-  // Auto-save preferences when they change (skip initial load)
+  // Auto-save preferences when they change (skip initial load and debounce)
   useEffect(() => {
     if (!preferencesLoaded) return;
     if (initialSave.current) {
       initialSave.current = false;
       return;
     }
-    savePreferences();
+    const timer = setTimeout(() => {
+      savePreferences();
+    }, 1000);
+    return () => clearTimeout(timer);
   }, [savePreferences, preferencesLoaded]);
 
   const formatTime = (seconds: number): string => {


### PR DESCRIPTION
## Summary
- reset autosave guard and reload preferences when switching drafts
- fetch all players via pagination instead of hardcoded limit
- debounce autosave calls to reduce API traffic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b471ce5f18832baeb470b43084a630