### PR TITLE
ci(deploy): align deploy runtime with build

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,14 +20,14 @@ jobs:
       - run: npm run lint
 
   deploy:
-    # needs: test
+    needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 20
           cache: 'npm'
       - run: npm ci
       - run: npm run build:production


### PR DESCRIPTION
## Summary
- Run the main-branch deploy gate after the build job succeeds.
- Use Node 20 for the deploy job so build:production matches the passing build runtime and avoids Node 18 dependency/runtime failures.

## Verification
- git diff --check
- npm ci
- FIREBASE_SERVICE_ACCOUNT_JSON_BASE64= FIREBASE_ADMIN_ALLOW_ADC=true GOOGLE_CLOUD_PROJECT=statly-build-check npm run build:production

## Notes
- This keeps the existing workflow placeholder deployment behavior; it fixes the failing deploy gate build. A real provider deploy step still needs to be wired separately if this repository is expected to deploy from GitHub Actions.

## Summary by Sourcery

Align the deployment workflow with the build job by gating deploy on a successful build and matching the deploy Node.js runtime to the build environment.

CI:
- Update the deploy job to depend on the build job instead of the test job in the GitHub Actions workflow.
- Switch the deploy job Node.js version from 18 to 20 to match the production build runtime.