### PR TITLE
fix: align test league timestamps for join route

### DIFF
--- a/src/app/api/leagues/join/route.ts
+++ b/src/app/api/leagues/join/route.ts
@@ -5,8 +5,11 @@ import { adminDb } from '@/lib/firebaseAdmin';
 import { commonErrors } from '@/lib/apiResponse';
 import type { JoinLeagueRequest, League, LeagueMember } from '@/types/leagues';
 import { generateDeterministicMemberId } from '@/utils/firestore';
+import { Timestamp } from 'firebase-admin/firestore';
 
 export const runtime = 'nodejs';
+
+const SEVEN_DAYS_IN_MS = 7 * 24 * 60 * 60 * 1000;
 
 // POST /api/leagues/join - Join league by code
 export async function POST(req: NextRequest) {
@@ -42,8 +45,8 @@ export async function POST(req: NextRequest) {
         maxTeams: 12,
         status: 'preseason',
         categories: ['disposals', 'goals', 'marks', 'tackles', 'inside_50s'],
-        createdAt: new Date().toISOString(),
-        draftDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        createdAt: Timestamp.now(),
+        draftDate: new Date(Date.now() + SEVEN_DAYS_IN_MS).toISOString(),
       };
 
       // Check if user is already a member (simulate check)


### PR DESCRIPTION
## Summary
- use Firestore `Timestamp` for test-league `createdAt`
- extract `SEVEN_DAYS_IN_MS` constant for draft date calculation

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*


------
https://chatgpt.com/codex/tasks/task_e_68b472eddb78832ba557ec6f27869ad0