### PR TITLE
refactor: use absolute invite link and resilient onboarding

### DIFF
--- a/src/app/api/leagues/join/route.ts
+++ b/src/app/api/leagues/join/route.ts
@@ -8,6 +8,8 @@ import { generateDeterministicMemberId } from '@/utils/firestore';
 
 export const runtime = 'nodejs';
 
+const SEVEN_DAYS_IN_MS = 7 * 24 * 60 * 60 * 1000;
+
 // POST /api/leagues/join - Join league by code
 export async function POST(req: NextRequest) {
   const userId = await getUserIdFromRequest(req);
@@ -42,8 +44,9 @@ export async function POST(req: NextRequest) {
         maxTeams: 12,
         status: 'preseason',
         categories: ['disposals', 'goals', 'marks', 'tackles', 'inside_50s'],
+        // createdAt as ISO string for parity with production
         createdAt: new Date().toISOString(),
-        draftDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        draftDate: new Date(Date.now() + SEVEN_DAYS_IN_MS).toISOString(),
       };
 
       // Check if user is already a member (simulate check)

--- a/src/app/leagues/[id]/LeaguePageClient.tsx
+++ b/src/app/leagues/[id]/LeaguePageClient.tsx
@@ -5,7 +5,7 @@ import { AppLayout } from '@/components/navigation';
 import { LoadingSpinner, Alert } from '@/components/ui';
 import LeagueOverview from '@/components/league/LeagueOverview';
 import type { League, LeagueMember } from '@/types/leagues';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import OnboardingChecklist from './OnboardingChecklist';
 
 interface Props {
@@ -118,13 +118,16 @@ export default function LeaguePageClient({ league, members, leagueId, errorMsg }
     );
   }
 
-  const currentMember = curMembers.find((m) => m.userId === user?.uid);
+  const currentMember = useMemo(
+    () => curMembers.find((m) => m.userId === user?.uid),
+    [curMembers, user?.uid]
+  );
 
   return (
     <AppLayout>
       <div>
         <h1 className="text-3xl font-bold mb-6">{curLeague.name}</h1>
-        <OnboardingChecklist member={currentMember} />
+        <OnboardingChecklist key={curLeague.id} member={currentMember} />
         {process.env.NODE_ENV === 'development' && (
           <div className="mb-4 p-4 bg-gray-100 rounded text-sm">
             <p><strong>Debug Info:</strong></p>

--- a/src/app/leagues/[id]/OnboardingChecklist.tsx
+++ b/src/app/leagues/[id]/OnboardingChecklist.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import type { LeagueMember } from '@/types/leagues';
 
 interface Task {
@@ -15,13 +15,19 @@ interface Props {
 
 export default function OnboardingChecklist({ member }: Props) {
   const [tasks, setTasks] = useState<Task[]>([]);
+  const memberRef = useRef<LeagueMember | undefined>(member);
 
   useEffect(() => {
+    memberRef.current = member;
+    if (!member) {
+      setTasks([]);
+      return;
+    }
     const initial: Task[] = [
       {
         id: 'team-name',
         label: 'Set your team name',
-        completed: Boolean(member?.teamName),
+        completed: Boolean(member.teamName),
       },
       {
         id: 'review-rules',
@@ -29,28 +35,29 @@ export default function OnboardingChecklist({ member }: Props) {
         completed: false,
       },
     ];
-    const saved = localStorage.getItem('league-onboarding');
-    if (saved) {
-      try {
-        const parsed = JSON.parse(saved) as Record<string, Task[]>;
-        setTasks(parsed[member?.leagueId ?? ''] ?? initial);
+    const storageKey = `league-onboarding:${member.leagueId}:${member.userId}`;
+    try {
+      const saved = localStorage.getItem(storageKey);
+      if (saved) {
+        setTasks(JSON.parse(saved) as Task[]);
         return;
-      } catch {
-        // ignore
       }
+    } catch (error) {
+      console.error('Failed to parse onboarding tasks from localStorage:', error);
     }
     setTasks(initial);
   }, [member]);
 
   useEffect(() => {
-    if (!member) return;
-    const storageKey = `league-onboarding:${member.leagueId}:${member.userId}`;
+    const cur = memberRef.current;
+    if (!cur) return;
+    const storageKey = `league-onboarding:${cur.leagueId}:${cur.userId}`;
     try {
       localStorage.setItem(storageKey, JSON.stringify(tasks));
     } catch {
       // ignore quota errors
     }
-  }, [tasks, member]);
+  }, [tasks]);
 
   const toggle = (id: string) => {
     setTasks((prev) =>
@@ -67,14 +74,14 @@ export default function OnboardingChecklist({ member }: Props) {
         {tasks.map((task) => (
           <li key={task.id} className="flex items-center">
             <input
-              id={task.id}
+              id={`${member.leagueId}-${task.id}`}
               type="checkbox"
               checked={task.completed}
               onChange={() => toggle(task.id)}
               className="mr-2 h-4 w-4"
             />
             <label
-              htmlFor={task.id}
+              htmlFor={`${member.leagueId}-${task.id}`}
               className={task.completed ? 'line-through text-gray-500' : ''}
             >
               {task.label}

--- a/src/components/league/InviteModal.tsx
+++ b/src/components/league/InviteModal.tsx
@@ -13,8 +13,11 @@ export default function InviteModal({ league, isOpen, onClose }: InviteModalProp
   const [copied, setCopied] = useState(false);
   
   const joinUrl = useMemo(() => {
-    const base = typeof window !== 'undefined' ? window.location.origin : '';
-    return `${base}/leagues/join?code=${encodeURIComponent(league.code)}`;
+    if (typeof window === 'undefined') return '';
+    return new URL(
+      `/leagues/join?code=${encodeURIComponent(league.code)}`,
+      window.location.origin
+    ).toString();
   }, [league.code]);
   
   const handleCopyCode = async () => {


### PR DESCRIPTION
## Summary
- ensure invite link uses absolute URL with SSR-safe origin
- memoize league member lookup and reset onboarding per league
- persist onboarding tasks per user/league with error handling

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b4734508e0832b8314608da52420cb