### PR TITLE
Enable Socket.io-driven real-time dashboard refresh

### DIFF
--- a/src/components/dashboard/TopPicksModule.client.tsx
+++ b/src/components/dashboard/TopPicksModule.client.tsx
@@ -4,12 +4,12 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { usePlayerStatsETL } from '@/hooks/usePlayerStats';
 import { useEffect, useMemo, memo } from 'react';
 import type { PlayerStat } from '@/hooks/usePlayerStats';
-import type { Socket } from 'socket.io-client';
+import type { TypedSocket } from '@/types/socket-events';
 
 const DEFAULT_TOP_PICKS_LIMIT = 8;
 
 interface TopPicksModuleClientProps {
-  socket: Socket | null;
+  socket: TypedSocket | null;
 }
 
 export default function TopPicksModuleClient({ socket }: TopPicksModuleClientProps) {

--- a/src/components/dashboard/TopPicksModule.tsx
+++ b/src/components/dashboard/TopPicksModule.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import TopPicksSkeleton from '@/components/ui/skeletons/TopPicksSkeleton';
-import type { Socket } from 'socket.io-client';
+import type { TypedSocket } from '@/types/socket-events';
 
-type Props = { socket: Socket | null };
+type Props = { socket: TypedSocket | null };
 
 const Client = dynamic(() => import('./TopPicksModule.client'), {
   ssr: false,

--- a/src/types/socket-events.ts
+++ b/src/types/socket-events.ts
@@ -1,0 +1,14 @@
+import type { Socket } from 'socket.io-client';
+
+export interface ServerToClientEvents {
+  'dashboard:update': { timestamp: string };
+  'leaderboard:update': { timestamp: string };
+  'top-picks:update': { timestamp: string };
+}
+
+export interface ClientToServerEvents {
+  'dashboard:refresh': void;
+  'module:refresh': (moduleId: string) => void;
+}
+
+export type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;


### PR DESCRIPTION
## Summary
- centralize socket event typings
- type TopPicksModule socket props with shared event maps

## Testing
- `npm test` *(fails: Argument of type 'Firestore | null' is not assignable to parameter of type 'Firestore')*

------
https://chatgpt.com/codex/tasks/task_e_68b583129dc4832baa44114e206511b9