### PR TITLE
feat: hook injury feed to dashboard updates

### DIFF
--- a/src/components/dashboard/LiveInjuryFeed.client.tsx
+++ b/src/components/dashboard/LiveInjuryFeed.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { useInjuryData } from '@/hooks/useInjuryData';
 import InjuryListDisplay from './InjuryListDisplay';
@@ -69,7 +69,7 @@ export default function LiveInjuryFeedClient({
   teamFilter,
   userTeamPlayers: _userTeamPlayers,
   autoRefresh = true,
-  socket: _socket,
+  socket,
 }: LiveInjuryFeedProps) {
   const reduceMotion = useReducedMotion();
   const [selectedTeam, setSelectedTeam] = useState<string>(teamFilter || '');
@@ -80,6 +80,17 @@ export default function LiveInjuryFeedClient({
     autoRefresh,
     refreshInterval: 300000,
   });
+
+  useEffect(() => {
+    if (!socket) return;
+    const onDash = () => refresh();
+    socket.on('dashboard:update', onDash);
+    // socket.on('injury-feed:update', onDash);
+    return () => {
+      socket.off('dashboard:update', onDash);
+      // socket.off('injury-feed:update', onDash);
+    };
+  }, [socket, refresh]);
 
   const sortedInjuries = useMemo(() => {
     const arr = injuries.slice();


### PR DESCRIPTION
## Summary
- listen for `dashboard:update` events in `LiveInjuryFeed` to keep data fresh
- rename `socket` prop and wire subscription cleanup

## Testing
- `npm test` *(fails: Argument of type 'Firestore | null' is not assignable to parameter of type 'Firestore')*


------
https://chatgpt.com/codex/tasks/task_e_68b582ea8838832b93de41f3989248af