### PR TITLE
refactor: sync triple id params

### DIFF
--- a/src/app/api/leagues/[id]/[id2]/roster/[userId]/route.ts
+++ b/src/app/api/leagues/[id]/[id2]/roster/[userId]/route.ts
@@ -7,7 +7,7 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
 export async function GET(_req: NextRequest, { params }: TripleIdParams) {
-  const { id, id2, userId } = await params;
+  const { id, id2, userId } = params;
   return NextResponse.json(
     { success: false, error: 'Not implemented', route: { id, id2, userId } },
     { status: 501 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -28,7 +28,7 @@ export type UserIdParams = { params: Promise<{ userId: string }> };
 export type MultiIdParams = { params: Promise<{ id: string; userId: string }> };
 
 /**
- * Standard params shape for routes with three ID parameters (Promise-based in Next.js 15+)
+ * Standard params shape for routes with three ID parameters
  */
-export type TripleIdParams = { params: Promise<{ id: string; id2: string; userId: string }> };
+export type TripleIdParams = { params: { id: string; id2: string; userId: string } };
 


### PR DESCRIPTION
## Summary
- remove redundant await in triple-id roster route
- define TripleIdParams with synchronous params

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b534b26738832b8d13c4e9e2656a1a