### PR TITLE
feat: persist user rankings to file store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ buildinfo
 Statly.worktrees/**
 lint.config.js
 .eslintrc.js
+data/user-rankings.json

--- a/src/app/api/user/rankings/route.ts
+++ b/src/app/api/user/rankings/route.ts
@@ -1,25 +1,55 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
 
-// In-memory store for player ranking preferences
+interface RankingPreferences {
+  draftId: string;
+  memberId: string;
+  excludedPlayers: string[];
+  playerOrder: string[];
+  watchlist: unknown[];
+  preDraftQueue: unknown[];
+  timestamp: number;
+}
+
+// Persistent file-based store for player ranking preferences
 // Keyed by `${draftId}:${memberId}`
-const rankingStore = new Map<string, any>();
+const DATA_DIR = path.join(process.cwd(), 'data');
+const DATA_FILE = path.join(DATA_DIR, 'user-rankings.json');
+
+async function readStore(): Promise<Record<string, RankingPreferences>> {
+  try {
+    const raw = await fs.readFile(DATA_FILE, 'utf8');
+    return JSON.parse(raw) as Record<string, RankingPreferences>;
+  } catch {
+    return {};
+  }
+}
+
+async function writeStore(store: Record<string, RankingPreferences>) {
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  await fs.writeFile(DATA_FILE, JSON.stringify(store), 'utf8');
+}
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const draftId = searchParams.get('draftId') || '';
   const memberId = searchParams.get('memberId') || '';
   const key = `${draftId}:${memberId}`;
-  const data = rankingStore.get(key) || {};
+  const store = await readStore();
+  const data = store[key] || {};
   return NextResponse.json(data);
 }
 
 export async function POST(req: NextRequest) {
-  const body = await req.json();
+  const body = (await req.json()) as RankingPreferences;
   const { draftId, memberId } = body;
   if (!draftId || !memberId) {
     return NextResponse.json({ error: 'draftId and memberId required' }, { status: 400 });
   }
   const key = `${draftId}:${memberId}`;
-  rankingStore.set(key, body);
+  const store = await readStore();
+  store[key] = body;
+  await writeStore(store);
   return NextResponse.json({ success: true });
 }


### PR DESCRIPTION
## Summary
- replace in-memory ranking store with file-based persistence
- add RankingPreferences interface for strong typing
- ignore generated ranking data file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b431779b90832b89f6844b3477bf22