### PR TITLE
fix: use synchronous params in auto-pick route

### DIFF
--- a/src/app/api/drafts/[id]/auto-pick/route.ts
+++ b/src/app/api/drafts/[id]/auto-pick/route.ts
@@ -70,10 +70,10 @@ type PickWithRelations = {
 
 export async function POST(
   request: NextRequest,
-  context: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   try {
-    const { id: draftId } = await context.params;
+    const { id: draftId } = params;
     if (typeof draftId !== 'string' || draftId.trim().length === 0) {
       return errorResponse('Missing or invalid draftId', 400);
     }


### PR DESCRIPTION
## Summary
- refactor auto-pick handler to accept synchronous route params

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-object-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b534fe6594832ba5f1265326a01115