### PR TITLE
chore: simplify league lookup

### DIFF
--- a/src/app/api/leagues/[id]/route.ts
+++ b/src/app/api/leagues/[id]/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest, { params }: LeagueParams) {
 
     // First try to get from Prisma database
     const prismaLeague = await prisma.league.findUnique({
-      where: { id: id },
+      where: { id },
       include: {
         settings: true,
         members: {


### PR DESCRIPTION
## Summary
- use shorthand `where` clause for league lookup

## Testing
- `npm test`
- `npm run lint` *(fails: unused variables and lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b534c94548832b9181d5c951d8a8dc