### PR TITLE
fix: make free agent availability use roster ownership

### DIFF
--- a/src/app/api/leagues/[id]/players/route.ts
+++ b/src/app/api/leagues/[id]/players/route.ts
@@ -42,32 +42,47 @@ async function getPrismaLeaguePlayers(input: {
     return { items: [], nextCursor: null, total: 0 };
   }
 
-  const idFilter: { in?: string[]; notIn?: string[]; gt?: string } = {};
+  const ownershipIdFilter: { in?: string[]; notIn?: string[] } = {};
   if (input.owned) {
-    idFilter.in = ownedPlayerIds;
+    ownershipIdFilter.in = ownedPlayerIds;
   } else if (ownedPlayerIds.length > 0) {
-    idFilter.notIn = ownedPlayerIds;
+    ownershipIdFilter.notIn = ownedPlayerIds;
   }
-  if (input.cursor) {
-    idFilter.gt = input.cursor;
-  }
+  const playerFilters = {
+    active: true,
+    ...(input.team ? { club: input.team } : {}),
+    ...(input.position ? { position: input.position } : {}),
+  };
+  const totalWhere = {
+    ...playerFilters,
+    ...(Object.keys(ownershipIdFilter).length > 0 ? { id: ownershipIdFilter } : {}),
+  };
 
-  const players = await prisma.player.findMany({
-    where: {
-      active: true,
-      ...(Object.keys(idFilter).length > 0 ? { id: idFilter } : {}),
-      ...(input.team ? { club: input.team } : {}),
-      ...(input.position ? { position: input.position } : {}),
-    },
-    orderBy: { id: 'asc' },
-    take: input.limit,
-    select: {
-      id: true,
-      name: true,
-      club: true,
-      position: true,
-    },
-  });
+  const pageIdFilter: { in?: string[]; notIn?: string[]; gt?: string } = {
+    ...ownershipIdFilter,
+  };
+  if (input.cursor) {
+    pageIdFilter.gt = input.cursor;
+  }
+  const pageWhere = {
+    ...playerFilters,
+    ...(Object.keys(pageIdFilter).length > 0 ? { id: pageIdFilter } : {}),
+  };
+
+  const [players, total] = await Promise.all([
+    prisma.player.findMany({
+      where: pageWhere,
+      orderBy: { id: 'asc' },
+      take: input.limit,
+      select: {
+        id: true,
+        name: true,
+        club: true,
+        position: true,
+      },
+    }),
+    prisma.player.count({ where: totalWhere }),
+  ]);
 
   const items = players.map((player) => ({
     id: player.id,
@@ -81,7 +96,7 @@ async function getPrismaLeaguePlayers(input: {
   return {
     items,
     nextCursor: players.length === input.limit && last ? last.id : null,
-    total: items.length,
+    total,
   };
 }
 

--- a/src/app/api/leagues/[id]/players/route.ts
+++ b/src/app/api/leagues/[id]/players/route.ts
@@ -126,21 +126,29 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     const owned = ownedStr === 'true' ? true : ownedStr === 'false' ? false : undefined;
 
     if (typeof owned === 'boolean') {
-      const prismaLeague = await prisma.league.findUnique({
-        where: { id: leagueId },
-        select: { id: true },
-      });
+      try {
+        const prismaLeague = await prisma.league.findUnique({
+          where: { id: leagueId },
+          select: { id: true },
+        });
 
-      if (prismaLeague) {
-        const result = await getPrismaLeaguePlayers({
+        if (prismaLeague) {
+          const result = await getPrismaLeaguePlayers({
+            leagueId,
+            owned,
+            limit,
+            cursor,
+            team,
+            position,
+          });
+          return NextResponse.json(result, { status: 200 });
+        }
+      } catch (error) {
+        console.warn('[players API] prisma ownership path failed, falling back:', {
           leagueId,
           owned,
-          limit,
-          cursor,
-          team,
-          position,
+          error: error instanceof Error ? error.message : String(error),
         });
-        return NextResponse.json(result, { status: 200 });
       }
     }
 

--- a/src/app/api/leagues/[id]/players/route.ts
+++ b/src/app/api/leagues/[id]/players/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { adminDb } from '@/lib/firebaseAdmin';
+import { prisma } from '@/lib/prisma';
 import { getAuthenticatedUserId } from '@/lib/serverAuth';
 import { verifyLeagueMembership } from '@/lib/leagueMembership';
 export const runtime = 'nodejs';
@@ -21,6 +22,67 @@ interface AvailableIndexDoc {
   position?: string;
   available?: boolean;
   team?: string;
+}
+
+async function getPrismaLeaguePlayers(input: {
+  leagueId: string;
+  owned: boolean;
+  limit: number;
+  cursor?: string;
+  team?: string;
+  position?: string;
+}) {
+  const ownerships = await prisma.leagueRosterPlayer.findMany({
+    where: { leagueId: input.leagueId },
+    select: { playerId: true, memberId: true },
+  });
+  const ownedPlayerIds = ownerships.map((ownership) => ownership.playerId);
+
+  if (input.owned && ownedPlayerIds.length === 0) {
+    return { items: [], nextCursor: null, total: 0 };
+  }
+
+  const idFilter: { in?: string[]; notIn?: string[]; gt?: string } = {};
+  if (input.owned) {
+    idFilter.in = ownedPlayerIds;
+  } else if (ownedPlayerIds.length > 0) {
+    idFilter.notIn = ownedPlayerIds;
+  }
+  if (input.cursor) {
+    idFilter.gt = input.cursor;
+  }
+
+  const players = await prisma.player.findMany({
+    where: {
+      active: true,
+      ...(Object.keys(idFilter).length > 0 ? { id: idFilter } : {}),
+      ...(input.team ? { club: input.team } : {}),
+      ...(input.position ? { position: input.position } : {}),
+    },
+    orderBy: { id: 'asc' },
+    take: input.limit,
+    select: {
+      id: true,
+      name: true,
+      club: true,
+      position: true,
+    },
+  });
+
+  const items = players.map((player) => ({
+    id: player.id,
+    name: player.name,
+    team: player.club,
+    position: player.position,
+    ownership: input.owned ? 100 : 0,
+  }));
+  const last = items[items.length - 1];
+
+  return {
+    items,
+    nextCursor: players.length === input.limit && last ? last.id : null,
+    total: items.length,
+  };
 }
 
 // GET /api/leagues/[id]/players?limit=100&cursor=<lastId>&team=XXX&position=YYY&owned=true|false
@@ -47,6 +109,25 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     const position = url.searchParams.get('position') || undefined;
     const ownedStr = url.searchParams.get('owned');
     const owned = ownedStr === 'true' ? true : ownedStr === 'false' ? false : undefined;
+
+    if (typeof owned === 'boolean') {
+      const prismaLeague = await prisma.league.findUnique({
+        where: { id: leagueId },
+        select: { id: true },
+      });
+
+      if (prismaLeague) {
+        const result = await getPrismaLeaguePlayers({
+          leagueId,
+          owned,
+          limit,
+          cursor,
+          team,
+          position,
+        });
+        return NextResponse.json(result, { status: 200 });
+      }
+    }
 
     // Prefer per-league availability index when filtering by owned/unowned
     if (typeof owned === 'boolean') {

--- a/src/app/api/leagues/[id]/waivers/submit/route.ts
+++ b/src/app/api/leagues/[id]/waivers/submit/route.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { adminDb } from '@/lib/firebaseAdmin';
+import { prisma } from '@/lib/prisma';
 import { getAuthenticatedUserId } from '@/lib/serverAuth';
 import { logger, withTiming } from '@/lib/logger';
 import { revalidateTag } from 'next/cache';
@@ -40,6 +41,14 @@ export const POST = withMetrics(
       const access = await getLeagueMembershipAccess(leagueId, userId);
       if (!access.isMember) {
         return NextResponse.json({ error: 'League membership required' }, { status: 403 });
+      }
+
+      const prismaOwnership = await prisma.leagueRosterPlayer.findFirst({
+        where: { leagueId, playerId: String(playerId) },
+        select: { playerId: true, memberId: true },
+      });
+      if (prismaOwnership) {
+        return NextResponse.json({ error: 'Player already owned' }, { status: 409 });
       }
 
       // Ownership checks (doc read + roster scan) concurrently to reduce latency

--- a/src/app/api/leagues/[id]/waivers/submit/route.ts
+++ b/src/app/api/leagues/[id]/waivers/submit/route.ts
@@ -43,10 +43,19 @@ export const POST = withMetrics(
         return NextResponse.json({ error: 'League membership required' }, { status: 403 });
       }
 
-      const prismaOwnership = await prisma.leagueRosterPlayer.findFirst({
-        where: { leagueId, playerId: String(playerId) },
-        select: { playerId: true, memberId: true },
-      });
+      let prismaOwnership: { playerId: string; memberId: string } | null = null;
+      try {
+        prismaOwnership = await prisma.leagueRosterPlayer.findFirst({
+          where: { leagueId, playerId: String(playerId) },
+          select: { playerId: true, memberId: true },
+        });
+      } catch (error) {
+        logger.warn('Prisma ownership pre-check failed; continuing with Firestore checks', {
+          leagueId,
+          playerId: String(playerId),
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
       if (prismaOwnership) {
         return NextResponse.json({ error: 'Player already owned' }, { status: 409 });
       }

--- a/tests/unit/leagueFreeAgentAvailability.test.ts
+++ b/tests/unit/leagueFreeAgentAvailability.test.ts
@@ -214,6 +214,25 @@ describe('league free-agent availability uses Prisma ownership as canonical', ()
     firestoreMocks.emptyQuery.startAfter.mockImplementation(() => firestoreMocks.emptyQuery);
     firestoreMocks.emptyQuery.limit.mockImplementation(() => firestoreMocks.emptyQuery);
     firestoreMocks.emptyQuery.get.mockResolvedValue({ docs: [], empty: true });
+    firestoreMocks.availablePlayersQuery.where.mockImplementation(
+      () => firestoreMocks.availablePlayersQuery
+    );
+    firestoreMocks.availablePlayersQuery.orderBy.mockImplementation(
+      () => firestoreMocks.availablePlayersQuery
+    );
+    firestoreMocks.availablePlayersQuery.startAfter.mockImplementation(
+      () => firestoreMocks.availablePlayersQuery
+    );
+    firestoreMocks.availablePlayersQuery.limit.mockImplementation(
+      () => firestoreMocks.availablePlayersQuery
+    );
+    firestoreMocks.availablePlayersQuery.get.mockResolvedValue({
+      docs: [
+        { id: 'drafted-player', data: () => ({ available: true }) },
+        { id: 'free-player', data: () => ({ available: true }) },
+      ],
+      empty: false,
+    });
 
     authMocks.getAuthenticatedUserId.mockResolvedValue('statly-dev-tester');
     leagueMembershipMocks.verifyLeagueMembership.mockResolvedValue({ isMember: true });
@@ -285,6 +304,24 @@ describe('league free-agent availability uses Prisma ownership as canonical', ()
     });
   });
 
+  it('falls back to Firestore availability when the Prisma player path fails', async () => {
+    prismaMocks.league.findUnique.mockRejectedValue(new Error('prisma unavailable'));
+
+    const { GET } = await import('../../src/app/api/leagues/[id]/players/route');
+
+    const response = await GET(request('/api/leagues/league-1/players?owned=false&limit=100'), {
+      params: Promise.resolve({ id: 'league-1' }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.items.map((player: { id: string }) => player.id)).toEqual([
+      'drafted-player',
+      'free-player',
+    ]);
+    expect(firestoreMocks.availablePlayersQuery.get).toHaveBeenCalled();
+  });
+
   it('returns Prisma-owned drafted players from the owned player API without relying on Firestore projection state', async () => {
     prismaMocks.player.findMany.mockResolvedValue([
       { id: 'drafted-player', name: 'Drafted Player', club: 'CARL', position: 'MID' },
@@ -344,6 +381,25 @@ describe('league free-agent availability uses Prisma ownership as canonical', ()
 
     expect(response.status).toBe(201);
     expect(body).toEqual({ id: 'claim-1' });
+  });
+
+  it('continues through Firestore waiver checks when the Prisma ownership pre-check fails', async () => {
+    prismaMocks.leagueRosterPlayer.findFirst.mockRejectedValue(new Error('prisma unavailable'));
+
+    const { POST } = await import('../../src/app/api/leagues/[id]/waivers/submit/route');
+
+    const response = await POST(
+      jsonRequest('/api/leagues/league-1/waivers/submit', {
+        teamId: 'member-1',
+        playerId: 'free-player',
+      }),
+      { params: Promise.resolve({ id: 'league-1' }) }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body).toEqual({ id: 'claim-1' });
+    expect(firestoreMocks.adminDb.runTransaction).toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/leagueFreeAgentAvailability.test.ts
+++ b/tests/unit/leagueFreeAgentAvailability.test.ts
@@ -23,6 +23,7 @@ const prismaMocks = vi.hoisted(() => ({
   },
   player: {
     findMany: vi.fn(),
+    count: vi.fn(),
   },
 }));
 
@@ -236,6 +237,7 @@ describe('league free-agent availability uses Prisma ownership as canonical', ()
     prismaMocks.player.findMany.mockResolvedValue([
       { id: 'free-player', name: 'Free Player', club: 'SYD', position: 'FWD' },
     ]);
+    prismaMocks.player.count.mockResolvedValue(1);
     firestoreMocks.adminDb.runTransaction.mockImplementation(async (work) => {
       const tx = {
         get: vi.fn(async () => ({ exists: false, data: () => undefined })),
@@ -260,6 +262,27 @@ describe('league free-agent availability uses Prisma ownership as canonical', ()
       select: { playerId: true, memberId: true },
     });
     expect(body.items.map((player: { id: string }) => player.id)).toEqual(['free-player']);
+  });
+
+  it('returns the full Prisma matching count instead of the current page size', async () => {
+    prismaMocks.player.count.mockResolvedValue(42);
+
+    const { GET } = await import('../../src/app/api/leagues/[id]/players/route');
+
+    const response = await GET(request('/api/leagues/league-1/players?owned=false&limit=10'), {
+      params: Promise.resolve({ id: 'league-1' }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.items).toHaveLength(1);
+    expect(body.total).toBe(42);
+    expect(prismaMocks.player.count).toHaveBeenCalledWith({
+      where: {
+        active: true,
+        id: { notIn: ['drafted-player'] },
+      },
+    });
   });
 
   it('returns Prisma-owned drafted players from the owned player API without relying on Firestore projection state', async () => {

--- a/tests/unit/leagueFreeAgentAvailability.test.ts
+++ b/tests/unit/leagueFreeAgentAvailability.test.ts
@@ -1,0 +1,337 @@
+import type { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authMocks = vi.hoisted(() => ({
+  getAuthenticatedUserId: vi.fn(),
+}));
+
+const leagueMembershipMocks = vi.hoisted(() => ({
+  verifyLeagueMembership: vi.fn(),
+}));
+
+const leagueAccessMocks = vi.hoisted(() => ({
+  getLeagueMembershipAccess: vi.fn(),
+}));
+
+const prismaMocks = vi.hoisted(() => ({
+  league: {
+    findUnique: vi.fn(),
+  },
+  leagueRosterPlayer: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+  },
+  player: {
+    findMany: vi.fn(),
+  },
+}));
+
+const firestoreMocks = vi.hoisted(() => {
+  const playerDocs = new Map<string, { name: string; team: string; position: string }>([
+    ['drafted-player', { name: 'Drafted Player', team: 'CARL', position: 'MID' }],
+    ['free-player', { name: 'Free Player', team: 'SYD', position: 'FWD' }],
+  ]);
+
+  const makeQuery = (docs: Array<{ id: string; data: Record<string, unknown> }>) => {
+    const query = {
+      where: vi.fn(() => query),
+      orderBy: vi.fn(() => query),
+      startAfter: vi.fn(() => query),
+      limit: vi.fn(() => query),
+      get: vi.fn().mockResolvedValue({
+        docs: docs.map((doc) => ({
+          id: doc.id,
+          data: () => doc.data,
+        })),
+        empty: docs.length === 0,
+      }),
+    };
+    return query;
+  };
+
+  const availablePlayersQuery = makeQuery([
+    { id: 'drafted-player', data: { available: true } },
+    { id: 'free-player', data: { available: true } },
+  ]);
+
+  const emptyQuery = makeQuery([]);
+  const ownershipDoc = { exists: false, data: () => undefined };
+  const settingsDoc = { exists: false, data: () => undefined };
+
+  const collection = vi.fn((collectionPath: string) => {
+    if (collectionPath === 'leagues') {
+      return {
+        doc: vi.fn((leagueId: string) => ({
+          collection: vi.fn((subcollection: string) => {
+            if (subcollection === 'availablePlayers') return availablePlayersQuery;
+            return emptyQuery;
+          }),
+          path: `leagues/${leagueId}`,
+        })),
+      };
+    }
+
+    if (collectionPath === 'players') {
+      return {
+        doc: vi.fn((playerId: string) => ({
+          id: playerId,
+          path: `players/${playerId}`,
+        })),
+      };
+    }
+
+    if (collectionPath.endsWith('/rosters')) return emptyQuery;
+    if (collectionPath.endsWith('/waivers')) {
+      return { doc: vi.fn(() => ({ id: 'claim-1', path: `${collectionPath}/claim-1` })) };
+    }
+    if (collectionPath.endsWith('/activity')) {
+      return { doc: vi.fn(() => ({ path: `${collectionPath}/activity-1` })) };
+    }
+
+    return emptyQuery;
+  });
+
+  const doc = vi.fn((path: string) => ({
+    path,
+    get: vi.fn().mockResolvedValue(path.endsWith('/config/settings') ? settingsDoc : ownershipDoc),
+  }));
+
+  return {
+    availablePlayersQuery,
+    emptyQuery,
+    runTransaction: vi.fn(),
+    adminDb: {
+      collection,
+      doc,
+      getAll: vi.fn(async (...refs: Array<{ id: string }>) =>
+        refs.map((ref) => ({
+          id: ref.id,
+          exists: playerDocs.has(ref.id),
+          data: () => playerDocs.get(ref.id),
+        }))
+      ),
+      runTransaction: vi.fn(),
+    },
+  };
+});
+
+vi.mock('@/lib/serverAuth', () => ({
+  getAuthenticatedUserId: authMocks.getAuthenticatedUserId,
+}));
+
+vi.mock('../../src/lib/serverAuth', () => ({
+  getAuthenticatedUserId: authMocks.getAuthenticatedUserId,
+}));
+
+vi.mock('@/lib/leagueMembership', () => ({
+  verifyLeagueMembership: leagueMembershipMocks.verifyLeagueMembership,
+}));
+
+vi.mock('../../src/lib/leagueMembership', () => ({
+  verifyLeagueMembership: leagueMembershipMocks.verifyLeagueMembership,
+}));
+
+vi.mock('@/server/leagues/membership', () => ({
+  getLeagueMembershipAccess: leagueAccessMocks.getLeagueMembershipAccess,
+}));
+
+vi.mock('../../src/server/leagues/membership', () => ({
+  getLeagueMembershipAccess: leagueAccessMocks.getLeagueMembershipAccess,
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: prismaMocks,
+}));
+
+vi.mock('../../src/lib/prisma', () => ({
+  prisma: prismaMocks,
+}));
+
+vi.mock('@/lib/firebaseAdmin', () => ({
+  adminDb: firestoreMocks.adminDb,
+}));
+
+vi.mock('../../src/lib/firebaseAdmin', () => ({
+  adminDb: firestoreMocks.adminDb,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    apiError: vi.fn(),
+    apiRequest: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  withTiming: vi.fn((_label: string, work: () => unknown) => work()),
+}));
+
+vi.mock('../../src/lib/logger', () => ({
+  logger: {
+    apiError: vi.fn(),
+    apiRequest: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  withTiming: vi.fn((_label: string, work: () => unknown) => work()),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+}));
+
+vi.mock('@/lib/cacheTags', () => ({
+  tags: {
+    league: (leagueId: string) => `league:${leagueId}`,
+    waivers: (leagueId: string) => `waivers:${leagueId}`,
+  },
+}));
+
+vi.mock('../../src/lib/cacheTags', () => ({
+  tags: {
+    league: (leagueId: string) => `league:${leagueId}`,
+    waivers: (leagueId: string) => `waivers:${leagueId}`,
+  },
+}));
+
+vi.mock('@/lib/metrics', () => ({
+  withMetrics: (handler: unknown) => handler,
+}));
+
+vi.mock('../../src/lib/metrics', () => ({
+  withMetrics: (handler: unknown) => handler,
+}));
+
+describe('league free-agent availability uses Prisma ownership as canonical', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    firestoreMocks.emptyQuery.where.mockImplementation(() => firestoreMocks.emptyQuery);
+    firestoreMocks.emptyQuery.orderBy.mockImplementation(() => firestoreMocks.emptyQuery);
+    firestoreMocks.emptyQuery.startAfter.mockImplementation(() => firestoreMocks.emptyQuery);
+    firestoreMocks.emptyQuery.limit.mockImplementation(() => firestoreMocks.emptyQuery);
+    firestoreMocks.emptyQuery.get.mockResolvedValue({ docs: [], empty: true });
+
+    authMocks.getAuthenticatedUserId.mockResolvedValue('statly-dev-tester');
+    leagueMembershipMocks.verifyLeagueMembership.mockResolvedValue({ isMember: true });
+    leagueAccessMocks.getLeagueMembershipAccess.mockResolvedValue({
+      leagueId: 'league-1',
+      userId: 'statly-dev-tester',
+      memberId: 'member-1',
+      role: 'OWNER',
+      isMember: true,
+      canManage: true,
+    });
+
+    prismaMocks.league.findUnique.mockResolvedValue({ id: 'league-1' });
+    prismaMocks.leagueRosterPlayer.findMany.mockResolvedValue([
+      { playerId: 'drafted-player', memberId: 'member-1' },
+    ]);
+    prismaMocks.leagueRosterPlayer.findFirst.mockResolvedValue({
+      playerId: 'drafted-player',
+      memberId: 'member-1',
+    });
+    prismaMocks.player.findMany.mockResolvedValue([
+      { id: 'free-player', name: 'Free Player', club: 'SYD', position: 'FWD' },
+    ]);
+    firestoreMocks.adminDb.runTransaction.mockImplementation(async (work) => {
+      const tx = {
+        get: vi.fn(async () => ({ exists: false, data: () => undefined })),
+        set: vi.fn(),
+        update: vi.fn(),
+      };
+      return work(tx);
+    });
+  });
+
+  it('excludes Prisma-owned drafted players from the free-agent player API even when Firestore availability is stale', async () => {
+    const { GET } = await import('../../src/app/api/leagues/[id]/players/route');
+
+    const response = await GET(request('/api/leagues/league-1/players?owned=false&limit=100'), {
+      params: Promise.resolve({ id: 'league-1' }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(prismaMocks.leagueRosterPlayer.findMany).toHaveBeenCalledWith({
+      where: { leagueId: 'league-1' },
+      select: { playerId: true, memberId: true },
+    });
+    expect(body.items.map((player: { id: string }) => player.id)).toEqual(['free-player']);
+  });
+
+  it('returns Prisma-owned drafted players from the owned player API without relying on Firestore projection state', async () => {
+    prismaMocks.player.findMany.mockResolvedValue([
+      { id: 'drafted-player', name: 'Drafted Player', club: 'CARL', position: 'MID' },
+    ]);
+
+    const { GET } = await import('../../src/app/api/leagues/[id]/players/route');
+
+    const response = await GET(request('/api/leagues/league-1/players?owned=true&limit=100'), {
+      params: Promise.resolve({ id: 'league-1' }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.items).toEqual([
+      expect.objectContaining({
+        id: 'drafted-player',
+        name: 'Drafted Player',
+        ownership: 100,
+      }),
+    ]);
+  });
+
+  it('rejects waiver claims for Prisma-owned drafted players before Firestore ownership checks', async () => {
+    const { POST } = await import('../../src/app/api/leagues/[id]/waivers/submit/route');
+
+    const response = await POST(
+      jsonRequest('/api/leagues/league-1/waivers/submit', {
+        teamId: 'member-1',
+        playerId: 'drafted-player',
+      }),
+      { params: Promise.resolve({ id: 'league-1' }) }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error).toBe('Player already owned');
+    expect(prismaMocks.leagueRosterPlayer.findFirst).toHaveBeenCalledWith({
+      where: { leagueId: 'league-1', playerId: 'drafted-player' },
+      select: { playerId: true, memberId: true },
+    });
+    expect(firestoreMocks.adminDb.runTransaction).not.toHaveBeenCalled();
+  });
+
+  it('allows waiver claims for undrafted players after Prisma confirms they are unowned', async () => {
+    prismaMocks.leagueRosterPlayer.findFirst.mockResolvedValue(null);
+
+    const { POST } = await import('../../src/app/api/leagues/[id]/waivers/submit/route');
+
+    const response = await POST(
+      jsonRequest('/api/leagues/league-1/waivers/submit', {
+        teamId: 'member-1',
+        playerId: 'free-player',
+      }),
+      { params: Promise.resolve({ id: 'league-1' }) }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body).toEqual({ id: 'claim-1' });
+  });
+});
+
+function request(path: string): NextRequest {
+  return new Request(`https://statly.test${path}`) as NextRequest;
+}
+
+function jsonRequest(path: string, body: unknown): NextRequest {
+  return new Request(`https://statly.test${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}


### PR DESCRIPTION
## Summary

- Makes league player availability use Prisma league roster ownership for Prisma-backed leagues before falling back to Firestore ownership.
- Prevents drafted/roster-owned players from appearing as available free agents.
- Rejects waiver submissions for Prisma-owned players before legacy Firestore ownership checks.
- Adds focused unit coverage for drafted-player exclusion, owned-player inclusion, waiver rejection, and undrafted-player allowance.

## Verification

- `npm run typecheck`
- `npm exec -- eslint src/app/api/leagues/[id]/players/route.ts src/app/api/leagues/[id]/waivers/submit/route.ts tests/unit/leagueFreeAgentAvailability.test.ts`
- `npm exec -- prettier --check src/app/api/leagues/[id]/players/route.ts src/app/api/leagues/[id]/waivers/submit/route.ts tests/unit/leagueFreeAgentAvailability.test.ts`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/DraftApplicationService.completionProjection.test.ts tests/unit/RosterProjectionService.test.ts tests/unit/waiverAvailabilityProjection.test.ts tests/unit/leagueFreeAgentAvailability.test.ts --coverage.enabled=false`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Browser/local smoke note

A full browser/full-draft soak was not run because the available local smoke/e2e paths create or delete fixture data and would touch the protected local `prisma/dev.db`. This PR is therefore intentionally limited to the server/API ownership boundary with targeted unit coverage.

## Summary by Sourcery

Use Prisma league roster ownership as the primary source of truth for free-agent availability and waiver eligibility in Prisma-backed leagues.

Bug Fixes:
- Exclude Prisma-owned players from the free-agent player list even when Firestore availability is stale.
- Reject waiver submissions for players already owned in Prisma before running legacy Firestore ownership checks.

Tests:
- Add unit tests covering drafted-player exclusion from free agents, owned-player inclusion, waiver rejection for Prisma-owned players, and waiver acceptance for undrafted players.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced player filtering now accurately reflects ownership status with pagination support.

* **Improvements**
  * Added validation to waiver submission flow to prevent claims on already-owned players.

* **Tests**
  * Added comprehensive unit tests for free-agent availability and ownership verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->