### PR TITLE
docs: add Codex agent-loop scaffolding

### DIFF
--- a/.agents/skills/draft-reliability-loop/SKILL.md
+++ b/.agents/skills/draft-reliability-loop/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: draft-reliability-loop
+description: Use when improving, verifying, or babysitting Statly draft-room reliability, realtime draft behavior, pick flow, roster projection, waiver availability, or draft-room regressions.
+---
+
+# Draft Reliability Loop
+
+## Purpose
+
+Use this skill to run repeatable Codex loops for Statly draft-room reliability work. Keep the loop evidence-driven: identify the failing path, fix the owning boundary, verify the browser/API behavior, then re-review before reporting or committing.
+
+This skill is documentation and workflow only. It must not be used as permission to change product runtime code without the normal Statly planning, council, implementation, and verification gates.
+
+## Required Inputs
+
+- `AGENTS.md`
+- The current draft-room source-of-truth spec or plan under `docs/superpowers/`
+- The user's requested draft-room issue, PR, or reliability target
+- Current `git status --short --branch`
+
+## Loop
+
+1. Plan the boundary.
+   - Read the relevant source-of-truth docs before editing.
+   - Run the logical council for substantive work.
+   - Continue only after `CHAIRMAN DECISION 1: PROCEED`.
+   - State the owning boundary: auth, API route, shared server service, client state, realtime sync, browser UI, tests, or docs.
+
+2. Reproduce or prove the path.
+   - Prefer browser verification for route, hydration, realtime, navigation, and visual behavior.
+   - Prefer API checks for command/read-model boundaries.
+   - Prefer focused tests for regressions that can be made deterministic.
+   - Record concrete IDs, URLs, commands, and observed state.
+
+3. Implement the smallest durable fix.
+   - Fix the source of truth, not only the visible symptom.
+   - Preserve Prisma as canonical for protected fantasy data unless the current source-of-truth doc says otherwise.
+   - Treat API routes as transport adapters over shared logic.
+   - Keep client state catch-up paths consistent with persisted server state.
+   - Do not add dependencies for loop mechanics.
+
+4. Review and fix.
+   - Run relevant tests, type checks, lint, and browser/API checks.
+   - Review `git diff` before staging.
+   - Run council Decision 2 on the staged or final diff when committing is in scope.
+   - If review finds defects, fix them and repeat verification.
+
+5. Re-review.
+   - Re-run the checks that failed or guarded the edited boundary.
+   - Re-run browser/API verification when behavior changed.
+   - Re-run Decision 2 before committing after material fixes.
+
+6. Report.
+   - Summarize what changed, why it changed, what was verified, and residual risk.
+   - Include concrete evidence rather than broad claims.
+   - Do not claim done if checks or browser verification were skipped; state the gap.
+
+## Draft-Room Reliability Checklist
+
+- [ ] Source-of-truth docs read.
+- [ ] Council Decision 1 returned `CHAIRMAN DECISION 1: PROCEED`.
+- [ ] Failing or risky path identified with concrete route/API/state.
+- [ ] Owning boundary stated before editing.
+- [ ] Runtime code changes, if any, stayed inside the approved boundary.
+- [ ] Protected files were not touched: `prisma/dev.db`, `.env`, secrets, `serviceAccountKey.json`, Firebase exports, `node_modules`, `dist`, `coverage`, and `test-results`.
+- [ ] Regression coverage or explicit verification evidence exists.
+- [ ] `git diff` reviewed.
+- [ ] Council Decision 2 completed before commit when commit is in scope.
+
+## Prompt Template
+
+Use this template when starting a draft-room reliability loop:
+
+```text
+Use the draft-reliability-loop skill.
+
+Target:
+[draft-room reliability issue, PR, stale behavior, or verification target]
+
+Read:
+- AGENTS.md
+- [current source-of-truth spec/plan]
+
+Constraints:
+- Preserve Statly council gates.
+- Fix the source of truth, not just the visible symptom.
+- Do not touch protected files or unrelated runtime code.
+
+Done when:
+- The failing path is reproduced or concretely identified.
+- The owning boundary is fixed or documented as out of scope.
+- Relevant tests/checks/browser or API verification are complete.
+- The final report includes evidence and residual risk.
+```
+
+## Common Mistakes
+
+| Mistake                                               | Correction                                                                          |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Treating a browser symptom as the owning boundary     | Trace to auth, API, persistence, realtime delivery, or client state before editing. |
+| Using council output as a substitute for verification | Council gates decide whether to proceed or commit; they do not prove behavior.      |
+| Fixing only the open tab state                        | Verify refresh, direct load, and persisted server state when draft data changes.    |
+| Letting local databases or env files enter the diff   | Check `git status --short` before and after verification.                           |
+| Reporting "done" with skipped checks                  | State skipped checks and why, then name the residual risk.                          |

--- a/.agents/skills/pr-babysitter/SKILL.md
+++ b/.agents/skills/pr-babysitter/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: pr-babysitter
+description: Use when monitoring Statly pull requests, triaging stale PRs, following up on CI or review feedback, preparing PR status reports, or deciding next PR actions.
+---
+
+# PR Babysitter
+
+## Purpose
+
+Use this skill to keep Statly pull requests moving without broadening scope. A PR babysitter inspects status, identifies the next unblocker, applies or prompts for bounded fixes, re-runs checks, and reports the remaining decision clearly.
+
+This skill does not replace Statly council gates. Substantive fixes still require Decision 1 before work and Decision 2 before commit.
+
+## Inputs
+
+- PR URL or branch name
+- Current `git status --short --branch`
+- Relevant issue, review, CI, or stale-PR context
+- `AGENTS.md`
+- Any source-of-truth spec or plan named by the PR
+
+## Standard PR Loop
+
+1. Inspect.
+   - Identify branch, target base, changed files, CI state, review state, conflicts, and stale age.
+   - Read the PR description and unresolved comments before editing.
+   - Separate product defects from documentation, test, CI, and merge hygiene issues.
+
+2. Decide the action boundary.
+   - No code changes: summarize status, owner, blocker, and next prompt.
+   - Documentation-only change: keep edits to docs or skill files.
+   - Runtime/test change: run Statly council Decision 1 before editing.
+   - Merge/commit action: require passing checks and Decision 2.
+
+3. Fix only the blocker.
+   - Address unresolved review comments directly.
+   - Prefer the smallest fix that preserves the PR's stated intent.
+   - Do not mix stale cleanup, refactors, dependency updates, or unrelated product work into a babysitting pass.
+
+4. Re-run checks.
+   - Run the failed CI command locally when possible.
+   - Run targeted tests for edited boundaries.
+   - Review `git diff` and `git status --short`.
+   - If committing is in scope, stage only intended files and run Decision 2.
+
+5. Report.
+   - State current PR status, what changed, checks run, what remains blocked, and the next owner/action.
+   - Include links, branch names, commands, and concrete failure messages when available.
+
+## Stale PR Triage
+
+Use this order when a PR is stale:
+
+1. Confirm whether the PR still matches the current source-of-truth docs.
+2. Check whether `origin/main` already contains the intended change.
+3. Classify the stale state:
+   - `ready`: checks pass, reviews resolved, no conflicts.
+   - `needs-rebase`: scope still valid, branch is behind or conflicted.
+   - `needs-fix`: CI, tests, browser verification, or review comments remain unresolved.
+   - `superseded`: newer merged work makes the PR obsolete.
+   - `abandon`: product direction changed or the PR solves the wrong boundary.
+4. Recommend one next action, not a menu of vague options.
+
+## Prompt Templates
+
+### PR Status Check
+
+```text
+Use the pr-babysitter skill.
+
+PR:
+[URL or branch]
+
+Goal:
+Inspect status only. Do not edit files.
+
+Report:
+- Current branch/base
+- CI and review state
+- Conflicts or stale risk
+- One recommended next action
+```
+
+### CI Follow-Up
+
+```text
+Use the pr-babysitter skill.
+
+PR:
+[URL or branch]
+
+Goal:
+Fix only the failing CI boundary.
+
+Constraints:
+- Preserve Statly council gates.
+- Do not touch protected files.
+- Do not broaden PR scope.
+
+Done when:
+- Failing CI path is identified.
+- Minimal fix is applied.
+- Relevant local check passes or residual risk is reported.
+```
+
+### Stale PR Triage
+
+```text
+Use the pr-babysitter skill.
+
+PR list:
+[URLs or branch names]
+
+Goal:
+Classify each PR as ready, needs-rebase, needs-fix, superseded, or abandon.
+
+Report:
+- Classification
+- Evidence
+- Next action
+- Whether council review is required before edits
+```
+
+## Escalation Rules
+
+- Ask the user before abandoning or closing a PR.
+- Ask the user before changing product direction.
+- Do not request approval merely because the work is routine after council Decision 1 has proceeded.
+- Stop and update the plan if the required fix crosses into a different product boundary than the PR described.
+
+## Common Mistakes
+
+| Mistake                                         | Correction                                                    |
+| ----------------------------------------------- | ------------------------------------------------------------- |
+| Treating stale as automatically obsolete        | Compare against `origin/main` and source-of-truth docs first. |
+| Fixing multiple unrelated PR issues in one pass | Fix the current blocker and report the rest.                  |
+| Reading only CI summaries                       | Inspect the failing command, logs, and changed files.         |
+| Staging unrelated dirty files                   | Stage explicit intended paths only.                           |
+| Reporting "blocked" without a next owner        | Name the blocker and who or what can unblock it.              |

--- a/.agents/skills/pr-babysitter/SKILL.md
+++ b/.agents/skills/pr-babysitter/SKILL.md
@@ -52,7 +52,7 @@ This skill does not replace Statly council gates. Substantive fixes still requir
 Use this order when a PR is stale:
 
 1. Confirm whether the PR still matches the current source-of-truth docs.
-2. Check whether `origin/main` already contains the intended change.
+2. Check whether the PR's actual base branch already contains the intended change.
 3. Classify the stale state:
    - `ready`: checks pass, reviews resolved, no conflicts.
    - `needs-rebase`: scope still valid, branch is behind or conflicted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,13 @@ Statly uses a repo-local adaptation of [karpathy/llm-council](https://github.com
 - If the logical scaffold is insufficient and Ollama/OpenRouter are unavailable, state that model-backed council review was skipped and continue with the best local review path; do not block urgent or trivial work solely on council availability.
 - Do not paste secrets into council prompts. The council is an engineering review aid, not product runtime code.
 
+## Codex Agent Loops
+
+- Use `docs/codex/agent-loop-operating-model.md` as the repo-local operating model for repeatable Codex loops that plan, implement, review, fix, re-review, and report.
+- Use `.agents/skills/draft-reliability-loop/SKILL.md` for draft-room reliability loops.
+- Use `.agents/skills/pr-babysitter/SKILL.md` for PR monitoring, CI follow-up, and stale PR triage loops.
+- These loop docs do not replace the council gates above; preserve Decision 1 before substantive work and Decision 2 before commit.
+
 ## Architecture Rules
 
 - Server Components should load protected server data through server-side loaders, services, or repositories.

--- a/docs/codex/agent-loop-operating-model.md
+++ b/docs/codex/agent-loop-operating-model.md
@@ -1,0 +1,151 @@
+# Codex Agent Loop Operating Model
+
+## Purpose
+
+This document defines the repeatable Codex agent-loop workflow for Statly. It is documentation and skill scaffolding only; it does not change product runtime behavior.
+
+Use it when a Codex session needs to plan, implement, review, fix, re-review, and report work in a way that preserves Statly's existing council gates and source-of-truth discipline.
+
+## Files
+
+- `.agents/skills/draft-reliability-loop/SKILL.md`: first concrete loop for draft-room reliability work.
+- `.agents/skills/pr-babysitter/SKILL.md`: PR monitoring, CI follow-up, stale PR triage, and status reporting loop.
+- `docs/codex/agent-loop-operating-model.md`: this operating model.
+- `AGENTS.md`: short pointer to this model and the repo-local skills.
+
+## Non-Negotiables
+
+- Preserve the council gates in `AGENTS.md`.
+- Do not treat council output as verification.
+- Do not change runtime code during documentation-only loop work.
+- Do not touch protected files: `prisma/dev.db`, `.env`, secrets, `serviceAccountKey.json`, Firebase exports, `node_modules`, `dist`, `coverage`, or `test-results`.
+- Keep diffs small, explicit, and reviewable.
+- Stage only intended files when commit work is in scope.
+
+## Core Loop
+
+1. Plan.
+   - Read `AGENTS.md` and any relevant source-of-truth spec or plan.
+   - Run the logical council for substantive work.
+   - Continue only after `CHAIRMAN DECISION 1: PROCEED`.
+   - State the files, ownership boundary, verification path, and protected-file exclusions.
+
+2. Implement.
+   - Make the smallest durable change at the owning boundary.
+   - Follow existing repo patterns.
+   - Avoid dependencies unless explicitly approved.
+   - Keep documentation-only work out of runtime files.
+
+3. Review.
+   - Run relevant markdown, lint, type, test, browser, or API checks.
+   - Review `git diff` for scope, correctness, and unrelated changes.
+   - Do not skip verification because the change is small.
+
+4. Fix.
+   - Address failed checks, review findings, or stale assumptions.
+   - If new required work crosses the approved boundary, stop and update the plan.
+
+5. Re-review.
+   - Re-run the checks that cover the edited boundary.
+   - Re-read the final diff.
+   - Run Decision 2 before commit when committing is in scope.
+
+6. Report.
+   - State what changed, why it changed, what was verified, and residual risk.
+   - Include concrete evidence: commands, routes, IDs, URLs, or file paths.
+   - Do not claim behavior was verified when only syntax or prose was checked.
+
+## First Concrete Loop: Draft-Room Reliability
+
+Use `.agents/skills/draft-reliability-loop/SKILL.md` for draft-room reliability work, including:
+
+- realtime draft state and persisted pick catch-up;
+- manual and automatic pick flow;
+- draft room hydration, reload, and direct-load behavior;
+- queue, watchlist, and available-player table regressions;
+- roster projection and waiver availability after completed drafts;
+- browser verification across desktop and mobile when UI behavior changes.
+
+The draft-room loop starts from the same pattern used in the fantasy consolidation docs: establish the source of truth, identify the failing path, fix the owning boundary, verify with concrete browser/API/test evidence, then record residual risk.
+
+## PR Babysitting Loop
+
+Use `.agents/skills/pr-babysitter/SKILL.md` when the task is to keep PRs moving rather than build new product scope.
+
+### Status Prompt
+
+```text
+Use the pr-babysitter skill.
+
+PR:
+[URL or branch]
+
+Goal:
+Inspect status only. Do not edit files.
+
+Report:
+- Current branch/base
+- CI and review state
+- Conflicts or stale risk
+- One recommended next action
+```
+
+### CI Follow-Up Prompt
+
+```text
+Use the pr-babysitter skill.
+
+PR:
+[URL or branch]
+
+Goal:
+Fix only the failing CI boundary.
+
+Constraints:
+- Preserve Statly council gates.
+- Do not touch protected files.
+- Do not broaden PR scope.
+
+Done when:
+- Failing CI path is identified.
+- Minimal fix is applied.
+- Relevant local check passes or residual risk is reported.
+```
+
+### Stale PR Triage Prompt
+
+```text
+Use the pr-babysitter skill.
+
+PR list:
+[URLs or branch names]
+
+Goal:
+Classify each PR as ready, needs-rebase, needs-fix, superseded, or abandon.
+
+Report:
+- Classification
+- Evidence
+- Next action
+- Whether council review is required before edits
+```
+
+## Review Evidence
+
+For documentation-only agent-loop work, relevant verification is usually:
+
+```bash
+npm exec -- prettier --check AGENTS.md .agents/skills/draft-reliability-loop/SKILL.md .agents/skills/pr-babysitter/SKILL.md docs/codex/agent-loop-operating-model.md
+git diff -- AGENTS.md .agents/skills/draft-reliability-loop/SKILL.md .agents/skills/pr-babysitter/SKILL.md docs/codex/agent-loop-operating-model.md
+git status --short
+```
+
+Runtime checks such as `npm run typecheck`, `npm run test:unit`, and browser verification are required when runtime code changes. They are optional for documentation-only scaffolding unless the edited docs reference runtime behavior that must be re-proven.
+
+## Done Criteria
+
+- The relevant skill or operating model explains the loop end to end.
+- Draft-room reliability is represented as the first concrete loop.
+- PR babysitting and stale PR triage have reusable prompts.
+- Existing council gates remain intact.
+- Verification evidence is recorded in the final report.


### PR DESCRIPTION
## Summary

- Adds repo-local Codex loop scaffolding for repeatable agent workflows.
- Adds a draft reliability skill for draft-room, pick-feed, timer, roster, and waiver reliability work.
- Adds a PR babysitter skill for review-comment triage and bounded follow-up fixes.
- Adds an operating model for planning, implementation, review, re-review, reporting, and stale PR triage.
- Adds an AGENTS.md pointer so future Codex sessions can discover the workflow.

## Verification

- `npm exec -- prettier --check ...` passed for touched markdown files.
- Skill frontmatter passed local Node validation.
- Final diff/status review showed only the four intended documentation paths.
- Council Decision 2 returned COMMIT.

## Note

The bundled `quick_validate.py` could not run because the available Python environments are missing the `yaml` module. Local frontmatter validation was used instead.

## Summary by Sourcery

Document Codex agent-loop workflows and introduce repo-local skills for draft-room reliability and PR babysitting.

Documentation:
- Add a Codex agent-loop operating model describing a repeatable plan-implement-review-fix-re-review-report workflow and its verification/done criteria.
- Document a draft-room reliability loop skill for evidence-driven reliability work across draft flows and regressions.
- Document a PR babysitter skill for monitoring PR status, handling CI follow-up, and triaging stale PRs, including prompt templates and escalation rules.
- Update AGENTS.md with pointers to the new Codex operating model and associated skills while reaffirming existing council gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Codex agent-loop operating model with step-by-step repeatable workflows from planning through reporting.
  * Introduced draft-room reliability verification procedures including evidence requirements, checklists, and file-protection boundaries.
  * Added pull request monitoring and stale-PR triage protocols with structured inspection and decision workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->