### PR TITLE
refactor: adjust lobby route params handling

### DIFF
--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -12,7 +12,7 @@ export async function GET(
   request: NextRequest,
   { params }: LeagueParams
 ) {
-  const { id: draftId } = await params;
+  const { id: draftId } = params;
   try {
 
     logger.info('Lobby API called', { draftId });
@@ -29,11 +29,7 @@ export async function GET(
 
     return successResponse(lobbyState);
   } catch (error) {
-    logger.error('Failed to get lobby state', {
-      draftId,
-      error: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    });
+    logger.error('Failed to get lobby state', error instanceof Error ? error : undefined, { draftId });
 
     return errorResponse(
       `Failed to get lobby state: ${error instanceof Error ? error.message : 'Unknown error'}`,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -3,9 +3,9 @@
  */
 
 /**
- * Standard params shape for league ID-based routes (Promise-based in Next.js 15+)
+ * Standard params shape for league ID-based routes (supports sync or Promise)
  */
-export type LeagueParams = { params: Promise<{ id: string }> };
+export type LeagueParams = { params: { id: string } | Promise<{ id: string }> };
 
 /**
  * Standard params shape for draft ID-based routes (Promise-based in Next.js 15+)


### PR DESCRIPTION
## Summary
- log lobby route errors by passing the error object to the logger
- allow LeagueParams type to accept synchronous params

## Testing
- `npm test`
- `npm run lint` *(fails: '_leagueId' is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5346e3874832b822da1d5b8ea0271