### PR TITLE
Address refresh handling and live draft updates

### DIFF
--- a/socketio-server.ts
+++ b/socketio-server.ts
@@ -48,12 +48,25 @@ io.on('connection', (socket) => {
   });
 
   // Dashboard handlers
+  const refreshCooldownMs = 1000;
+  let lastDashboardRefresh = 0;
+  let lastModuleRefresh = 0;
+
   socket.on('dashboard:refresh', () => {
+    const now = Date.now();
+    if (now - lastDashboardRefresh < refreshCooldownMs) return;
+    lastDashboardRefresh = now;
     io.emit('dashboard:update', { timestamp: new Date().toISOString() });
   });
 
-  socket.on('module:refresh', (moduleId: string) => {
-    io.emit(`${moduleId}:update`, { timestamp: new Date().toISOString() });
+  socket.on('module:refresh', (moduleId: unknown) => {
+    if (typeof moduleId !== 'string') return;
+    const safeId = moduleId.trim().toLowerCase();
+    if (!/^[a-z0-9-]{1,64}$/.test(safeId)) return;
+    const now = Date.now();
+    if (now - lastModuleRefresh < refreshCooldownMs) return;
+    lastModuleRefresh = now;
+    io.emit(`${safeId}:update`, { timestamp: new Date().toISOString() });
   });
 
   socket.on('join:draft', (data: { draftId: string }) => {
@@ -269,7 +282,7 @@ httpServer.on('error', (error) => {
 });
 
 // Periodic demo updates for dashboard modules
-setInterval(() => {
+const demoInterval = setInterval(() => {
   io.emit('leaderboard:update', { timestamp: new Date().toISOString() });
   io.emit('top-picks:update', { timestamp: new Date().toISOString() });
 }, 30000);
@@ -285,6 +298,7 @@ httpServer.listen(PORT, () => {
 // Handle graceful shutdown
 process.on('SIGTERM', () => {
   console.log('SIGTERM received, shutting down gracefully');
+  clearInterval(demoInterval);
   httpServer.close(() => {
     console.log('Process terminated');
   });
@@ -292,6 +306,7 @@ process.on('SIGTERM', () => {
 
 process.on('SIGINT', () => {
   console.log('SIGINT received, shutting down gracefully');
+   clearInterval(demoInterval);
   httpServer.close(() => {
     console.log('Process terminated');
   });

--- a/src/components/dashboard/LeaderboardModule.tsx
+++ b/src/components/dashboard/LeaderboardModule.tsx
@@ -3,8 +3,12 @@ import { usePlayerStatsETL } from '@/hooks/usePlayerStats';
 import { useEffect, useState } from 'react';
 import type { Socket } from 'socket.io-client';
 
+interface ServerToClientEvents {
+  'leaderboard:update': (data: { timestamp: string }) => void;
+}
+
 interface LeaderboardModuleProps {
-  socket: Socket | null;
+  socket: Socket<ServerToClientEvents> | null;
 }
 
 interface LeaderboardEntry {

--- a/src/components/dashboard/LiveDraftModule.tsx
+++ b/src/components/dashboard/LiveDraftModule.tsx
@@ -2,12 +2,14 @@
 
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { User } from 'firebase/auth';
 import { fetchApi } from '@/lib/api';
+import type { Socket } from 'socket.io-client';
 
 interface LiveDraftModuleProps {
   user: User;
+  socket?: Socket | null;
 }
 
 interface DraftMeta {
@@ -24,50 +26,56 @@ interface DraftMeta {
   }>;
 }
 
-export default function LiveDraftModule({ user }: LiveDraftModuleProps) {
+export default function LiveDraftModule({ user, socket }: LiveDraftModuleProps) {
   const [draft, setDraft] = useState<DraftMeta | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const loadDraft = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const listRes = await fetchApi('drafts/list');
+      const drafts = listRes.data?.drafts ?? [];
+      const activeDraft = drafts.find((d: { id: string; status: string }) => d.status !== 'COMPLETED');
+      if (!activeDraft) {
+        setDraft(null);
+        return;
+      }
+
+      const detailRes = await fetchApi(`drafts/${activeDraft.id}`);
+      const d = detailRes.data;
+      const meta: DraftMeta = {
+        id: d.id,
+        status: d.status,
+        currentPick: d.currentPick,
+        totalPicks: d.totalPicks,
+        round: d.round,
+        direction: d.direction,
+        timePerPick: d.timePerPick,
+        participants: d.participants,
+      };
+      setDraft(meta);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load draft');
+    } finally {
+      setLoading(false);
+    }
+  }, [user?.uid]);
 
   useEffect(() => {
-    let isMounted = true;
-    const loadDraft = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const listRes = await fetchApi('drafts/list');
-        const drafts = listRes.data?.drafts ?? [];
-        const activeDraft = drafts.find((d: { id: string; status: string }) => d.status !== 'COMPLETED');
-        if (!activeDraft) {
-          if (isMounted) setDraft(null);
-          return;
-        }
-
-        const detailRes = await fetchApi(`drafts/${activeDraft.id}`);
-        const d = detailRes.data;
-        const meta: DraftMeta = {
-          id: d.id,
-          status: d.status,
-          currentPick: d.currentPick,
-          totalPicks: d.totalPicks,
-          round: d.round,
-          direction: d.direction,
-          timePerPick: d.timePerPick,
-          participants: d.participants,
-        };
-        if (isMounted) setDraft(meta);
-      } catch (e) {
-        if (isMounted) setError(e instanceof Error ? e.message : 'Failed to load draft');
-      } finally {
-        if (isMounted) setLoading(false);
-      }
-    };
-
     loadDraft();
+  }, [loadDraft]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const reload = () => loadDraft();
+    socket.on('dashboard:update', reload);
+    // socket.on('live-draft:update', reload);
     return () => {
-      isMounted = false;
+      socket.off('dashboard:update', reload);
+      // socket.off('live-draft:update', reload);
     };
-  }, []);
+  }, [socket, loadDraft]);
 
   // Determine turn information
   const teamCount = draft?.participants.length ?? 0;


### PR DESCRIPTION
## Summary
- Rate-limit dashboard refresh events and validate module IDs on server
- Clear demo update interval on shutdown to avoid hanging processes
- Reintroduce socket-driven LiveDraft refresh and type leaderboard socket events

## Testing
- `npm test` *(fails: Argument of type 'Firestore | null' is not assignable to parameter of type 'Firestore')*


------
https://chatgpt.com/codex/tasks/task_e_68b582a97e4c832baaffb113423810f5