### PR TITLE
test: guard player table readability

### DIFF
--- a/tests/unit/PlayerGrid.a11y.test.tsx
+++ b/tests/unit/PlayerGrid.a11y.test.tsx
@@ -196,6 +196,8 @@ describe('PlayerGrid accessibility', () => {
     expect(source).toContain('grid grid-cols-3 items-center gap-2');
     expect(source).toContain('h-10 w-full justify-center');
     expect(source).toContain('inline-flex min-w-12 justify-center tabular-nums');
+    expect(source).not.toContain('font-mono');
+    expect(source).not.toMatch(/\btracking-\[-/);
     expect(source).not.toContain('motion.tr');
     expect(source).not.toContain("from 'framer-motion'");
     expect(source).not.toContain('flex flex-wrap items-center justify-center gap-2');


### PR DESCRIPTION
## Summary

- Adds focused regression coverage for the active draft player table readability baseline.
- Guards against reintroducing cramped `font-mono` and negative tracking treatment in `PlayerGrid`.
- Confirms the current implementation already uses readable table typography with `tabular-nums`.

## Verification

- `npm exec -- prettier --check tests/unit/PlayerGrid.a11y.test.tsx`
- `npm exec -- eslint tests/unit/PlayerGrid.a11y.test.tsx`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/PlayerGrid.a11y.test.tsx --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

- Test-only change.
- No runtime code changed.
- No protected, local, generated, database, env, Firebase, or secret files touched.

## Summary by Sourcery

Tests:
- Add accessibility test expectations that PlayerGrid omits mono font and negative tracking in the active draft player table typography.