### PR TITLE
Enable Socket.io-driven real-time dashboard refresh

### DIFF
--- a/socketio-server.ts
+++ b/socketio-server.ts
@@ -48,12 +48,25 @@ io.on('connection', (socket) => {
   });
 
   // Dashboard handlers
+  const refreshCooldownMs = 1000;
+  let lastDashboardRefresh = 0;
+  let lastModuleRefresh = 0;
+
   socket.on('dashboard:refresh', () => {
+    const now = Date.now();
+    if (now - lastDashboardRefresh < refreshCooldownMs) return;
+    lastDashboardRefresh = now;
     io.emit('dashboard:update', { timestamp: new Date().toISOString() });
   });
 
-  socket.on('module:refresh', (moduleId: string) => {
-    io.emit(`${moduleId}:update`, { timestamp: new Date().toISOString() });
+  socket.on('module:refresh', (moduleId: unknown) => {
+    if (typeof moduleId !== 'string') return;
+    const safeId = moduleId.trim().toLowerCase();
+    if (!/^[a-z0-9-]{1,64}$/.test(safeId)) return;
+    const now = Date.now();
+    if (now - lastModuleRefresh < refreshCooldownMs) return;
+    lastModuleRefresh = now;
+    io.emit(`${safeId}:update`, { timestamp: new Date().toISOString() });
   });
 
   socket.on('join:draft', (data: { draftId: string }) => {
@@ -269,7 +282,7 @@ httpServer.on('error', (error) => {
 });
 
 // Periodic demo updates for dashboard modules
-setInterval(() => {
+const demoInterval = setInterval(() => {
   io.emit('leaderboard:update', { timestamp: new Date().toISOString() });
   io.emit('top-picks:update', { timestamp: new Date().toISOString() });
 }, 30000);
@@ -285,6 +298,7 @@ httpServer.listen(PORT, () => {
 // Handle graceful shutdown
 process.on('SIGTERM', () => {
   console.log('SIGTERM received, shutting down gracefully');
+  clearInterval(demoInterval);
   httpServer.close(() => {
     console.log('Process terminated');
   });
@@ -292,6 +306,7 @@ process.on('SIGTERM', () => {
 
 process.on('SIGINT', () => {
   console.log('SIGINT received, shutting down gracefully');
+  clearInterval(demoInterval);
   httpServer.close(() => {
     console.log('Process terminated');
   });

--- a/src/components/dashboard/LeaderboardModule.tsx
+++ b/src/components/dashboard/LeaderboardModule.tsx
@@ -3,8 +3,12 @@ import { usePlayerStatsETL } from '@/hooks/usePlayerStats';
 import { useEffect, useState } from 'react';
 import type { Socket } from 'socket.io-client';
 
+type LeaderboardServerEvents = {
+  'leaderboard:update': () => void;
+};
+
 interface LeaderboardModuleProps {
-  socket: Socket | null;
+  socket: Socket<LeaderboardServerEvents> | null;
 }
 
 interface LeaderboardEntry {

--- a/src/components/dashboard/LeagueManagementModule.tsx
+++ b/src/components/dashboard/LeagueManagementModule.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
 import type { User } from 'firebase/auth';
 import type { League, LeagueMember } from '@/types/leagues';
+import type { Socket } from 'socket.io-client';
 
 interface LeagueWithMembers extends League {
   members: LeagueMember[];
@@ -12,56 +13,67 @@ interface LeagueWithMembers extends League {
 
 interface LeagueManagementModuleProps {
   user: User;
+  socket?: Socket | null;
 }
 
-export default function LeagueManagementModule({ user }: LeagueManagementModuleProps) {
+export default function LeagueManagementModule({ user, socket }: LeagueManagementModuleProps) {
   const [leagues, setLeagues] = useState<LeagueWithMembers[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const fetchUserLeagues = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      // Early validation
+      if (!user?.uid) {
+        console.error('User authentication error:', { user, hasUid: !!user?.uid });
+        throw new Error('User not authenticated');
+      }
+
+      console.log('Fetching leagues for user:', user.uid);
+
+      // Fetch user's league memberships
+      const membershipsResponse = await fetch(`/api/leagues/user/${user.uid}`);
+
+      if (!membershipsResponse.ok) {
+        throw new Error('Failed to fetch user league memberships');
+      }
+
+      const membershipsData = await membershipsResponse.json();
+      console.log('League memberships data:', membershipsData); // Debug log
+
+      // Handle the API response format - it now returns leagues directly
+      const leagues = membershipsData.leagues || membershipsData.data?.leagues || [];
+      if (!Array.isArray(leagues)) {
+        console.warn('Leagues data is not an array:', leagues);
+        setLeagues([]);
+        return;
+      }
+
+      setLeagues(leagues);
+    } catch (err) {
+      console.error('Error fetching user leagues:', err);
+      setError('Failed to load leagues');
+    } finally {
+      setLoading(false);
+    }
+  }, [user?.uid]);
 
   useEffect(() => {
-    const fetchUserLeagues = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-
-        // Early validation
-        if (!user?.uid) {
-          console.error('User authentication error:', { user, hasUid: !!user?.uid });
-          throw new Error('User not authenticated');
-        }
-        
-        console.log('Fetching leagues for user:', user.uid);
-        
-        // Fetch user's league memberships
-        const membershipsResponse = await fetch(`/api/leagues/user/${user.uid}`);
-        
-        if (!membershipsResponse.ok) {
-          throw new Error('Failed to fetch user league memberships');
-        }
-
-        const membershipsData = await membershipsResponse.json();
-        console.log('League memberships data:', membershipsData); // Debug log
-        
-        // Handle the API response format - it now returns leagues directly
-        const leagues = membershipsData.leagues || membershipsData.data?.leagues || [];
-        if (!Array.isArray(leagues)) {
-          console.warn('Leagues data is not an array:', leagues);
-          setLeagues([]);
-          return;
-        }
-        
-        setLeagues(leagues);
-      } catch (err) {
-        console.error('Error fetching user leagues:', err);
-        setError('Failed to load leagues');
-      } finally {
-        setLoading(false);
-      }
-    };
-
     fetchUserLeagues();
-  }, [user]);
+  }, [fetchUserLeagues]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const onDash = () => fetchUserLeagues();
+    socket.on('dashboard:update', onDash);
+    // socket.on('league-management:update', onDash);
+    return () => {
+      socket.off('dashboard:update', onDash);
+      // socket.off('league-management:update', onDash);
+    };
+  }, [socket, fetchUserLeagues]);
 
   if (loading) {
     return (

--- a/src/components/dashboard/LiveDraftModule.tsx
+++ b/src/components/dashboard/LiveDraftModule.tsx
@@ -2,12 +2,14 @@
 
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import type { User } from 'firebase/auth';
 import { fetchApi } from '@/lib/api';
+import type { Socket } from 'socket.io-client';
 
 interface LiveDraftModuleProps {
   user: User;
+  socket?: Socket | null;
 }
 
 interface DraftMeta {
@@ -24,50 +26,56 @@ interface DraftMeta {
   }>;
 }
 
-export default function LiveDraftModule({ user }: LiveDraftModuleProps) {
+export default function LiveDraftModule({ user, socket }: LiveDraftModuleProps) {
   const [draft, setDraft] = useState<DraftMeta | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const loadDraft = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const listRes = await fetchApi('drafts/list');
+      const drafts = listRes.data?.drafts ?? [];
+      const activeDraft = drafts.find((d: { id: string; status: string }) => d.status !== 'COMPLETED');
+      if (!activeDraft) {
+        setDraft(null);
+        return;
+      }
+
+      const detailRes = await fetchApi(`drafts/${activeDraft.id}`);
+      const d = detailRes.data;
+      const meta: DraftMeta = {
+        id: d.id,
+        status: d.status,
+        currentPick: d.currentPick,
+        totalPicks: d.totalPicks,
+        round: d.round,
+        direction: d.direction,
+        timePerPick: d.timePerPick,
+        participants: d.participants,
+      };
+      setDraft(meta);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load draft');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    let isMounted = true;
-    const loadDraft = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const listRes = await fetchApi('drafts/list');
-        const drafts = listRes.data?.drafts ?? [];
-        const activeDraft = drafts.find((d: { id: string; status: string }) => d.status !== 'COMPLETED');
-        if (!activeDraft) {
-          if (isMounted) setDraft(null);
-          return;
-        }
-
-        const detailRes = await fetchApi(`drafts/${activeDraft.id}`);
-        const d = detailRes.data;
-        const meta: DraftMeta = {
-          id: d.id,
-          status: d.status,
-          currentPick: d.currentPick,
-          totalPicks: d.totalPicks,
-          round: d.round,
-          direction: d.direction,
-          timePerPick: d.timePerPick,
-          participants: d.participants,
-        };
-        if (isMounted) setDraft(meta);
-      } catch (e) {
-        if (isMounted) setError(e instanceof Error ? e.message : 'Failed to load draft');
-      } finally {
-        if (isMounted) setLoading(false);
-      }
-    };
-
     loadDraft();
+  }, [loadDraft, user?.uid]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const reload = () => loadDraft();
+    socket.on('dashboard:update', reload);
+    // socket.on('live-draft:update', reload);
     return () => {
-      isMounted = false;
+      socket.off('dashboard:update', reload);
+      // socket.off('live-draft:update', reload);
     };
-  }, []);
+  }, [socket, loadDraft]);
 
   // Determine turn information
   const teamCount = draft?.participants.length ?? 0;


### PR DESCRIPTION
## Summary
- wire LeagueManagementModule and LiveDraftModule to optional socket updates and refetch on dashboard events
- rate-limit dashboard refresh handlers and validate module IDs on Socket.IO server; clear demo interval on shutdown
- add typed socket events for LeaderboardModule

## Testing
- `npm test` *(fails: Argument of type 'Firestore | null' is not assignable to parameter of type 'Firestore')*


------
https://chatgpt.com/codex/tasks/task_e_68b582b12548832b899c0aa8850c9f9a