### PR TITLE
fix(rosters): allow free agents to load on roster error

### DIFF
--- a/src/app/rosters/page.tsx
+++ b/src/app/rosters/page.tsx
@@ -101,7 +101,6 @@ export default function RostersPage() {
           if (!controller.signal.aborted) setRosterPlayers(owned);
         } else if (!controller.signal.aborted) {
           setError('Failed to load roster data.');
-          return;
         }
 
         const faRes = await fetch(


### PR DESCRIPTION
## Summary
- avoid early return when roster fetch fails

## Testing
- `npm test`
- `npm run lint` *(fails: 684 problems (16 errors, 668 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b581f6fd50832b8acdb19c96ef64cf

## Summary by Sourcery

Bug Fixes:
- Continue fetching free agents even when the roster data fetch fails by removing the early return