### PR TITLE
fix: handle auto-pick params synchronously

### DIFF
--- a/src/app/api/drafts/[id]/auto-pick/route.ts
+++ b/src/app/api/drafts/[id]/auto-pick/route.ts
@@ -70,10 +70,10 @@ type PickWithRelations = {
 
 export async function POST(
   request: NextRequest,
-  context: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   try {
-    const { id: draftId } = await context.params;
+    const { id: draftId } = params;
     if (typeof draftId !== 'string' || draftId.trim().length === 0) {
       return errorResponse('Missing or invalid draftId', 400);
     }


### PR DESCRIPTION
## Summary
- extract draftId directly from route params in auto-pick handler

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, no-empty-object-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b5348a2fc8832b9511fa0229debe3b