### PR TITLE
refactor: centralize session cookie constant

### DIFF
--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -9,10 +9,10 @@ import { logger } from '@/lib/logger';
 import { getLobbyState } from '@/lib/draftLobby';
 import { ensureLobbyColumns } from '@/lib/ensureLobbyColumns';
 import { registerHistogram, observeHistogram } from '@/server/metrics';
+import { SESSION_COOKIE_NAME } from '@/constants';
 
 const API_DRAFT_LOBBY_GET_DURATION_SECONDS =
   'api_draft_lobby_get_duration_seconds';
-const SESSION_COOKIE_NAME = 'statly_session'; // TODO: move to shared constant
 
 registerHistogram(API_DRAFT_LOBBY_GET_DURATION_SECONDS, [
   0.005,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,6 @@
 
 // Default match UID used in demos and initial state
 export const DEFAULT_UID = '2025-R18-ADE-COL';
+
+// Name of the session cookie used across the application
+export const SESSION_COOKIE_NAME = 'statly_session';


### PR DESCRIPTION
## Summary
- define `SESSION_COOKIE_NAME` in shared constants module
- import session cookie constant into lobby route to avoid hardcoding

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in src/types/draft.ts; 67 errors, 661 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b47864cc08832bb05da79c066fb6ec