### PR TITLE
fix: validate onboarding storage data

### DIFF
--- a/src/app/leagues/[id]/OnboardingChecklist.tsx
+++ b/src/app/leagues/[id]/OnboardingChecklist.tsx
@@ -31,13 +31,19 @@ export default function OnboardingChecklist({ member }: Props) {
     ];
 
     const leagueId = member?.leagueId;
-    const userId = member?.userId ?? 'anon';
-    if (leagueId) {
+    const userId = member?.userId;
+    if (leagueId && userId) {
       const storageKey = `league-onboarding:${leagueId}:${userId}`;
       try {
         const saved = localStorage.getItem(storageKey);
         if (saved) {
-          setTasks(JSON.parse(saved) as Task[]);
+          const parsed = JSON.parse(saved);
+          if (!Array.isArray(parsed)) {
+            throw new Error(
+              'Onboarding data from localStorage is not an array.'
+            );
+          }
+          setTasks(parsed as Task[]);
           return;
         }
       } catch (err) {
@@ -53,7 +59,7 @@ export default function OnboardingChecklist({ member }: Props) {
   }, [member]);
 
   useEffect(() => {
-    if (!member) return;
+    if (!member?.leagueId || !member?.userId) return;
     const storageKey = `league-onboarding:${member.leagueId}:${member.userId}`;
     try {
       localStorage.setItem(storageKey, JSON.stringify(tasks));


### PR DESCRIPTION
## Summary
- validate structure of onboarding checklist data loaded from localStorage
- require both leagueId and userId before reading or writing to storage

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b479aa0060832bb992bfc3c1d3a15a