### PR TITLE
Persist user rankings and validate GET parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,7 @@ buildinfo
 .db
 Statly.worktrees/**
 lint.config.js
+
+# User ranking data
+data/user-rankings.json
 .eslintrc.js

--- a/src/app/api/user/rankings/route.ts
+++ b/src/app/api/user/rankings/route.ts
@@ -1,25 +1,58 @@
 import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs/promises';
+import path from 'path';
 
-// In-memory store for player ranking preferences
-// Keyed by `${draftId}:${memberId}`
-const rankingStore = new Map<string, any>();
+interface RankingPreferences {
+  draftId: string;
+  memberId: string;
+  excludedPlayers: string[];
+  playerOrder: string[];
+  watchlist: unknown[];
+  preDraftQueue: unknown[];
+  timestamp: number;
+}
+
+const dataFile = path.join(process.cwd(), 'data', 'user-rankings.json');
+
+async function readStore(): Promise<Record<string, RankingPreferences>> {
+  try {
+    const file = await fs.readFile(dataFile, 'utf-8');
+    return JSON.parse(file) as Record<string, RankingPreferences>;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {};
+    }
+    throw err;
+  }
+}
+
+async function writeStore(store: Record<string, RankingPreferences>) {
+  await fs.mkdir(path.dirname(dataFile), { recursive: true });
+  await fs.writeFile(dataFile, JSON.stringify(store, null, 2));
+}
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
-  const draftId = searchParams.get('draftId') || '';
-  const memberId = searchParams.get('memberId') || '';
+  const draftId = searchParams.get('draftId');
+  const memberId = searchParams.get('memberId');
+  if (!draftId || !memberId) {
+    return NextResponse.json({ error: 'draftId and memberId required' }, { status: 400 });
+  }
   const key = `${draftId}:${memberId}`;
-  const data = rankingStore.get(key) || {};
+  const store = await readStore();
+  const data = store[key] || {};
   return NextResponse.json(data);
 }
 
 export async function POST(req: NextRequest) {
-  const body = await req.json();
+  const body = (await req.json()) as RankingPreferences;
   const { draftId, memberId } = body;
   if (!draftId || !memberId) {
     return NextResponse.json({ error: 'draftId and memberId required' }, { status: 400 });
   }
   const key = `${draftId}:${memberId}`;
-  rankingStore.set(key, body);
+  const store = await readStore();
+  store[key] = body;
+  await writeStore(store);
   return NextResponse.json({ success: true });
 }


### PR DESCRIPTION
## Summary
- store user ranking preferences in a JSON file instead of memory for persistence
- validate `draftId` and `memberId` on rankings GET requests
- ignore generated `data/user-rankings.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b432494eb8832b8ee4ed596d918d42