### PR TITLE
fix(rosters): parse roster data from success wrapper

### DIFF
--- a/src/app/rosters/page.tsx
+++ b/src/app/rosters/page.tsx
@@ -79,7 +79,7 @@ export default function RostersPage() {
         );
         if (res.ok) {
           const json = await res.json();
-          const owned: RosterPlayer[] = json.roster?.players || [];
+          const owned: RosterPlayer[] = json?.data?.roster?.players ?? [];
           setRosterPlayers(owned);
 
           if (db) {


### PR DESCRIPTION
## Summary
- parse roster API response from `data` property to populate owned players correctly

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b570857acc832b989fac567c2b36af