### PR TITLE
refactor: reuse JoinedLeagueSummary type

### DIFF
--- a/src/app/leagues/join/page.tsx
+++ b/src/app/leagues/join/page.tsx
@@ -8,17 +8,16 @@ import Button from '@/components/Button';
 import { LoadingSpinner } from '@/components/ui';
 import Link from 'next/link';
 import { AppLayout } from '@/components/navigation';
+import type { JoinedLeagueSummary } from '@/types/leagues';
 
 export default function JoinLeaguePage() {
   const [code, setCode] = useState('');
   const [teamName, setTeamName] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const [joinedLeague, setJoinedLeague] = useState<{
-    id: string;
-    name: string;
-    draftDate?: string;
-  } | null>(null);
+  const [joinedLeague, setJoinedLeague] = useState<JoinedLeagueSummary | null>(
+    null,
+  );
   const { user } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/src/types/leagues.ts
+++ b/src/types/leagues.ts
@@ -81,6 +81,13 @@ export interface JoinLeagueRequest {
   teamName: string;
 }
 
+// League summary returned after joining
+export interface JoinedLeagueSummary {
+  id: string;
+  name: string;
+  draftDate?: string;
+}
+
 // League Update Request (only editable fields)
 export interface UpdateLeagueRequest {
   name?: string;


### PR DESCRIPTION
## Summary
- define `JoinedLeagueSummary` in shared league types
- use `JoinedLeagueSummary` for joined league state in join page

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b56ff5baa4832bb43a1c2b7f206b1a