### PR TITLE
Enable Socket.io-driven real-time dashboard refresh

### DIFF
--- a/socketio-server.ts
+++ b/socketio-server.ts
@@ -48,12 +48,25 @@ io.on('connection', (socket) => {
   });
 
   // Dashboard handlers
+  const refreshCooldownMs = 1000;
+  let lastDashboardRefresh = 0;
+  let lastModuleRefresh = 0;
+
   socket.on('dashboard:refresh', () => {
+    const now = Date.now();
+    if (now - lastDashboardRefresh < refreshCooldownMs) return;
+    lastDashboardRefresh = now;
     io.emit('dashboard:update', { timestamp: new Date().toISOString() });
   });
 
-  socket.on('module:refresh', (moduleId: string) => {
-    io.emit(`${moduleId}:update`, { timestamp: new Date().toISOString() });
+  socket.on('module:refresh', (moduleId: unknown) => {
+    if (typeof moduleId !== 'string') return;
+    const safeId = moduleId.trim().toLowerCase();
+    if (!/^[a-z0-9-]{1,64}$/.test(safeId)) return;
+    const now = Date.now();
+    if (now - lastModuleRefresh < refreshCooldownMs) return;
+    lastModuleRefresh = now;
+    io.emit(`${safeId}:update`, { timestamp: new Date().toISOString() });
   });
 
   socket.on('join:draft', (data: { draftId: string }) => {
@@ -269,7 +282,7 @@ httpServer.on('error', (error) => {
 });
 
 // Periodic demo updates for dashboard modules
-setInterval(() => {
+const demoInterval = setInterval(() => {
   io.emit('leaderboard:update', { timestamp: new Date().toISOString() });
   io.emit('top-picks:update', { timestamp: new Date().toISOString() });
 }, 30000);
@@ -285,6 +298,7 @@ httpServer.listen(PORT, () => {
 // Handle graceful shutdown
 process.on('SIGTERM', () => {
   console.log('SIGTERM received, shutting down gracefully');
+  clearInterval(demoInterval);
   httpServer.close(() => {
     console.log('Process terminated');
   });
@@ -292,6 +306,7 @@ process.on('SIGTERM', () => {
 
 process.on('SIGINT', () => {
   console.log('SIGINT received, shutting down gracefully');
+  clearInterval(demoInterval);
   httpServer.close(() => {
     console.log('Process terminated');
   });

--- a/src/components/ModularDashboard.tsx
+++ b/src/components/ModularDashboard.tsx
@@ -8,6 +8,7 @@ import { db } from '@/lib/firebaseClient';
 import type { Player } from '@/types/players';
 import { logger } from '@/lib/logger';
 import { io, type Socket } from 'socket.io-client';
+import { SocketProvider } from '@/context/SocketContext';
 
 // Module Components
 import LiveDraftModule from './dashboard/LiveDraftModule';
@@ -186,13 +187,14 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
 
   useEffect(() => {
     const fetchPlayers = async () => {
-      if (!db) {
+      const database = db;
+      if (!database) {
         logger.error('Firebase database not initialized. Cannot fetch players.');
         return;
       }
 
       try {
-        const querySnapshot = await getDocs(collection(db!, 'players'));
+        const querySnapshot = await getDocs(collection(database, 'players'));
         const data = querySnapshot.docs.map((doc) => {
           const docData = doc.data();
           return {
@@ -212,12 +214,18 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
   }, []);
 
   useEffect(() => {
-    const s = io();
+    const s = io(process.env.NEXT_PUBLIC_SOCKET_URL ?? undefined, {
+      transports: ['websocket'],
+      withCredentials: false,
+    });
     setSocket(s);
+    s.on('connect', () => logger.info('Socket connected', { id: s.id }));
+    s.on('connect_error', (err) => logger.error('Socket connect_error', err));
     s.on('dashboard:update', (data) => {
       logger.info('Dashboard update received', data);
     });
     return () => {
+      s.off('dashboard:update');
       s.disconnect();
     };
   }, []);
@@ -264,7 +272,8 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50">
+    <SocketProvider value={socket}>
+      <main className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50">
       {/* Hero Header */}
       <div className="bg-white border-b border-slate-200">
         <div className="container mx-auto px-4 py-8">
@@ -282,7 +291,8 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
             <div className="flex items-center space-x-3">
               <button
                 onClick={() => socket?.emit('dashboard:refresh')}
-                className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                disabled={!socket?.connected}
+                className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path
@@ -381,7 +391,9 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
                       <div className="flex items-center space-x-2 opacity-0 group-hover:opacity-100 transition-opacity">
                         <button
                           onClick={() => socket?.emit('module:refresh', module.id)}
-                          className="p-1 hover:bg-slate-100 rounded transition-colors"
+                          aria-label={`Refresh ${module.title}`}
+                          disabled={!socket?.connected}
+                          className="p-1 hover:bg-slate-100 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                           title="Refresh module"
                         >
                           <svg
@@ -429,7 +441,6 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
                         players={players}
                         activities={mockActivities}
                         stats={mockStats}
-                        socket={socket}
                         {...module.props}
                       />
                     </div>
@@ -465,6 +476,7 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
           </div>
         )}
       </div>
-    </main>
+      </main>
+    </SocketProvider>
   );
 }

--- a/src/components/dashboard/LeaderboardModule.tsx
+++ b/src/components/dashboard/LeaderboardModule.tsx
@@ -2,9 +2,10 @@ import { motion } from 'framer-motion';
 import { usePlayerStatsETL } from '@/hooks/usePlayerStats';
 import { useEffect, useState } from 'react';
 import type { Socket } from 'socket.io-client';
+import { useSocket } from '@/context/SocketContext';
 
-interface LeaderboardModuleProps {
-  socket: Socket | null;
+interface LeaderboardEvents {
+  'leaderboard:update': { timestamp: string };
 }
 
 interface LeaderboardEntry {
@@ -17,7 +18,8 @@ interface LeaderboardEntry {
   isCurrentUser?: boolean;
 }
 
-export default function LeaderboardModule({ socket }: LeaderboardModuleProps) {
+export default function LeaderboardModule() {
+  const socket = useSocket() as Socket<LeaderboardEvents> | null;
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
   const { data: playerStats, loading, error, refetch } = usePlayerStatsETL('2025');
 
@@ -35,7 +37,7 @@ export default function LeaderboardModule({ socket }: LeaderboardModuleProps) {
   useEffect(() => {
     if (playerStats && playerStats.length > 0) {
       // Transform ETL data to leaderboard format
-      const entries: LeaderboardEntry[] = playerStats
+      const entries: LeaderboardEntry[] = [...playerStats]
         .sort((a, b) => b.fantasy_points - a.fantasy_points)
         .slice(0, 8)
         .map((stat, index) => ({

--- a/src/components/dashboard/LeagueManagementModule.tsx
+++ b/src/components/dashboard/LeagueManagementModule.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
 import type { User } from 'firebase/auth';
 import type { League, LeagueMember } from '@/types/leagues';
+import { useSocket } from '@/context/SocketContext';
 
 interface LeagueWithMembers extends League {
   members: LeagueMember[];
@@ -15,53 +16,58 @@ interface LeagueManagementModuleProps {
 }
 
 export default function LeagueManagementModule({ user }: LeagueManagementModuleProps) {
+  const socket = useSocket();
   const [leagues, setLeagues] = useState<LeagueWithMembers[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchUserLeagues = async () => {
-      try {
-        setLoading(true);
-        setError(null);
+  const fetchUserLeagues = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
 
-        // Early validation
-        if (!user?.uid) {
-          console.error('User authentication error:', { user, hasUid: !!user?.uid });
-          throw new Error('User not authenticated');
-        }
-        
-        console.log('Fetching leagues for user:', user.uid);
-        
-        // Fetch user's league memberships
-        const membershipsResponse = await fetch(`/api/leagues/user/${user.uid}`);
-        
-        if (!membershipsResponse.ok) {
-          throw new Error('Failed to fetch user league memberships');
-        }
-
-        const membershipsData = await membershipsResponse.json();
-        console.log('League memberships data:', membershipsData); // Debug log
-        
-        // Handle the API response format - it now returns leagues directly
-        const leagues = membershipsData.leagues || membershipsData.data?.leagues || [];
-        if (!Array.isArray(leagues)) {
-          console.warn('Leagues data is not an array:', leagues);
-          setLeagues([]);
-          return;
-        }
-        
-        setLeagues(leagues);
-      } catch (err) {
-        console.error('Error fetching user leagues:', err);
-        setError('Failed to load leagues');
-      } finally {
-        setLoading(false);
+      if (!user?.uid) {
+        console.error('User authentication error:', { user, hasUid: !!user?.uid });
+        throw new Error('User not authenticated');
       }
-    };
 
+      const membershipsResponse = await fetch(`/api/leagues/user/${user.uid}`);
+
+      if (!membershipsResponse.ok) {
+        throw new Error('Failed to fetch user league memberships');
+      }
+
+      const membershipsData = await membershipsResponse.json();
+      const leagues = membershipsData.leagues || membershipsData.data?.leagues || [];
+      if (!Array.isArray(leagues)) {
+        console.warn('Leagues data is not an array:', leagues);
+        setLeagues([]);
+        return;
+      }
+
+      setLeagues(leagues);
+    } catch (err) {
+      console.error('Error fetching user leagues:', err);
+      setError('Failed to load leagues');
+    } finally {
+      setLoading(false);
+    }
+  }, [user?.uid]);
+
+  useEffect(() => {
     fetchUserLeagues();
-  }, [user]);
+  }, [fetchUserLeagues]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const onDash = () => fetchUserLeagues();
+    socket.on('dashboard:update', onDash);
+    socket.on('league-management:update', onDash);
+    return () => {
+      socket.off('dashboard:update', onDash);
+      socket.off('league-management:update', onDash);
+    };
+  }, [socket, fetchUserLeagues]);
 
   if (loading) {
     return (

--- a/src/components/dashboard/LiveDraftModule.tsx
+++ b/src/components/dashboard/LiveDraftModule.tsx
@@ -2,9 +2,10 @@
 
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import type { User } from 'firebase/auth';
 import { fetchApi } from '@/lib/api';
+import { useSocket } from '@/context/SocketContext';
 
 interface LiveDraftModuleProps {
   user: User;
@@ -25,49 +26,57 @@ interface DraftMeta {
 }
 
 export default function LiveDraftModule({ user }: LiveDraftModuleProps) {
+  const socket = useSocket();
   const [draft, setDraft] = useState<DraftMeta | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let isMounted = true;
-    const loadDraft = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const listRes = await fetchApi('drafts/list');
-        const drafts = listRes.data?.drafts ?? [];
-        const activeDraft = drafts.find((d: { id: string; status: string }) => d.status !== 'COMPLETED');
-        if (!activeDraft) {
-          if (isMounted) setDraft(null);
-          return;
-        }
-
-        const detailRes = await fetchApi(`drafts/${activeDraft.id}`);
-        const d = detailRes.data;
-        const meta: DraftMeta = {
-          id: d.id,
-          status: d.status,
-          currentPick: d.currentPick,
-          totalPicks: d.totalPicks,
-          round: d.round,
-          direction: d.direction,
-          timePerPick: d.timePerPick,
-          participants: d.participants,
-        };
-        if (isMounted) setDraft(meta);
-      } catch (e) {
-        if (isMounted) setError(e instanceof Error ? e.message : 'Failed to load draft');
-      } finally {
-        if (isMounted) setLoading(false);
+  const loadDraft = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const listRes = await fetchApi('drafts/list');
+      const drafts = listRes.data?.drafts ?? [];
+      const activeDraft = drafts.find((d: { id: string; status: string }) => d.status !== 'COMPLETED');
+      if (!activeDraft) {
+        setDraft(null);
+        return;
       }
-    };
 
-    loadDraft();
-    return () => {
-      isMounted = false;
-    };
+      const detailRes = await fetchApi(`drafts/${activeDraft.id}`);
+      const d = detailRes.data;
+      const meta: DraftMeta = {
+        id: d.id,
+        status: d.status,
+        currentPick: d.currentPick,
+        totalPicks: d.totalPicks,
+        round: d.round,
+        direction: d.direction,
+        timePerPick: d.timePerPick,
+        participants: d.participants,
+      };
+      setDraft(meta);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load draft');
+    } finally {
+      setLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    loadDraft();
+  }, [loadDraft, user?.uid]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const reload = () => loadDraft();
+    socket.on('dashboard:update', reload);
+    socket.on('live-draft:update', reload);
+    return () => {
+      socket.off('dashboard:update', reload);
+      socket.off('live-draft:update', reload);
+    };
+  }, [socket, loadDraft]);
 
   // Determine turn information
   const teamCount = draft?.participants.length ?? 0;

--- a/src/components/dashboard/LiveInjuryFeed.client.tsx
+++ b/src/components/dashboard/LiveInjuryFeed.client.tsx
@@ -1,16 +1,15 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { useInjuryData } from '@/hooks/useInjuryData';
 import InjuryListDisplay from './InjuryListDisplay';
-import type { Socket } from 'socket.io-client';
+import { useSocket } from '@/context/SocketContext';
 
 interface LiveInjuryFeedProps {
   teamFilter?: string;
   userTeamPlayers?: string[];
   autoRefresh?: boolean;
-  socket?: Socket | null;
 }
 
 const AFL_TEAMS = [
@@ -69,9 +68,9 @@ export default function LiveInjuryFeedClient({
   teamFilter,
   userTeamPlayers: _userTeamPlayers,
   autoRefresh = true,
-  socket: _socket,
 }: LiveInjuryFeedProps) {
   const reduceMotion = useReducedMotion();
+  const socket = useSocket();
   const [selectedTeam, setSelectedTeam] = useState<string>(teamFilter || '');
   const [sortBy, setSortBy] = useState<SortKey>('team');
 
@@ -80,6 +79,15 @@ export default function LiveInjuryFeedClient({
     autoRefresh,
     refreshInterval: 300000,
   });
+
+  useEffect(() => {
+    if (!socket) return;
+    const onDash = () => refresh();
+    socket.on('dashboard:update', onDash);
+    return () => {
+      socket.off('dashboard:update', onDash);
+    };
+  }, [socket, refresh]);
 
   const sortedInjuries = useMemo(() => {
     const arr = injuries.slice();

--- a/src/components/dashboard/LiveInjuryFeed.tsx
+++ b/src/components/dashboard/LiveInjuryFeed.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import LiveInjuryFeedSkeleton from '@/components/ui/skeletons/LiveInjuryFeedSkeleton';
-import type { Socket } from 'socket.io-client';
 
 type Props = {
   teamFilter?: string;
   userTeamPlayers?: string[];
   autoRefresh?: boolean;
-  socket?: Socket | null;
 };
 
 const Client = dynamic<Props>(() => import('./LiveInjuryFeed.client'), {

--- a/src/components/dashboard/PlayerSpotlightModule.client.tsx
+++ b/src/components/dashboard/PlayerSpotlightModule.client.tsx
@@ -1,14 +1,11 @@
 'use client';
 
 import { motion, useReducedMotion } from 'framer-motion';
-import { useMemo } from 'react';
-import type { Socket } from 'socket.io-client';
+import { useEffect, useMemo } from 'react';
+import { useSocket } from '@/context/SocketContext';
 
-interface PlayerSpotlightModuleProps {
-  socket: Socket | null;
-}
-
-export default function PlayerSpotlightModuleClient({ socket: _socket }: PlayerSpotlightModuleProps) {
+export default function PlayerSpotlightModuleClient() {
+  const socket = useSocket();
   const reduceMotion = useReducedMotion();
 
   const featuredPlayer = {
@@ -35,6 +32,19 @@ export default function PlayerSpotlightModuleClient({ socket: _socket }: PlayerS
   }, [featuredPlayer.form]);
 
   const maxForm = useMemo(() => Math.max(...featuredPlayer.form), [featuredPlayer.form]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const onUpdate = () => {
+      // TODO: fetch spotlight data
+    };
+    socket.on('player-spotlight:update', onUpdate);
+    socket.on('module:refresh', onUpdate);
+    return () => {
+      socket.off('player-spotlight:update', onUpdate);
+      socket.off('module:refresh', onUpdate);
+    };
+  }, [socket]);
 
   return (
     <div className="space-y-4">

--- a/src/components/dashboard/PlayerSpotlightModule.tsx
+++ b/src/components/dashboard/PlayerSpotlightModule.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import PlayerSpotlightSkeleton from '@/components/ui/skeletons/PlayerSpotlightSkeleton';
-import type { Socket } from 'socket.io-client';
-
-type Props = { socket: Socket | null };
 
 const Client = dynamic(() => import('@/components/dashboard/PlayerSpotlightModule.client'), {
   ssr: false,
   loading: () => <PlayerSpotlightSkeleton />,
-}) as React.ComponentType<Props>;
+});
 
-export default function PlayerSpotlightModule(props: Props) {
-  return <Client {...props} />;
+export default function PlayerSpotlightModule() {
+  return <Client />;
 }

--- a/src/components/dashboard/TeamAnalyticsModule.client.tsx
+++ b/src/components/dashboard/TeamAnalyticsModule.client.tsx
@@ -9,13 +9,23 @@ import {
   ArrowTrendingDownIcon,
 } from '@heroicons/react/24/outline';
 import Link from 'next/link';
-import type { Socket } from 'socket.io-client';
+import { useSocket } from '@/context/SocketContext';
 
-interface TeamAnalyticsModuleProps {
-  socket: Socket | null;
-}
+export default function TeamAnalyticsModuleClient() {
+  const _socket = useSocket();
+  const MODULE_ID = 'team-analytics';
+  const [, forceRerender] = React.useReducer((x) => x + 1, 0);
 
-export default function TeamAnalyticsModuleClient({ socket: _socket }: TeamAnalyticsModuleProps) {
+  React.useEffect(() => {
+    if (!_socket) return;
+    const onUpdate = () => forceRerender();
+    _socket.on('dashboard:update', onUpdate);
+    _socket.on(`${MODULE_ID}:update`, onUpdate);
+    return () => {
+      _socket.off('dashboard:update', onUpdate);
+      _socket.off(`${MODULE_ID}:update`, onUpdate);
+    };
+  }, [_socket]);
   const teamData = {
     weeklyScore: 2156,
     projectedScore: 2189,

--- a/src/components/dashboard/TeamAnalyticsModule.tsx
+++ b/src/components/dashboard/TeamAnalyticsModule.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import TeamAnalyticsSkeleton from '@/components/ui/skeletons/TeamAnalyticsSkeleton';
-import type { Socket } from 'socket.io-client';
-
-type Props = { socket: Socket | null };
 
 const Client = dynamic(() => import('@/components/dashboard/TeamAnalyticsModule.client'), {
   ssr: false,
   loading: () => <TeamAnalyticsSkeleton />,
-}) as React.ComponentType<Props>;
+});
 
-export default function TeamAnalyticsModule(props: Props) {
-  return <Client {...props} />;
+export default function TeamAnalyticsModule() {
+  return <Client />;
 }

--- a/src/components/dashboard/TopPicksModule.client.tsx
+++ b/src/components/dashboard/TopPicksModule.client.tsx
@@ -4,15 +4,12 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { usePlayerStatsETL } from '@/hooks/usePlayerStats';
 import { useEffect, useMemo, memo } from 'react';
 import type { PlayerStat } from '@/hooks/usePlayerStats';
-import type { Socket } from 'socket.io-client';
+import { useSocket } from '@/context/SocketContext';
 
 const DEFAULT_TOP_PICKS_LIMIT = 8;
 
-interface TopPicksModuleClientProps {
-  socket: Socket | null;
-}
-
-export default function TopPicksModuleClient({ socket }: TopPicksModuleClientProps) {
+export default function TopPicksModuleClient() {
+  const socket = useSocket();
   const reduceMotion = useReducedMotion();
   const { data: playerStats, loading, error, refetch } = usePlayerStatsETL('2025');
 

--- a/src/components/dashboard/TopPicksModule.tsx
+++ b/src/components/dashboard/TopPicksModule.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import TopPicksSkeleton from '@/components/ui/skeletons/TopPicksSkeleton';
-import type { Socket } from 'socket.io-client';
-
-type Props = { socket: Socket | null };
 
 const Client = dynamic(() => import('./TopPicksModule.client'), {
   ssr: false,
   loading: () => <TopPicksSkeleton count={8} rowHeight={96} />,
-}) as React.ComponentType<Props>;
+});
 
-export default function TopPicksModule(props: Props) {
-  return <Client {...props} />;
+export default function TopPicksModule() {
+  return <Client />;
 }

--- a/src/context/SocketContext.tsx
+++ b/src/context/SocketContext.tsx
@@ -1,0 +1,9 @@
+"use client";
+import { createContext, useContext } from 'react';
+import type { Socket } from 'socket.io-client';
+
+export const SocketContext = createContext<Socket | null>(null);
+export const SocketProvider = SocketContext.Provider;
+export function useSocket() {
+  return useContext(SocketContext);
+}


### PR DESCRIPTION
## Summary
- extract SocketContext and drop socket prop drilling in dashboard modules
- reintroduce real-time refresh via sockets for LiveDraft and LeagueManagement modules
- rate-limit dashboard refresh events and clear periodic intervals on shutdown

## Testing
- `npm test` *(fails: Argument of type 'Firestore | null' is not assignable to parameter of type 'Firestore' in LeagueChat.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b5831d82bc832ba642b28987d516a2