### PR TITLE
fix: isolate onboarding storage per user

### DIFF
--- a/src/app/leagues/[id]/OnboardingChecklist.tsx
+++ b/src/app/leagues/[id]/OnboardingChecklist.tsx
@@ -31,13 +31,19 @@ export default function OnboardingChecklist({ member }: Props) {
     ];
 
     const leagueId = member?.leagueId;
-    const userId = member?.userId ?? 'anon';
-    if (leagueId) {
+    const userId = member?.userId;
+    if (leagueId && userId) {
       const storageKey = `league-onboarding:${leagueId}:${userId}`;
       try {
         const saved = localStorage.getItem(storageKey);
         if (saved) {
-          setTasks(JSON.parse(saved) as Task[]);
+          const parsed = JSON.parse(saved);
+          if (!Array.isArray(parsed)) {
+            throw new Error(
+              'Onboarding data from localStorage is not an array.'
+            );
+          }
+          setTasks(parsed as Task[]);
           return;
         }
       } catch (err) {
@@ -54,7 +60,9 @@ export default function OnboardingChecklist({ member }: Props) {
 
   useEffect(() => {
     if (!member) return;
-    const storageKey = `league-onboarding:${member.leagueId}:${member.userId}`;
+    const { leagueId, userId } = member;
+    if (!leagueId || !userId) return;
+    const storageKey = `league-onboarding:${leagueId}:${userId}`;
     try {
       localStorage.setItem(storageKey, JSON.stringify(tasks));
     } catch {


### PR DESCRIPTION
## Summary
- ensure onboarding storage only uses league and user IDs without fallback
- validate parsed localStorage data is an array before using

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*


------
https://chatgpt.com/codex/tasks/task_e_68b479abbbec832baf882e12f1af0c16