### PR TITLE
refactor: simplify league lookup

### DIFF
--- a/src/app/api/leagues/[id]/route.ts
+++ b/src/app/api/leagues/[id]/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest, { params }: LeagueParams) {
 
     // First try to get from Prisma database
     const prismaLeague = await prisma.league.findUnique({
-      where: { id: id },
+      where: { id },
       include: {
         settings: true,
         members: {


### PR DESCRIPTION
## Summary
- use object shorthand when querying league by id

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68b53554bc54832bb0985189400dfb98