### PR TITLE
refactor: simplify lobby error logging

### DIFF
--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -29,10 +29,8 @@ export async function GET(
 
     return successResponse(lobbyState);
   } catch (error) {
-    logger.error('Failed to get lobby state', {
+    logger.error('Failed to get lobby state', error, {
       draftId,
-      error: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
     });
 
     return errorResponse(


### PR DESCRIPTION
## Summary
- pass caught error object directly to `logger.error` in draft lobby route

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, no-empty-object-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b53471c610832b866e8bd97696a561