### PR TITLE
refactor: use shared session cookie constant

### DIFF
--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -9,10 +9,10 @@ import { logger } from '@/lib/logger';
 import { getLobbyState } from '@/lib/draftLobby';
 import { ensureLobbyColumns } from '@/lib/ensureLobbyColumns';
 import { registerHistogram, observeHistogram } from '@/server/metrics';
+import { SESSION_COOKIE_NAME } from '@/constants';
 
 const API_DRAFT_LOBBY_GET_DURATION_SECONDS =
   'api_draft_lobby_get_duration_seconds';
-const SESSION_COOKIE_NAME = 'statly_session'; // TODO: move to shared constant
 
 registerHistogram(API_DRAFT_LOBBY_GET_DURATION_SECONDS, [
   0.005,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,6 @@
 
 // Default match UID used in demos and initial state
 export const DEFAULT_UID = '2025-R18-ADE-COL';
+
+// Name of the session cookie used for admin authentication
+export const SESSION_COOKIE_NAME = 'statly_session';


### PR DESCRIPTION
## Summary
- extract session cookie name into shared constants module
- consume shared cookie name when verifying lobby session

## Testing
- `npm test`
- `npm run lint` *(fails: 67 errors, 661 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b478718850832baba12db3f70118bd