### PR TITLE
feat(rosters): add league-scoped roster and waiver actions

### DIFF
--- a/src/app/api/leagues/[id]/free-agents/route.ts
+++ b/src/app/api/leagues/[id]/free-agents/route.ts
@@ -1,0 +1,62 @@
+import type { NextRequest } from 'next/server';
+import { adminDb } from '@/lib/firebaseAdmin';
+import { getAuthenticatedUserId } from '@/lib/serverAuth';
+import { verifyLeagueMembership } from '@/lib/leagueMembership';
+import { successResponse, errorResponse } from '@/lib/apiResponse';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id: leagueId } = await params;
+  try {
+    const userId = await getAuthenticatedUserId(req);
+    if (!userId) return errorResponse('Unauthorized', 401);
+    const membership = await verifyLeagueMembership(leagueId, userId);
+    if (!membership.isMember) return errorResponse('Forbidden', 403);
+
+    const indexSnap = await adminDb
+      .collection('leagues')
+      .doc(leagueId)
+      .collection('availablePlayers')
+      .where('available', '==', true)
+      .get();
+
+    const ids = indexSnap.docs.map((d) => d.id);
+    let players: Array<{ id: string; name: string; team?: string; position?: string; injury?: string; waiverExpiresAt?: number }> = [];
+    if (ids.length) {
+      const refs = ids.map((id) => adminDb.collection('players').doc(id));
+      const docs = await adminDb.getAll(...refs);
+      players = docs
+        .filter((d) => d.exists)
+        .map((d) => {
+          const data = d.data() as any;
+          const rawExpiry = data.waiverExpiresAt || data.waiverExpiry;
+          const toMs = (v: any): number | undefined => {
+            if (!v) return undefined;
+            if (typeof v?.toDate === 'function') return v.toDate().getTime();
+            if (typeof v === 'number') return v > 1e12 ? v : v * 1000;
+            if (typeof v === 'string') {
+              const ms = Date.parse(v);
+              return Number.isNaN(ms) ? undefined : ms;
+            }
+            return undefined;
+          };
+          return {
+            id: d.id,
+            name: data.name,
+            team: data.team,
+            position: data.position,
+            injury: data.injury ?? data.status,
+            waiverExpiresAt: toMs(rawExpiry),
+          };
+        });
+    }
+
+    return successResponse({ players });
+  } catch (err) {
+    return errorResponse('Failed to load free agents', 500, undefined, {
+      error: err instanceof Error ? err.message : err,
+    });
+  }
+}

--- a/src/app/rosters/page.tsx
+++ b/src/app/rosters/page.tsx
@@ -2,9 +2,7 @@
 
 import { useEffect, useState, type ReactNode } from 'react';
 import Link from 'next/link';
-import { collection, getDocs } from 'firebase/firestore';
 import { AppLayout } from '@/components/navigation';
-import { db } from '@/lib/firebaseClient';
 import { useAuth } from '@/AuthContext';
 import { useTeamContext } from '@/contexts/TeamContext';
 import type { Player } from '@/types/players';
@@ -13,32 +11,25 @@ type RosterPlayer = Pick<
   Player,
   'id' | 'name' | 'team' | 'position' | 'injury'
 > & {
-  waiverExpiresAt?: string;
+  // milliseconds since epoch
+  waiverExpiresAt?: number;
 };
 
-function WaiverTimer({ expiry }: { expiry: Date }) {
-  const [remaining, setRemaining] = useState('');
+function WaiverTimer({ expiryMs, now }: { expiryMs: number; now: number }) {
+  const diff = Math.max(0, expiryMs - now);
+  const h = Math.floor(diff / 3600000);
+  const m = Math.floor((diff % 3600000) / 60000);
+  const s = Math.floor((diff % 60000) / 1000);
+  const text =
+    diff === 0
+      ? 'Available'
+      : `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
 
-  useEffect(() => {
-    const update = () => {
-      const diff = expiry.getTime() - Date.now();
-      if (diff <= 0) {
-        setRemaining('Available');
-      } else {
-        const h = Math.floor(diff / 3600000);
-        const m = Math.floor((diff % 3600000) / 60000);
-        const s = Math.floor((diff % 60000) / 1000);
-        setRemaining(
-          `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-        );
-      }
-    };
-    update();
-    const id = setInterval(update, 1000);
-    return () => clearInterval(id);
-  }, [expiry]);
-
-  return <span className="text-xs text-gray-500">{remaining}</span>;
+  return (
+    <span role="timer" aria-live="polite" className="text-xs text-gray-500">
+      {text}
+    </span>
+  );
 }
 
 function PlayerCard({
@@ -69,43 +60,57 @@ export default function RostersPage() {
   const { activeLeague } = useTeamContext();
   const [rosterPlayers, setRosterPlayers] = useState<RosterPlayer[]>([]);
   const [freeAgents, setFreeAgents] = useState<RosterPlayer[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  // Shared clock for all countdowns
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
 
   useEffect(() => {
+    const controller = new AbortController();
     const load = async () => {
       if (!user || !activeLeague) return;
       try {
-        const res = await fetch(
-          `/api/leagues/${activeLeague}/roster/${user.uid}`
-        );
+        const res = await fetch(`/api/leagues/${activeLeague}/roster/${user.uid}`, {
+          signal: controller.signal,
+        });
         if (res.ok) {
           const json = await res.json();
-          const owned: RosterPlayer[] = json.roster?.players || [];
-          setRosterPlayers(owned);
+          const owned: RosterPlayer[] = json.data?.roster?.players ?? [];
+          if (!controller.signal.aborted) setRosterPlayers(owned);
+        } else if (!controller.signal.aborted) {
+          setError('Failed to load roster data.');
+        }
 
-          if (db) {
-            const snap = await getDocs(collection(db, 'players'));
-            const ownedIds = new Set(owned.map((p) => String(p.id)));
-            const fa: RosterPlayer[] = snap.docs
-              .map((d) => {
-                const data = d.data();
-                return {
-                  id: d.id,
-                  name: data.name,
-                  team: data.team,
-                  position: data.position,
-                  injury: data.injury ?? data.status,
-                  waiverExpiresAt: data.waiverExpiresAt || data.waiverExpiry,
-                } as RosterPlayer;
-              })
-              .filter((p) => !ownedIds.has(String(p.id)));
-            setFreeAgents(fa);
+        const faRes = await fetch(`/api/leagues/${activeLeague}/free-agents`, {
+          signal: controller.signal,
+        });
+        if (faRes.ok) {
+          const faJson = await faRes.json();
+          const fa: RosterPlayer[] = (faJson.data?.players || []).map((p: any) => ({
+            id: p.id,
+            name: p.name,
+            team: p.team,
+            position: p.position,
+            injury: p.injury,
+            waiverExpiresAt: typeof p.waiverExpiresAt === 'number' ? p.waiverExpiresAt : undefined,
+          }));
+          if (!controller.signal.aborted) setFreeAgents(fa);
+        }
+      } catch (err: any) {
+        if (err?.name !== 'AbortError') {
+          console.error('Failed to load roster', err);
+          if (!controller.signal.aborted) {
+            setError('Failed to load roster data. Please try refreshing the page.');
           }
         }
-      } catch (err) {
-        console.error('Failed to load roster', err);
       }
     };
     load();
+    return () => controller.abort();
   }, [user, activeLeague]);
 
   const handleClaim = (player: RosterPlayer, isWaiver: boolean) => {
@@ -115,6 +120,11 @@ export default function RostersPage() {
   return (
     <AppLayout>
       <main className="p-6 space-y-8">
+        {error && (
+          <p className="text-red-600" role="alert">
+            {error}
+          </p>
+        )}
         <section>
           <h1 className="text-2xl font-bold mb-4">My Roster</h1>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -123,6 +133,7 @@ export default function RostersPage() {
                 <Link
                   href={`/tradecentre?playerOut=${p.id}`}
                   className="px-3 py-1 rounded bg-blue-600 text-white text-sm"
+                  aria-label={`Propose trade with ${p.name}`}
                 >
                   Propose Trade
                 </Link>
@@ -140,14 +151,12 @@ export default function RostersPage() {
           <h2 className="text-2xl font-bold mb-4">Available Players</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {freeAgents.map((p) => {
-              const expiry = p.waiverExpiresAt
-                ? new Date(p.waiverExpiresAt)
-                : null;
-              const underWaiver = expiry ? expiry.getTime() > Date.now() : false;
+              const expiryMs = p.waiverExpiresAt;
+              const underWaiver = typeof expiryMs === 'number' ? expiryMs > now : false;
               return (
                 <PlayerCard key={p.id} player={p}>
-                  {underWaiver && expiry ? (
-                    <WaiverTimer expiry={expiry} />
+                  {underWaiver && typeof expiryMs === 'number' ? (
+                    <WaiverTimer expiryMs={expiryMs} now={now} />
                   ) : (
                     <span className="text-xs text-green-600">FA</span>
                   )}
@@ -155,12 +164,14 @@ export default function RostersPage() {
                     type="button"
                     onClick={() => handleClaim(p, underWaiver)}
                     className="px-2 py-1 rounded bg-emerald-600 text-white text-sm"
+                    aria-label={`${underWaiver ? 'Submit waiver claim for' : 'Add free agent'} ${p.name}`}
                   >
                     {underWaiver ? 'Claim' : 'Add FA'}
                   </button>
                   <Link
                     href={`/tradecentre?playerIn=${p.id}`}
                     className="px-2 py-1 rounded bg-blue-600 text-white text-sm"
+                    aria-label={`Open Trade Centre for ${p.name}`}
                   >
                     Trade
                   </Link>


### PR DESCRIPTION
## Summary
- store waiver expiry timestamps as numbers
- fetch free agents via API and use shared timer tick
- improve error handling and accessibility

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*


------
https://chatgpt.com/codex/tasks/task_e_68b570a23100832b80b04da9b16985ae