### PR TITLE
refactor: simplify lobby route error logging

### DIFF
--- a/src/app/api/drafts/[id]/lobby/route.ts
+++ b/src/app/api/drafts/[id]/lobby/route.ts
@@ -29,11 +29,11 @@ export async function GET(
 
     return successResponse(lobbyState);
   } catch (error) {
-    logger.error('Failed to get lobby state', {
-      draftId,
-      error: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    });
+    logger.error(
+      'Failed to get lobby state',
+      error instanceof Error ? error : undefined,
+      { draftId }
+    );
 
     return errorResponse(
       `Failed to get lobby state: ${error instanceof Error ? error.message : 'Unknown error'}`,


### PR DESCRIPTION
## Summary
- streamline lobby API error logging by passing the caught error directly with context

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used, _config is defined but never used, _priorities is defined but never used, _get is defined but never used, _api is defined but never used, The {} ("empty object") type allows any non-nullish value, including literals like 0 and "". ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b535032b0c832bb4d4c3e473f30065