### PR TITLE
fix: reduce trade review auth log verbosity

### DIFF
--- a/src/app/api/trades/review/route.ts
+++ b/src/app/api/trades/review/route.ts
@@ -204,12 +204,13 @@ export async function GET(request: Request) {
       return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
     }
     
-    // Log user info for audit purposes (safely handling optional fields)
-    console.log('User authentication successful', { 
-      uid: decoded?.uid, 
-      email: decoded?.email, 
-      roles: decoded?.roles,
-      isAdmin: decoded?.admin === true || (Array.isArray(decoded?.roles) && decoded.roles.includes('admin'))
+    // Auth OK (debug)
+    console.debug('TradeReview auth OK', {
+      uid: decoded?.uid,
+      roles: Array.isArray(decoded?.roles) ? decoded.roles : [],
+      isAdmin:
+        decoded?.admin === true ||
+        (Array.isArray(decoded?.roles) && decoded.roles.includes('admin')),
     });
     
     const roles: string[] = Array.isArray(decoded?.roles) ? decoded.roles : [];


### PR DESCRIPTION
## Summary
- replace verbose auth console log with debug-level log sans email

## Testing
- `npm test`
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' in waiverService and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b5357da9c8832b8501555dc4f19442