### PR TITLE
fix: avoid reawaiting params in player route

### DIFF
--- a/src/app/api/players/[id]/route.ts
+++ b/src/app/api/players/[id]/route.ts
@@ -4,18 +4,19 @@ import { type NextRequest } from 'next/server';
 import { getPlayer } from '@/lib/data';
 import { logger } from '@/lib/logger';
 import { commonErrors, successResponse } from '@/lib/apiResponse';
-import type { LeagueParams } from '@/types/api';
 
-export async function GET(_request: NextRequest, { params }: LeagueParams) {
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const { id } = params;
   try {
-    const { id } = await params;
     const player = await getPlayer(id);
     if (!player) {
       return commonErrors.notFound('Player not found');
     }
     return successResponse(player);
   } catch (error) {
-    const { id } = await params;
     logger.error('Failed to fetch player', error, { playerId: id });
     return commonErrors.internalServerError('Failed to fetch player');
   }


### PR DESCRIPTION
## Summary
- simplify player route params handling
- log errors without re-awaiting params

## Testing
- `npm test`
- `npm run lint` *(fails: `_leagueId` is defined but never used` in waiverService.ts, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5357698b4832bbefc281c19501e23