### PR TITLE
Handle empty merged source verification

### DIFF
--- a/Scripts/verify-player-read-models-core.ts
+++ b/Scripts/verify-player-read-models-core.ts
@@ -116,7 +116,7 @@ export type VerifyPlayerReadModelsOutput = {
   publishedSeason: number;
   publication: unknown;
   sourceStatus: {
-    merged: 'not_requested' | 'live' | 'timeout' | 'unavailable';
+    merged: 'not_requested' | 'live' | 'empty' | 'timeout' | 'unavailable';
     mergedError: string | null;
     mergedTimeoutMs: number;
     dataSource: string;
@@ -518,7 +518,7 @@ export async function runVerifyPlayerReadModels(
   }
 
   const populatedStages: MatchLogPopulatedStages = {
-    merged: args.mode === 'merged_live' && mergedError == null,
+    merged: args.mode === 'merged_live' && mergedError == null && mergedRows.length > 0,
     raw: true,
     projection: true,
     api: false,
@@ -643,7 +643,9 @@ export async function runVerifyPlayerReadModels(
         args.mode === 'persisted'
           ? 'not_requested'
           : mergedError == null
-            ? 'live'
+            ? mergedRows.length > 0
+              ? 'live'
+              : 'empty'
             : mergedError.includes('timed out')
               ? 'timeout'
               : 'unavailable',

--- a/etl/fetch_fw_round.R
+++ b/etl/fetch_fw_round.R
@@ -63,8 +63,27 @@ required_cols <- c(
 )
 for (col in required_cols) {
   if (!(col %in% names(df))) {
-    df[[col]] <- NA
+    df[[col]] <- rep(NA, nrow(df))
   }
+}
+
+write_meta <- function(outfile, sources) {
+  meta_outfile <- paste0(outfile, ".meta.json")
+  jsonlite::write_json(
+    list(sources = sources),
+    meta_outfile,
+    auto_unbox = TRUE,
+    null = "null"
+  )
+}
+
+if (nrow(df) == 0) {
+  write_meta(outfile, list(list(
+    source = Sys.getenv("DATA_SOURCE", unset = "fryzigg"),
+    rows = 0
+  )))
+  file.create(outfile)
+  quit(status = 0)
 }
 
 if ("round" %in% names(df) && "round_1" %in% names(df)) {
@@ -143,3 +162,8 @@ for (i in seq_len(nrow(df))) {
   json_line <- jsonlite::toJSON(as.list(row), auto_unbox = TRUE)
   writeLines(json_line, con)
 }
+
+write_meta(outfile, list(list(
+  source = Sys.getenv("DATA_SOURCE", unset = "fryzigg"),
+  rows = nrow(df)
+)))

--- a/tests/verify-player-read-models-core.test.ts
+++ b/tests/verify-player-read-models-core.test.ts
@@ -185,6 +185,25 @@ describe('runVerifyPlayerReadModels', () => {
     });
   });
 
+  it('passes clean raw and projection checks when optional live merged source is empty', async () => {
+    const output = await runVerifyPlayerReadModels(
+      parseVerifyPlayerReadModelsArgs(['--season=2026', '--rounds=0', '--include-merged-live']),
+      {
+        loadRawRows: async () => [row()],
+        loadProjectionRows: async () => [row()],
+        loadSeasonSummaryRows: async () => [],
+        loadPublication: async () => null,
+        resolvePublishedSeason: async () => 2026,
+        loadMergedRows: async () => [],
+      }
+    );
+
+    expect(output.sourceStatus.merged).toBe('empty');
+    expect(output.populatedStages.merged).toBe(false);
+    expect(output.matchLogIssues.byCode).toEqual({});
+    expect(output.status).toBe('pass');
+  });
+
   it('reports aggregate mismatches against raw totals', async () => {
     const output = await runVerifyPlayerReadModels(
       parseVerifyPlayerReadModelsArgs(['--season=2026']),


### PR DESCRIPTION
## Summary
- Fixes `etl/fetch_fw_round.R` so zero-row fitzRoy/live source results emit empty NDJSON plus metadata instead of crashing while adding missing columns.
- Teaches the player read-model verifier to report an empty optional merged-live source as `sourceStatus.merged: "empty"` and avoid treating that source as a populated reconciliation stage.
- Adds verifier coverage for clean raw/projection checks when the optional live merged source is empty.

## Verification
- `OUTFILE=/tmp/statly-r-test.ndjson DATA_SOURCE=afltables,footywire_match FOOTYWIRE_MATCH_IDS='' SEASON=2026 ROUND=0 Rscript fetch_fw_round.R 2026 0 /tmp/statly-r-test.ndjson` exits 0, writes 0 rows, and emits metadata.
- `npx vitest run tests/verify-player-read-models-core.test.ts`
- `npm --silent run verify:player-read-models -- --season=2026 --rounds=0 --include-merged-live --json` now returns `ok: true`, `status: pass`, `sourceStatus.merged: "empty"`.
- Full operational 2026 round 0 path after guarded local sync: 230 raw rows, 230 projection rows, 230 season summaries, no issue codes, no raw drift codes.
- `npm run prepush:ci` passed locally: typecheck, lint, env/firebase check, route/artifact/dependency guards, 80 test files / 363 tests, and format check.

Closes #396.

## Summary by Sourcery

Handle empty merged live data sources without errors and ensure verification logic treats them as an explicit empty state.

Bug Fixes:
- Prevent the Fitzroy/footywire round fetch script from crashing when the fetched dataset has zero rows by emitting metadata and an empty NDJSON file instead.

Enhancements:
- Track merged live source status as 'empty' when no merged rows are returned and exclude it from populated reconciliation stages in the player read-model verifier.

Tests:
- Add verification coverage to ensure raw and projection checks pass and the merged source is treated as empty when the optional live merged source returns no rows.