### PR TITLE
refactor: extract session cookie constant

### DIFF
--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -8,11 +8,11 @@ import { successResponse, errorResponse } from '@/lib/apiResponse';
 import { logger } from '@/lib/logger';
 import { getLobbyState } from '@/lib/draftLobby';
 import { ensureLobbyColumns } from '@/lib/ensureLobbyColumns';
+import { SESSION_COOKIE_NAME } from '@/constants';
 import { registerHistogram, observeHistogram } from '@/server/metrics';
 
 const API_DRAFT_LOBBY_GET_DURATION_SECONDS =
   'api_draft_lobby_get_duration_seconds';
-const SESSION_COOKIE_NAME = 'statly_session'; // TODO: move to shared constant
 
 registerHistogram(API_DRAFT_LOBBY_GET_DURATION_SECONDS, [
   0.005,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,6 @@
 
 // Default match UID used in demos and initial state
 export const DEFAULT_UID = '2025-R18-ADE-COL';
+
+// Name of the session cookie used for admin authentication
+export const SESSION_COOKIE_NAME = 'statly_session';


### PR DESCRIPTION
## Summary
- move `statly_session` cookie name into shared constants module
- import shared cookie constant in lobby route and reuse for auth

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-unused-vars, @typescript-eslint/no-floating-promises)*

------
https://chatgpt.com/codex/tasks/task_e_68b47879906c832baf08ca66594bacae