### PR TITLE
fix: correct PlayerSpotlight socket listener

### DIFF
--- a/src/components/dashboard/PlayerSpotlightModule.client.tsx
+++ b/src/components/dashboard/PlayerSpotlightModule.client.tsx
@@ -39,10 +39,8 @@ export default function PlayerSpotlightModuleClient() {
       // TODO: fetch spotlight data
     };
     socket.on('player-spotlight:update', onUpdate);
-    socket.on('module:refresh', onUpdate);
     return () => {
       socket.off('player-spotlight:update', onUpdate);
-      socket.off('module:refresh', onUpdate);
     };
   }, [socket]);
 


### PR DESCRIPTION
## Summary
- remove unused `module:refresh` listener in PlayerSpotlight client

## Testing
- `npm test` *(fails: Firestore | null not assignable to Firestore in LeagueChat.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b58de41400832b8deb7d6966d1ade2