### PR TITLE
refactor: adjust lobby route params handling

### DIFF
--- a/src/app/api/leagues/[id]/sync-draft-results/route.ts
+++ b/src/app/api/leagues/[id]/sync-draft-results/route.ts
@@ -33,9 +33,10 @@ export async function POST(
   { params }: LeagueParams
 ) {
   const { id: leagueId } = await params;
-  const body: SyncDraftResultsRequest = await request.json();
+  let body: SyncDraftResultsRequest;
 
   try {
+    body = await request.json();
     if (!body.draftId?.trim()) {
       return errorResponse('Draft ID is required', 400);
     }
@@ -196,11 +197,11 @@ export async function POST(
     });
 
   } catch (error) {
-    logger.error('Failed to sync draft results to league', {
-      leagueId,
-      draftId: body.draftId,
-      error: error instanceof Error ? error.message : 'Unknown error',
-    });
+      logger.error('Failed to sync draft results to league', {
+        leagueId,
+        draftId: body?.draftId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
 
     return errorResponse(
       'Failed to sync draft results',


### PR DESCRIPTION
## Summary
- refactor draft lobby API params handling to destructure synchronously
- drop redundant `await` usage in error logging
- parse draft-sync request body inside try block for safer error handling

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-object-type, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b5355b7128832b857361c2385ca2a0