### PR TITLE
refactor: handle league member params synchronously

### DIFF
--- a/src/app/api/leagues/[id]/members/route.ts
+++ b/src/app/api/leagues/[id]/members/route.ts
@@ -4,13 +4,12 @@ import { adminDb } from '@/lib/firebaseAdmin';
 import { commonErrors } from '@/lib/apiResponse';
 import { withRequestTracing } from '@/lib/requestTracing';
 import type { LeagueMember, League, LeagueMemberDoc } from '@/types/leagues';
-import type { LeagueParams } from '@/types/api';
 import { Timestamp } from 'firebase-admin/firestore';
 import { getUserIdFromRequest } from '@/lib/serverAuth';
 
 // GET /api/leagues/[id]/members - Get league members
-export async function GET(req: NextRequest, { params }: LeagueParams) {
-  const { id: leagueId } = await params;
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const { id: leagueId } = params;
   const tracer = withRequestTracing(req, { endpoint: 'league-members', leagueId });
 
   try {


### PR DESCRIPTION
## Summary
- simplify league member route params to sync object and drop unnecessary await

## Testing
- `npm test`
- `npm run lint` *(fails: '_leagueId' is defined but never used and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b53544d3a4832ba808bbf792732453