### PR TITLE
fix: track lobby auth metrics and lint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -108,6 +108,7 @@ export default [
     },
     plugins: {
       '@typescript-eslint': tsPlugin,
+      'jsx-a11y': a11yPlugin,
     },
     rules: {
       // TS recommended (type-aware)
@@ -127,24 +128,6 @@ export default [
       '@typescript-eslint/consistent-type-imports': 'warn',
       '@typescript-eslint/explicit-module-boundary-types': 'warn',
       '@typescript-eslint/no-floating-promises': ['warn', { ignoreVoid: true }],
-     plugins: {
-       '@typescript-eslint': tsPlugin,
-      'jsx-a11y': a11yPlugin,
-     },
-     rules: {
-       // TS recommended (type-aware)
-       ...tsPlugin.configs.recommended.rules,
- 
-       // Use TS instead of prop-types
-       'react/prop-types': 'off',
- 
-       // TS handles undefined vars; disabling avoids noise with types
-       'no-undef': 'off',
- 
-       // Hygiene
-       // Enable accessibility rule for table headers: ensure headers have valid scope
-       'jsx-a11y/scope': 'error',
-     },
       // Keep velocity but still nudge away from `any`
       '@typescript-eslint/no-explicit-any': 'warn',
 
@@ -153,6 +136,8 @@ export default [
         'warn',
         { checksVoidReturn: { attributes: false } },
       ],
+      // Enable accessibility rule for table headers: ensure headers have valid scope
+      'jsx-a11y/scope': 'error',
     },
   },
 

--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -1,3 +1,5 @@
+export const runtime = 'nodejs';
+
 import type { NextRequest } from 'next/server';
 import { cookies } from 'next/headers';
 import { adminAuth } from '@/lib/firebaseAdmin';
@@ -7,8 +9,11 @@ import { logger } from '@/lib/logger';
 import { getLobbyState } from '@/lib/draftLobby';
 import { ensureLobbyColumns } from '@/lib/ensureLobbyColumns';
 import { registerHistogram, observeHistogram } from '@/server/metrics';
+import { SESSION_COOKIE_NAME } from '@/constants';
 
-registerHistogram('api_draft_lobby_get_duration_seconds', [
+const API_DRAFT_LOBBY_GET_DURATION_SECONDS = 'api_draft_lobby_get_duration_seconds';
+
+registerHistogram(API_DRAFT_LOBBY_GET_DURATION_SECONDS, [
   0.005,
   0.01,
   0.025,
@@ -26,20 +31,31 @@ registerHistogram('api_draft_lobby_get_duration_seconds', [
  */
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const start = Date.now();
+  const startMs = Date.now();
+  let outcome: 'success' | 'error' = 'success';
+  let auth: 'none' | 'verified' | 'invalid' = 'none';
+  let draftId: string | undefined;
   try {
     const ParamsSchema = z.object({ id: z.string().min(1) });
-    const { id: draftId } = ParamsSchema.parse(await params);
+    const parsed = ParamsSchema.safeParse(params);
+    if (!parsed.success) {
+      outcome = 'error';
+      logger.warn('Invalid draft id', { issues: parsed.error.issues });
+      return errorResponse('Invalid draft id', 400);
+    }
+    draftId = parsed.data.id;
 
     // Attempt to verify session cookie; lobby data is still returned even if auth fails
     try {
-      const sessionCookie = (await cookies()).get('statly_session')?.value;
+      const sessionCookie = cookies().get(SESSION_COOKIE_NAME)?.value;
       if (sessionCookie) {
         await adminAuth.verifySessionCookie(sessionCookie, true);
+        auth = 'verified';
       }
     } catch (authErr) {
+      auth = 'invalid';
       logger.debug('Lobby request auth verification failed', { error: authErr });
     }
 
@@ -55,27 +71,20 @@ export async function GET(
 
     logger.info('Lobby state retrieved', { draftId, status: lobbyState.status });
 
-    observeHistogram(
-      'api_draft_lobby_get_duration_seconds',
-      (Date.now() - start) / 1000
-    );
-
     return successResponse(lobbyState);
   } catch (error) {
-    observeHistogram(
-      'api_draft_lobby_get_duration_seconds',
-      (Date.now() - start) / 1000
-    );
-
+    outcome = 'error';
     logger.error('Failed to get lobby state', {
-      draftId: (await params).id,
+      draftId,
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-
-    return errorResponse(
-      `Failed to get lobby state: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      500
+    return errorResponse('Failed to get lobby state', 500);
+  } finally {
+    observeHistogram(
+      API_DRAFT_LOBBY_GET_DURATION_SECONDS,
+      (Date.now() - startMs) / 1000,
+      { outcome, auth }
     );
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,6 @@
 
 // Default match UID used in demos and initial state
 export const DEFAULT_UID = '2025-R18-ADE-COL';
+
+// Name of the Firebase auth session cookie
+export const SESSION_COOKIE_NAME = 'statly_session';


### PR DESCRIPTION
## Summary
- register lobby metrics with constants and observe once with outcome/auth labels
- pin lobby route to Node runtime and verify session cookie without blocking lobby response
- correct ESLint flat config placement and share session cookie name constant

## Testing
- `npm test`
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' and '@typescript-eslint/no-empty-object-type' errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b4369cab68832ba015e2ede7c1240d