### PR TITLE
refactor: adjust lobby route params handling

### DIFF
--- a/src/app/api/drafts/[id]/participants/route.ts
+++ b/src/app/api/drafts/[id]/participants/route.ts
@@ -8,7 +8,6 @@ import { NextResponse } from 'next/server';
 import { getLiveDraftEngine } from '@/services/liveDraftEngine';
 import { logger } from '@/lib/logger';
 import { z } from 'zod';
-import type { LeagueParams } from '@/types/api';
 
 // Validation schema
 const UpdateParticipantSchema = z.object({
@@ -19,9 +18,13 @@ const UpdateParticipantSchema = z.object({
 // PUT /api/drafts/[id]/participants - Update participant status
 export async function PUT(
   request: NextRequest,
-  { params }: LeagueParams
+  { params }: { params: { id: string } }
 ) {
-  const { id: draftId } = await params;
+  const { id: draftId } = params;
+  if (typeof draftId !== 'string' || draftId.trim() === '') {
+    logger.warn('Invalid draft id in participants route', { draftId });
+    return NextResponse.json({ error: 'Invalid draft id' }, { status: 400 });
+  }
   
   try {
     const body = await request.json();


### PR DESCRIPTION
## Summary
- refactor draft participant API to read params synchronously
- add early validation for draft id in participant status updates

## Testing
- `npm test`
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' in waiverService)*

------
https://chatgpt.com/codex/tasks/task_e_68b5350a2e10832b92e48d4862006e10