### PR TITLE
refactor: adjust lobby route params handling

### DIFF
--- a/src/app/api/leagues/[id]/waivers/process/route.ts
+++ b/src/app/api/leagues/[id]/waivers/process/route.ts
@@ -43,7 +43,7 @@ interface RosterDoc {
 }
 
 export const POST = withMetrics(async (req: NextRequest, { params }: LeagueParams) => {
-  const { id: leagueId } = params;
+  const { id: leagueId } = await params;
   try {
     // Stronger auth: verify Firebase ID token from Authorization header or session
     const userId = await getAuthenticatedUserId(req);

--- a/src/app/api/leagues/[id]/waivers/process/route.ts
+++ b/src/app/api/leagues/[id]/waivers/process/route.ts
@@ -43,7 +43,7 @@ interface RosterDoc {
 }
 
 export const POST = withMetrics(async (req: NextRequest, { params }: LeagueParams) => {
-  const { id: leagueId } = await params;
+  const { id: leagueId } = params;
   try {
     // Stronger auth: verify Firebase ID token from Authorization header or session
     const userId = await getAuthenticatedUserId(req);

--- a/src/app/api/leagues/[id]/waivers/process/route.ts
+++ b/src/app/api/leagues/[id]/waivers/process/route.ts
@@ -43,6 +43,7 @@ interface RosterDoc {
 }
 
 export const POST = withMetrics(async (req: NextRequest, { params }: LeagueParams) => {
+  // Await params to handle both synchronous and asynchronous Next.js 15 params
   const { id: leagueId } = await params;
   try {
     // Stronger auth: verify Firebase ID token from Authorization header or session

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -5,7 +5,7 @@
 /**
  * Standard params shape for league ID-based routes (Promise-based in Next.js 15+)
  */
-export type LeagueParams = { params: Promise<{ id: string }> };
+export type LeagueParams = { params: { id: string } | Promise<{ id: string }> };
 
 /**
  * Standard params shape for draft ID-based routes (Promise-based in Next.js 15+)


### PR DESCRIPTION
## Summary
- refactor draft lobby API params handling to destructure synchronously
- drop redundant `await` usage in error logging
- allow synchronous league params in waiver processing route

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b5356881a8832b8a116b986cf8a332