### PR TITLE
refactor: adjust lobby route params handling

### DIFF
--- a/src/app/api/drafts/[id]/debug/route.ts
+++ b/src/app/api/drafts/[id]/debug/route.ts
@@ -80,11 +80,11 @@ export async function GET(
 
     return successResponse(debugInfo);
   } catch (error) {
-    logger.error('Failed to get debug info', {
-      draftId,
-      error: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    });
+    logger.error(
+      'Failed to get debug info',
+      error instanceof Error ? error : undefined,
+      { draftId }
+    );
 
     return errorResponse(`Debug failed: ${error instanceof Error ? error.message : 'Unknown error'}`, 500);
   }


### PR DESCRIPTION
## Summary
- refactor draft lobby API params handling to destructure synchronously
- drop redundant `await` usage in error logging
- ensure error object passed to debug logger

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b5349706e8832baf28b948a64256d4