### PR TITLE
Validate time zone when creating leagues

### DIFF
--- a/src/app/api/leagues/route.ts
+++ b/src/app/api/leagues/route.ts
@@ -5,6 +5,7 @@ import { getUserIdFromRequest } from '@/lib/serverAuth';
 import { adminDb } from '@/lib/firebaseAdmin';
 import type { League, CreateLeagueRequest, LeagueMember } from '@/types/leagues';
 import { generateDeterministicMemberId } from '@/utils/firestore';
+import { isValidTimeZone } from '@/lib/timezone';
 
 // Generate unique league code
 function generateLeagueCode(): string {
@@ -90,6 +91,9 @@ export async function POST(req: NextRequest) {
 
     // Create league object
     const now = new Date().toISOString();
+    const timeZone =
+      body.timeZone && isValidTimeZone(body.timeZone) ? body.timeZone : 'UTC';
+
     const league: Omit<League, 'id'> = {
       name: body.name,
       code,
@@ -97,6 +101,7 @@ export async function POST(req: NextRequest) {
       ownerId: userId,
       maxTeams: body.maxTeams || 10,
       categories: body.categories,
+      timeZone,
       tradeSettings: {
         tradeLimit: body.tradeSettings?.tradeLimit || 10,
         tradeReview: body.tradeSettings?.tradeReview || 'none',

--- a/src/app/leagues/new/page.tsx
+++ b/src/app/leagues/new/page.tsx
@@ -6,11 +6,15 @@ import { useAuth } from '@/AuthContext';
 import { fetchApi } from '@/lib/api';
 import Button from '@/components/Button';
 import { AppLayout } from '@/components/navigation';
+import { isValidTimeZone } from '@/lib/timezone';
 
 export default function NewLeaguePage() {
   const [leagueName, setLeagueName] = useState('');
   const [teamCount, setTeamCount] = useState(12);
   const [scoringFormat, setScoringFormat] = useState('standard');
+  const [timeZone, setTimeZone] = useState(
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
@@ -26,12 +30,14 @@ export default function NewLeaguePage() {
     setError(null);
 
     try {
+      const tz = isValidTimeZone(timeZone) ? timeZone : 'UTC';
       const newLeague = await fetchApi('leagues', {
         method: 'POST',
         body: JSON.stringify({
           name: leagueName,
           teamCount,
           scoringFormat,
+          timeZone: tz,
           commissionerId: user.uid,
         }),
       });
@@ -90,6 +96,23 @@ export default function NewLeaguePage() {
             <option value="ppr">Points Per Reception (PPR)</option>
             <option value="nine-category">9-Category Head-to-Head</option>
           </select>
+        </div>
+
+        <div>
+          <label htmlFor="timeZone" className="block text-sm font-medium mb-2">
+            Time Zone
+          </label>
+          <input
+            id="timeZone"
+            type="text"
+            value={timeZone}
+            onChange={(e) => setTimeZone(e.target.value)}
+            placeholder="e.g. America/New_York"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <p className="text-xs text-gray-500 mt-1">
+            Use a valid IANA time zone, such as "America/New_York".
+          </p>
         </div>
 
         {error && <p className="text-red-500">{error}</p>}

--- a/src/components/league/LeagueChat.tsx
+++ b/src/components/league/LeagueChat.tsx
@@ -11,9 +11,9 @@ export default function LeagueChat({ leagueId }: LeagueChatProps) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!leagueId) return;
+    if (!leagueId || !db) return;
 
-    const q = query(collection(db, "someCollection"), orderBy("someField"), limit(200));
+    const q = query(collection(db, 'someCollection'), orderBy('someField'), limit(200));
 
     const unsubscribe = onSnapshot(q, (_snapshot) => {
       // handle snapshot

--- a/src/types/leagues.ts
+++ b/src/types/leagues.ts
@@ -37,6 +37,7 @@ export interface League {
   description?: string;
   draftDate?: string; // ISO timestamp
   currentTeams?: number; // Computed field for current member count
+  timeZone?: string; // IANA time zone identifier
 }
 
 // Firestore document shape for league members (server-side)
@@ -73,6 +74,7 @@ export interface CreateLeagueRequest {
   tradeSettings?: Partial<TradeSettings>;
   waiverWire?: Partial<WaiverWireSettings>;
   draftDate?: string;
+  timeZone?: string;
 }
 
 // League Join Request


### PR DESCRIPTION
## Summary
- add IANA time zone input and validation to new league form, defaulting to UTC when invalid
- validate and store league time zone on the server API
- handle null Firestore instance in LeagueChat to satisfy type checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b42d5cf7e4832b92777dca17ebe838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added time zone support when creating leagues. The form now detects your browser’s time zone and allows manual entry (e.g., America/New_York), defaulting to UTC if invalid or unavailable. The selected time zone is saved with the league.
- Bug Fixes
  - Improved reliability of league chat loading by safely handling cases where the database connection isn’t ready, reducing potential errors during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->