### PR TITLE
refactor: log errors directly in lobby route

### DIFF
--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -12,9 +12,12 @@ export async function GET(
   request: NextRequest,
   { params }: LeagueParams
 ) {
-  const { id: draftId } = await params;
+  const { id: draftId } = params;
+  if (typeof draftId !== 'string' || draftId.trim() === '') {
+    logger.warn('Invalid draft id in lobby route', { draftId });
+    return errorResponse('Invalid draft id', 400);
+  }
   try {
-
     logger.info('Lobby API called', { draftId });
 
     // Ensure lobby columns exist before querying
@@ -29,11 +32,15 @@ export async function GET(
 
     return successResponse(lobbyState);
   } catch (error) {
-    logger.error('Failed to get lobby state', {
-      draftId,
-      error: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    });
+    logger.error(
+      'Failed to get lobby state',
+      error as Error,
+      {
+        draftId,
+        path: request.nextUrl?.pathname ?? request.url,
+        requestId: request.headers.get('x-request-id') ?? undefined,
+      }
+    );
 
     return errorResponse(
       `Failed to get lobby state: ${error instanceof Error ? error.message : 'Unknown error'}`,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -3,9 +3,9 @@
  */
 
 /**
- * Standard params shape for league ID-based routes (Promise-based in Next.js 15+)
+ * Standard params shape for league ID-based routes (accepts sync or Promise params)
  */
-export type LeagueParams = { params: Promise<{ id: string }> };
+export type LeagueParams = { params: { id: string } | Promise<{ id: string }> };
 
 /**
  * Standard params shape for draft ID-based routes (Promise-based in Next.js 15+)


### PR DESCRIPTION
## Summary
- allow LeagueParams to accept synchronous params
- validate draftId and pass Error objects directly to logger in draft lobby route

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used, _config is defined but never used, _priorities is defined but never used, _requestId is defined but never used, _get is defined but never used, _api is defined but never used, The `{}` ("empty object") type allows any non-nullish value, including literals like 0 and "".)*


------
https://chatgpt.com/codex/tasks/task_e_68b534812824832b979a3b91c7267aa3