### PR TITLE
docs: point fantasy source of truth at main

### DIFF
--- a/docs/superpowers/plans/2026-06-07-fantasy-website-consolidation-execution.md
+++ b/docs/superpowers/plans/2026-06-07-fantasy-website-consolidation-execution.md
@@ -6,7 +6,9 @@ Council gate: `CHAIRMAN DECISION 1: PROCEED`
 
 Source of truth: `docs/superpowers/specs/2026-06-07-fantasy-website-consolidation.md`
 
-Implementation base: `/Users/robert/.config/superpowers/worktrees/Statly/fantasy-hardening-readiness` on `codex/fantasy-league-draft-hardening`
+Canonical implementation: `origin/main` at PR #414 merge commit `6118fdf5` or later.
+
+Historical implementation base: `/Users/robert/.config/superpowers/worktrees/Statly/fantasy-hardening-readiness` on `codex/fantasy-league-draft-hardening`.
 
 ## Objective
 
@@ -14,7 +16,7 @@ Turn the current hardening branch into one working fantasy website experience wi
 
 ## Rules
 
-- Do not edit dirty local `main` for this work.
+- Use `origin/main` as the current fantasy website source of truth after PR #414. The old hardening branch is historical provenance only.
 - Do not rely on stale root-level "complete" markdown claims.
 - Do not introduce a new visual system.
 - Do not stage `prisma/dev.db`, `.env`, `.next`, emulator data, or unrelated dirty files.

--- a/docs/superpowers/specs/2026-06-07-fantasy-website-consolidation.md
+++ b/docs/superpowers/specs/2026-06-07-fantasy-website-consolidation.md
@@ -10,11 +10,11 @@ Statly has several markdown files that describe different versions of the fantas
 
 This spec supersedes the root-level completion summaries for planning and implementation decisions. The older markdown files remain useful as historical evidence, but they are not product authority unless this file references them directly.
 
-## Canonical Branch
+## Canonical Implementation
 
-Use `/Users/robert/.config/superpowers/worktrees/Statly/fantasy-hardening-readiness` on branch `codex/fantasy-league-draft-hardening` as the implementation base.
+After PR #414 merged on 2026-06-07, use `origin/main` at merge commit `6118fdf5` or later as the canonical fantasy website implementation.
 
-Do not use local `/Users/robert/Developer/Statly` `main` for this consolidation work. That worktree is dirty and diverged from `origin/main`, and it has been the source of old/new runtime confusion.
+The former `/Users/robert/.config/superpowers/worktrees/Statly/fantasy-hardening-readiness` worktree and `codex/fantasy-league-draft-hardening` branch are historical implementation provenance only. Do not treat that branch as a separate current product version.
 
 ## Historical Document Map
 


### PR DESCRIPTION
## Summary
- updates the fantasy consolidation source-of-truth docs after PR #414 merged
- makes origin/main at merge commit 6118fdf5 or later the canonical implementation
- marks the old hardening worktree/branch as historical provenance only

## Verification
- rg found no stale canonical feature-branch implementation-base wording in the two updated docs
- git diff --check

## Summary by Sourcery

Update fantasy website consolidation documentation to point to origin/main as the canonical implementation and reframe the previous hardening branch as historical provenance only.

Documentation:
- Clarify that origin/main at PR #414 merge commit 6118fdf5 or later is the canonical fantasy website implementation source of truth.
- Mark the old fantasy hardening worktree and branch as historical-only and no longer the implementation base in planning and spec docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated planning and specification documentation to define the current canonical implementation source following recent work completion.
  * Reclassified previous development references as historical provenance to prevent confusion and improve traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->