### PR TITLE
fix: correct aflPlayers import path casing

### DIFF
--- a/src/lib/playerPositionMapping.ts
+++ b/src/lib/playerPositionMapping.ts
@@ -4,7 +4,7 @@
  */
 
 // Import the existing AFL players data
-// import aflPlayers from '../data/aflPlayers';
+import aflPlayers from '@/Data/aflPlayers';
 
 // Create a map for fast lookups
 const playerPositionMap = new Map<string, string>();
@@ -90,7 +90,7 @@ const additionalPlayers: Array<{ name: string; position: string }> = [
 // Initialize the position map
 // function initializePositionMap() {
 //   // Add players from the AFL players data file
-//   // TODO: Re-enable when @/data/aflPlayers is available
+//   // TODO: Re-enable when @/Data/aflPlayers is available
 //   // aflPlayers.forEach((player: any) => {
 //   //   const normalizedName = normalizePlayerName(player.name);
 //   //   if (player.position) {


### PR DESCRIPTION
## Summary
- fix aflPlayers import to use `@/Data` for case-sensitive environments
- update related comment to match new path

## Testing
- `npm test` *(fails: Argument of type 'Firestore | null' is not assignable to parameter of type 'Firestore')*


------
https://chatgpt.com/codex/tasks/task_e_68b42ecd1724832b8c2a2179b85e35aa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized internal references for player data to use a unified path alias, improving consistency and maintainability across the codebase.
- Chores
  - Updated inline notes to reflect the standardized path alias and ensure alignment with current conventions.
  - Clarified comments to avoid confusion caused by differing path casing.
  - No user-facing changes; screens, interactions, and data remain unchanged, and overall app behavior is unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->