### PR TITLE
fix(deploy): package Prisma Linux engine for Netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "bash -lc 'cd \"$(git rev-parse --show-toplevel)\" && next dev --turbopack'",
-    "build": "next build",
-    "build:production": "next build",
+    "build": "npm run prisma:generate && next build",
+    "build:production": "npm run prisma:generate && next build",
     "start": "next start",
     "socket": "bash -lc 'cd \"$(git rev-parse --show-toplevel)\" && NODE_ENV=development tsx -r dotenv/config ./src/server/socketioServer.ts'",
     "dev:full": "concurrently \"npm run dev\" \"npm run socket\"",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary\n- add Netlify Linux Prisma engine target to the Prisma client generator\n- regenerate Prisma as part of build and production build so local Netlify deploys do not package a stale Mac-only client\n\n## Verification\n- npm run prisma:generate produced both darwin-arm64 and rhel-openssl-3.0.x engines\n- npm run build:production\n- npm run lint (passes with existing warnings)\n- git diff --check\n\n## Notes\n- Current origin/main does not contain docs/BRANCH_COMPLETION_GUIDE.md or npm run branch:complete, so that completion gate could not be run from this hotfix branch.\n- Build logs still show existing Redis placeholder noise from tracked production env; this PR fixes the live unhandled Prisma runtime crash shown in Netlify logs.

## Summary by Sourcery

Ensure Prisma client generation runs as part of app builds so Netlify deployments include the correct Linux engine.

Bug Fixes:
- Prevent Netlify deployments from packaging a stale, Mac-only Prisma client by regenerating the client during builds.

Deployment:
- Wire Prisma client generation into build and production build scripts to produce the appropriate engines for Netlify Linux environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to automatically generate required client libraries during compilation
  * Enhanced deployment compatibility to support additional system environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/statlyaus/Statly/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->