### PR TITLE
refactor: use synchronous params in user profile route

### DIFF
--- a/src/app/api/user/profile/[userId]/route.ts
+++ b/src/app/api/user/profile/[userId]/route.ts
@@ -18,8 +18,8 @@ export async function GET(
   { params }: UserIdParams
 ) {
   try {
-    const { userId } = await params;
-    
+    const { userId } = params;
+
     if (!userId) {
       return NextResponse.json(
         { error: 'User ID is required' },
@@ -57,15 +57,16 @@ export async function PUT(
   { params }: UserIdParams
 ) {
   try {
-    const { userId } = await params;
-    const updates = await request.json();
-    
+    const { userId } = params;
+
     if (!userId) {
       return NextResponse.json(
         { error: 'User ID is required' },
         { status: 400 }
       );
     }
+
+    const updates = await request.json();
 
     logger.info('API: Updating user profile', { userId, updateKeys: Object.keys(updates) });
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -20,7 +20,7 @@ export type IdParams = { params: Promise<{ id: string }> };
 /**
  * Standard params shape for routes with userId parameter (Promise-based in Next.js 15+)
  */
-export type UserIdParams = { params: Promise<{ userId: string }> };
+export type UserIdParams = { params: { userId: string } };
 
 /**
  * Standard params shape for routes with multiple ID parameters (Promise-based in Next.js 15+)


### PR DESCRIPTION
## Summary
- handle user profile route params synchronously
- validate userId before parsing request body

## Testing
- `npm test`
- `npm run lint` *(fails: '_leagueId' is defined but never used...)*

------
https://chatgpt.com/codex/tasks/task_e_68b53589786c832bad60afc0e95d42b6