### PR TITLE
feat(rosters): add free-agent API and shared waiver timer

### DIFF
--- a/src/app/api/leagues/[id]/free-agents/route.ts
+++ b/src/app/api/leagues/[id]/free-agents/route.ts
@@ -1,0 +1,54 @@
+import type { NextRequest } from 'next/server';
+import { successResponse, errorResponse } from '@/lib/apiResponse';
+import { adminDb } from '@/lib/firebaseAdmin';
+import { getUserIdFromRequest } from '@/lib/serverAuth';
+import { verifyLeagueMembership } from '@/lib/leagueMembership';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const toMs = (v: any): number | undefined => {
+  if (!v) return undefined;
+  if (typeof v?.toDate === 'function') return v.toDate().getTime();
+  if (typeof v === 'number') return v > 1e12 ? v : v * 1000;
+  if (typeof v === 'string') {
+    const ms = Date.parse(v);
+    return Number.isNaN(ms) ? undefined : ms;
+  }
+  return undefined;
+};
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const { id: leagueId } = params;
+    const userId = await getUserIdFromRequest(_req);
+    if (!userId) return errorResponse('Unauthorized', 401);
+    const membership = await verifyLeagueMembership(leagueId, userId);
+    if (!membership.isMember) return errorResponse('Forbidden', 403);
+
+    const snap = await adminDb
+      .collection('leagues')
+      .doc(leagueId)
+      .collection('availablePlayers')
+      .where('available', '==', true)
+      .get();
+
+    const players = snap.docs.map((doc) => {
+      const data = doc.data() as any;
+      const rawExpiry = data.waiverExpiresAt || data.waiverExpiry;
+      return {
+        id: doc.id,
+        name: data.name,
+        team: data.team,
+        position: data.position,
+        injury: data.injury ?? data.status,
+        waiverExpiresAt: toMs(rawExpiry),
+      };
+    });
+
+    return successResponse({ players });
+  } catch (e) {
+    console.error('Failed to load free agents', e);
+    return errorResponse('Failed to load free agents');
+  }
+}

--- a/src/app/rosters/page.tsx
+++ b/src/app/rosters/page.tsx
@@ -2,9 +2,7 @@
 
 import { useEffect, useState, type ReactNode } from 'react';
 import Link from 'next/link';
-import { collection, getDocs } from 'firebase/firestore';
 import { AppLayout } from '@/components/navigation';
-import { db } from '@/lib/firebaseClient';
 import { useAuth } from '@/AuthContext';
 import { useTeamContext } from '@/contexts/TeamContext';
 import type { Player } from '@/types/players';
@@ -13,32 +11,35 @@ type RosterPlayer = Pick<
   Player,
   'id' | 'name' | 'team' | 'position' | 'injury'
 > & {
-  waiverExpiresAt?: string;
+  // milliseconds since epoch
+  waiverExpiresAt?: number;
 };
 
-function WaiverTimer({ expiry }: { expiry: Date }) {
-  const [remaining, setRemaining] = useState('');
+const toMs = (v: any): number | undefined => {
+  if (!v) return undefined;
+  if (typeof v?.toDate === 'function') return v.toDate().getTime();
+  if (typeof v === 'number') return v > 1e12 ? v : v * 1000;
+  if (typeof v === 'string') {
+    const ms = Date.parse(v);
+    return Number.isNaN(ms) ? undefined : ms;
+  }
+  return undefined;
+};
 
-  useEffect(() => {
-    const update = () => {
-      const diff = expiry.getTime() - Date.now();
-      if (diff <= 0) {
-        setRemaining('Available');
-      } else {
-        const h = Math.floor(diff / 3600000);
-        const m = Math.floor((diff % 3600000) / 60000);
-        const s = Math.floor((diff % 60000) / 1000);
-        setRemaining(
-          `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-        );
-      }
-    };
-    update();
-    const id = setInterval(update, 1000);
-    return () => clearInterval(id);
-  }, [expiry]);
-
-  return <span className="text-xs text-gray-500">{remaining}</span>;
+function WaiverTimer({ expiryMs, now }: { expiryMs: number; now: number }) {
+  const diff = Math.max(0, expiryMs - now);
+  const h = Math.floor(diff / 3600000);
+  const m = Math.floor((diff % 3600000) / 60000);
+  const s = Math.floor((diff % 60000) / 1000);
+  const text =
+    diff === 0
+      ? 'Available'
+      : `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return (
+    <span role="timer" aria-live="polite" className="text-xs text-gray-500">
+      {text}
+    </span>
+  );
 }
 
 function PlayerCard({
@@ -69,52 +70,92 @@ export default function RostersPage() {
   const { activeLeague } = useTeamContext();
   const [rosterPlayers, setRosterPlayers] = useState<RosterPlayer[]>([]);
   const [freeAgents, setFreeAgents] = useState<RosterPlayer[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  // Shared clock for all countdowns
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const [pendingId, setPendingId] = useState<string | null>(null);
 
   useEffect(() => {
+    const controller = new AbortController();
     const load = async () => {
       if (!user || !activeLeague) return;
       try {
+        setError(null);
         const res = await fetch(
-          `/api/leagues/${activeLeague}/roster/${user.uid}`
+          `/api/leagues/${activeLeague}/roster/${user.uid}`,
+          { signal: controller.signal }
         );
         if (res.ok) {
           const json = await res.json();
-          const owned: RosterPlayer[] = json.roster?.players || [];
-          setRosterPlayers(owned);
+          const owned: RosterPlayer[] =
+            json.data?.roster?.players?.map((p: any) => ({
+              ...p,
+              waiverExpiresAt: toMs(p.waiverExpiresAt),
+            })) || [];
+          if (!controller.signal.aborted) setRosterPlayers(owned);
+        } else if (!controller.signal.aborted) {
+          setError('Failed to load roster data.');
+          return;
+        }
 
-          if (db) {
-            const snap = await getDocs(collection(db, 'players'));
-            const ownedIds = new Set(owned.map((p) => String(p.id)));
-            const fa: RosterPlayer[] = snap.docs
-              .map((d) => {
-                const data = d.data();
-                return {
-                  id: d.id,
-                  name: data.name,
-                  team: data.team,
-                  position: data.position,
-                  injury: data.injury ?? data.status,
-                  waiverExpiresAt: data.waiverExpiresAt || data.waiverExpiry,
-                } as RosterPlayer;
-              })
-              .filter((p) => !ownedIds.has(String(p.id)));
-            setFreeAgents(fa);
-          }
+        const faRes = await fetch(
+          `/api/leagues/${activeLeague}/free-agents`,
+          { signal: controller.signal }
+        );
+        if (faRes.ok) {
+          const faJson = await faRes.json();
+          const fa: RosterPlayer[] = (faJson.data?.players || faJson.players || []).map(
+            (p: any) => ({
+              id: p.id,
+              name: p.name,
+              team: p.team,
+              position: p.position,
+              injury: p.injury,
+              waiverExpiresAt: toMs(p.waiverExpiresAt),
+            })
+          );
+          if (!controller.signal.aborted) setFreeAgents(fa);
         }
       } catch (err) {
+        if (controller.signal.aborted) return;
         console.error('Failed to load roster', err);
+        setError('Failed to load roster data. Please try refreshing the page.');
       }
     };
     load();
+    return () => controller.abort();
   }, [user, activeLeague]);
 
-  const handleClaim = (player: RosterPlayer, isWaiver: boolean) => {
-    console.log(isWaiver ? 'Submit waiver claim' : 'Add free agent', player.id);
+  const handleClaim = async (player: RosterPlayer, isWaiver: boolean) => {
+    if (!activeLeague) return;
+    setPendingId(player.id);
+    try {
+      const res = await fetch(
+        `/api/leagues/${activeLeague}/${isWaiver ? 'claims' : 'free-agents'}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ playerId: player.id }),
+        }
+      );
+      if (!res.ok) throw new Error('Request failed');
+    } catch (e) {
+      console.error('Failed to process player action', e);
+    } finally {
+      setPendingId(null);
+    }
   };
 
   return (
     <AppLayout>
       <main className="p-6 space-y-8">
+        {error && <p className="text-red-600">{error}</p>}
         <section>
           <h1 className="text-2xl font-bold mb-4">My Roster</h1>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -123,6 +164,7 @@ export default function RostersPage() {
                 <Link
                   href={`/tradecentre?playerOut=${p.id}`}
                   className="px-3 py-1 rounded bg-blue-600 text-white text-sm"
+                  aria-label={`Propose trade with ${p.name}`}
                 >
                   Propose Trade
                 </Link>
@@ -140,14 +182,12 @@ export default function RostersPage() {
           <h2 className="text-2xl font-bold mb-4">Available Players</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {freeAgents.map((p) => {
-              const expiry = p.waiverExpiresAt
-                ? new Date(p.waiverExpiresAt)
-                : null;
-              const underWaiver = expiry ? expiry.getTime() > Date.now() : false;
+              const expiryMs = p.waiverExpiresAt;
+              const underWaiver = typeof expiryMs === 'number' ? expiryMs > now : false;
               return (
                 <PlayerCard key={p.id} player={p}>
-                  {underWaiver && expiry ? (
-                    <WaiverTimer expiry={expiry} />
+                  {underWaiver && expiryMs ? (
+                    <WaiverTimer expiryMs={expiryMs} now={now} />
                   ) : (
                     <span className="text-xs text-green-600">FA</span>
                   )}
@@ -155,12 +195,15 @@ export default function RostersPage() {
                     type="button"
                     onClick={() => handleClaim(p, underWaiver)}
                     className="px-2 py-1 rounded bg-emerald-600 text-white text-sm"
+                    disabled={pendingId === p.id}
+                    aria-label={`${underWaiver ? 'Submit waiver claim for' : 'Add free agent'} ${p.name}`}
                   >
                     {underWaiver ? 'Claim' : 'Add FA'}
                   </button>
                   <Link
                     href={`/tradecentre?playerIn=${p.id}`}
                     className="px-2 py-1 rounded bg-blue-600 text-white text-sm"
+                    aria-label={`Open Trade Centre for ${p.name}`}
                   >
                     Trade
                   </Link>


### PR DESCRIPTION
## Summary
- normalize `waiverExpiresAt` and render with shared timer
- fetch roster via `data` wrapper and load free agents from new API
- add basic error handling and accessible labels

## Testing
- `npm test`
- `npm run lint` *(fails: 684 problems (16 errors, 668 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b570d31a20832ba269d2ddbcaf4733