### PR TITLE
refactor: adjust lobby route params handling

### DIFF
--- a/src/app/api/drafts/[id]/schedule/route.ts
+++ b/src/app/api/drafts/[id]/schedule/route.ts
@@ -148,7 +148,7 @@ export async function DELETE(
   request: NextRequest,
   { params }: LeagueParams
 ) {
-  const { id: draftId } = await Promise.resolve(params);
+  const { id: draftId } = params;
   try {
 
     // Find the draft

--- a/src/app/api/drafts/[id]/schedule/route.ts
+++ b/src/app/api/drafts/[id]/schedule/route.ts
@@ -19,7 +19,7 @@ export async function PUT(
   request: NextRequest,
   { params }: LeagueParams
 ) {
-  const { id: draftId } = await params;
+  const { id: draftId } = await Promise.resolve(params);
   try {
     const body: UpdateScheduleRequest = await request.json();
 
@@ -148,7 +148,7 @@ export async function DELETE(
   request: NextRequest,
   { params }: LeagueParams
 ) {
-  const { id: draftId } = await params;
+  const { id: draftId } = await Promise.resolve(params);
   try {
 
     // Find the draft


### PR DESCRIPTION
## Summary
- resolve draft schedule handlers' params before mutation

## Testing
- `npm test`
- `npm run lint` *(fails: _leagueId is defined but never used, _config is defined but never used, _priorities is defined but never used, _leagueId is defined but never used, _requestId is defined but never used, _get is defined but never used, _api is defined but never used, The `{}` ("empty object") type allows any non-nullish value, including literals like `0` and `""`., If that's what you want, disable this lint rule with an inline comment or configure the 'allowObjectTypes' rule option., If you want a type meaning "any object", you probably want `object` instead., If you want a type meaning "any value", you probably want `unknown` instead.)*

------
https://chatgpt.com/codex/tasks/task_e_68b535bd328c832bb91cd1cb58a2345e