### PR TITLE
refactor: streamline players error logging

### DIFF
--- a/src/app/api/drafts/[id]/players/route.ts
+++ b/src/app/api/drafts/[id]/players/route.ts
@@ -16,8 +16,10 @@ const VALID_POSITIONS = ['DEF', 'MID', 'FWD', 'RUC'] as const;
 // GET /api/drafts/[id]/players
 // Paginated available players for a draft with filtering
 export async function GET(request: NextRequest, { params }: LeagueParams) {
+  let draftId: string | undefined;
   try {
     const { id } = await params;
+    draftId = id;
 
     if (!id || typeof id !== 'string' || id.length < 10) {
       return errorResponse('Invalid draft id', 400);
@@ -148,13 +150,11 @@ export async function GET(request: NextRequest, { params }: LeagueParams) {
     logger.info('Draft players retrieved', { draftId: id, page, pageSize, count: players.length });
     return response;
   } catch (error) {
-    logger.error('Failed to retrieve draft players', {
-      error: {
-        name: error instanceof Error ? error.name : 'Unknown',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-    });
+    logger.error(
+      'Failed to retrieve draft players',
+      error instanceof Error ? error : undefined,
+      { draftId }
+    );
     return errorResponse('Failed to retrieve draft players', 500);
   }
 }


### PR DESCRIPTION
## Summary
- log draft player fetch failures with direct Error parameter and draftId context

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used, _config is defined but never used, _priorities is defined but never used, _get is defined but never used, _api is defined but never used, The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5351b81b8832b937e0393d374a867