### PR TITLE
refactor: adjust lobby route params handling

### DIFF
--- a/src/app/api/leagues/[id]/link-draft/route.ts
+++ b/src/app/api/leagues/[id]/link-draft/route.ts
@@ -89,14 +89,10 @@ export async function POST(
     });
 
   } catch (error) {
-    logger.error('Failed to link league to draft', {
+    logger.error('Failed to link league to draft', error instanceof Error ? error : undefined, {
       leagueId,
-      error: error instanceof Error ? error.message : 'Unknown error',
     });
 
-    return errorResponse(
-      'Failed to link league to draft',
-      500
-    );
+    return errorResponse('Failed to link league to draft', 500);
   }
 }


### PR DESCRIPTION
## Summary
- refactor draft lobby API params handling to destructure synchronously
- drop redundant `await` usage in error logging
- pass error to `logger.error` in link-draft route for cleaner stack traces

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used, _config is defined but never used, _priorities is defined but never used, _leagueId is defined but never used, _requestId is defined but never used, _get is defined but never used, _api is defined but never used, The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.)*

------
https://chatgpt.com/codex/tasks/task_e_68b534c2bf24832bb9ab41e44dd1b1e4