### PR TITLE
fix(rosters): clear timer and fetch free agents via API

### DIFF
--- a/src/app/rosters/page.tsx
+++ b/src/app/rosters/page.tsx
@@ -2,9 +2,7 @@
 
 import { useEffect, useState, type ReactNode } from 'react';
 import Link from 'next/link';
-import { collection, getDocs } from 'firebase/firestore';
 import { AppLayout } from '@/components/navigation';
-import { db } from '@/lib/firebaseClient';
 import { useAuth } from '@/AuthContext';
 import { useTeamContext } from '@/contexts/TeamContext';
 import type { Player } from '@/types/players';
@@ -24,17 +22,24 @@ function WaiverTimer({ expiry }: { expiry: Date }) {
       const diff = expiry.getTime() - Date.now();
       if (diff <= 0) {
         setRemaining('Available');
-      } else {
-        const h = Math.floor(diff / 3600000);
-        const m = Math.floor((diff % 3600000) / 60000);
-        const s = Math.floor((diff % 60000) / 1000);
-        setRemaining(
-          `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-        );
+        return true;
       }
+      const h = Math.floor(diff / 3600000);
+      const m = Math.floor((diff % 3600000) / 60000);
+      const s = Math.floor((diff % 60000) / 1000);
+      setRemaining(
+        `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+      );
+      return false;
     };
-    update();
-    const id = setInterval(update, 1000);
+
+    if (update()) return; // Already expired
+
+    const id = setInterval(() => {
+      if (update()) {
+        clearInterval(id);
+      }
+    }, 1000);
     return () => clearInterval(id);
   }, [expiry]);
 
@@ -79,25 +84,15 @@ export default function RostersPage() {
         );
         if (res.ok) {
           const json = await res.json();
-          const owned: RosterPlayer[] = json.roster?.players || [];
+          const owned: RosterPlayer[] = json.data?.roster?.players ?? [];
           setRosterPlayers(owned);
 
-          if (db) {
-            const snap = await getDocs(collection(db, 'players'));
-            const ownedIds = new Set(owned.map((p) => String(p.id)));
-            const fa: RosterPlayer[] = snap.docs
-              .map((d) => {
-                const data = d.data();
-                return {
-                  id: d.id,
-                  name: data.name,
-                  team: data.team,
-                  position: data.position,
-                  injury: data.injury ?? data.status,
-                  waiverExpiresAt: data.waiverExpiresAt || data.waiverExpiry,
-                } as RosterPlayer;
-              })
-              .filter((p) => !ownedIds.has(String(p.id)));
+          const faRes = await fetch(
+            `/api/leagues/${activeLeague}/free-agents`
+          );
+          if (faRes.ok) {
+            const faJson = await faRes.json();
+            const fa: RosterPlayer[] = faJson.data ?? [];
             setFreeAgents(fa);
           }
         }


### PR DESCRIPTION
## Summary
- clear WaiverTimer interval after expiry
- parse roster players from API data wrapper
- load free agents via league API instead of client filtering

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b570934350832b91cdc3bb5a8f77c8