### PR TITLE
fix: validate queue rank

### DIFF
--- a/src/app/api/drafts/[id]/queue/route.ts
+++ b/src/app/api/drafts/[id]/queue/route.ts
@@ -109,13 +109,16 @@ export async function POST(request: NextRequest, { params }: LeagueParams) {
 
     // Determine rank - if omitted, set to next available
     let finalRank = rank;
-    if (!finalRank) {
+    if (finalRank == null) {
       const maxRank = await prisma.queueItem.findFirst({
         where: { memberId },
         orderBy: { rank: 'desc' },
         select: { rank: true },
       });
-      finalRank = (maxRank?.rank || 0) + 1;
+      finalRank = (maxRank?.rank ?? 0) + 1;
+    }
+    if (!Number.isInteger(finalRank) || finalRank < 1) {
+      return commonErrors.badRequest('Invalid rank');
     }
 
     // Add to queue


### PR DESCRIPTION
## Summary
- ensure queue rank defaults only when unspecified and validate positive integer

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used, _config is defined but never used, _priorities is defined but never used, _leagueId is defined but never used, _requestId is defined but never used, _get is defined but never used, _api is defined but never used, The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5349bb038832b948c0d79a60266da