### PR TITLE
refactor: adjust lobby route params handling

### DIFF
--- a/src/app/api/drafts/[id]/schedule/route.ts
+++ b/src/app/api/drafts/[id]/schedule/route.ts
@@ -6,7 +6,7 @@ import { DraftStatus } from '@prisma/client';
 import { scheduleDraftStart } from '@/api/queues/draftQueue';
 import { localToUtc, isValidTimeZone } from '@/lib/timezone';
 import { updateDraftReminders } from '@/lib/reminders';
-import type { LeagueParams } from '@/types/api';
+import type { DraftParams } from '@/types/api';
 
 interface UpdateScheduleRequest {
   scheduledTime: string;
@@ -17,7 +17,7 @@ interface UpdateScheduleRequest {
 
 export async function PUT(
   request: NextRequest,
-  { params }: LeagueParams
+  { params }: DraftParams
 ) {
   const { id: draftId } = await params;
   try {
@@ -146,7 +146,7 @@ export async function PUT(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: LeagueParams
+  { params }: DraftParams
 ) {
   const { id: draftId } = await params;
   try {


### PR DESCRIPTION
## Summary
- switch draft schedule API to use `DraftParams` type

## Testing
- `npm test`
- `npm run lint` *(fails: '_leagueId' is defined but never used; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b535b0ce04832bba338ae77c8fd16c