### PR TITLE
refactor: validate league player route params synchronously

### DIFF
--- a/src/app/api/leagues/[id]/players/route.ts
+++ b/src/app/api/leagues/[id]/players/route.ts
@@ -24,7 +24,10 @@ interface AvailableIndexDoc {
 
 // GET /api/leagues/[id]/players?limit=100&cursor=<lastId>&team=XXX&position=YYY&owned=true|false
 export async function GET(req: NextRequest, { params }: LeagueParams) {
-  const { id: leagueId } = await params;
+  const { id: leagueId } = params;
+  if (typeof leagueId !== 'string' || !leagueId.trim()) {
+    return NextResponse.json({ error: 'Invalid league id' }, { status: 400 });
+  }
 
   // AuthN + AuthZ: require authenticated user and league membership
   const userId = await getAuthenticatedUserId(req);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -3,9 +3,11 @@
  */
 
 /**
- * Standard params shape for league ID-based routes (Promise-based in Next.js 15+)
+ * Standard params shape for league ID-based routes. Accepts either a plain object
+ * or a Promise resolving to that object to support both synchronous and
+ * asynchronous Next.js contexts.
  */
-export type LeagueParams = { params: Promise<{ id: string }> };
+export type LeagueParams = { params: { id: string } | Promise<{ id: string }> };
 
 /**
  * Standard params shape for draft ID-based routes (Promise-based in Next.js 15+)


### PR DESCRIPTION
## Summary
- validate league route params synchronously and reject blank IDs
- allow `LeagueParams` to accept plain objects as well as promises

## Testing
- `npm test`
- `npm run lint` *(fails: @_typescript-eslint/no-unused-vars and no-empty-object-type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b534c903dc832bb84d773b90e976d0