### PR TITLE
Enable Socket.io-driven real-time dashboard refresh

### DIFF
--- a/socketio-server.ts
+++ b/socketio-server.ts
@@ -48,12 +48,25 @@ io.on('connection', (socket) => {
   });
 
   // Dashboard handlers
+  const refreshCooldownMs = 1000;
+  let lastDashboardRefresh = 0;
+  let lastModuleRefresh = 0;
+
   socket.on('dashboard:refresh', () => {
+    const now = Date.now();
+    if (now - lastDashboardRefresh < refreshCooldownMs) return;
+    lastDashboardRefresh = now;
     io.emit('dashboard:update', { timestamp: new Date().toISOString() });
   });
 
-  socket.on('module:refresh', (moduleId: string) => {
-    io.emit(`${moduleId}:update`, { timestamp: new Date().toISOString() });
+  socket.on('module:refresh', (moduleId: unknown) => {
+    if (typeof moduleId !== 'string') return;
+    const safeId = moduleId.trim().toLowerCase();
+    if (!/^[a-z0-9-]{1,64}$/.test(safeId)) return;
+    const now = Date.now();
+    if (now - lastModuleRefresh < refreshCooldownMs) return;
+    lastModuleRefresh = now;
+    io.emit(`${safeId}:update`, { timestamp: new Date().toISOString() });
   });
 
   socket.on('join:draft', (data: { draftId: string }) => {
@@ -269,7 +282,7 @@ httpServer.on('error', (error) => {
 });
 
 // Periodic demo updates for dashboard modules
-setInterval(() => {
+const demoInterval = setInterval(() => {
   io.emit('leaderboard:update', { timestamp: new Date().toISOString() });
   io.emit('top-picks:update', { timestamp: new Date().toISOString() });
 }, 30000);
@@ -285,6 +298,7 @@ httpServer.listen(PORT, () => {
 // Handle graceful shutdown
 process.on('SIGTERM', () => {
   console.log('SIGTERM received, shutting down gracefully');
+  clearInterval(demoInterval);
   httpServer.close(() => {
     console.log('Process terminated');
   });
@@ -292,6 +306,7 @@ process.on('SIGTERM', () => {
 
 process.on('SIGINT', () => {
   console.log('SIGINT received, shutting down gracefully');
+  clearInterval(demoInterval);
   httpServer.close(() => {
     console.log('Process terminated');
   });

--- a/src/components/ModularDashboard.tsx
+++ b/src/components/ModularDashboard.tsx
@@ -186,13 +186,14 @@ export default function ModularDashboard({ user }: ModularDashboardProps) {
 
   useEffect(() => {
     const fetchPlayers = async () => {
-      if (!db) {
+      const database = db;
+      if (!database) {
         logger.error('Firebase database not initialized. Cannot fetch players.');
         return;
       }
 
       try {
-        const querySnapshot = await getDocs(collection(db!, 'players'));
+        const querySnapshot = await getDocs(collection(database, 'players'));
         const data = querySnapshot.docs.map((doc) => {
           const docData = doc.data();
           return {

--- a/src/components/dashboard/LeaderboardModule.tsx
+++ b/src/components/dashboard/LeaderboardModule.tsx
@@ -2,9 +2,10 @@ import { motion } from 'framer-motion';
 import { usePlayerStatsETL } from '@/hooks/usePlayerStats';
 import { useEffect, useState } from 'react';
 import type { Socket } from 'socket.io-client';
+import type { ServerToClientEvents, ClientToServerEvents } from '@/types/socketEvents';
 
 interface LeaderboardModuleProps {
-  socket: Socket | null;
+  socket: Socket<ServerToClientEvents, ClientToServerEvents> | null;
 }
 
 interface LeaderboardEntry {
@@ -23,7 +24,7 @@ export default function LeaderboardModule({ socket }: LeaderboardModuleProps) {
 
   useEffect(() => {
     if (!socket) return;
-    const handler = () => {
+    const handler = (_payload: { timestamp: string }) => {
       refetch();
     };
     socket.on('leaderboard:update', handler);

--- a/src/components/dashboard/LeagueManagementModule.tsx
+++ b/src/components/dashboard/LeagueManagementModule.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
 import type { User } from 'firebase/auth';
 import type { League, LeagueMember } from '@/types/leagues';
+import type { Socket } from 'socket.io-client';
+import type { ServerToClientEvents, ClientToServerEvents } from '@/types/socketEvents';
 
 interface LeagueWithMembers extends League {
   members: LeagueMember[];
@@ -12,56 +14,65 @@ interface LeagueWithMembers extends League {
 
 interface LeagueManagementModuleProps {
   user: User;
+  socket?: Socket<ServerToClientEvents, ClientToServerEvents> | null;
 }
 
-export default function LeagueManagementModule({ user }: LeagueManagementModuleProps) {
+export default function LeagueManagementModule({ user, socket }: LeagueManagementModuleProps) {
   const [leagues, setLeagues] = useState<LeagueWithMembers[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchUserLeagues = async () => {
-      try {
-        setLoading(true);
-        setError(null);
+  const fetchUserLeagues = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
 
-        // Early validation
-        if (!user?.uid) {
-          console.error('User authentication error:', { user, hasUid: !!user?.uid });
-          throw new Error('User not authenticated');
-        }
-        
-        console.log('Fetching leagues for user:', user.uid);
-        
-        // Fetch user's league memberships
-        const membershipsResponse = await fetch(`/api/leagues/user/${user.uid}`);
-        
-        if (!membershipsResponse.ok) {
-          throw new Error('Failed to fetch user league memberships');
-        }
-
-        const membershipsData = await membershipsResponse.json();
-        console.log('League memberships data:', membershipsData); // Debug log
-        
-        // Handle the API response format - it now returns leagues directly
-        const leagues = membershipsData.leagues || membershipsData.data?.leagues || [];
-        if (!Array.isArray(leagues)) {
-          console.warn('Leagues data is not an array:', leagues);
-          setLeagues([]);
-          return;
-        }
-        
-        setLeagues(leagues);
-      } catch (err) {
-        console.error('Error fetching user leagues:', err);
-        setError('Failed to load leagues');
-      } finally {
-        setLoading(false);
+      if (!user?.uid) {
+        console.error('User authentication error:', { user, hasUid: !!user?.uid });
+        throw new Error('User not authenticated');
       }
-    };
 
+      console.log('Fetching leagues for user:', user.uid);
+
+      const membershipsResponse = await fetch(`/api/leagues/user/${user.uid}`);
+
+      if (!membershipsResponse.ok) {
+        throw new Error('Failed to fetch user league memberships');
+      }
+
+      const membershipsData = await membershipsResponse.json();
+      console.log('League memberships data:', membershipsData);
+
+      const leagues = membershipsData.leagues || membershipsData.data?.leagues || [];
+      if (!Array.isArray(leagues)) {
+        console.warn('Leagues data is not an array:', leagues);
+        setLeagues([]);
+        return;
+      }
+
+      setLeagues(leagues);
+    } catch (err) {
+      console.error('Error fetching user leagues:', err);
+      setError('Failed to load leagues');
+    } finally {
+      setLoading(false);
+    }
+  }, [user?.uid]);
+
+  useEffect(() => {
     fetchUserLeagues();
-  }, [user]);
+  }, [fetchUserLeagues]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const onDash = (_payload: { timestamp: string }) => fetchUserLeagues();
+    socket.on('dashboard:update', onDash);
+    socket.on('league-management:update', onDash);
+    return () => {
+      socket.off('dashboard:update', onDash);
+      socket.off('league-management:update', onDash);
+    };
+  }, [socket, fetchUserLeagues]);
 
   if (loading) {
     return (

--- a/src/components/dashboard/LiveDraftModule.tsx
+++ b/src/components/dashboard/LiveDraftModule.tsx
@@ -2,12 +2,15 @@
 
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { User } from 'firebase/auth';
 import { fetchApi } from '@/lib/api';
+import type { Socket } from 'socket.io-client';
+import type { ServerToClientEvents, ClientToServerEvents } from '@/types/socketEvents';
 
 interface LiveDraftModuleProps {
   user: User;
+  socket?: Socket<ServerToClientEvents, ClientToServerEvents> | null;
 }
 
 interface DraftMeta {
@@ -24,50 +27,57 @@ interface DraftMeta {
   }>;
 }
 
-export default function LiveDraftModule({ user }: LiveDraftModuleProps) {
+export default function LiveDraftModule({ user, socket }: LiveDraftModuleProps) {
   const [draft, setDraft] = useState<DraftMeta | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const loadDraft = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const listRes = await fetchApi('drafts/list');
+      const drafts = listRes.data?.drafts ?? [];
+      const activeDraft = drafts.find((d: { id: string; status: string }) => d.status !== 'COMPLETED');
+      if (!activeDraft) {
+        setDraft(null);
+        return;
+      }
+
+      const detailRes = await fetchApi(`drafts/${activeDraft.id}`);
+      const d = detailRes.data;
+      const meta: DraftMeta = {
+        id: d.id,
+        status: d.status,
+        currentPick: d.currentPick,
+        totalPicks: d.totalPicks,
+        round: d.round,
+        direction: d.direction,
+        timePerPick: d.timePerPick,
+        participants: d.participants,
+      };
+      setDraft(meta);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load draft');
+    } finally {
+      setLoading(false);
+    }
+  }, [user?.uid]);
 
   useEffect(() => {
-    let isMounted = true;
-    const loadDraft = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const listRes = await fetchApi('drafts/list');
-        const drafts = listRes.data?.drafts ?? [];
-        const activeDraft = drafts.find((d: { id: string; status: string }) => d.status !== 'COMPLETED');
-        if (!activeDraft) {
-          if (isMounted) setDraft(null);
-          return;
-        }
-
-        const detailRes = await fetchApi(`drafts/${activeDraft.id}`);
-        const d = detailRes.data;
-        const meta: DraftMeta = {
-          id: d.id,
-          status: d.status,
-          currentPick: d.currentPick,
-          totalPicks: d.totalPicks,
-          round: d.round,
-          direction: d.direction,
-          timePerPick: d.timePerPick,
-          participants: d.participants,
-        };
-        if (isMounted) setDraft(meta);
-      } catch (e) {
-        if (isMounted) setError(e instanceof Error ? e.message : 'Failed to load draft');
-      } finally {
-        if (isMounted) setLoading(false);
-      }
-    };
-
+    if (!user?.uid) return;
     loadDraft();
+  }, [user?.uid, loadDraft]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const reload = (_payload: { timestamp: string }) => loadDraft();
+    socket.on('dashboard:update', reload);
+    socket.on('live-draft:update', reload);
     return () => {
-      isMounted = false;
+      socket.off('dashboard:update', reload);
+      socket.off('live-draft:update', reload);
     };
-  }, []);
+  }, [socket, loadDraft]);
 
   // Determine turn information
   const teamCount = draft?.participants.length ?? 0;

--- a/src/components/dashboard/TopPicksModule.client.tsx
+++ b/src/components/dashboard/TopPicksModule.client.tsx
@@ -5,11 +5,12 @@ import { usePlayerStatsETL } from '@/hooks/usePlayerStats';
 import { useEffect, useMemo, memo } from 'react';
 import type { PlayerStat } from '@/hooks/usePlayerStats';
 import type { Socket } from 'socket.io-client';
+import type { ServerToClientEvents, ClientToServerEvents } from '@/types/socketEvents';
 
 const DEFAULT_TOP_PICKS_LIMIT = 8;
 
 interface TopPicksModuleClientProps {
-  socket: Socket | null;
+  socket: Socket<ServerToClientEvents, ClientToServerEvents> | null;
 }
 
 export default function TopPicksModuleClient({ socket }: TopPicksModuleClientProps) {
@@ -24,7 +25,7 @@ export default function TopPicksModuleClient({ socket }: TopPicksModuleClientPro
 
   useEffect(() => {
     if (!socket) return;
-    const handler = () => {
+    const handler = (_payload: { timestamp: string }) => {
       refetch();
     };
     socket.on('top-picks:update', handler);

--- a/src/components/dashboard/TopPicksModule.tsx
+++ b/src/components/dashboard/TopPicksModule.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import dynamic from 'next/dynamic';
 import TopPicksSkeleton from '@/components/ui/skeletons/TopPicksSkeleton';
 import type { Socket } from 'socket.io-client';
+import type { ServerToClientEvents, ClientToServerEvents } from '@/types/socketEvents';
 
-type Props = { socket: Socket | null };
+type Props = { socket: Socket<ServerToClientEvents, ClientToServerEvents> | null };
 
 const Client = dynamic(() => import('./TopPicksModule.client'), {
   ssr: false,

--- a/src/types/socketEvents.ts
+++ b/src/types/socketEvents.ts
@@ -1,0 +1,12 @@
+export interface ServerToClientEvents {
+  'dashboard:update': (payload: { timestamp: string }) => void;
+  'leaderboard:update': (payload: { timestamp: string }) => void;
+  'top-picks:update': (payload: { timestamp: string }) => void;
+  'live-draft:update': (payload: { timestamp: string }) => void;
+  'league-management:update': (payload: { timestamp: string }) => void;
+}
+
+export interface ClientToServerEvents {
+  'dashboard:refresh': () => void;
+  'module:refresh': (moduleId: string) => void;
+}


### PR DESCRIPTION
## Summary
- enforce typed Socket.IO events and hook modules into updates for live refresh
- rate-limit dashboard refreshes server-side and clear demo interval on shutdown
- narrow Firestore instance handling to satisfy type checks

## Testing
- `npm test` *(fails: Firestore | null is not assignable to Firestore in LeagueChat.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b5830dd844832bb73a3b94f2dc3fd4