### PR TITLE
refactor(rosters): virtualize lists and streamline waiver timers

### DIFF
--- a/src/app/rosters/page.tsx
+++ b/src/app/rosters/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState, type ReactNode } from 'react';
 import Link from 'next/link';
-import { collection, getDocs } from 'firebase/firestore';
+import { FixedSizeList } from 'react-window';
+import { collection, getDocs, query, where } from 'firebase/firestore';
 import { AppLayout } from '@/components/navigation';
 import { db } from '@/lib/firebaseClient';
 import { useAuth } from '@/AuthContext';
@@ -13,32 +14,26 @@ type RosterPlayer = Pick<
   Player,
   'id' | 'name' | 'team' | 'position' | 'injury'
 > & {
-  waiverExpiresAt?: string;
+  // milliseconds since epoch
+  waiverExpiresAt?: number;
 };
 
-function WaiverTimer({ expiry }: { expiry: Date }) {
-  const [remaining, setRemaining] = useState('');
-
-  useEffect(() => {
-    const update = () => {
-      const diff = expiry.getTime() - Date.now();
-      if (diff <= 0) {
-        setRemaining('Available');
-      } else {
-        const h = Math.floor(diff / 3600000);
-        const m = Math.floor((diff % 3600000) / 60000);
-        const s = Math.floor((diff % 60000) / 1000);
-        setRemaining(
-          `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-        );
-      }
-    };
-    update();
-    const id = setInterval(update, 1000);
-    return () => clearInterval(id);
-  }, [expiry]);
-
-  return <span className="text-xs text-gray-500">{remaining}</span>;
+function WaiverTimer({ expiryMs, now }: { expiryMs: number; now: number }) {
+  const diff = Math.max(0, expiryMs - now);
+  const h = Math.floor(diff / 3600000);
+  const m = Math.floor((diff % 3600000) / 60000);
+  const s = Math.floor((diff % 60000) / 1000);
+  const text =
+    diff === 0
+      ? 'Available'
+      : `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(
+          s
+        ).padStart(2, '0')}`;
+  return (
+    <span role="timer" aria-live="polite" className="text-xs text-gray-500">
+      {text}
+    </span>
+  );
 }
 
 function PlayerCard({
@@ -69,110 +64,179 @@ export default function RostersPage() {
   const { activeLeague } = useTeamContext();
   const [rosterPlayers, setRosterPlayers] = useState<RosterPlayer[]>([]);
   const [freeAgents, setFreeAgents] = useState<RosterPlayer[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  // Shared clock for all countdowns
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
 
   useEffect(() => {
+    const controller = new AbortController();
     const load = async () => {
       if (!user || !activeLeague) return;
       try {
         const res = await fetch(
-          `/api/leagues/${activeLeague}/roster/${user.uid}`
+          `/api/leagues/${activeLeague}/roster/${user.uid}`,
+          { signal: controller.signal }
         );
         if (res.ok) {
           const json = await res.json();
-          const owned: RosterPlayer[] = json.roster?.players || [];
-          setRosterPlayers(owned);
+          const owned: RosterPlayer[] =
+            json.data?.roster?.players ?? [];
+          if (!controller.signal.aborted) setRosterPlayers(owned);
 
           if (db) {
-            const snap = await getDocs(collection(db, 'players'));
+            const snap = await getDocs(
+              query(
+                collection(db, 'leagues', activeLeague, 'availablePlayers'),
+                where('available', '==', true)
+              )
+            );
             const ownedIds = new Set(owned.map((p) => String(p.id)));
             const fa: RosterPlayer[] = snap.docs
               .map((d) => {
                 const data = d.data();
+                const rawExpiry = data.waiverExpiresAt || data.waiverExpiry;
+                const toMs = (v: any): number | undefined => {
+                  if (!v) return undefined;
+                  if (typeof v?.toDate === 'function') return v.toDate().getTime();
+                  if (typeof v === 'number') return v > 1e12 ? v : v * 1000;
+                  if (typeof v === 'string') {
+                    const ms = Date.parse(v);
+                    return Number.isNaN(ms) ? undefined : ms;
+                  }
+                  return undefined;
+                };
                 return {
                   id: d.id,
                   name: data.name,
                   team: data.team,
                   position: data.position,
                   injury: data.injury ?? data.status,
-                  waiverExpiresAt: data.waiverExpiresAt || data.waiverExpiry,
+                  waiverExpiresAt: toMs(rawExpiry),
                 } as RosterPlayer;
               })
               .filter((p) => !ownedIds.has(String(p.id)));
-            setFreeAgents(fa);
+            if (!controller.signal.aborted) setFreeAgents(fa);
           }
+        } else if (!controller.signal.aborted) {
+          setError('Failed to load roster data. Please try refreshing the page.');
         }
-      } catch (err) {
-        console.error('Failed to load roster', err);
+      } catch (err: any) {
+        if (!controller.signal.aborted) {
+          console.error('Failed to load roster', err);
+          setError('Failed to load roster data. Please try refreshing the page.');
+        }
       }
     };
     load();
+    return () => controller.abort();
   }, [user, activeLeague]);
 
-  const handleClaim = (player: RosterPlayer, isWaiver: boolean) => {
-    console.log(isWaiver ? 'Submit waiver claim' : 'Add free agent', player.id);
+  const handleClaim = async (player: RosterPlayer, isWaiver: boolean) => {
+    try {
+      const res = await fetch(
+        `/api/leagues/${activeLeague}/${isWaiver ? 'claims' : 'free-agents'}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ playerId: player.id }),
+          credentials: 'include',
+        }
+      );
+      if (!res.ok) throw new Error('Request failed');
+      // TODO: refresh roster/freeAgents or update state optimistically
+    } catch (e) {
+      console.error('Failed to process player action', e);
+    }
   };
 
   return (
     <AppLayout>
       <main className="p-6 space-y-8">
+        {error && (
+          <p className="text-center text-red-600" role="alert">
+            {error}
+          </p>
+        )}
         <section>
           <h1 className="text-2xl font-bold mb-4">My Roster</h1>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {rosterPlayers.map((p) => (
-              <PlayerCard key={p.id} player={p}>
-                <Link
-                  href={`/tradecentre?playerOut=${p.id}`}
-                  className="px-3 py-1 rounded bg-blue-600 text-white text-sm"
-                >
-                  Propose Trade
-                </Link>
-              </PlayerCard>
-            ))}
-            {rosterPlayers.length === 0 && (
-              <p className="col-span-full text-center text-gray-500">
-                No players on roster.
-              </p>
-            )}
-          </div>
+          {rosterPlayers.length === 0 ? (
+            <p className="text-center text-gray-500">No players on roster.</p>
+          ) : (
+            <FixedSizeList
+              height={Math.min(400, rosterPlayers.length * 100)}
+              itemCount={rosterPlayers.length}
+              itemSize={100}
+              width="100%"
+            >
+              {({ index, style }) => {
+                const p = rosterPlayers[index];
+                return (
+                  <div style={style} className="pr-4">
+                    <PlayerCard key={p.id} player={p}>
+                      <Link
+                        href={`/tradecentre?playerOut=${p.id}`}
+                        className="px-3 py-1 rounded bg-blue-600 text-white text-sm"
+                        aria-label={`Propose trade with ${p.name}`}
+                      >
+                        Propose Trade
+                      </Link>
+                    </PlayerCard>
+                  </div>
+                );
+              }}
+            </FixedSizeList>
+          )}
         </section>
 
         <section>
           <h2 className="text-2xl font-bold mb-4">Available Players</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {freeAgents.map((p) => {
-              const expiry = p.waiverExpiresAt
-                ? new Date(p.waiverExpiresAt)
-                : null;
-              const underWaiver = expiry ? expiry.getTime() > Date.now() : false;
-              return (
-                <PlayerCard key={p.id} player={p}>
-                  {underWaiver && expiry ? (
-                    <WaiverTimer expiry={expiry} />
-                  ) : (
-                    <span className="text-xs text-green-600">FA</span>
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => handleClaim(p, underWaiver)}
-                    className="px-2 py-1 rounded bg-emerald-600 text-white text-sm"
-                  >
-                    {underWaiver ? 'Claim' : 'Add FA'}
-                  </button>
-                  <Link
-                    href={`/tradecentre?playerIn=${p.id}`}
-                    className="px-2 py-1 rounded bg-blue-600 text-white text-sm"
-                  >
-                    Trade
-                  </Link>
-                </PlayerCard>
-              );
-            })}
-            {freeAgents.length === 0 && (
-              <p className="col-span-full text-center text-gray-500">
-                No available players.
-              </p>
-            )}
-          </div>
+          {freeAgents.length === 0 ? (
+            <p className="text-center text-gray-500">No available players.</p>
+          ) : (
+            <FixedSizeList
+              height={Math.min(400, freeAgents.length * 100)}
+              itemCount={freeAgents.length}
+              itemSize={100}
+              width="100%"
+            >
+              {({ index, style }) => {
+                const p = freeAgents[index];
+                const expiryMs = p.waiverExpiresAt;
+                const underWaiver = expiryMs ? expiryMs > now : false;
+                return (
+                  <div style={style} className="pr-4">
+                    <PlayerCard key={p.id} player={p}>
+                      {underWaiver && expiryMs ? (
+                        <WaiverTimer expiryMs={expiryMs} now={now} />
+                      ) : (
+                        <span className="text-xs text-green-600">FA</span>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => handleClaim(p, underWaiver)}
+                        className="px-2 py-1 rounded bg-emerald-600 text-white text-sm"
+                        aria-label={`${underWaiver ? 'Submit waiver claim for' : 'Add free agent'} ${p.name}`}
+                      >
+                        {underWaiver ? 'Claim' : 'Add FA'}
+                      </button>
+                      <Link
+                        href={`/tradecentre?playerIn=${p.id}`}
+                        className="px-2 py-1 rounded bg-blue-600 text-white text-sm"
+                        aria-label={`Open Trade Centre for ${p.name}`}
+                      >
+                        Trade
+                      </Link>
+                    </PlayerCard>
+                  </div>
+                );
+              }}
+            </FixedSizeList>
+          )}
         </section>
       </main>
     </AppLayout>


### PR DESCRIPTION
## Summary
- convert waiver timers to stateless component with shared clock
- query league-scoped free agents and normalize expiry timestamps
- virtualize roster and free-agent lists with accessible actions

## Testing
- `npm test`
- `npm run lint` *(fails: ConfigError: Key "rules": Key "plugins": Expected severity of "off", 0, "warn", 1, "error", or 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68b570c471e0832bb6331dce75c65e26