### PR TITLE
fix: harden pre-draft queue auth and validation

### DIFF
--- a/src/app/api/drafts/[id]/pre-queue/route.ts
+++ b/src/app/api/drafts/[id]/pre-queue/route.ts
@@ -2,7 +2,8 @@ import type { NextRequest } from 'next/server';
 import { successResponse, errorResponse } from '@/lib/apiResponse';
 import { logger } from '@/lib/logger';
 import { updatePreDraftQueue, getPreDraftQueue } from '@/lib/draftLobby';
-import type { DraftParams } from '@/types/api';
+import { prisma } from '@/lib/prisma';
+import { getUserIdFromRequest } from '@/lib/serverAuth';
 
 interface PreQueueRequest {
   memberId: string;
@@ -18,15 +19,25 @@ interface PreQueueRequest {
  */
 export async function GET(
   request: NextRequest,
-  { params }: DraftParams
+  { params }: { params: { id: string } }
 ) {
-  const { id: draftId } = await params;
+  const { id: draftId } = params;
   try {
+    const reqUserId = await getUserIdFromRequest(request);
+    if (!reqUserId) return errorResponse('Unauthorized', 401);
+
     const url = new URL(request.url);
     const memberId = url.searchParams.get('memberId');
-
     if (!memberId) {
       return errorResponse('Missing memberId parameter', 400);
+    }
+
+    const member = await prisma.leagueMember.findUnique({
+      where: { id: memberId },
+      select: { userId: true },
+    });
+    if (!member || member.userId !== reqUserId) {
+      return errorResponse('Forbidden', 403);
     }
 
     const queue = await getPreDraftQueue(draftId, memberId);
@@ -47,21 +58,37 @@ export async function GET(
  */
 export async function PUT(
   request: NextRequest,
-  { params }: DraftParams
+  { params }: { params: { id: string } }
 ) {
-  const { id: draftId } = await params;
+  const { id: draftId } = params;
   try {
-    const body: PreQueueRequest = await request.json();
+    const reqUserId = await getUserIdFromRequest(request);
+    if (!reqUserId) return errorResponse('Unauthorized', 401);
 
+    const body: PreQueueRequest = await request.json();
     if (!body.memberId || !Array.isArray(body.queue)) {
       return errorResponse('Missing memberId or invalid queue format', 400);
     }
 
-    // Validate queue items
+    const member = await prisma.leagueMember.findUnique({
+      where: { id: body.memberId },
+      select: { userId: true },
+    });
+    if (!member || member.userId !== reqUserId) {
+      return errorResponse('Forbidden', 403);
+    }
+
+    const seenIds = new Set<string>();
+    const seenRanks = new Set<number>();
     for (const item of body.queue) {
-      if (!item.playerId || typeof item.rank !== 'number') {
+      if (!item.playerId || !Number.isInteger(item.rank) || item.rank < 1) {
         return errorResponse('Invalid queue item format', 400);
       }
+      if (seenIds.has(item.playerId) || seenRanks.has(item.rank)) {
+        return errorResponse('Duplicate playerId or rank in queue', 400);
+      }
+      seenIds.add(item.playerId);
+      seenRanks.add(item.rank);
     }
 
     const updatedQueue = await updatePreDraftQueue(draftId, body.memberId, body.queue);


### PR DESCRIPTION
## Summary
- require authenticated ownership before accessing pre-draft queue
- validate queue item ranks and prevent duplicates

## Testing
- `npm test`
- `npm run lint` *(fails: '_leagueId' is defined but never used, `_config` is defined but never used, `_priorities` is defined but never used, `_leagueId` is defined but never used, `_requestId` is defined but never used, `_get` is defined but never used, `_api` is defined but never used, The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.)*


------
https://chatgpt.com/codex/tasks/task_e_68b535a8b9d0832b84c3501c259f62a8