### PR TITLE
refactor: adjust lobby route params handling

### DIFF
--- a/src/app/api/drafts/[id]/schedule/route.ts
+++ b/src/app/api/drafts/[id]/schedule/route.ts
@@ -20,6 +20,10 @@ export async function PUT(
   { params }: LeagueParams
 ) {
   const { id: draftId } = await params;
+  if (typeof draftId !== 'string' || !draftId.trim()) {
+    logger.warn('Invalid draft id in schedule route', { draftId });
+    return errorResponse('Invalid draft id', 400);
+  }
   try {
     const body: UpdateScheduleRequest = await request.json();
 


### PR DESCRIPTION
## Summary
- refactor draft lobby API params handling to destructure synchronously
- drop redundant `await` usage in error logging
- validate draft id before rescheduling a draft

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used, _config is defined but never used, _priorities is defined but never used, _leagueId is defined but never used, _requestId is defined but never used, _get is defined but never used, _api is defined but never used, The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`.)*


------
https://chatgpt.com/codex/tasks/task_e_68b535b5cdc4832bb77473cd0cca34a5