### PR TITLE
refactor: destructure draft params synchronously

### DIFF
--- a/src/app/api/drafts/[id]/route.ts
+++ b/src/app/api/drafts/[id]/route.ts
@@ -4,15 +4,17 @@ import { logger } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { createHash } from 'crypto';
-import type { LeagueParams } from '@/types/api';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-export async function GET(request: NextRequest, { params }: LeagueParams) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
   try {
-    const { id } = await params;
+    const { id } = params;
 
     // Strict id validation (Draft IDs are CUIDs per Prisma schema)
     if (!z.string().cuid().safeParse(id).success) {


### PR DESCRIPTION
## Summary
- destructure draft route params synchronously to avoid unnecessary await

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b53527fc08832b81021c397f1632cf