### PR TITLE
refactor: reuse draftId in lobby error logging

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -108,6 +108,7 @@ export default [
     },
     plugins: {
       '@typescript-eslint': tsPlugin,
+      'jsx-a11y': a11yPlugin,
     },
     rules: {
       // TS recommended (type-aware)
@@ -127,24 +128,6 @@ export default [
       '@typescript-eslint/consistent-type-imports': 'warn',
       '@typescript-eslint/explicit-module-boundary-types': 'warn',
       '@typescript-eslint/no-floating-promises': ['warn', { ignoreVoid: true }],
-     plugins: {
-       '@typescript-eslint': tsPlugin,
-      'jsx-a11y': a11yPlugin,
-     },
-     rules: {
-       // TS recommended (type-aware)
-       ...tsPlugin.configs.recommended.rules,
- 
-       // Use TS instead of prop-types
-       'react/prop-types': 'off',
- 
-       // TS handles undefined vars; disabling avoids noise with types
-       'no-undef': 'off',
- 
-       // Hygiene
-       // Enable accessibility rule for table headers: ensure headers have valid scope
-       'jsx-a11y/scope': 'error',
-     },
       // Keep velocity but still nudge away from `any`
       '@typescript-eslint/no-explicit-any': 'warn',
 
@@ -153,6 +136,8 @@ export default [
         'warn',
         { checksVoidReturn: { attributes: false } },
       ],
+      // Enable accessibility rule for table headers: ensure headers have valid scope
+      'jsx-a11y/scope': 'error',
     },
   },
 

--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -1,3 +1,5 @@
+export const runtime = 'nodejs';
+
 import type { NextRequest } from 'next/server';
 import { cookies } from 'next/headers';
 import { adminAuth } from '@/lib/firebaseAdmin';
@@ -29,9 +31,11 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const start = Date.now();
+  let draftId: string | undefined;
   try {
     const ParamsSchema = z.object({ id: z.string().min(1) });
-    const { id: draftId } = ParamsSchema.parse(await params);
+    const parsedParams = ParamsSchema.parse(await params);
+    draftId = parsedParams.id;
 
     // Attempt to verify session cookie; lobby data is still returned even if auth fails
     try {
@@ -68,7 +72,7 @@ export async function GET(
     );
 
     logger.error('Failed to get lobby state', {
-      draftId: (await params).id,
+      draftId,
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });


### PR DESCRIPTION
## Summary
- reuse validated `draftId` when logging lobby route errors
- declare Node.js runtime for lobby handler
- fix misconfigured ESLint plugins

## Testing
- `npm test`
- `npm run lint` *(fails: 67 errors, 661 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b43685efc4832b8c9a60667e8fb34f