### PR TITLE
fix: log onboarding checklist parse errors

### DIFF
--- a/src/app/leagues/[id]/OnboardingChecklist.tsx
+++ b/src/app/leagues/[id]/OnboardingChecklist.tsx
@@ -35,8 +35,11 @@ export default function OnboardingChecklist({ member }: Props) {
         const parsed = JSON.parse(saved) as Record<string, Task[]>;
         setTasks(parsed[member?.leagueId ?? ''] ?? initial);
         return;
-      } catch {
-        // ignore
+      } catch (error) {
+        console.error(
+          'Failed to parse onboarding tasks from localStorage:',
+          error
+        );
       }
     }
     setTasks(initial);


### PR DESCRIPTION
## Summary
- log failures when parsing onboarding tasks from localStorage

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Config (unnamed): Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b56ffd06fc832b9ea07a6a8b315309