### PR TITLE
test: add coverage for missing dashboard settings

### DIFF
--- a/src/hooks/useDashboardSettings.ts
+++ b/src/hooks/useDashboardSettings.ts
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { doc, getDoc, onSnapshot, setDoc } from 'firebase/firestore';
 import { db } from '@/lib/firebaseClient';
 import { z } from 'zod';
+import * as Sentry from '@sentry/react';
 
 export const dashboardSettingsSchema = z.object({
   layout: z.array(
@@ -47,9 +48,6 @@ export function useDashboardSettings(uid: string, initial?: DashboardSettings) {
     initialData: initial,
     staleTime: 60_000,
   });
-
-// At the top of the file, alongside your other imports
-import * as Sentry from '@sentry/react';
 
   useEffect(() => {
     if (!db) return;

--- a/tests/unit/useDashboardSettings.test.tsx
+++ b/tests/unit/useDashboardSettings.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { getDoc } from 'firebase/firestore';
 import {
   useDashboardSettings,
   defaultDashboardSettings,
@@ -27,6 +28,28 @@ describe('useDashboardSettings', () => {
     );
     await act(async () => {
       await expect(result.current.updateSettings({ theme: 'dark' })).resolves.toBeDefined();
+    });
+  });
+
+  it('falls back to default when Firestore data missing', async () => {
+    vi.mocked(getDoc).mockResolvedValueOnce({ exists: () => false });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useDashboardSettings('u1'), { wrapper });
+    await waitFor(() => {
+      expect(result.current.settings).toEqual(defaultDashboardSettings);
+    });
+  });
+
+  it('falls back to default when Firestore data invalid', async () => {
+    vi.mocked(getDoc).mockResolvedValueOnce({ exists: () => true, data: () => null });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useDashboardSettings('u1'), { wrapper });
+    await waitFor(() => {
+      expect(result.current.settings).toEqual(defaultDashboardSettings);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add tests for missing or invalid Firestore dashboard settings
- fix misplaced Sentry import in useDashboardSettings

## Testing
- `npm run test:unit tests/unit/useDashboardSettings.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c022a5090c832baccf696643644596