### PR TITLE
feat: add invite link improvements and onboarding

### DIFF
--- a/src/app/leagues/[id]/LeaguePageClient.tsx
+++ b/src/app/leagues/[id]/LeaguePageClient.tsx
@@ -5,7 +5,7 @@ import { AppLayout } from '@/components/navigation';
 import { LoadingSpinner, Alert } from '@/components/ui';
 import LeagueOverview from '@/components/league/LeagueOverview';
 import type { League, LeagueMember } from '@/types/leagues';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import OnboardingChecklist from './OnboardingChecklist';
 
 interface Props {
@@ -118,13 +118,16 @@ export default function LeaguePageClient({ league, members, leagueId, errorMsg }
     );
   }
 
-  const currentMember = curMembers.find((m) => m.userId === user?.uid);
+  const currentMember = useMemo(
+    () => curMembers.find((m) => m.userId === user?.uid),
+    [curMembers, user?.uid]
+  );
 
   return (
     <AppLayout>
       <div>
         <h1 className="text-3xl font-bold mb-6">{curLeague.name}</h1>
-        <OnboardingChecklist member={currentMember} />
+        <OnboardingChecklist key={curLeague.id} member={currentMember} />
         {process.env.NODE_ENV === 'development' && (
           <div className="mb-4 p-4 bg-gray-100 rounded text-sm">
             <p><strong>Debug Info:</strong></p>

--- a/src/app/leagues/[id]/OnboardingChecklist.tsx
+++ b/src/app/leagues/[id]/OnboardingChecklist.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { LeagueMember } from '@/types/leagues';
 
 interface Task {
@@ -15,13 +15,19 @@ interface Props {
 
 export default function OnboardingChecklist({ member }: Props) {
   const [tasks, setTasks] = useState<Task[]>([]);
+  const memberRef = useRef<LeagueMember | undefined>();
 
   useEffect(() => {
+    memberRef.current = member;
+    if (!member) {
+      setTasks([]);
+      return;
+    }
     const initial: Task[] = [
       {
         id: 'team-name',
         label: 'Set your team name',
-        completed: Boolean(member?.teamName),
+        completed: Boolean(member.teamName),
       },
       {
         id: 'review-rules',
@@ -29,28 +35,29 @@ export default function OnboardingChecklist({ member }: Props) {
         completed: false,
       },
     ];
-    const saved = localStorage.getItem('league-onboarding');
-    if (saved) {
-      try {
-        const parsed = JSON.parse(saved) as Record<string, Task[]>;
-        setTasks(parsed[member?.leagueId ?? ''] ?? initial);
+    const storageKey = `league-onboarding:${member.leagueId}:${member.userId}`;
+    try {
+      const saved = localStorage.getItem(storageKey);
+      if (saved) {
+        setTasks(JSON.parse(saved) as Task[]);
         return;
-      } catch {
-        // ignore
       }
+    } catch (error) {
+      console.error('Failed to parse onboarding tasks from localStorage:', error);
     }
     setTasks(initial);
   }, [member]);
 
   useEffect(() => {
-    if (!member) return;
-    const storageKey = `league-onboarding:${member.leagueId}:${member.userId}`;
+    const cur = memberRef.current;
+    if (!cur) return;
+    const storageKey = `league-onboarding:${cur.leagueId}:${cur.userId}`;
     try {
       localStorage.setItem(storageKey, JSON.stringify(tasks));
     } catch {
       // ignore quota errors
     }
-  }, [tasks, member]);
+  }, [tasks]);
 
   const toggle = (id: string) => {
     setTasks((prev) =>
@@ -67,14 +74,14 @@ export default function OnboardingChecklist({ member }: Props) {
         {tasks.map((task) => (
           <li key={task.id} className="flex items-center">
             <input
-              id={task.id}
+              id={`${member.leagueId}-${task.id}`}
               type="checkbox"
               checked={task.completed}
               onChange={() => toggle(task.id)}
               className="mr-2 h-4 w-4"
             />
             <label
-              htmlFor={task.id}
+              htmlFor={`${member.leagueId}-${task.id}`}
               className={task.completed ? 'line-through text-gray-500' : ''}
             >
               {task.label}

--- a/src/app/leagues/join/page.tsx
+++ b/src/app/leagues/join/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/AuthContext';
 import { fetchApi } from '@/lib/api';
+import type { JoinedLeagueSummary } from '@/types/leagues';
 import Button from '@/components/Button';
 import { LoadingSpinner } from '@/components/ui';
 import Link from 'next/link';
@@ -14,11 +15,9 @@ export default function JoinLeaguePage() {
   const [teamName, setTeamName] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const [joinedLeague, setJoinedLeague] = useState<{
-    id: string;
-    name: string;
-    draftDate?: string;
-  } | null>(null);
+  const [joinedLeague, setJoinedLeague] = useState<JoinedLeagueSummary | null>(
+    null
+  );
   const { user } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -27,11 +26,13 @@ export default function JoinLeaguePage() {
   useEffect(() => {
     const urlCode = searchParams?.get('code');
     const urlTeam = searchParams?.get('team');
-    if (urlCode) {
-      setCode(urlCode.toUpperCase());
+    const decodedCode = urlCode ? decodeURIComponent(urlCode).trim() : '';
+    const decodedTeam = urlTeam ? decodeURIComponent(urlTeam).trim() : '';
+    if (decodedCode) {
+      setCode(decodedCode.toUpperCase());
     }
-    if (urlTeam) {
-      setTeamName(urlTeam);
+    if (decodedTeam) {
+      setTeamName(decodedTeam);
     }
   }, [searchParams]);
 
@@ -63,7 +64,15 @@ export default function JoinLeaguePage() {
         }
       });
 
-      setJoinedLeague(result.data.league);
+      if (
+        result?.success &&
+        result?.data?.league?.id &&
+        result?.data?.league?.name
+      ) {
+        setJoinedLeague(result.data.league);
+      } else {
+        throw new Error(result?.error || 'Unexpected response');
+      }
 
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to join league');
@@ -90,8 +99,28 @@ export default function JoinLeaguePage() {
 
   const handleAddToCalendar = () => {
     if (!joinedLeague?.draftDate) return;
-    const format = (date: string) => date.replace(/[-:]/g, '').split('.')[0] + 'Z';
-    const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Statly//EN\nBEGIN:VEVENT\nUID:${joinedLeague.id}-draft@statly\nDTSTAMP:${format(new Date().toISOString())}\nDTSTART:${format(joinedLeague.draftDate)}\nSUMMARY:${joinedLeague.name} Draft\nDESCRIPTION:Draft for ${joinedLeague.name}\nEND:VEVENT\nEND:VCALENDAR`;
+    const esc = (s: string) =>
+      s.replace(/([,;\\])/g, '\\$1').replace(/\r?\n/g, '\\n');
+    const format = (date: string) =>
+      date.replace(/[-:]/g, '').split('.')[0] + 'Z';
+    const start = format(joinedLeague.draftDate);
+    const dtstamp = format(new Date().toISOString());
+    const summary = `${esc(joinedLeague.name)} Draft`;
+    const description = `Draft for ${esc(joinedLeague.name)}`;
+    const lines = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//Statly//EN',
+      'BEGIN:VEVENT',
+      `UID:${joinedLeague.id}-draft@statly`,
+      `DTSTAMP:${dtstamp}`,
+      `DTSTART:${start}`,
+      `SUMMARY:${summary}`,
+      `DESCRIPTION:${description}`,
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ];
+    const ics = lines.join('\r\n');
     const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');

--- a/src/components/league/InviteModal.tsx
+++ b/src/components/league/InviteModal.tsx
@@ -13,8 +13,11 @@ export default function InviteModal({ league, isOpen, onClose }: InviteModalProp
   const [copied, setCopied] = useState(false);
   
   const joinUrl = useMemo(() => {
-    const base = typeof window !== 'undefined' ? window.location.origin : '';
-    return `${base}/leagues/join?code=${encodeURIComponent(league.code)}`;
+    if (typeof window === 'undefined') return '';
+    return new URL(
+      `/leagues/join?code=${encodeURIComponent(league.code)}`,
+      window.location.origin
+    ).toString();
   }, [league.code]);
   
   const handleCopyCode = async () => {

--- a/src/types/leagues.ts
+++ b/src/types/leagues.ts
@@ -81,6 +81,12 @@ export interface JoinLeagueRequest {
   teamName: string;
 }
 
+export interface JoinedLeagueSummary {
+  id: string;
+  name: string;
+  draftDate?: string;
+}
+
 // League Update Request (only editable fields)
 export interface UpdateLeagueRequest {
   name?: string;


### PR DESCRIPTION
## Summary
- use per-league onboarding storage with safe parsing and race-free saving
- harden league join page and calendar export
- memoize current member lookup and use absolute invite links

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b56ff22c68832bb0bb6b4c787b37f6