### PR TITLE
fix(rosters): handle roster errors and fetch free agents via api

### DIFF
--- a/src/app/api/leagues/[league]/free-agents/route.ts
+++ b/src/app/api/leagues/[league]/free-agents/route.ts
@@ -1,0 +1,36 @@
+import type { NextRequest } from 'next/server';
+import { successResponse, errorResponse } from '@/lib/apiResponse';
+import { adminDb } from '@/lib/firebaseAdmin';
+
+export async function GET(_req: NextRequest, { params }: { params: { league: string } }) {
+  try {
+    const { league } = params;
+    if (!league) {
+      return errorResponse('League ID is required', 400);
+    }
+
+    const snap = await adminDb
+      .collection('leagues')
+      .doc(league)
+      .collection('availablePlayers')
+      .where('available', '==', true)
+      .get();
+
+    const players = snap.docs.map((d) => {
+      const data = d.data();
+      return {
+        id: d.id,
+        name: data.name,
+        team: data.team,
+        position: data.position,
+        injury: data.injury ?? data.status,
+        waiverExpiresAt: data.waiverExpiresAt || data.waiverExpiry,
+      };
+    });
+
+    return successResponse({ players });
+  } catch (err) {
+    console.error('Failed to fetch free agents', err);
+    return errorResponse('Failed to fetch free agents');
+  }
+}

--- a/src/app/rosters/page.tsx
+++ b/src/app/rosters/page.tsx
@@ -2,17 +2,12 @@
 
 import { useEffect, useState, type ReactNode } from 'react';
 import Link from 'next/link';
-import { collection, getDocs } from 'firebase/firestore';
 import { AppLayout } from '@/components/navigation';
-import { db } from '@/lib/firebaseClient';
 import { useAuth } from '@/AuthContext';
 import { useTeamContext } from '@/contexts/TeamContext';
 import type { Player } from '@/types/players';
 
-type RosterPlayer = Pick<
-  Player,
-  'id' | 'name' | 'team' | 'position' | 'injury'
-> & {
+type RosterPlayer = Pick<Player, 'id' | 'name' | 'team' | 'position' | 'injury'> & {
   waiverExpiresAt?: string;
 };
 
@@ -24,37 +19,36 @@ function WaiverTimer({ expiry }: { expiry: Date }) {
       const diff = expiry.getTime() - Date.now();
       if (diff <= 0) {
         setRemaining('Available');
-      } else {
-        const h = Math.floor(diff / 3600000);
-        const m = Math.floor((diff % 3600000) / 60000);
-        const s = Math.floor((diff % 60000) / 1000);
-        setRemaining(
-          `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-        );
+        return true;
       }
+      const h = Math.floor(diff / 3600000);
+      const m = Math.floor((diff % 3600000) / 60000);
+      const s = Math.floor((diff % 60000) / 1000);
+      setRemaining(
+        `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+      );
+      return false;
     };
-    update();
-    const id = setInterval(update, 1000);
+
+    if (update()) return; // Already expired
+
+    const id = setInterval(() => {
+      if (update()) {
+        clearInterval(id);
+      }
+    }, 1000);
     return () => clearInterval(id);
   }, [expiry]);
 
   return <span className="text-xs text-gray-500">{remaining}</span>;
 }
 
-function PlayerCard({
-  player,
-  children,
-}: {
-  player: RosterPlayer;
-  children?: ReactNode;
-}) {
+function PlayerCard({ player, children }: { player: RosterPlayer; children?: ReactNode }) {
   return (
     <div className="p-4 border rounded shadow-sm bg-white">
       <h2 className="font-semibold text-lg">
         {player.name}
-        {player.injury && (
-          <span className="ml-2 text-sm text-red-600">{player.injury}</span>
-        )}
+        {player.injury && <span className="ml-2 text-sm text-red-600">{player.injury}</span>}
       </h2>
       <p className="text-sm text-gray-600">
         {player.team} - {player.position}
@@ -69,40 +63,32 @@ export default function RostersPage() {
   const { activeLeague } = useTeamContext();
   const [rosterPlayers, setRosterPlayers] = useState<RosterPlayer[]>([]);
   const [freeAgents, setFreeAgents] = useState<RosterPlayer[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const load = async () => {
       if (!user || !activeLeague) return;
       try {
-        const res = await fetch(
-          `/api/leagues/${activeLeague}/roster/${user.uid}`
-        );
+        const res = await fetch(`/api/leagues/${activeLeague}/roster/${user.uid}`);
         if (res.ok) {
           const json = await res.json();
-          const owned: RosterPlayer[] = json.roster?.players || [];
+          const owned: RosterPlayer[] = json.data?.roster?.players ?? [];
           setRosterPlayers(owned);
 
-          if (db) {
-            const snap = await getDocs(collection(db, 'players'));
-            const ownedIds = new Set(owned.map((p) => String(p.id)));
-            const fa: RosterPlayer[] = snap.docs
-              .map((d) => {
-                const data = d.data();
-                return {
-                  id: d.id,
-                  name: data.name,
-                  team: data.team,
-                  position: data.position,
-                  injury: data.injury ?? data.status,
-                  waiverExpiresAt: data.waiverExpiresAt || data.waiverExpiry,
-                } as RosterPlayer;
-              })
-              .filter((p) => !ownedIds.has(String(p.id)));
+          const faRes = await fetch(`/api/leagues/${activeLeague}/free-agents`);
+          if (faRes.ok) {
+            const faJson = await faRes.json();
+            const fa: RosterPlayer[] = faJson.data?.players ?? [];
             setFreeAgents(fa);
+          } else {
+            throw new Error('Failed to fetch free agents');
           }
+        } else {
+          throw new Error('Failed to fetch roster');
         }
       } catch (err) {
         console.error('Failed to load roster', err);
+        setError('Failed to load roster data. Please try refreshing the page.');
       }
     };
     load();
@@ -115,6 +101,11 @@ export default function RostersPage() {
   return (
     <AppLayout>
       <main className="p-6 space-y-8">
+        {error && (
+          <p className="text-red-600" role="alert">
+            {error}
+          </p>
+        )}
         <section>
           <h1 className="text-2xl font-bold mb-4">My Roster</h1>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -123,15 +114,14 @@ export default function RostersPage() {
                 <Link
                   href={`/tradecentre?playerOut=${p.id}`}
                   className="px-3 py-1 rounded bg-blue-600 text-white text-sm"
+                  aria-label={`Propose trade with ${p.name}`}
                 >
                   Propose Trade
                 </Link>
               </PlayerCard>
             ))}
             {rosterPlayers.length === 0 && (
-              <p className="col-span-full text-center text-gray-500">
-                No players on roster.
-              </p>
+              <p className="col-span-full text-center text-gray-500">No players on roster.</p>
             )}
           </div>
         </section>
@@ -140,9 +130,7 @@ export default function RostersPage() {
           <h2 className="text-2xl font-bold mb-4">Available Players</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {freeAgents.map((p) => {
-              const expiry = p.waiverExpiresAt
-                ? new Date(p.waiverExpiresAt)
-                : null;
+              const expiry = p.waiverExpiresAt ? new Date(p.waiverExpiresAt) : null;
               const underWaiver = expiry ? expiry.getTime() > Date.now() : false;
               return (
                 <PlayerCard key={p.id} player={p}>
@@ -155,12 +143,14 @@ export default function RostersPage() {
                     type="button"
                     onClick={() => handleClaim(p, underWaiver)}
                     className="px-2 py-1 rounded bg-emerald-600 text-white text-sm"
+                    aria-label={`${underWaiver ? 'Submit waiver claim for' : 'Add free agent'} ${p.name}`}
                   >
                     {underWaiver ? 'Claim' : 'Add FA'}
                   </button>
                   <Link
                     href={`/tradecentre?playerIn=${p.id}`}
                     className="px-2 py-1 rounded bg-blue-600 text-white text-sm"
+                    aria-label={`Open Trade Centre for ${p.name}`}
                   >
                     Trade
                   </Link>
@@ -168,9 +158,7 @@ export default function RostersPage() {
               );
             })}
             {freeAgents.length === 0 && (
-              <p className="col-span-full text-center text-gray-500">
-                No available players.
-              </p>
+              <p className="col-span-full text-center text-gray-500">No available players.</p>
             )}
           </div>
         </section>
@@ -178,4 +166,3 @@ export default function RostersPage() {
     </AppLayout>
   );
 }
-


### PR DESCRIPTION
## Summary
- clear waiver timers once expired
- parse roster response data and load free agents via backend endpoint
- display friendly error message and add accessible labels

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*


------
https://chatgpt.com/codex/tasks/task_e_68b570991410832b83818c866432f6c6