### PR TITLE
fix: guard unmounted state updates in dashboard modules

### DIFF
--- a/src/components/dashboard/LeagueManagementModule.tsx
+++ b/src/components/dashboard/LeagueManagementModule.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
 import type { User } from 'firebase/auth';
@@ -20,8 +20,16 @@ export default function LeagueManagementModule({ user }: LeagueManagementModuleP
   const [leagues, setLeagues] = useState<LeagueWithMembers[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   const fetchUserLeagues = useCallback(async () => {
+    if (!isMounted.current) return;
     try {
       setLoading(true);
       setError(null);
@@ -41,16 +49,16 @@ export default function LeagueManagementModule({ user }: LeagueManagementModuleP
       const leagues = membershipsData.leagues || membershipsData.data?.leagues || [];
       if (!Array.isArray(leagues)) {
         console.warn('Leagues data is not an array:', leagues);
-        setLeagues([]);
+        if (isMounted.current) setLeagues([]);
         return;
       }
 
-      setLeagues(leagues);
+      if (isMounted.current) setLeagues(leagues);
     } catch (err) {
       console.error('Error fetching user leagues:', err);
-      setError('Failed to load leagues');
+      if (isMounted.current) setError('Failed to load leagues');
     } finally {
-      setLoading(false);
+      if (isMounted.current) setLoading(false);
     }
   }, [user?.uid]);
 

--- a/src/components/dashboard/LiveDraftModule.tsx
+++ b/src/components/dashboard/LiveDraftModule.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import type { User } from 'firebase/auth';
 import { fetchApi } from '@/lib/api';
 import { useSocket } from '@/context/SocketContext';
@@ -30,8 +30,16 @@ export default function LiveDraftModule({ user }: LiveDraftModuleProps) {
   const [draft, setDraft] = useState<DraftMeta | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   const loadDraft = useCallback(async () => {
+    if (!isMounted.current) return;
     setLoading(true);
     setError(null);
     try {
@@ -39,7 +47,7 @@ export default function LiveDraftModule({ user }: LiveDraftModuleProps) {
       const drafts = listRes.data?.drafts ?? [];
       const activeDraft = drafts.find((d: { id: string; status: string }) => d.status !== 'COMPLETED');
       if (!activeDraft) {
-        setDraft(null);
+        if (isMounted.current) setDraft(null);
         return;
       }
 
@@ -55,17 +63,17 @@ export default function LiveDraftModule({ user }: LiveDraftModuleProps) {
         timePerPick: d.timePerPick,
         participants: d.participants,
       };
-      setDraft(meta);
+      if (isMounted.current) setDraft(meta);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load draft');
+      if (isMounted.current) setError(e instanceof Error ? e.message : 'Failed to load draft');
     } finally {
-      setLoading(false);
+      if (isMounted.current) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
     loadDraft();
-  }, [loadDraft, user?.uid]);
+  }, [loadDraft]);
 
   useEffect(() => {
     if (!socket) return;


### PR DESCRIPTION
## Summary
- add isMounted refs to LiveDraft and LeagueManagement modules to avoid state updates after unmount
- remove redundant user uid dependency from LiveDraftModule to prevent extra fetches

## Testing
- `npm test` *(fails: Argument of type 'Firestore | null' is not assignable to parameter of type 'Firestore' in LeagueChat.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b58dd64284832ba12fa2d9db88b403