### PR TITLE
refactor: centralize session cookie constant

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -108,6 +108,7 @@ export default [
     },
     plugins: {
       '@typescript-eslint': tsPlugin,
+      'jsx-a11y': a11yPlugin,
     },
     rules: {
       // TS recommended (type-aware)
@@ -127,24 +128,10 @@ export default [
       '@typescript-eslint/consistent-type-imports': 'warn',
       '@typescript-eslint/explicit-module-boundary-types': 'warn',
       '@typescript-eslint/no-floating-promises': ['warn', { ignoreVoid: true }],
-     plugins: {
-       '@typescript-eslint': tsPlugin,
-      'jsx-a11y': a11yPlugin,
-     },
-     rules: {
-       // TS recommended (type-aware)
-       ...tsPlugin.configs.recommended.rules,
- 
-       // Use TS instead of prop-types
-       'react/prop-types': 'off',
- 
-       // TS handles undefined vars; disabling avoids noise with types
-       'no-undef': 'off',
- 
-       // Hygiene
-       // Enable accessibility rule for table headers: ensure headers have valid scope
-       'jsx-a11y/scope': 'error',
-     },
+
+      // Enable accessibility rule for table headers: ensure headers have valid scope
+      'jsx-a11y/scope': 'error',
+
       // Keep velocity but still nudge away from `any`
       '@typescript-eslint/no-explicit-any': 'warn',
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
+import { SESSION_COOKIE_NAME } from '@/constants';
 
 // Example protected route enforcement placeholder.
 // If you move to server-verified Firebase sessions, replace the stub with real checks.
@@ -43,7 +44,7 @@ export async function middleware(req: NextRequest) {
   if (!isProtected) return NextResponse.next();
 
   // Read a session cookie set by server after verifying Firebase ID token
-  const session = req.cookies.get('statly_session');
+  const session = req.cookies.get(SESSION_COOKIE_NAME);
   if (!session) {
     url.pathname = '/login';
     url.searchParams.set('next', req.nextUrl.pathname + req.nextUrl.search);

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import { adminAuth } from '@/lib/firebaseAdmin';
-
-const COOKIE_NAME = 'statly_session';
+import { SESSION_COOKIE_NAME } from '@/constants';
 
 export async function POST(request: Request) {
   try {
@@ -17,7 +16,7 @@ export async function POST(request: Request) {
     const sessionCookie = await adminAuth.createSessionCookie(idToken, { expiresIn });
 
     const res = NextResponse.json({ ok: true, uid: decoded.uid });
-    res.cookies.set(COOKIE_NAME, sessionCookie, {
+    res.cookies.set(SESSION_COOKIE_NAME, sessionCookie, {
       httpOnly: true,
       secure: true,
       sameSite: 'lax',
@@ -34,7 +33,7 @@ export async function POST(request: Request) {
 export async function DELETE() {
   try {
     const res = NextResponse.json({ ok: true });
-    res.cookies.set(COOKIE_NAME, '', {
+    res.cookies.set(SESSION_COOKIE_NAME, '', {
       httpOnly: true,
       secure: true,
       sameSite: 'lax',

--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -1,4 +1,6 @@
-import type { NextRequest } from 'next/server';
+export const runtime = 'nodejs';
+
+import type { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { adminAuth } from '@/lib/firebaseAdmin';
 import { z } from 'zod';
@@ -7,8 +9,11 @@ import { logger } from '@/lib/logger';
 import { getLobbyState } from '@/lib/draftLobby';
 import { ensureLobbyColumns } from '@/lib/ensureLobbyColumns';
 import { registerHistogram, observeHistogram } from '@/server/metrics';
+import { SESSION_COOKIE_NAME } from '@/constants';
 
-registerHistogram('api_draft_lobby_get_duration_seconds', [
+const API_DRAFT_LOBBY_GET_DURATION_SECONDS = 'api_draft_lobby_get_duration_seconds';
+
+registerHistogram(API_DRAFT_LOBBY_GET_DURATION_SECONDS, [
   0.005,
   0.01,
   0.025,
@@ -25,21 +30,33 @@ registerHistogram('api_draft_lobby_get_duration_seconds', [
  * Get current lobby state
  */
 export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const start = Date.now();
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+): Promise<NextResponse> {
+  const startMs = Date.now();
+  let outcome: 'ok' | 'error' = 'ok';
+  let auth: 'noauth' | 'ok' | 'invauth' = 'noauth';
+  let draftId: string | undefined;
   try {
     const ParamsSchema = z.object({ id: z.string().min(1) });
-    const { id: draftId } = ParamsSchema.parse(await params);
+    const parsed = ParamsSchema.safeParse(params);
+    if (!parsed.success) {
+      outcome = 'error';
+      logger.warn('Invalid draft id', { issues: parsed.error.issues });
+      return errorResponse('Invalid draft id', 400);
+    }
+    draftId = parsed.data.id;
 
     // Attempt to verify session cookie; lobby data is still returned even if auth fails
     try {
-      const sessionCookie = (await cookies()).get('statly_session')?.value;
+      const cookieStore = await cookies();
+      const sessionCookie = cookieStore.get(SESSION_COOKIE_NAME)?.value;
       if (sessionCookie) {
         await adminAuth.verifySessionCookie(sessionCookie, true);
+        auth = 'ok';
       }
     } catch (authErr) {
+      auth = 'invauth';
       logger.debug('Lobby request auth verification failed', { error: authErr });
     }
 
@@ -55,27 +72,21 @@ export async function GET(
 
     logger.info('Lobby state retrieved', { draftId, status: lobbyState.status });
 
-    observeHistogram(
-      'api_draft_lobby_get_duration_seconds',
-      (Date.now() - start) / 1000
-    );
-
     return successResponse(lobbyState);
   } catch (error) {
-    observeHistogram(
-      'api_draft_lobby_get_duration_seconds',
-      (Date.now() - start) / 1000
-    );
-
+    outcome = 'error';
     logger.error('Failed to get lobby state', {
-      draftId: (await params).id,
+      draftId,
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
 
-    return errorResponse(
-      `Failed to get lobby state: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      500
+    return errorResponse('Failed to get lobby state', 500);
+  } finally {
+    observeHistogram(
+      API_DRAFT_LOBBY_GET_DURATION_SECONDS,
+      (Date.now() - startMs) / 1000,
+      { outcome, auth }
     );
   }
 }

--- a/src/app/api/drafts/[id]/pause/route.ts
+++ b/src/app/api/drafts/[id]/pause/route.ts
@@ -11,6 +11,7 @@ import { prisma } from '@/lib/prisma';
 import { DraftStatus } from '@prisma/client';
 import { cookies } from 'next/headers';
 import { adminAuth } from '@/lib/firebaseAdmin';
+import { SESSION_COOKIE_NAME } from '@/constants';
 import { getLiveDraftEngine } from '@/services/liveDraftEngine';
 import { revalidateTag } from 'next/cache';
 
@@ -27,7 +28,7 @@ export async function POST(request: NextRequest, context: { params: { id: string
   try {
     // Verify user authentication
     const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get('statly_session')?.value;
+    const sessionCookie = cookieStore.get(SESSION_COOKIE_NAME)?.value;
     
     if (!sessionCookie) {
       return errorResponse('Unauthorized', 401);

--- a/src/app/api/drafts/[id]/pick/route.ts
+++ b/src/app/api/drafts/[id]/pick/route.ts
@@ -9,6 +9,7 @@ import { revalidateTag } from 'next/cache';
 import { tags } from '@/lib/cacheTags';
 import { cookies } from 'next/headers';
 import { adminAuth } from '@/lib/firebaseAdmin';
+import { SESSION_COOKIE_NAME } from '@/constants';
 import { getLiveDraftEngine, type LiveDraftPick } from '@/services/liveDraftEngine';
 import { isValidLeagueId } from '@/lib/validation';
 
@@ -65,7 +66,7 @@ export async function POST(request: NextRequest, context: { params: { id: string
 
     // Derive user from server session cookie
     const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get('statly_session')?.value;
+    const sessionCookie = cookieStore.get(SESSION_COOKIE_NAME)?.value;
     requestContext.hasSessionCookie = Boolean(sessionCookie);
     if (!sessionCookie) {
       logger.warn('Draft pick request failed (unauthorized:missing_session)', {

--- a/src/app/api/drafts/[id]/resume/route.ts
+++ b/src/app/api/drafts/[id]/resume/route.ts
@@ -10,6 +10,7 @@ import { prisma } from '@/lib/prisma';
 import { DraftStatus } from '@prisma/client';
 import { cookies } from 'next/headers';
 import { adminAuth } from '@/lib/firebaseAdmin';
+import { SESSION_COOKIE_NAME } from '@/constants';
 import { getLiveDraftEngine } from '@/services/liveDraftEngine';
 import { revalidateTag } from 'next/cache';
 
@@ -26,7 +27,7 @@ export async function POST(request: NextRequest, context: { params: { id: string
   try {
     // Verify user authentication
     const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get('statly_session')?.value;
+    const sessionCookie = cookieStore.get(SESSION_COOKIE_NAME)?.value;
     
     if (!sessionCookie) {
       return errorResponse('Unauthorized', 401);

--- a/src/app/api/drafts/history/route.ts
+++ b/src/app/api/drafts/history/route.ts
@@ -4,6 +4,7 @@ import { logger } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
 import { cookies } from 'next/headers';
 import { adminAuth } from '@/lib/firebaseAdmin';
+import { SESSION_COOKIE_NAME } from '@/constants';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -13,7 +14,7 @@ export async function GET(request: NextRequest) {
   try {
     // Verify user authentication
     const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get('statly_session')?.value;
+    const sessionCookie = cookieStore.get(SESSION_COOKIE_NAME)?.value;
     
     if (!sessionCookie) {
       return errorResponse('Unauthorized', 401);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,7 @@
 // Shared application constants
 
+// Name of the Firebase session cookie
+export const SESSION_COOKIE_NAME = 'statly_session';
+
 // Default match UID used in demos and initial state
 export const DEFAULT_UID = '2025-R18-ADE-COL';

--- a/src/lib/serverAuth.ts
+++ b/src/lib/serverAuth.ts
@@ -1,10 +1,11 @@
 import type { NextRequest } from 'next/server';
 import { adminAuth } from '@/lib/firebaseAdmin';
+import { SESSION_COOKIE_NAME } from '@/constants';
 
 /**
  * Resolve the authenticated user id from the request.
  * - In development: trusts x-auth-user header injected by middleware (Bearer dev:<userId>)
- * - In production: verifies Firebase session cookie (statly_session)
+ * - In production: verifies Firebase session cookie (SESSION_COOKIE_NAME)
  */
 export async function getUserIdFromRequest(request: NextRequest): Promise<string | null> {
   if (process.env.NODE_ENV !== 'production') {
@@ -12,7 +13,7 @@ export async function getUserIdFromRequest(request: NextRequest): Promise<string
     if (devUser) return devUser;
   }
 
-  const sessionCookie = request.cookies.get('statly_session')?.value;
+  const sessionCookie = request.cookies.get(SESSION_COOKIE_NAME)?.value;
   if (!sessionCookie) return null;
 
   try {


### PR DESCRIPTION
## Summary
- define SESSION_COOKIE_NAME and replace hardcoded cookie lookups across APIs and middleware
- pin draft lobby route to Node runtime and capture auth/outcome labels for histogram metric
- straighten ESLint config structure for type-aware rules
- standardize lobby auth metric labels and await cookies() for type safety

## Testing
- `npx eslint src/app/api/drafts/[id]/lobby/route.ts`
- `npm run lint:ci` *(fails: Missing script)*
- `npm run typecheck` *(fails: Cannot find module '@/data/aflPlayers')*
- `npm run build` *(fails: Module not found '@/data/aflPlayers'; Server Actions must be async functions)*
- `npm run test:unit` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b436ebc944832b97103a4412a98546