### PR TITLE
Enable Socket.io-driven real-time dashboard refresh

### DIFF
--- a/socketio-server.ts
+++ b/socketio-server.ts
@@ -47,6 +47,15 @@ io.on('connection', (socket) => {
     socket.emit('test-response', { message: 'Hello from server!' });
   });
 
+  // Dashboard handlers
+  socket.on('dashboard:refresh', () => {
+    io.emit('dashboard:update', { timestamp: new Date().toISOString() });
+  });
+
+  socket.on('module:refresh', (moduleId: string) => {
+    io.emit(`${moduleId}:update`, { timestamp: new Date().toISOString() });
+  });
+
   socket.on('join:draft', (data: { draftId: string }) => {
     const { draftId } = data;
     console.log(`👤 User ${socket.id} joining draft: ${draftId}`);
@@ -258,6 +267,12 @@ httpServer.on('error', (error) => {
   console.error('❌ Server error:', error);
   process.exit(1);
 });
+
+// Periodic demo updates for dashboard modules
+setInterval(() => {
+  io.emit('leaderboard:update', { timestamp: new Date().toISOString() });
+  io.emit('top-picks:update', { timestamp: new Date().toISOString() });
+}, 30000);
 
 httpServer.listen(PORT, () => {
   console.log(`🚀 Socket.IO server running on port ${PORT}`);

--- a/src/components/ModularDashboard.tsx
+++ b/src/components/ModularDashboard.tsx
@@ -7,6 +7,7 @@ import { collection, getDocs } from 'firebase/firestore';
 import { db } from '@/lib/firebaseClient';
 import type { Player } from '@/types/players';
 import { logger } from '@/lib/logger';
+import { io, type Socket } from 'socket.io-client';
 
 // Module Components
 import LiveDraftModule from './dashboard/LiveDraftModule';
@@ -145,7 +146,7 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
   const [players, setPlayers] = useState<Player[]>([]);
   const [modules, setModules] = useState<DashboardModule[]>(defaultModules);
   const [isCustomizing, setIsCustomizing] = useState(false);
-  const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const [socket, setSocket] = useState<Socket | null>(null);
 
   const firstName = useMemo(() => {
     return user.displayName?.trim().split(/\s+/)[0] || user.email?.split('@')[0] || 'Player';
@@ -210,6 +211,17 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
     fetchPlayers();
   }, []);
 
+  useEffect(() => {
+    const s = io();
+    setSocket(s);
+    s.on('dashboard:update', (data) => {
+      logger.info('Dashboard update received', data);
+    });
+    return () => {
+      s.disconnect();
+    };
+  }, []);
+
   // Filter modules based on conditions
   const visibleModules = useMemo(() => {
     return modules
@@ -217,10 +229,6 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
       .slice()
       .sort((a, b) => a.priority - b.priority);
   }, [modules]);
-
-  const handleRefreshModule = (_moduleId: string) => {
-    setRefreshTrigger((prev) => prev + 1);
-  };
 
   const handleToggleModule = (moduleId: string) => {
     setModules((prev) =>
@@ -273,7 +281,7 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
             {/* Dashboard Controls */}
             <div className="flex items-center space-x-3">
               <button
-                onClick={() => setRefreshTrigger((prev) => prev + 1)}
+                onClick={() => socket?.emit('dashboard:refresh')}
                 className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -372,7 +380,7 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
                       <h3 className="font-semibold text-slate-900">{module.title}</h3>
                       <div className="flex items-center space-x-2 opacity-0 group-hover:opacity-100 transition-opacity">
                         <button
-                          onClick={() => handleRefreshModule(module.id)}
+                          onClick={() => socket?.emit('module:refresh', module.id)}
                           className="p-1 hover:bg-slate-100 rounded transition-colors"
                           title="Refresh module"
                         >
@@ -421,7 +429,7 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
                         players={players}
                         activities={mockActivities}
                         stats={mockStats}
-                        refreshTrigger={refreshTrigger}
+                        socket={socket}
                         {...module.props}
                       />
                     </div>

--- a/src/components/dashboard/EnhancedInjuryFeed.tsx
+++ b/src/components/dashboard/EnhancedInjuryFeed.tsx
@@ -14,7 +14,6 @@ interface InjuryData {
 }
 
 interface EnhancedInjuryFeedProps {
-  refreshTrigger?: number;
   teamFilter?: string;
   autoRefresh?: boolean;
 }

--- a/src/components/dashboard/InjuryAlertsModule.tsx
+++ b/src/components/dashboard/InjuryAlertsModule.tsx
@@ -13,13 +13,9 @@ interface InjuryData {
 
 interface InjuryAlertsModuleProps {
   alerts: Array<{ injured: InjuryData; replacements: InjuryData[] }>;
-  refreshTrigger: number;
 }
 
-export default function InjuryAlertsModule({
-  alerts,
-  refreshTrigger: _refreshTrigger,
-}: InjuryAlertsModuleProps) {
+export default function InjuryAlertsModule({ alerts }: InjuryAlertsModuleProps) {
   if (alerts.length === 0) {
     return (
       <div className="text-center py-6">

--- a/src/components/dashboard/LeaderboardModule.tsx
+++ b/src/components/dashboard/LeaderboardModule.tsx
@@ -1,9 +1,10 @@
 import { motion } from 'framer-motion';
 import { usePlayerStatsETL } from '@/hooks/usePlayerStats';
 import { useEffect, useState } from 'react';
+import type { Socket } from 'socket.io-client';
 
 interface LeaderboardModuleProps {
-  refreshTrigger: number;
+  socket: Socket | null;
 }
 
 interface LeaderboardEntry {
@@ -16,15 +17,20 @@ interface LeaderboardEntry {
   isCurrentUser?: boolean;
 }
 
-export default function LeaderboardModule({ refreshTrigger }: LeaderboardModuleProps) {
+export default function LeaderboardModule({ socket }: LeaderboardModuleProps) {
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
   const { data: playerStats, loading, error, refetch } = usePlayerStatsETL('2025');
 
   useEffect(() => {
-    if (refreshTrigger > 0) {
+    if (!socket) return;
+    const handler = () => {
       refetch();
-    }
-  }, [refreshTrigger, refetch]);
+    };
+    socket.on('leaderboard:update', handler);
+    return () => {
+      socket.off('leaderboard:update', handler);
+    };
+  }, [socket, refetch]);
 
   useEffect(() => {
     if (playerStats && playerStats.length > 0) {

--- a/src/components/dashboard/LeagueManagementModule.tsx
+++ b/src/components/dashboard/LeagueManagementModule.tsx
@@ -12,13 +12,9 @@ interface LeagueWithMembers extends League {
 
 interface LeagueManagementModuleProps {
   user: User;
-  refreshTrigger?: number;
 }
 
-export default function LeagueManagementModule({
-  user,
-  refreshTrigger,
-}: LeagueManagementModuleProps) {
+export default function LeagueManagementModule({ user }: LeagueManagementModuleProps) {
   const [leagues, setLeagues] = useState<LeagueWithMembers[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -65,7 +61,7 @@ export default function LeagueManagementModule({
     };
 
     fetchUserLeagues();
-  }, [user, refreshTrigger]);
+  }, [user]);
 
   if (loading) {
     return (

--- a/src/components/dashboard/LeagueManagementModule.tsx
+++ b/src/components/dashboard/LeagueManagementModule.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
 import type { User } from 'firebase/auth';
 import type { League, LeagueMember } from '@/types/leagues';
+import type { Socket } from 'socket.io-client';
 
 interface LeagueWithMembers extends League {
   members: LeagueMember[];
@@ -12,56 +13,68 @@ interface LeagueWithMembers extends League {
 
 interface LeagueManagementModuleProps {
   user: User;
+  socket?: Socket | null;
 }
 
-export default function LeagueManagementModule({ user }: LeagueManagementModuleProps) {
+export default function LeagueManagementModule({ user, socket }: LeagueManagementModuleProps) {
   const [leagues, setLeagues] = useState<LeagueWithMembers[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchUserLeagues = async () => {
-      try {
-        setLoading(true);
-        setError(null);
+  const fetchUserLeagues = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
 
-        // Early validation
-        if (!user?.uid) {
-          console.error('User authentication error:', { user, hasUid: !!user?.uid });
-          throw new Error('User not authenticated');
-        }
-        
-        console.log('Fetching leagues for user:', user.uid);
-        
-        // Fetch user's league memberships
-        const membershipsResponse = await fetch(`/api/leagues/user/${user.uid}`);
-        
-        if (!membershipsResponse.ok) {
-          throw new Error('Failed to fetch user league memberships');
-        }
-
-        const membershipsData = await membershipsResponse.json();
-        console.log('League memberships data:', membershipsData); // Debug log
-        
-        // Handle the API response format - it now returns leagues directly
-        const leagues = membershipsData.leagues || membershipsData.data?.leagues || [];
-        if (!Array.isArray(leagues)) {
-          console.warn('Leagues data is not an array:', leagues);
-          setLeagues([]);
-          return;
-        }
-        
-        setLeagues(leagues);
-      } catch (err) {
-        console.error('Error fetching user leagues:', err);
-        setError('Failed to load leagues');
-      } finally {
-        setLoading(false);
+      // Early validation
+      if (!user?.uid) {
+        console.error('User authentication error:', { user, hasUid: !!user?.uid });
+        throw new Error('User not authenticated');
       }
-    };
 
+      console.log('Fetching leagues for user:', user.uid);
+
+      // Fetch user's league memberships
+      const membershipsResponse = await fetch(`/api/leagues/user/${user.uid}`);
+
+      if (!membershipsResponse.ok) {
+        throw new Error('Failed to fetch user league memberships');
+      }
+
+      const membershipsData = await membershipsResponse.json();
+      console.log('League memberships data:', membershipsData); // Debug log
+
+      // Handle the API response format - it now returns leagues directly
+      const leagues = membershipsData.leagues || membershipsData.data?.leagues || [];
+      if (!Array.isArray(leagues)) {
+        console.warn('Leagues data is not an array:', leagues);
+        setLeagues([]);
+        return;
+      }
+
+      setLeagues(leagues);
+    } catch (err) {
+      console.error('Error fetching user leagues:', err);
+      setError('Failed to load leagues');
+    } finally {
+      setLoading(false);
+    }
+  }, [user?.uid]);
+
+  useEffect(() => {
     fetchUserLeagues();
-  }, [user]);
+  }, [fetchUserLeagues]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const onRefresh = () => fetchUserLeagues();
+    socket.on('dashboard:update', onRefresh);
+    socket.on('league-management:update', onRefresh);
+    return () => {
+      socket.off('dashboard:update', onRefresh);
+      socket.off('league-management:update', onRefresh);
+    };
+  }, [socket, fetchUserLeagues]);
 
   if (loading) {
     return (

--- a/src/components/dashboard/LiveDraftModule.tsx
+++ b/src/components/dashboard/LiveDraftModule.tsx
@@ -7,7 +7,6 @@ import type { User } from 'firebase/auth';
 import { fetchApi } from '@/lib/api';
 
 interface LiveDraftModuleProps {
-  refreshTrigger: number;
   user: User;
 }
 
@@ -25,7 +24,7 @@ interface DraftMeta {
   }>;
 }
 
-export default function LiveDraftModule({ refreshTrigger, user }: LiveDraftModuleProps) {
+export default function LiveDraftModule({ user }: LiveDraftModuleProps) {
   const [draft, setDraft] = useState<DraftMeta | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -68,7 +67,7 @@ export default function LiveDraftModule({ refreshTrigger, user }: LiveDraftModul
     return () => {
       isMounted = false;
     };
-  }, [refreshTrigger]);
+  }, []);
 
   // Determine turn information
   const teamCount = draft?.participants.length ?? 0;

--- a/src/components/dashboard/LiveInjuryFeed.client.tsx
+++ b/src/components/dashboard/LiveInjuryFeed.client.tsx
@@ -4,12 +4,13 @@ import { useMemo, useState } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { useInjuryData } from '@/hooks/useInjuryData';
 import InjuryListDisplay from './InjuryListDisplay';
+import type { Socket } from 'socket.io-client';
 
 interface LiveInjuryFeedProps {
-  refreshTrigger: number;
   teamFilter?: string;
   userTeamPlayers?: string[];
   autoRefresh?: boolean;
+  socket?: Socket | null;
 }
 
 const AFL_TEAMS = [
@@ -65,10 +66,10 @@ function parseReturnToDays(expectedReturn?: string, status?: string): number {
 }
 
 export default function LiveInjuryFeedClient({
-  refreshTrigger: _refreshTrigger,
   teamFilter,
   userTeamPlayers: _userTeamPlayers,
   autoRefresh = true,
+  socket: _socket,
 }: LiveInjuryFeedProps) {
   const reduceMotion = useReducedMotion();
   const [selectedTeam, setSelectedTeam] = useState<string>(teamFilter || '');

--- a/src/components/dashboard/LiveInjuryFeed.tsx
+++ b/src/components/dashboard/LiveInjuryFeed.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import LiveInjuryFeedSkeleton from '@/components/ui/skeletons/LiveInjuryFeedSkeleton';
+import type { Socket } from 'socket.io-client';
 
 type Props = {
-  refreshTrigger: number;
   teamFilter?: string;
   userTeamPlayers?: string[];
   autoRefresh?: boolean;
+  socket?: Socket | null;
 };
 
 const Client = dynamic<Props>(() => import('./LiveInjuryFeed.client'), {

--- a/src/components/dashboard/LiveScoringModule.tsx
+++ b/src/components/dashboard/LiveScoringModule.tsx
@@ -2,13 +2,7 @@ import React from 'react';
 import { PlayIcon, TrophyIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
 
-interface LiveScoringModuleProps {
-  refreshTrigger: number;
-}
-
-export default function LiveScoringModule({
-  refreshTrigger: _refreshTrigger,
-}: LiveScoringModuleProps) {
+export default function LiveScoringModule() {
   // Mock live scoring data
   const liveData = {
     userScore: 1847,

--- a/src/components/dashboard/PlayerSpotlightModule.client.tsx
+++ b/src/components/dashboard/PlayerSpotlightModule.client.tsx
@@ -2,12 +2,13 @@
 
 import { motion, useReducedMotion } from 'framer-motion';
 import { useMemo } from 'react';
+import type { Socket } from 'socket.io-client';
 
 interface PlayerSpotlightModuleProps {
-  refreshTrigger: number;
+  socket: Socket | null;
 }
 
-export default function PlayerSpotlightModuleClient({ refreshTrigger: _refreshTrigger }: PlayerSpotlightModuleProps) {
+export default function PlayerSpotlightModuleClient({ socket: _socket }: PlayerSpotlightModuleProps) {
   const reduceMotion = useReducedMotion();
 
   const featuredPlayer = {

--- a/src/components/dashboard/PlayerSpotlightModule.tsx
+++ b/src/components/dashboard/PlayerSpotlightModule.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import PlayerSpotlightSkeleton from '@/components/ui/skeletons/PlayerSpotlightSkeleton';
+import type { Socket } from 'socket.io-client';
 
-type Props = { refreshTrigger: number };
+type Props = { socket: Socket | null };
 
 const Client = dynamic(() => import('@/components/dashboard/PlayerSpotlightModule.client'), {
   ssr: false,

--- a/src/components/dashboard/QuickActionsModule.tsx
+++ b/src/components/dashboard/QuickActionsModule.tsx
@@ -1,13 +1,7 @@
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 
-interface QuickActionsModuleProps {
-  refreshTrigger: number;
-}
-
-export default function QuickActionsModule({
-  refreshTrigger: _refreshTrigger,
-}: QuickActionsModuleProps) {
+export default function QuickActionsModule() {
   const actions = [
     {
       title: 'Create League',

--- a/src/components/dashboard/RecentActivityModule.tsx
+++ b/src/components/dashboard/RecentActivityModule.tsx
@@ -11,12 +11,10 @@ interface Activity {
 
 interface RecentActivityModuleProps {
   activities: Activity[];
-  refreshTrigger: number;
 }
 
 export default function RecentActivityModule({
   activities,
-  refreshTrigger: _refreshTrigger,
 }: RecentActivityModuleProps) {
   const getActivityIcon = (type: Activity['type']) => {
     switch (type) {

--- a/src/components/dashboard/StatsOverviewModule.tsx
+++ b/src/components/dashboard/StatsOverviewModule.tsx
@@ -9,12 +9,10 @@ interface StatItem {
 
 interface StatsOverviewModuleProps {
   stats: StatItem[];
-  refreshTrigger: number;
 }
 
 export default function StatsOverviewModule({
   stats,
-  refreshTrigger: _refreshTrigger,
 }: StatsOverviewModuleProps) {
   const formatValue = (value: string | number, format?: StatItem['format']) => {
     if (typeof value === 'string') return value;

--- a/src/components/dashboard/TeamAnalyticsModule.client.tsx
+++ b/src/components/dashboard/TeamAnalyticsModule.client.tsx
@@ -9,14 +9,13 @@ import {
   ArrowTrendingDownIcon,
 } from '@heroicons/react/24/outline';
 import Link from 'next/link';
+import type { Socket } from 'socket.io-client';
 
 interface TeamAnalyticsModuleProps {
-  refreshTrigger: number;
+  socket: Socket | null;
 }
 
-export default function TeamAnalyticsModuleClient({
-  refreshTrigger: _refreshTrigger,
-}: TeamAnalyticsModuleProps) {
+export default function TeamAnalyticsModuleClient({ socket: _socket }: TeamAnalyticsModuleProps) {
   const teamData = {
     weeklyScore: 2156,
     projectedScore: 2189,

--- a/src/components/dashboard/TeamAnalyticsModule.tsx
+++ b/src/components/dashboard/TeamAnalyticsModule.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import TeamAnalyticsSkeleton from '@/components/ui/skeletons/TeamAnalyticsSkeleton';
+import type { Socket } from 'socket.io-client';
 
-type Props = { refreshTrigger: number };
+type Props = { socket: Socket | null };
 
 const Client = dynamic(() => import('@/components/dashboard/TeamAnalyticsModule.client'), {
   ssr: false,

--- a/src/components/dashboard/TopPicksModule.client.tsx
+++ b/src/components/dashboard/TopPicksModule.client.tsx
@@ -4,14 +4,15 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { usePlayerStatsETL } from '@/hooks/usePlayerStats';
 import { useEffect, useMemo, memo } from 'react';
 import type { PlayerStat } from '@/hooks/usePlayerStats';
+import type { Socket } from 'socket.io-client';
 
 const DEFAULT_TOP_PICKS_LIMIT = 8;
 
 interface TopPicksModuleClientProps {
-  refreshTrigger: number;
+  socket: Socket | null;
 }
 
-export default function TopPicksModuleClient({ refreshTrigger }: TopPicksModuleClientProps) {
+export default function TopPicksModuleClient({ socket }: TopPicksModuleClientProps) {
   const reduceMotion = useReducedMotion();
   const { data: playerStats, loading, error, refetch } = usePlayerStatsETL('2025');
 
@@ -22,10 +23,15 @@ export default function TopPicksModuleClient({ refreshTrigger }: TopPicksModuleC
   );
 
   useEffect(() => {
-    if (refreshTrigger > 0) {
+    if (!socket) return;
+    const handler = () => {
       refetch();
-    }
-  }, [refreshTrigger, refetch]);
+    };
+    socket.on('top-picks:update', handler);
+    return () => {
+      socket.off('top-picks:update', handler);
+    };
+  }, [socket, refetch]);
 
   if (loading) {
     return (

--- a/src/components/dashboard/TopPicksModule.client.tsx
+++ b/src/components/dashboard/TopPicksModule.client.tsx
@@ -4,12 +4,12 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { usePlayerStatsETL } from '@/hooks/usePlayerStats';
 import { useEffect, useMemo, memo } from 'react';
 import type { PlayerStat } from '@/hooks/usePlayerStats';
-import type { Socket } from 'socket.io-client';
+import type { TypedSocket } from '@/types/socket-events';
 
 const DEFAULT_TOP_PICKS_LIMIT = 8;
 
 interface TopPicksModuleClientProps {
-  socket: Socket | null;
+  socket: TypedSocket | null;
 }
 
 export default function TopPicksModuleClient({ socket }: TopPicksModuleClientProps) {

--- a/src/components/dashboard/TopPicksModule.tsx
+++ b/src/components/dashboard/TopPicksModule.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import TopPicksSkeleton from '@/components/ui/skeletons/TopPicksSkeleton';
-import type { Socket } from 'socket.io-client';
+import type { TypedSocket } from '@/types/socket-events';
 
-type Props = { socket: Socket | null };
+type Props = { socket: TypedSocket | null };
 
 const Client = dynamic(() => import('./TopPicksModule.client'), {
   ssr: false,

--- a/src/components/dashboard/TopPicksModule.tsx
+++ b/src/components/dashboard/TopPicksModule.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import TopPicksSkeleton from '@/components/ui/skeletons/TopPicksSkeleton';
+import type { Socket } from 'socket.io-client';
 
-type Props = { refreshTrigger: number };
+type Props = { socket: Socket | null };
 
 const Client = dynamic(() => import('./TopPicksModule.client'), {
   ssr: false,

--- a/src/components/dashboard/WaiversModule.tsx
+++ b/src/components/dashboard/WaiversModule.tsx
@@ -7,11 +7,7 @@ import {
 } from '@heroicons/react/24/outline';
 import Link from 'next/link';
 
-interface WaiversModuleProps {
-  refreshTrigger: number;
-}
-
-export default function WaiversModule({ refreshTrigger: _refreshTrigger }: WaiversModuleProps) {
+export default function WaiversModule() {
   // Mock waiver data
   const waiverData = {
     fAABBalance: 75,

--- a/src/components/dashboard/WeekendSummaryModule.tsx
+++ b/src/components/dashboard/WeekendSummaryModule.tsx
@@ -1,12 +1,6 @@
 import { WeekendSummary } from '../WeekendSummary';
 
-interface WeekendSummaryModuleProps {
-  refreshTrigger: number;
-}
-
-export default function WeekendSummaryModule({
-  refreshTrigger: _refreshTrigger,
-}: WeekendSummaryModuleProps) {
+export default function WeekendSummaryModule() {
   return (
     <div className="h-full">
       <WeekendSummary />

--- a/src/types/socket-events.ts
+++ b/src/types/socket-events.ts
@@ -1,0 +1,14 @@
+import type { Socket } from 'socket.io-client';
+
+export interface ServerToClientEvents {
+  'dashboard:update': { timestamp: string };
+  'leaderboard:update': { timestamp: string };
+  'top-picks:update': { timestamp: string };
+}
+
+export interface ClientToServerEvents {
+  'dashboard:refresh': void;
+  'module:refresh': (moduleId: string) => void;
+}
+
+export type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;


### PR DESCRIPTION
## Summary
- Remove refreshTrigger state and hook up a shared Socket.IO client in `ModularDashboard`
- Listen for real-time `leaderboard:update` and `top-picks:update` events inside respective modules
- Emit dashboard and module refresh events from Socket.IO server and broadcast periodic demo updates

## Testing
- `npm test` *(fails: Argument of type 'Firestore | null' is not assignable to parameter of type 'Firestore')*

------
https://chatgpt.com/codex/tasks/task_e_68b42e7cac94832b9135614e82781159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Real-time dashboard updates via socket connections.
  - Global "Refresh" and per-module refresh now trigger instant live updates.
  - Leaderboard and Top Picks auto-refresh every 30 seconds.

- Refactor
  - Dashboard modules migrated to socket-driven updates and simplified refresh behavior for more consistent live experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->