### PR TITLE
refactor: capture league id within link-draft handler

### DIFF
--- a/src/app/api/leagues/[id]/link-draft/route.ts
+++ b/src/app/api/leagues/[id]/link-draft/route.ts
@@ -13,8 +13,9 @@ export async function POST(
   request: NextRequest,
   { params }: LeagueParams
 ) {
-  const { id: leagueId } = await params;
+  let leagueId: string | undefined;
   try {
+    ({ id: leagueId } = await params);
     const body: LinkDraftRequest = await request.json();
 
     // Dev shortcut for test league: accept link without DB writes


### PR DESCRIPTION
## Summary
- capture `leagueId` after resolving params to make error logging safer

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, no-empty-object-type)*

------
https://chatgpt.com/codex/tasks/task_e_68b5353db9e0832ba3f0f0d66155b1bd