### PR TITLE
feat(homepage): refresh AFL fantasy positioning

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,132 +1,309 @@
-'use client';
+import type { Metadata } from 'next';
+import type { ReactElement } from 'react';
 
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { useAuth } from '@/AuthContext';
-import AuthForm from '@/components/AuthForm';
-import ErrorTestButton from '@/components/ErrorTestButton';
 import Link from 'next/link';
+import {
+  ArrowRight,
+  BarChart3,
+  GitPullRequestArrow,
+  LayoutDashboard,
+  ListChecks,
+  Radio,
+  ShieldCheck,
+  Users,
+} from 'lucide-react';
 
-export default function LoginPage() {
-  const { user, loading } = useAuth();
-  const router = useRouter();
+export const metadata: Metadata = {
+  title: 'Statly | AFL Fantasy League Management, Player Data & Live Scoring',
+  description:
+    'Statly is an AFL fantasy workspace for managing leagues, rosters, trades, waivers, player research, and live scoring from one clean dashboard.',
+};
 
-  // If the user is already logged in, redirect them to the dashboard.
-  useEffect(() => {
-    if (!loading && user) {
-      router.push('/dashboard');
-    }
-  }, [user, loading, router]);
+const decisionMoments = [
+  {
+    icon: ListChecks,
+    title: 'Before lockout',
+    description: 'Set your lineup with role, injury, form, and matchup context in view.',
+  },
+  {
+    icon: Radio,
+    title: 'During the round',
+    description: 'Track live matchup swings, player score movement, and the moments that matter.',
+  },
+  {
+    icon: GitPullRequestArrow,
+    title: 'After teams and news',
+    description: 'Compare waiver and trade options before the next fantasy decision closes.',
+  },
+];
 
-  // Development helper function
-  const quickTestLogin = async () => {
-    try {
-      // Create test user and login
-      const response = await fetch('/api/dev/test-user', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-      });
+const leagueModules = [
+  {
+    icon: ListChecks,
+    title: 'Rosters',
+    description: 'See starters, bench risk, coverage gaps, and lineup pressure before lockout.',
+  },
+  {
+    icon: ShieldCheck,
+    title: 'Waivers',
+    description: 'Review claims, priority, and available player signals before the next run.',
+  },
+  {
+    icon: GitPullRequestArrow,
+    title: 'Trades',
+    description: 'Compare incoming and outgoing value with context managers can act on.',
+  },
+  {
+    icon: Radio,
+    title: 'Live scoring',
+    description: 'Follow matchup movement and player score swings while the round is active.',
+  },
+  {
+    icon: BarChart3,
+    title: 'Player research',
+    description: 'Compare role, form, injury context, ownership, rankings, and trends.',
+  },
+  {
+    icon: Users,
+    title: 'League activity',
+    description: 'Keep roster moves, trade movement, and manager actions visible in one place.',
+  },
+];
 
-      if (response.ok) {
-        const data = await response.json();
-        console.log('🧪 Test user created/retrieved:', data.user?.email || 'No email provided');
+const products = [
+  {
+    icon: LayoutDashboard,
+    title: 'Statly Fantasy',
+    description: 'Manage your league, team, trades, waivers, lineups, and live rounds.',
+    href: '/dashboard',
+    action: 'View Fantasy Workspace',
+  },
+  {
+    icon: BarChart3,
+    title: 'Draft & Trade Hub',
+    description: 'Research historical AFL trades, draft picks, club movement, and player deals.',
+    href: '/tradecentre',
+    action: 'Open Trade Hub',
+  },
+];
 
-        // Use the custom token to sign in
-        const { signInWithCustomToken } = await import('firebase/auth');
-        const { auth } = await import('@/lib/firebaseClient');
+const previewRows = [
+  { name: 'N. Daicos', role: 'DEF/MID', signal: 'Role up', action: 'Compare' },
+  { name: 'M. Bontempelli', role: 'MID', signal: 'Captain tier', action: 'Shortlist' },
+  { name: 'E. Gulden', role: 'MID', signal: 'Stable role', action: 'Track live' },
+];
 
-        if (auth) {
-          await signInWithCustomToken(auth, data.customToken);
-          console.log('✅ Test login successful');
-          router.push('/leagues/test-league-id');
-        }
-      } else {
-        console.error('Failed to create test user');
-        // Fallback: just navigate to test the bypass
-        router.push('/leagues/test-league-id');
-      }
-    } catch (error) {
-      console.error('Test login failed:', error);
-      // Fallback: just navigate to test the bypass
-      router.push('/leagues/test-league-id');
-    }
-  };
-
-  // Don't render the form if the user is logged in, to prevent a flash.
-  if (user) {
-    return null;
-  }
-
+export default function HomePage(): ReactElement {
   return (
-    <div className="flex min-h-[calc(100vh-100px)] flex-col items-center justify-center space-y-4">
-      <AuthForm />
+    <main className="min-h-screen bg-background text-foreground">
+      <section className="border-b border-border bg-primary text-primary-foreground">
+        <div className="mx-auto grid max-w-6xl gap-10 px-6 py-16 lg:grid-cols-[minmax(0,1.05fr)_minmax(360px,0.95fr)] lg:items-end lg:px-10 lg:py-20">
+          <div className="max-w-3xl space-y-6">
+            <p className="inline-flex items-center rounded-full border border-primary-foreground/25 bg-primary-foreground/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.18em]">
+              AFL draft and custom fantasy leagues
+            </p>
 
-      {/* Development Tools */}
-      {process.env.NODE_ENV === 'development' && (
-        <div className="border-t pt-4 mt-4 w-full max-w-sm">
-          <h3 className="text-sm font-medium text-gray-600 mb-2">🧪 Development Tools</h3>
-          <div className="space-y-2">
-            <button
-              onClick={async () => {
-                try {
-                  // Create a quick test draft
-                  const response = await fetch('/api/drafts', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                      name: `Quick Test Draft ${Date.now()}`,
-                      leagueSize: 12,
-                      draftType: 'snake',
-                      timePerPick: 120,
-                    }),
-                  });
+            <div className="space-y-4">
+              <h1 className="max-w-4xl text-balance text-4xl font-black leading-tight sm:text-5xl lg:text-6xl">
+                AFL fantasy league management, without the clutter.
+              </h1>
+              <p className="max-w-2xl text-base leading-8 text-primary-foreground/80 sm:text-lg">
+                Run your league, manage your roster, compare players, review trades, submit waiver
+                claims, and track live scores from one AFL-first workspace.
+              </p>
+            </div>
 
-                  if (response.ok) {
-                    const { data: draft } = await response.json();
-                    router.push(`/drafts/${draft.id}`);
-                  } else {
-                    // Fallback to existing draft
-                    router.push('/drafts/cme98gp7p00047gbvh741f9tm');
-                  }
-                } catch (error) {
-                  console.error('Failed to create test draft:', error);
-                  // Fallback to existing draft
-                  router.push('/drafts/cme98gp7p00047gbvh741f9tm');
-                }
-              }}
-              className="w-full bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700"
-            >
-              🚀 Quick Test Draft
-            </button>
-            <Link
-              href="/drafts/cme98gp7p00047gbvh741f9tm"
-              className="block w-full bg-purple-600 text-white text-center py-2 px-4 rounded hover:bg-purple-700"
-            >
-              🎯 Test Draft Room (Skip Auth)
-            </Link>
-            <button
-              onClick={quickTestLogin}
-              className="w-full bg-green-600 text-white py-2 px-4 rounded hover:bg-green-700"
-            >
-              ⚡ Quick Admin Login (League Owner)
-            </button>
-            <div className="border-t pt-2">
-              <h4 className="text-xs font-medium text-gray-500 mb-2">🐛 Sentry Testing</h4>
-              <ErrorTestButton />
+            <div className="flex flex-wrap gap-3">
               <Link
-                href="/sentry-test"
-                className="block w-full bg-orange-600 text-white text-center py-2 px-4 rounded hover:bg-orange-700 mt-2"
+                href="/dashboard"
+                className="inline-flex items-center gap-2 rounded-lg bg-background px-5 py-3 text-sm font-semibold text-foreground transition hover:bg-background/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
               >
-                🧪 Full Sentry Test Dashboard
+                View Fantasy Workspace
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+              <Link
+                href="#player-research-preview"
+                className="inline-flex items-center rounded-lg border border-primary-foreground/25 bg-primary-foreground/10 px-5 py-3 text-sm font-medium text-primary-foreground transition hover:bg-primary-foreground/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
+              >
+                Preview Player Research
               </Link>
             </div>
+
+            <p className="text-sm leading-6 text-primary-foreground/75">
+              Built for draft, keeper, and custom AFL fantasy leagues.
+            </p>
+          </div>
+
+          <aside
+            id="player-research-preview"
+            className="rounded-lg border border-primary-foreground/20 bg-background/10 p-5 shadow-sm backdrop-blur"
+            aria-label="Sample Statly player research panel"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold">Player research preview</p>
+                <p className="mt-1 text-xs leading-5 text-primary-foreground/75">
+                  Example AFL-first signals managers can compare before lockout.
+                </p>
+              </div>
+              <div className="rounded-md bg-primary-foreground/10 p-2">
+                <ShieldCheck className="h-5 w-5" aria-hidden="true" />
+              </div>
+            </div>
+
+            <div className="mt-5 overflow-hidden rounded-md border border-primary-foreground/15">
+              <div className="grid grid-cols-[1.1fr_0.55fr_0.85fr_0.75fr] bg-foreground/25 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-primary-foreground/65">
+                <span>Player</span>
+                <span>Role</span>
+                <span>Signal</span>
+                <span>Action</span>
+              </div>
+              {previewRows.map((player) => (
+                <div
+                  key={player.name}
+                  className="grid grid-cols-[1.1fr_0.55fr_0.85fr_0.75fr] border-t border-primary-foreground/15 bg-background/10 px-3 py-3 text-xs sm:text-sm"
+                >
+                  <span className="font-semibold">{player.name}</span>
+                  <span className="text-primary-foreground/75">{player.role}</span>
+                  <span className="font-semibold">{player.signal}</span>
+                  <span className="text-primary-foreground/75">{player.action}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-5 grid grid-cols-3 gap-3">
+              {[
+                { label: 'Waiver options', value: '18' },
+                { label: 'Live swing', value: '+24' },
+                { label: 'Trade notes', value: '6' },
+              ].map((item) => (
+                <div
+                  key={item.label}
+                  className="rounded-md border border-primary-foreground/15 bg-foreground/20 p-3"
+                >
+                  <p className="text-lg font-black leading-none">{item.value}</p>
+                  <p className="mt-2 text-[11px] leading-4 text-primary-foreground/70">
+                    {item.label}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <section className="bg-background">
+        <div className="mx-auto max-w-6xl px-6 py-12 lg:px-10 lg:py-16">
+          <div className="max-w-2xl space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Weekly Decisions
+            </p>
+            <h2 className="text-balance text-3xl font-black text-foreground sm:text-4xl">
+              Built for weekly AFL fantasy decisions.
+            </h2>
+            <p className="text-sm leading-7 text-muted-foreground sm:text-base">
+              Move from team news to lineup, live scoring, waiver, and trade decisions without
+              losing the league context around each call.
+            </p>
+          </div>
+
+          <div className="mt-8 grid gap-4 lg:grid-cols-3">
+            {decisionMoments.map(({ icon: Icon, title, description }) => (
+              <article
+                key={title}
+                className="rounded-lg border border-border bg-card p-6 text-card-foreground shadow-sm"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="rounded-md bg-muted p-3 text-foreground">
+                    <Icon className="h-5 w-5" aria-hidden="true" />
+                  </div>
+                  <h3 className="text-lg font-semibold text-foreground">{title}</h3>
+                </div>
+                <p className="mt-4 text-sm leading-6 text-muted-foreground">{description}</p>
+              </article>
+            ))}
           </div>
         </div>
-      )}
+      </section>
 
-      <Link href="/tradecentre" className="text-blue-600 underline">
-        Visit Trade Centre
-      </Link>
-    </div>
+      <section className="bg-muted/35">
+        <div className="mx-auto max-w-6xl px-6 py-14 lg:px-10">
+          <div className="max-w-2xl space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              League Workspace
+            </p>
+            <h2 className="text-balance text-3xl font-black text-foreground sm:text-4xl">
+              Everything your league needs in one place.
+            </h2>
+            <p className="text-sm leading-7 text-muted-foreground sm:text-base">
+              Keep the core fantasy modules close together so managers can see the next action
+              instead of hunting through disconnected tools.
+            </p>
+          </div>
+
+          <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {leagueModules.map(({ icon: Icon, title, description }) => (
+              <div
+                key={title}
+                className="rounded-lg border border-border bg-card p-5 text-card-foreground shadow-sm"
+              >
+                <div className="flex items-start gap-3">
+                  <div className="rounded-md bg-muted p-2 text-foreground">
+                    <Icon className="h-4 w-4" aria-hidden="true" />
+                  </div>
+                  <div>
+                    <h3 className="text-base font-semibold text-foreground">{title}</h3>
+                    <p className="mt-2 text-sm leading-6 text-muted-foreground">{description}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-border bg-background">
+        <div className="mx-auto max-w-6xl px-6 py-14 lg:px-10 lg:py-16">
+          <div className="max-w-2xl space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Statly Products
+            </p>
+            <h2 className="text-balance text-3xl font-black text-foreground sm:text-4xl">
+              Two workspaces, one AFL-first product family.
+            </h2>
+            <p className="text-sm leading-7 text-muted-foreground sm:text-base">
+              Use Statly Fantasy for league management and fantasy gameplay. Use the Draft &amp;
+              Trade Hub for public AFL research and historical player movement.
+            </p>
+          </div>
+
+          <div className="mt-8 grid gap-5 md:grid-cols-2">
+            {products.map(({ icon: Icon, ...product }) => (
+              <article
+                key={product.title}
+                className="rounded-lg border border-border bg-card p-6 text-card-foreground shadow-sm"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="rounded-md bg-muted p-3 text-foreground">
+                    <Icon className="h-5 w-5" aria-hidden="true" />
+                  </div>
+                  <h3 className="text-2xl font-bold text-foreground">{product.title}</h3>
+                </div>
+                <p className="mt-4 text-sm leading-6 text-muted-foreground">
+                  {product.description}
+                </p>
+                <Link
+                  href={product.href}
+                  className="mt-6 inline-flex items-center gap-2 rounded-lg border border-border bg-muted px-4 py-3 text-sm font-semibold text-foreground transition hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  {product.action}
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </Link>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
   );
 }

--- a/src/app/players/PlayersPageServer.tsx
+++ b/src/app/players/PlayersPageServer.tsx
@@ -4,6 +4,7 @@ import PlayersPageClient from './PlayersPageClient';
 import { logger } from '@/lib/logger';
 import { unstable_cache } from 'next/cache';
 import type { JSX } from 'react';
+import Link from 'next/link';
 
 const getCachedPlayers = unstable_cache(() => getPlayers(), ['players:list:all'], {
   revalidate: 300,
@@ -16,7 +17,72 @@ export default async function PlayersPageServer(): Promise<JSX.Element> {
     players = await getCachedPlayers();
   } catch (err) {
     logger.error('Failed to fetch players', err);
-    return <div className="p-4 text-red-500">Failed to load players.</div>;
+    return (
+      <main className="mx-auto max-w-3xl px-6 py-12">
+        <div
+          role="alert"
+          aria-live="polite"
+          className="rounded-lg border border-border bg-card p-6 text-card-foreground shadow-sm"
+        >
+          <p className="text-sm font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            Player Data
+          </p>
+          <h1 className="mt-3 text-2xl font-bold text-foreground">Player data could not load.</h1>
+          <p className="mt-3 text-sm leading-6 text-muted-foreground">
+            Try again, or sign in to access your league-specific player view if this data requires
+            your Statly account.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link
+              href="/players"
+              className="inline-flex items-center rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              Retry
+            </Link>
+            <Link
+              href="/login"
+              className="inline-flex items-center rounded-lg border border-border bg-background px-4 py-2 text-sm font-semibold text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              Sign in
+            </Link>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  if (players.length === 0) {
+    return (
+      <main className="mx-auto max-w-3xl px-6 py-12">
+        <section
+          aria-live="polite"
+          className="rounded-lg border border-border bg-card p-6 text-card-foreground shadow-sm"
+        >
+          <p className="text-sm font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            Player Data
+          </p>
+          <h1 className="mt-3 text-2xl font-bold text-foreground">No players are available yet.</h1>
+          <p className="mt-3 text-sm leading-6 text-muted-foreground">
+            Player data loaded successfully, but no player records were returned. Check back after
+            the next data refresh or sign in for league-specific player tools.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link
+              href="/players"
+              className="inline-flex items-center rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              Refresh
+            </Link>
+            <Link
+              href="/dashboard"
+              className="inline-flex items-center rounded-lg border border-border bg-background px-4 py-2 text-sm font-semibold text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              Open dashboard
+            </Link>
+          </div>
+        </section>
+      </main>
+    );
   }
 
   return <PlayersPageClient players={players} />;

--- a/src/components/PlayerSearch.tsx
+++ b/src/components/PlayerSearch.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useId, useRef, useState } from 'react';
+import { type ReactElement, useEffect, useId, useRef, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -59,7 +59,7 @@ export default function PlayerSearch({
   size = 'md',
   variant = 'default',
   navigateToProfile = true,
-}: PlayerSearchProps) {
+}: PlayerSearchProps): ReactElement {
   const [query, setQuery] = useState('');
   const [players, setPlayers] = useState<PlayerSearchResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -119,7 +119,7 @@ export default function PlayerSearch({
         const nextPlayers = Array.isArray(data?.players) ? data.players : [];
         setPlayers(nextPlayers);
         setSelectedIndex(nextPlayers.length > 0 ? 0 : -1);
-      } catch (_error) {
+      } catch {
         if (controller.signal.aborted || requestIdRef.current !== requestId) {
           return;
         }
@@ -298,48 +298,40 @@ export default function PlayerSearch({
 
       {isOpen && (trimmedQuery.length >= MIN_QUERY_LENGTH || players.length > 0 || isLoading) && (
         <div className="absolute z-50 w-full mt-1 rounded-lg border border-gray-200 bg-white shadow-lg">
-          <div className="bg-white text-gray-900">
-            <div className="max-h-96 overflow-y-auto">
-              <div id={listboxId} role="listbox">
-                {isLoading ? (
-                  <div className="px-4 py-3 text-center text-gray-500" role="status">
-                    <Loader2 className="mx-auto h-5 w-5 animate-spin text-blue-600" />
-                    <span className="ml-2">Searching...</span>
-                  </div>
-                ) : players.length > 0 ? (
-                  <div className="p-0">
-                    {players.map((player, index) => (
-                      <div
-                        key={player.id}
-                        id={`${listboxId}-option-${player.id}`}
-                        role="option"
-                        aria-selected={index === selectedIndex}
-                        tabIndex={-1}
-                        className="block rounded-none px-0 py-0 hover:bg-transparent"
-                        onMouseEnter={() => handleOptionHover(index)}
-                        onClick={() => handlePlayerSelect(player)}
-                        onKeyDown={(event) => {
-                          if (event.key === 'Enter' || event.key === ' ') {
-                            event.preventDefault();
-                            handlePlayerSelect(player);
-                          }
-                        }}
-                      >
-                        {renderPlayerItem(player, index)}
-                      </div>
-                    ))}
-                    {players.length === 20 && (
-                      <div className="border-t px-4 py-2 text-center text-sm text-gray-500">
-                        Showing top 20 results. Refine your search for more specific results.
-                      </div>
-                    )}
-                  </div>
-                ) : trimmedQuery.length >= MIN_QUERY_LENGTH ? (
-                  <div className="px-4 py-3 text-center text-gray-500">
-                    No players found for &ldquo;{query}&rdquo;
-                  </div>
-                ) : null}
-              </div>
+          <div className="max-h-96 overflow-y-auto bg-white text-gray-900">
+            <div id={listboxId} role="listbox">
+              {isLoading ? (
+                <div className="px-4 py-3 text-center text-gray-500" role="status">
+                  <Loader2 className="mx-auto h-5 w-5 animate-spin text-blue-600" />
+                  <span className="ml-2">Searching...</span>
+                </div>
+              ) : players.length > 0 ? (
+                <div>
+                  {players.map((player, index) => (
+                    <button
+                      key={player.id}
+                      id={`${listboxId}-option-${player.id}`}
+                      type="button"
+                      role="option"
+                      aria-selected={index === selectedIndex}
+                      className="block w-full rounded-none px-0 py-0 hover:bg-transparent"
+                      onMouseEnter={() => handleOptionHover(index)}
+                      onClick={() => handlePlayerSelect(player)}
+                    >
+                      {renderPlayerItem(player, index)}
+                    </button>
+                  ))}
+                  {players.length === 20 && (
+                    <div className="border-t px-4 py-2 text-center text-sm text-gray-500">
+                      Showing top 20 results. Refine your search for more specific results.
+                    </div>
+                  )}
+                </div>
+              ) : trimmedQuery.length >= MIN_QUERY_LENGTH ? (
+                <div className="px-4 py-3 text-sm text-gray-500" role="status">
+                  No players found for &ldquo;{query}&rdquo;
+                </div>
+              ) : null}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replaces the root auth/dev-tools page with a public AFL fantasy homepage that clarifies the category, promise, weekly decision moments, league modules, product proof, and Statly Fantasy vs Draft & Trade Hub split.
- Adds homepage metadata for AFL fantasy league management, player data, and live scoring discoverability.
- Removes missing shadcn command/scroll imports from the active player search component and replaces them with native accessible listbox markup.
- Adds a shared `PlayerSearchResult` API result type and durable player-page server fallback states for fetch failure and empty data.

## Why
The homepage needed to show why Statly is useful before sending visitors into product routes. The `/players` destination also needed to stop compiling through missing UI exports before the homepage can safely promote player research.

## Verification
- `npx eslint src/app/page.tsx src/app/players/PlayersPageServer.tsx src/components/PlayerSearch.tsx src/types/players.ts`
- `npm run format:check`
- `git diff --check`
- `npm run typecheck -- --pretty false` still exits non-zero from existing base errors; no output references the touched files or the related `src/app/test-search/page.tsx` after the search result type fix.
- Dev server smoke test on `http://localhost:3010`: `/` returned 200, `/players` returned 200, and homepage content was present in the response stream.

## Notes
- Stacked on #401 (`codex/format-baseline`) so this PR does not include repository-wide Prettier normalization noise.
- `docs/BRANCH_COMPLETION_GUIDE.md` and `npm run branch:complete` are not present on this clean base.

## Summary by Sourcery

Replace the authenticated dev-tools landing page with a public AFL fantasy marketing homepage and harden player-related experiences.

New Features:
- Introduce a public AFL fantasy homepage that highlights Statly’s value, weekly decision flows, and product split between Statly Fantasy and the Draft & Trade Hub.
- Add SEO metadata for AFL fantasy league management, player data, and live scoring discoverability on the root page.

Enhancements:
- Improve the players server page with user-friendly fallback views for data fetch failures and empty player datasets, including navigation back into the app.
- Refine the player search dropdown to use accessible listbox markup with button-based options and clearer status messaging.