### PR TITLE
refactor: secure pre-draft queue access

### DIFF
--- a/src/app/api/drafts/[id]/pre-queue/route.ts
+++ b/src/app/api/drafts/[id]/pre-queue/route.ts
@@ -1,7 +1,9 @@
 import type { NextRequest } from 'next/server';
-import { successResponse, errorResponse } from '@/lib/apiResponse';
+import { successResponse, errorResponse, commonErrors } from '@/lib/apiResponse';
 import { logger } from '@/lib/logger';
 import { updatePreDraftQueue, getPreDraftQueue } from '@/lib/draftLobby';
+import { prisma } from '@/lib/prisma';
+import { getUserIdFromRequest } from '@/lib/serverAuth';
 import type { DraftParams } from '@/types/api';
 
 interface PreQueueRequest {
@@ -22,11 +24,39 @@ export async function GET(
 ) {
   const { id: draftId } = await params;
   try {
+    const reqUserId = await getUserIdFromRequest(request);
+    if (!reqUserId) {
+      return commonErrors.unauthorized();
+    }
+
     const url = new URL(request.url);
     const memberId = url.searchParams.get('memberId');
 
     if (!memberId) {
-      return errorResponse('Missing memberId parameter', 400);
+      return commonErrors.badRequest('Missing memberId parameter');
+    }
+
+    // Verify draft exists and member belongs to this draft
+    const draft = await prisma.draft.findUnique({
+      where: { id: draftId },
+      include: {
+        league: {
+          include: { members: { where: { id: memberId } } },
+        },
+      },
+    });
+
+    if (!draft) {
+      return commonErrors.notFound('Draft not found');
+    }
+
+    const member = draft.league?.members[0];
+    if (!member) {
+      return commonErrors.forbidden('Not a member of this draft');
+    }
+
+    if (member.userId !== reqUserId) {
+      return commonErrors.forbidden('Forbidden');
     }
 
     const queue = await getPreDraftQueue(draftId, memberId);
@@ -51,20 +81,64 @@ export async function PUT(
 ) {
   const { id: draftId } = await params;
   try {
+    const reqUserId = await getUserIdFromRequest(request);
+    if (!reqUserId) {
+      return commonErrors.unauthorized();
+    }
+
     const body: PreQueueRequest = await request.json();
 
     if (!body.memberId || !Array.isArray(body.queue)) {
-      return errorResponse('Missing memberId or invalid queue format', 400);
+      return commonErrors.badRequest('Missing memberId or invalid queue format');
+    }
+
+    // Verify draft exists and member belongs to user
+    const draft = await prisma.draft.findUnique({
+      where: { id: draftId },
+      include: {
+        league: {
+          include: { members: { where: { id: body.memberId } } },
+        },
+      },
+    });
+
+    if (!draft) {
+      return commonErrors.notFound('Draft not found');
+    }
+
+    const member = draft.league?.members[0];
+    if (!member) {
+      return commonErrors.forbidden('Not a member of this draft');
+    }
+
+    if (member.userId !== reqUserId) {
+      return commonErrors.forbidden('Forbidden');
     }
 
     // Validate queue items
+    const seenPlayers = new Set<string>();
+    const seenRanks = new Set<number>();
     for (const item of body.queue) {
-      if (!item.playerId || typeof item.rank !== 'number') {
-        return errorResponse('Invalid queue item format', 400);
+      if (
+        !item.playerId ||
+        typeof item.rank !== 'number' ||
+        !Number.isInteger(item.rank) ||
+        item.rank < 1
+      ) {
+        return commonErrors.badRequest('Invalid queue item format');
       }
+      if (seenPlayers.has(item.playerId) || seenRanks.has(item.rank)) {
+        return commonErrors.badRequest('Duplicate playerId or rank in queue');
+      }
+      seenPlayers.add(item.playerId);
+      seenRanks.add(item.rank);
     }
 
-    const updatedQueue = await updatePreDraftQueue(draftId, body.memberId, body.queue);
+    const updatedQueue = await updatePreDraftQueue(
+      draftId,
+      body.memberId,
+      body.queue,
+    );
 
     return successResponse({ queue: updatedQueue });
   } catch (error) {


### PR DESCRIPTION
## Summary
- enforce authentication and member ownership checks in pre-draft queue API
- validate queue items for positive integer rank and duplicate player or rank values

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars in waiverService.ts, createPlayerStore.ts, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b535a4e558832bbb76096e92069640