### PR TITLE
fix: log leagueId in waiver submit

### DIFF
--- a/src/app/api/leagues/[id]/waivers/submit/route.ts
+++ b/src/app/api/leagues/[id]/waivers/submit/route.ts
@@ -17,9 +17,13 @@ interface WaiverSettings {
   minimumBid?: number;
 }
 
-export const POST = withMetrics(async (req: NextRequest, context: { params: Promise<{ id: string }> }) => {
+export const POST = withMetrics(async (
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) => {
+  let leagueId: string | undefined;
   try {
-    const { id: leagueId } = await context.params;
+    leagueId = params.id;
     if (!leagueId) return NextResponse.json({ error: 'Missing leagueId' }, { status: 400 });
 
     const userId = await getAuthenticatedUserId(req);
@@ -176,7 +180,11 @@ export const POST = withMetrics(async (req: NextRequest, context: { params: Prom
         return NextResponse.json({ error: 'Insufficient FAAB remaining' }, { status: 400 });
       }
     }
-    logger.apiError('POST', '/api/leagues/[id]/waivers/submit', err);
+    logger.apiError(
+      'POST',
+      `/api/leagues/${leagueId ?? '[id]'}/waivers/submit`,
+      err
+    );
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
 }, 'POST /api/leagues/[id]/waivers/submit');


### PR DESCRIPTION
## Summary
- use synchronous route params in waiver submit handler
- include leagueId in waiver submit error logs for better traceability

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used, _config is defined but never used, _priorities is defined but never used, _leagueId is defined but never used, _requestId is defined but never used, _get is defined but never used, _api is defined but never used, The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`., ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b534d5dfcc832b92bb2e7d7f270060