### PR TITLE
fix: guard missing players in draft queue results

### DIFF
--- a/src/app/api/drafts/[id]/queue/route.ts
+++ b/src/app/api/drafts/[id]/queue/route.ts
@@ -313,12 +313,25 @@ export async function GET(request: NextRequest, { params }: LeagueParams) {
       },
     });
 
-    // Map players to queue items
+    // Map players to queue items and warn if any are missing
     const playerMap = new Map(players.map(player => [player.id, player]));
-    const queueWithPlayers = queueItems.map(item => ({
-      ...item,
-      player: playerMap.get(item.playerId),
-    }));
+    const queueWithPlayers = queueItems
+      .map(item => ({
+        ...item,
+        player: playerMap.get(item.playerId),
+      }))
+      .filter(item => {
+        if (!item.player) {
+          logger.warn('Queue item references missing player', {
+            draftId,
+            memberId,
+            playerId: item.playerId,
+            queueItemId: item.id,
+          });
+          return false;
+        }
+        return true;
+      });
 
     logger.info('Queue retrieved', {
       draftId,


### PR DESCRIPTION
## Summary
- filter out queue entries that reference deleted players
- log missing player references when fetching draft queues

## Testing
- `npm test`
- `npm run lint` *(fails: 310 problems (198 errors, 112 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b534a8df10832b9fbc406361046b93