### PR TITLE
feat: server-first dashboard skeleton

### DIFF
--- a/src/app/dashboard/ClientShell.tsx
+++ b/src/app/dashboard/ClientShell.tsx
@@ -36,7 +36,18 @@ function Inner({ uid, initialSettings }: Props) {
           .sort((a, b) => a.order - b.order)
           .map((m) => {
             const Comp = moduleMap[m.id];
-            if (!Comp) return null;
+            if (!Comp) {
+              console.warn(`Unknown module ID encountered in dashboard layout: ${m.id}`);
+              return (
+                <div
+                  key={m.id}
+                  className="border border-red-500 bg-red-50 text-red-700 p-2 rounded"
+                  data-unknown-module
+                >
+                  Unknown module: <strong>{m.id}</strong>
+                </div>
+              );
+            }
             return <Comp key={m.id} />;
           })}
       </div>

--- a/src/app/dashboard/ClientShell.tsx
+++ b/src/app/dashboard/ClientShell.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import React from 'react';
+import { QueryProvider } from '@/providers/QueryProvider';
+import { SocketProvider } from '@/providers/SocketProvider';
+import { useDashboardSettings, DashboardSettings } from '@/hooks/useDashboardSettings';
+import TopPicksModule from '@/components/modules/TopPicksModule';
+import { AppLayout } from '@/components/navigation';
+
+interface Props {
+  uid: string;
+  initialSettings: DashboardSettings;
+}
+
+const moduleMap: Record<string, React.ComponentType> = {
+  topPicks: TopPicksModule,
+};
+
+export default function ClientShell({ uid, initialSettings }: Props) {
+  return (
+    <QueryProvider>
+      <SocketProvider uid={uid}>
+        <Inner uid={uid} initialSettings={initialSettings} />
+      </SocketProvider>
+    </QueryProvider>
+  );
+}
+
+function Inner({ uid, initialSettings }: Props) {
+  const { settings } = useDashboardSettings(uid, initialSettings);
+  return (
+    <AppLayout>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {settings.layout
+          .filter((m) => m.enabled)
+          .sort((a, b) => a.order - b.order)
+          .map((m) => {
+            const Comp = moduleMap[m.id];
+            if (!Comp) return null;
+            return <Comp key={m.id} />;
+          })}
+      </div>
+    </AppLayout>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,33 +1,33 @@
-'use client';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import ClientShell from './ClientShell';
+import {
+  DashboardSettings,
+  defaultDashboardSettings,
+} from '@/hooks/useDashboardSettings';
+import { adminAuth, adminDb } from '@/lib/firebaseAdmin';
 
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { useAuth } from '@/AuthContext';
-import { AppLayout } from '@/components/navigation';
-import DashboardLoading from '@/components/DashboardLoading';
-import UserDashboard from '@/components/UserDashboard';
+export default async function Page() {
+  const session = cookies().get('statly_session')?.value;
+  if (!session) redirect('/login');
 
-export default function Page() {
-  const { user, loading } = useAuth();
-  const router = useRouter();
-
-  useEffect(() => {
-    if (!loading && !user) {
-      router.replace('/login');
-    }
-  }, [loading, user, router]);
-
-  if (loading) {
-    return <DashboardLoading />;
+  let uid: string;
+  try {
+    const decoded = await adminAuth.verifySessionCookie(session, true);
+    uid = decoded.uid as string;
+  } catch {
+    redirect('/login');
   }
 
-  if (!user) {
-    return null;
-  }
+  const ref = adminDb
+    .collection('users')
+    .doc(uid)
+    .collection('dashboardSettings')
+    .doc('default');
+  const snap = await ref.get();
+  const settings = snap.exists
+    ? (snap.data() as DashboardSettings)
+    : defaultDashboardSettings;
 
-  return (
-    <AppLayout>
-      <UserDashboard user={user} />
-    </AppLayout>
-  );
+  return <ClientShell uid={uid} initialSettings={settings} />;
 }

--- a/src/components/dashboard/DashboardCard.tsx
+++ b/src/components/dashboard/DashboardCard.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import React, { ReactNode } from 'react';
+// Before
+- import React, { ReactNode } from 'react';
+// After
+ import type { ReactNode } from 'react';
 
 interface Props {
   title: string;

--- a/src/components/dashboard/DashboardCard.tsx
+++ b/src/components/dashboard/DashboardCard.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-// Before
-- import React, { ReactNode } from 'react';
-// After
- import type { ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 
 interface Props {
   title: string;
@@ -25,10 +22,12 @@ export default function DashboardCard({
   return (
     <div className="bg-white rounded-xl shadow-sm border border-gray-200">
       <div className="flex items-center justify-between p-4 border-b border-gray-100">
-        <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+        <h3 id="card-title" className="text-lg font-semibold text-gray-900">
+          {title}
+        </h3>
         {actions}
       </div>
-      <div className="p-4">
+      <div className="p-4" aria-labelledby="card-title" aria-busy={!!isLoading}>
         {isLoading ? (
           <div
             className="h-20 animate-pulse bg-gray-100 rounded"
@@ -48,9 +47,8 @@ export default function DashboardCard({
         ) : (
           children
         )}
-          children
-        )}
       </div>
     </div>
   );
 }
+

--- a/src/components/dashboard/DashboardCard.tsx
+++ b/src/components/dashboard/DashboardCard.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React, { ReactNode } from 'react';
+
+interface Props {
+  title: string;
+  actions?: ReactNode;
+  isLoading?: boolean;
+  error?: string;
+  empty?: boolean;
+  children?: ReactNode;
+}
+
+export default function DashboardCard({
+  title,
+  actions,
+  isLoading,
+  error,
+  empty,
+  children,
+}: Props) {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200">
+      <div className="flex items-center justify-between p-4 border-b border-gray-100">
+        <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+        {actions}
+      </div>
+      <div className="p-4">
+        {isLoading ? (
+          <div className="h-20 animate-pulse bg-gray-100 rounded" />
+        ) : error ? (
+          <div className="text-red-500" role="alert">
+            {error}
+          </div>
+        ) : empty ? (
+          <div className="text-gray-500">No data</div>
+        ) : (
+          children
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/DashboardCard.tsx
+++ b/src/components/dashboard/DashboardCard.tsx
@@ -30,14 +30,24 @@ export default function DashboardCard({
       </div>
       <div className="p-4">
         {isLoading ? (
-          <div className="h-20 animate-pulse bg-gray-100 rounded" />
+          <div
+            className="h-20 animate-pulse bg-gray-100 rounded"
+            role="status"
+            aria-live="polite"
+            aria-label="Loading"
+            aria-busy="true"
+          />
         ) : error ? (
           <div className="text-red-500" role="alert">
             {error}
           </div>
         ) : empty ? (
-          <div className="text-gray-500">No data</div>
+          <div className="text-gray-500" role="status" aria-live="polite">
+            No data
+          </div>
         ) : (
+          children
+        )}
           children
         )}
       </div>

--- a/src/components/modules/TopPicksModule.tsx
+++ b/src/components/modules/TopPicksModule.tsx
@@ -13,9 +13,26 @@ interface Player {
 }
 
 async function fetchTopPicks(): Promise<Player[]> {
-  const res = await fetch('/api/top-picks');
-  if (!res.ok) throw new Error('Failed to load');
-  return res.json();
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000); // 10s timeout
+
+  try {
+    const res = await fetch('/api/top-picks', {
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+
+    if (!res.ok) {
+      throw new Error(`Failed to load top picks: ${res.status} ${res.statusText}`);
+    }
+    return res.json();
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('Request timeout: Failed to load top picks');
+    }
+    throw error;
+  }
 }
 
 export default function TopPicksModule() {

--- a/src/components/modules/TopPicksModule.tsx
+++ b/src/components/modules/TopPicksModule.tsx
@@ -42,7 +42,23 @@ export default function TopPicksModule() {
     staleTime: 30_000,
   });
 
-  useSocketChannel('topPicks', () => refetch());
+import React, { useCallback } from 'react';
+
+export default function TopPicksModule() {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['top-picks'],
+    queryFn: fetchTopPicks,
+    staleTime: 30_000,
+  });
+
+  const handleSocketUpdate = useCallback(() => {
+    refetch();
+  }, [refetch]);
+  
+  useSocketChannel('topPicks', handleSocketUpdate);
+
+  // ...rest of your component
+}
 
   return (
     <DashboardCard

--- a/src/components/modules/TopPicksModule.tsx
+++ b/src/components/modules/TopPicksModule.tsx
@@ -72,9 +72,12 @@ export default function TopPicksModule() {
           {({ index, style }) => {
             const p = data[index];
             return (
-              <div style={style} className="flex justify-between px-2">
-                <span>{p.name}</span>
-                <span className="font-semibold">{p.score}</span>
+              <div
+                style={style}
+                className="flex justify-between items-center px-3 py-2 hover:bg-gray-50 transition-colors cursor-pointer border-b border-gray-100"
+              >
+                <span className="text-gray-800">{p.name}</span>
+                <span className="font-semibold text-gray-900">{p.score.toFixed(1)}</span>
               </div>
             );
           }}

--- a/src/components/modules/TopPicksModule.tsx
+++ b/src/components/modules/TopPicksModule.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React from 'react';
+import { FixedSizeList } from 'react-window';
+import { useQuery } from '@tanstack/react-query';
+import DashboardCard from '../dashboard/DashboardCard';
+import { useSocketChannel } from '@/providers/SocketProvider';
+
+interface Player {
+  id: string;
+  name: string;
+  score: number;
+}
+
+async function fetchTopPicks(): Promise<Player[]> {
+  const res = await fetch('/api/top-picks');
+  if (!res.ok) throw new Error('Failed to load');
+  return res.json();
+}
+
+export default function TopPicksModule() {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['top-picks'],
+    queryFn: fetchTopPicks,
+    staleTime: 30_000,
+  });
+
+  useSocketChannel('topPicks', () => refetch());
+
+  return (
+    <DashboardCard
+      title="Top Picks"
+      isLoading={isLoading}
+      error={error?.message}
+      empty={!data || data.length === 0}
+    >
+      {data && (
+        <FixedSizeList height={300} itemCount={data.length} itemSize={48} width="100%">
+          {({ index, style }) => {
+            const p = data[index];
+            return (
+              <div style={style} className="flex justify-between px-2">
+                <span>{p.name}</span>
+                <span className="font-semibold">{p.score}</span>
+              </div>
+            );
+          }}
+        </FixedSizeList>
+      )}
+    </DashboardCard>
+  );
+}

--- a/src/hooks/useDashboardSettings.ts
+++ b/src/hooks/useDashboardSettings.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { doc, getDoc, onSnapshot, setDoc } from 'firebase/firestore';
+import { db } from '@/lib/firebaseClient';
+import { z } from 'zod';
+
+export const dashboardSettingsSchema = z.object({
+  layout: z.array(
+    z.object({
+      id: z.string(),
+      enabled: z.boolean(),
+      order: z.number(),
+      size: z.enum(['sm', 'md', 'lg']),
+    })
+  ),
+  theme: z.enum(['light', 'dark', 'system']).default('system'),
+  updatedAt: z.number(),
+  version: z.literal(1),
+});
+
+export type DashboardSettings = z.infer<typeof dashboardSettingsSchema>;
+
+export const defaultDashboardSettings: DashboardSettings = {
+  layout: [],
+  theme: 'system',
+  updatedAt: Date.now(),
+  version: 1,
+};
+
+export function useDashboardSettings(uid: string, initial?: DashboardSettings) {
+  const queryClient = useQueryClient();
+  const key = ['dashboard-settings', uid];
+
+  const fetchSettings = async (): Promise<DashboardSettings> => {
+    if (!db) return defaultDashboardSettings;
+    const ref = doc(db, 'users', uid, 'dashboardSettings', 'default');
+    const snap = await getDoc(ref);
+    if (!snap.exists()) return defaultDashboardSettings;
+    return dashboardSettingsSchema.parse(snap.data());
+  };
+
+  const { data } = useQuery({
+    queryKey: key,
+    queryFn: fetchSettings,
+    initialData: initial,
+    staleTime: 60_000,
+  });
+
+  useEffect(() => {
+    if (!db) return;
+    const ref = doc(db, 'users', uid, 'dashboardSettings', 'default');
+    return onSnapshot(ref, (snap) => {
+      if (!snap.exists()) return;
+      const data = dashboardSettingsSchema.safeParse(snap.data());
+      if (data.success) {
+        queryClient.setQueryData(key, data.data);
+      }
+    });
+  }, [uid, queryClient]);
+
+  const mutation = useMutation({
+    mutationFn: async (partial: Partial<DashboardSettings>) => {
+      if (!db) return defaultDashboardSettings;
+      const ref = doc(db, 'users', uid, 'dashboardSettings', 'default');
+      const updated = { ...data!, ...partial, updatedAt: Date.now() } as DashboardSettings;
+      await setDoc(ref, updated, { merge: true });
+      return updated;
+    },
+    onMutate: async (partial) => {
+      await queryClient.cancelQueries({ queryKey: key });
+      const prev = queryClient.getQueryData<DashboardSettings>(key);
+      const optimistic = { ...prev!, ...partial, updatedAt: Date.now() } as DashboardSettings;
+      queryClient.setQueryData(key, optimistic);
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev) queryClient.setQueryData(key, ctx.prev);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: key });
+    },
+  });
+
+  return { settings: data || defaultDashboardSettings, updateSettings: mutation.mutateAsync };
+}

--- a/src/hooks/useDashboardSettings.ts
+++ b/src/hooks/useDashboardSettings.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { doc, getDoc, onSnapshot, setDoc } from 'firebase/firestore';
 import { db } from '@/lib/firebaseClient';

--- a/src/hooks/useDashboardSettings.ts
+++ b/src/hooks/useDashboardSettings.ts
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { doc, getDoc, onSnapshot, setDoc } from 'firebase/firestore';
 import { db } from '@/lib/firebaseClient';
 import { z } from 'zod';
+import * as Sentry from '@sentry/react';
 
 export const dashboardSettingsSchema = z.object({
   layout: z.array(
@@ -47,9 +48,6 @@ export function useDashboardSettings(uid: string, initial?: DashboardSettings) {
     initialData: initial,
     staleTime: 60_000,
   });
-
-// At the top of the file, alongside your other imports
-import * as Sentry from '@sentry/react';
 
   useEffect(() => {
     if (!db) return;

--- a/src/hooks/useDashboardSettings.ts
+++ b/src/hooks/useDashboardSettings.ts
@@ -64,14 +64,14 @@ export function useDashboardSettings(uid: string, initial?: DashboardSettings) {
     mutationFn: async (partial: Partial<DashboardSettings>) => {
       if (!db) return defaultDashboardSettings;
       const ref = doc(db, 'users', uid, 'dashboardSettings', 'default');
-      const updated = { ...data!, ...partial, updatedAt: Date.now() } as DashboardSettings;
+      const updated = { ...(data ?? defaultDashboardSettings), ...partial, updatedAt: Date.now() } as DashboardSettings;
       await setDoc(ref, updated, { merge: true });
       return updated;
     },
     onMutate: async (partial) => {
       await queryClient.cancelQueries({ queryKey: key });
       const prev = queryClient.getQueryData<DashboardSettings>(key);
-      const optimistic = { ...prev!, ...partial, updatedAt: Date.now() } as DashboardSettings;
+      const optimistic = { ...(prev ?? defaultDashboardSettings), ...partial, updatedAt: Date.now() } as DashboardSettings;
       queryClient.setQueryData(key, optimistic);
       return { prev };
     },

--- a/src/hooks/useDashboardSettings.ts
+++ b/src/hooks/useDashboardSettings.ts
@@ -48,16 +48,30 @@ export function useDashboardSettings(uid: string, initial?: DashboardSettings) {
     staleTime: 60_000,
   });
 
+// At the top of the file, alongside your other imports
+import * as Sentry from '@sentry/react';
+
   useEffect(() => {
     if (!db) return;
     const ref = doc(db, 'users', uid, 'dashboardSettings', 'default');
-    return onSnapshot(ref, (snap) => {
-      if (!snap.exists()) return;
-      const data = dashboardSettingsSchema.safeParse(snap.data());
-      if (data.success) {
-        queryClient.setQueryData(key, data.data);
+    return onSnapshot(
+      ref,
+      (snap) => {
+        if (!snap.exists()) return;
+        const data = dashboardSettingsSchema.safeParse(snap.data());
+        if (data.success) {
+          queryClient.setQueryData(key, data.data);
+        } else {
+          Sentry.captureMessage(
+            'Invalid dashboardSettings snapshot',
+            { extra: { issues: data.error.issues } }
+          );
+        }
+      },
+      (err) => {
+        Sentry.captureException(err);
       }
-    });
+    );
   }, [uid, queryClient]);
 
   const mutation = useMutation({

--- a/src/providers/QueryProvider.tsx
+++ b/src/providers/QueryProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { ReactNode, useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import {
   Hydrate,
   QueryClient,

--- a/src/providers/QueryProvider.tsx
+++ b/src/providers/QueryProvider.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React, { ReactNode, useState } from 'react';
+import {
+  Hydrate,
+  QueryClient,
+  QueryClientProvider,
+  DehydratedState,
+} from '@tanstack/react-query';
+
+interface Props {
+  children: ReactNode;
+  state?: DehydratedState;
+}
+
+export function QueryProvider({ children, state }: Props) {
+  const [client] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            gcTime: 5 * 60_000,
+            refetchOnWindowFocus: false,
+          },
+        },
+      })
+  );
+
+  return (
+    <QueryClientProvider client={client}>
+      <Hydrate state={state}>{children}</Hydrate>
+    </QueryClientProvider>
+  );
+}

--- a/src/providers/SocketProvider.tsx
+++ b/src/providers/SocketProvider.tsx
@@ -32,6 +32,14 @@ export function SocketProvider({ uid, children }: Props) {
       Sentry.captureException(err);
     });
 
+    socket.on('error', (err) => {
+      Sentry.captureException(err);
+    });
+
+    socket.on('disconnect', (reason) => {
+      Sentry.captureException(new Error(`Socket disconnected: ${reason}`));
+    });
+
     const handleVisibility = () => {
       if (document.visibilityState === 'hidden') {
         socket.close();

--- a/src/providers/SocketProvider.tsx
+++ b/src/providers/SocketProvider.tsx
@@ -4,8 +4,8 @@ import React, {
   createContext,
   useContext,
   useEffect,
-  useRef,
-  ReactNode,
+  useState,
+  type ReactNode,
 } from 'react';
 import { io, type Socket } from 'socket.io-client';
 import * as Sentry from '@sentry/react';
@@ -18,44 +18,45 @@ interface Props {
 const SocketContext = createContext<Socket | null>(null);
 
 export function SocketProvider({ uid, children }: Props) {
-  const socketRef = useRef<Socket | null>(null);
+  const [socket, setSocket] = useState<Socket | null>(null);
 
   useEffect(() => {
-    const socket = io('/', {
+    const s = io('/', {
       auth: { uid },
       transports: ['websocket'],
       reconnection: true,
     });
-    socketRef.current = socket;
+    setSocket(s);
 
-    socket.on('connect_error', (err) => {
+    s.on('connect_error', (err) => {
       Sentry.captureException(err);
     });
 
-    socket.on('error', (err) => {
+    s.on('error', (err) => {
       Sentry.captureException(err);
     });
 
-    socket.on('disconnect', (reason) => {
+    s.on('disconnect', (reason) => {
       Sentry.captureException(new Error(`Socket disconnected: ${reason}`));
     });
 
     const handleVisibility = () => {
       if (document.visibilityState === 'hidden') {
-        socket.close();
-      } else if (!socket.connected) {
-        socket.connect();
+        s.close();
+      } else if (!s.connected) {
+        s.connect();
       }
     };
     document.addEventListener('visibilitychange', handleVisibility);
 
     return () => {
       document.removeEventListener('visibilitychange', handleVisibility);
-      socket.disconnect();
+      s.disconnect();
+      setSocket(null);
     };
   }, [uid]);
 
-  return <SocketContext.Provider value={socketRef.current}>{children}</SocketContext.Provider>;
+  return <SocketContext.Provider value={socket}>{children}</SocketContext.Provider>;
 }
 
 export function useSocket() {

--- a/src/providers/SocketProvider.tsx
+++ b/src/providers/SocketProvider.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  ReactNode,
+} from 'react';
+import { io, type Socket } from 'socket.io-client';
+import * as Sentry from '@sentry/react';
+
+interface Props {
+  uid: string;
+  children: ReactNode;
+}
+
+const SocketContext = createContext<Socket | null>(null);
+
+export function SocketProvider({ uid, children }: Props) {
+  const socketRef = useRef<Socket | null>(null);
+
+  useEffect(() => {
+    const socket = io('/', {
+      auth: { uid },
+      transports: ['websocket'],
+      reconnection: true,
+    });
+    socketRef.current = socket;
+
+    socket.on('connect_error', (err) => {
+      Sentry.captureException(err);
+    });
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        socket.close();
+      } else if (!socket.connected) {
+        socket.connect();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility);
+      socket.disconnect();
+    };
+  }, [uid]);
+
+  return <SocketContext.Provider value={socketRef.current}>{children}</SocketContext.Provider>;
+}
+
+export function useSocket() {
+  return useContext(SocketContext);
+}
+
+export function useSocketChannel<T>(channel: string, handler: (data: T) => void) {
+  const socket = useSocket();
+  useEffect(() => {
+    if (!socket) return;
+    socket.on(channel, handler);
+    return () => {
+      socket.off(channel, handler);
+    };
+  }, [socket, channel, handler]);
+}

--- a/tests/e2e/dashboard.test.ts
+++ b/tests/e2e/dashboard.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
-test('dashboard settings persist', async () => {
-  await test.step('load dashboard', async ({ page }) => {
+test('dashboard settings persist', async ({ page }) => {
+  await test.step('load dashboard', async () => {
     await page.goto('/dashboard');
     await expect(page).toHaveURL(/dashboard/);
   });

--- a/tests/e2e/dashboard.test.ts
+++ b/tests/e2e/dashboard.test.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('dashboard settings persist', async () => {
+  await test.step('load dashboard', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/dashboard/);
+  });
+});

--- a/tests/integration/query-hydration.test.tsx
+++ b/tests/integration/query-hydration.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { dehydrate, QueryClient } from '@tanstack/react-query';
+import { renderToString } from 'react-dom/server';
+import { QueryProvider } from '@/providers/QueryProvider';
+import { useQuery } from '@tanstack/react-query';
+
+function Example() {
+  const { data } = useQuery({ queryKey: ['x'], queryFn: () => 'hello' });
+  return <div>{data}</div>;
+}
+
+describe('query hydration', () => {
+  it('hydrates prefetched data', async () => {
+    const qc = new QueryClient();
+    await qc.prefetchQuery({ queryKey: ['x'], queryFn: () => 'hello' });
+    const html = renderToString(
+      <QueryProvider state={dehydrate(qc)}>
+        <Example />
+      </QueryProvider>
+    );
+    expect(html).toContain('hello');
+  });
+});

--- a/tests/setup/unit.setup.ts
+++ b/tests/setup/unit.setup.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, vi } from 'vitest';
 
 beforeAll(() => {
-  vi.stubGlobal('fetch', (..._args: any[]) => {
+  vi.stubGlobal('fetch', () => {
     throw new Error('Network calls are disabled in unit tests. Mock them.');
   });
 });

--- a/tests/unit/DashboardCard.test.tsx
+++ b/tests/unit/DashboardCard.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import DashboardCard from '../../src/components/dashboard/DashboardCard';
+
+describe('DashboardCard', () => {
+  it('renders error state', () => {
+    const { getByRole } = render(<DashboardCard title="Test" error="boom" />);
+    expect(getByRole('alert').textContent).toContain('boom');
+  });
+});

--- a/tests/unit/SocketProvider.test.tsx
+++ b/tests/unit/SocketProvider.test.tsx
@@ -1,20 +1,56 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
-import { SocketProvider } from '../../src/providers/SocketProvider';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { SocketProvider, useSocket } from '../../src/providers/SocketProvider';
+import * as Sentry from '@sentry/react';
 
-const { io } = vi.hoisted(() => ({
-  io: vi.fn(() => ({ on: vi.fn(), off: vi.fn(), disconnect: vi.fn() })),
-}));
+const { socket, io } = vi.hoisted(() => {
+  const socket = {
+    on: vi.fn(),
+    off: vi.fn(),
+    disconnect: vi.fn(),
+    close: vi.fn(),
+    connect: vi.fn(),
+    connected: true,
+  };
+  return { socket, io: vi.fn(() => socket) };
+});
 vi.mock('socket.io-client', () => ({ io }));
+vi.mock('@sentry/react', () => ({ captureException: vi.fn() }));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('SocketProvider', () => {
-  it('creates socket with auth', () => {
+  it('creates socket with auth and provides it via context', async () => {
+    let received: any = null;
+    const Child = () => {
+      received = useSocket();
+      return null;
+    };
+    const { unmount } = render(
+      <SocketProvider uid="abc">
+        <Child />
+      </SocketProvider>
+    );
+    expect(io).toHaveBeenCalledWith('/', expect.objectContaining({ auth: { uid: 'abc' } }));
+
+    await waitFor(() => expect(received).toBe(socket));
+
+    unmount();
+    expect(socket.disconnect).toHaveBeenCalled();
+  });
+
+  it('reports socket errors via Sentry', () => {
     render(
       <SocketProvider uid="abc">
         <div />
       </SocketProvider>
     );
-    expect(io).toHaveBeenCalledWith('/', expect.objectContaining({ auth: { uid: 'abc' } }));
+
+    const handler = socket.on.mock.calls.find((c) => c[0] === 'connect_error')?.[1];
+    handler?.(new Error('boom'));
+    expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error));
   });
 });

--- a/tests/unit/SocketProvider.test.tsx
+++ b/tests/unit/SocketProvider.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { SocketProvider } from '../../src/providers/SocketProvider';
+
+const { io } = vi.hoisted(() => ({
+  io: vi.fn(() => ({ on: vi.fn(), off: vi.fn(), disconnect: vi.fn() })),
+}));
+vi.mock('socket.io-client', () => ({ io }));
+
+describe('SocketProvider', () => {
+  it('creates socket with auth', () => {
+    render(
+      <SocketProvider uid="abc">
+        <div />
+      </SocketProvider>
+    );
+    expect(io).toHaveBeenCalledWith('/', expect.objectContaining({ auth: { uid: 'abc' } }));
+  });
+});

--- a/tests/unit/useDashboardSettings.test.tsx
+++ b/tests/unit/useDashboardSettings.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useDashboardSettings,
+  defaultDashboardSettings,
+} from '../../src/hooks/useDashboardSettings';
+
+const { setDoc } = vi.hoisted(() => ({ setDoc: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn(),
+  getDoc: vi.fn().mockResolvedValue({ exists: () => true, data: () => defaultDashboardSettings }),
+  setDoc,
+  onSnapshot: vi.fn(() => () => {}),
+}));
+vi.mock('@/lib/firebaseClient', () => ({ db: {} }));
+
+describe('useDashboardSettings', () => {
+  it('optimistically updates settings', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(
+      () => useDashboardSettings('u1', defaultDashboardSettings),
+      { wrapper }
+    );
+    await act(async () => {
+      await expect(result.current.updateSettings({ theme: 'dark' })).resolves.toBeDefined();
+    });
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -12,6 +12,8 @@
     "src/**/*.spec.tsx",
     "src/**/__tests__/**/*.ts",
     "src/**/__tests__/**/*.tsx",
+    "tests/**/*.test.ts",
+    "tests/**/*.test.tsx",
     "vitest.setup.*",
     "src/testUtils/setupTests.ts"
   ],

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -6,8 +6,8 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     name: 'unit',
-    environment: 'node',
-    include: ['tests/unit/**/*.test.ts'],
+    environment: 'jsdom',
+    include: ['tests/unit/**/*.test.ts', 'tests/unit/**/*.test.tsx'],
     exclude: ['node_modules'],
     globals: true,
     clearMocks: true,


### PR DESCRIPTION
## Summary
- expose SocketProvider's socket via state and handle additional error events
- add unit tests verifying socket context, cleanup and Sentry error reporting
- tidy dashboard settings hook and card imports

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68c022982d90832bb75e7fc9e650e7dd

## Summary by Sourcery

Expose the socket instance via context in SocketProvider, handle additional socket error events, and improve dashboard component and hook imports.

New Features:
- Expose the socket instance via context in SocketProvider.

Enhancements:
- Handle additional socket error events and report them to Sentry.
- Refine dashboard card component accessibility and loading state handling.
- Tidy up dashboard settings hook and card imports.

Tests:
- Add unit tests for socket context exposure, cleanup, and Sentry error reporting.