### PR TITLE
refactor: destructure waiver params synchronously

### DIFF
--- a/src/app/api/leagues/[id]/waivers/process/route.ts
+++ b/src/app/api/leagues/[id]/waivers/process/route.ts
@@ -7,7 +7,6 @@ import { logger, withTiming } from '@/lib/logger';
 import { revalidateTag } from 'next/cache';
 import { tags } from '@/lib/cacheTags';
 import { withMetrics } from '@/lib/metrics';
-import type { LeagueParams } from '@/types/api';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
@@ -42,8 +41,11 @@ interface RosterDoc {
   updatedAt?: FirebaseFirestore.Timestamp | Date;
 }
 
-export const POST = withMetrics(async (req: NextRequest, { params }: LeagueParams) => {
-  const { id: leagueId } = await params;
+export const POST = withMetrics(async (
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) => {
+  const { id: leagueId } = params;
   try {
     // Stronger auth: verify Firebase ID token from Authorization header or session
     const userId = await getAuthenticatedUserId(req);


### PR DESCRIPTION
## Summary
- remove LeagueParams type import and destructure params synchronously in waiver processing route

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68b53562aa54832bbbc42eeeccd49af2