### PR TITLE
refactor: adjust lobby route params handling

### DIFF
--- a/src/app/api/leagues/[id]/roster/[userId]/route.ts
+++ b/src/app/api/leagues/[id]/roster/[userId]/route.ts
@@ -72,6 +72,8 @@ export async function GET(
   request: NextRequest,
   { params }: MultiIdParams
 ) {
+  let leagueId: string | undefined;
+  let userId: string | undefined;
   try {
     const resolvedParams = await params;
     
@@ -87,7 +89,9 @@ export async function GET(
       return errorResponse('User ID is required', 400);
     }
     
-    const { id: leagueId, userId } = resolvedParams;
+    const { id: lId, userId: uId } = resolvedParams;
+    leagueId = lId;
+    userId = uId;
 
     // Auth: require server-validated identity
     const reqUserId = await getUserIdFromRequest(request);
@@ -224,7 +228,10 @@ export async function GET(
 
     return successResponse(response);
   } catch (error) {
-    logger.error('Failed to get league roster', { error: error instanceof Error ? error.message : String(error) });
+    logger.error('Failed to get league roster', error instanceof Error ? error : undefined, {
+      leagueId,
+      userId,
+    });
     return errorResponse('Failed to retrieve roster', 500);
   }
 }
@@ -233,6 +240,8 @@ export async function PUT(
   request: NextRequest,
   { params }: MultiIdParams
 ) {
+  let leagueId: string | undefined;
+  let userId: string | undefined;
   try {
     const resolvedParams = await params;
     
@@ -248,7 +257,9 @@ export async function PUT(
       return errorResponse('User ID is required', 400);
     }
     
-    const { id: leagueId, userId } = resolvedParams;
+    const { id: lId, userId: uId } = resolvedParams;
+    leagueId = lId;
+    userId = uId;
     const raw = await request.json();
     const body = PutSchema.parse(raw);
 
@@ -314,7 +325,10 @@ export async function PUT(
       },
     });
   } catch (error) {
-    logger.error('Failed to update league roster', { error: error instanceof Error ? error.message : String(error) });
+    logger.error('Failed to update league roster', error instanceof Error ? error : undefined, {
+      leagueId,
+      userId,
+    });
     return errorResponse('Failed to update roster', 500);
   }
 }


### PR DESCRIPTION
## Summary
- log league and user context when roster route errors

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b5354d7d38832babdd277d32681c63