### PR TITLE
Guard dashboard modules against unmounted updates

### DIFF
--- a/src/components/dashboard/LeagueManagementModule.tsx
+++ b/src/components/dashboard/LeagueManagementModule.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
 import type { User } from 'firebase/auth';
@@ -20,8 +20,16 @@ export default function LeagueManagementModule({ user }: LeagueManagementModuleP
   const [leagues, setLeagues] = useState<LeagueWithMembers[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   const fetchUserLeagues = useCallback(async () => {
+    if (!isMounted.current) return;
     try {
       setLoading(true);
       setError(null);
@@ -38,19 +46,20 @@ export default function LeagueManagementModule({ user }: LeagueManagementModuleP
       }
 
       const membershipsData = await membershipsResponse.json();
+      if (!isMounted.current) return;
       const leagues = membershipsData.leagues || membershipsData.data?.leagues || [];
       if (!Array.isArray(leagues)) {
         console.warn('Leagues data is not an array:', leagues);
-        setLeagues([]);
+        if (isMounted.current) setLeagues([]);
         return;
       }
 
-      setLeagues(leagues);
+      if (isMounted.current) setLeagues(leagues);
     } catch (err) {
       console.error('Error fetching user leagues:', err);
-      setError('Failed to load leagues');
+      if (isMounted.current) setError('Failed to load leagues');
     } finally {
-      setLoading(false);
+      if (isMounted.current) setLoading(false);
     }
   }, [user?.uid]);
 

--- a/src/components/dashboard/LiveDraftModule.tsx
+++ b/src/components/dashboard/LiveDraftModule.tsx
@@ -61,8 +61,9 @@ export default function LiveDraftModule({ user }: LiveDraftModuleProps) {
       };
       if (isMounted.current) setDraft(meta);
     } catch (e) {
-      if (isMounted.current)
+      if (isMounted.current) {
         setError(e instanceof Error ? e.message : 'Failed to load draft');
+      }
     } finally {
       if (isMounted.current) setLoading(false);
     }

--- a/src/components/dashboard/LiveDraftModule.tsx
+++ b/src/components/dashboard/LiveDraftModule.tsx
@@ -70,10 +70,13 @@ export default function LiveDraftModule({ user }: LiveDraftModuleProps) {
 
   useEffect(() => {
     loadDraft();
+  }, [loadDraft]);
+
+  useEffect(() => {
     return () => {
       isMounted.current = false;
     };
-  }, [loadDraft]);
+  }, []);
 
   useEffect(() => {
     if (!socket) return;

--- a/src/components/dashboard/LiveDraftModule.tsx
+++ b/src/components/dashboard/LiveDraftModule.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import type { User } from 'firebase/auth';
 import { fetchApi } from '@/lib/api';
 import { useSocket } from '@/context/SocketContext';
@@ -30,20 +30,24 @@ export default function LiveDraftModule({ user }: LiveDraftModuleProps) {
   const [draft, setDraft] = useState<DraftMeta | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const isMounted = useRef(true);
 
   const loadDraft = useCallback(async () => {
+    if (!isMounted.current) return;
     setLoading(true);
     setError(null);
     try {
       const listRes = await fetchApi('drafts/list');
+      if (!isMounted.current) return;
       const drafts = listRes.data?.drafts ?? [];
       const activeDraft = drafts.find((d: { id: string; status: string }) => d.status !== 'COMPLETED');
       if (!activeDraft) {
-        setDraft(null);
+        if (isMounted.current) setDraft(null);
         return;
       }
 
       const detailRes = await fetchApi(`drafts/${activeDraft.id}`);
+      if (!isMounted.current) return;
       const d = detailRes.data;
       const meta: DraftMeta = {
         id: d.id,
@@ -55,17 +59,21 @@ export default function LiveDraftModule({ user }: LiveDraftModuleProps) {
         timePerPick: d.timePerPick,
         participants: d.participants,
       };
-      setDraft(meta);
+      if (isMounted.current) setDraft(meta);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load draft');
+      if (isMounted.current)
+        setError(e instanceof Error ? e.message : 'Failed to load draft');
     } finally {
-      setLoading(false);
+      if (isMounted.current) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
     loadDraft();
-  }, [loadDraft, user?.uid]);
+    return () => {
+      isMounted.current = false;
+    };
+  }, [loadDraft]);
 
   useEffect(() => {
     if (!socket) return;

--- a/src/components/dashboard/PlayerSpotlightModule.client.tsx
+++ b/src/components/dashboard/PlayerSpotlightModule.client.tsx
@@ -39,10 +39,8 @@ export default function PlayerSpotlightModuleClient() {
       // TODO: fetch spotlight data
     };
     socket.on('player-spotlight:update', onUpdate);
-    socket.on('module:refresh', onUpdate);
     return () => {
       socket.off('player-spotlight:update', onUpdate);
-      socket.off('module:refresh', onUpdate);
     };
   }, [socket]);
 


### PR DESCRIPTION
## Summary
- prevent state updates after unmount in dashboard modules
- remove redundant socket listener in PlayerSpotlight module

## Testing
- `npm test` *(fails: Argument of type 'Firestore | null' is not assignable to parameter of type 'Firestore' in LeagueChat.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b58df8d194832b9d9450ce46f8a876