### PR TITLE
fix: validate draft results request

### DIFF
--- a/src/app/api/leagues/[id]/sync-draft-results/route.ts
+++ b/src/app/api/leagues/[id]/sync-draft-results/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from 'next/server';
-import { successResponse, errorResponse } from '@/lib/apiResponse';
+import { successResponse, errorResponse, commonErrors } from '@/lib/apiResponse';
 import { logger } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
 import { adminDb } from '@/lib/firebaseAdmin';
@@ -33,11 +33,12 @@ export async function POST(
   { params }: LeagueParams
 ) {
   const { id: leagueId } = await params;
-  const body: SyncDraftResultsRequest = await request.json();
+  let body: SyncDraftResultsRequest;
 
   try {
+    body = await request.json();
     if (!body.draftId?.trim()) {
-      return errorResponse('Draft ID is required', 400);
+      return commonErrors.badRequest('Draft ID is required');
     }
 
     // First try to sync with Prisma database
@@ -198,7 +199,7 @@ export async function POST(
   } catch (error) {
     logger.error('Failed to sync draft results to league', {
       leagueId,
-      draftId: body.draftId,
+      draftId: body?.draftId,
       error: error instanceof Error ? error.message : 'Unknown error',
     });
 


### PR DESCRIPTION
## Summary
- ensure draft results sync API validates draftId and reports parsing errors

## Testing
- `npm test`
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' and '@typescript-eslint/no-empty-object-type' errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b535bf7520832baecf1ef8ba2c6e6b