### PR TITLE
fix: clean up LeagueTabs async lint

### DIFF
--- a/src/components/league/LeagueTabs.tsx
+++ b/src/components/league/LeagueTabs.tsx
@@ -39,7 +39,11 @@ interface Tab {
   badge?: number;
 }
 
-export default function LeagueTabs({ league, members, currentUserId }: LeagueTabsProps) {
+export default function LeagueTabs({
+  league,
+  members,
+  currentUserId,
+}: LeagueTabsProps): React.JSX.Element {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
@@ -1061,7 +1065,7 @@ function MyTeamRosterManager({ league, members, currentUserId }: MyTeamRosterMan
       }
     };
 
-    fetchRosterData();
+    void fetchRosterData();
   }, [league?.id, currentUserId]);
 
   // Convert roster data to Team format for MyTeamPanel
@@ -1165,7 +1169,7 @@ function MyTeamRosterManager({ league, members, currentUserId }: MyTeamRosterMan
               console.error('Failed to refresh roster:', error);
             }
           };
-          refreshRoster();
+          void refreshRoster();
         }, 1000);
       } else {
         const error = await response.json();


### PR DESCRIPTION
## Summary

- Rebuilds the useful one-file lint/type cleanup from #206 on current main.
- Adds an explicit React-compatible return type to LeagueTabs.
- Marks intentionally unawaited roster refresh calls with `void`.

## Verification

- `npm exec -- prettier --check src/components/league/LeagueTabs.tsx`
- `npm exec -- eslint src/components/league/LeagueTabs.tsx`
- `npm run typecheck`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

The original #206 workflow could not be rerun because GitHub reported the run was more than a month old. The old `JSX.Element` annotation also failed current typecheck, so this rebuild uses `React.JSX.Element` instead.

## Summary by Sourcery

Clarify LeagueTabs component typing and align async roster refresh calls with linting rules.

Bug Fixes:
- Prevent unawaited async calls in MyTeamRosterManager from triggering lint errors by explicitly discarding their returned promises.

Enhancements:
- Specify an explicit React.JSX.Element return type for the LeagueTabs component to satisfy current type checking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This release contains internal code quality improvements with no user-facing changes. Code patterns were refined to enhance maintainability while preserving all existing functionality.

**Affected Components:**
* League management interface code structure updated for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->