### PR TITLE
test: keep legacy draft lobby out of live room

### DIFF
--- a/tests/unit/draftRoomRuntimeSurface.test.ts
+++ b/tests/unit/draftRoomRuntimeSurface.test.ts
@@ -10,10 +10,13 @@ describe('draft room runtime source of truth', () => {
   it('keeps the live draft route on the unified draft room surface', () => {
     const routeSource = read('src/app/(app)/drafts/[id]/page.tsx');
 
-    expect(routeSource).toContain("import UnifiedDraftRoom from '@/components/draft/UnifiedDraftRoom'");
+    expect(routeSource).toContain(
+      "import UnifiedDraftRoom from '@/components/draft/UnifiedDraftRoom'"
+    );
     expect(routeSource).toContain('<DraftProvider draftId={draftId} userId={user.uid}>');
     expect(routeSource).toContain('<UnifiedDraftRoom draftId={draftId} userId={user.uid} />');
     expect(routeSource).not.toMatch(/AvailablePlayersTable(_new)?/);
+    expect(routeSource).not.toMatch(/\bDraftLobby\b/);
   });
 
   it('keeps the unified room wired to the current table and rails', () => {
@@ -26,12 +29,11 @@ describe('draft room runtime source of truth', () => {
     expect(roomSource).toContain('<DraftLeftRail');
     expect(roomSource).toContain('<PickFeed');
     expect(roomSource).not.toMatch(/AvailablePlayersTable(_new)?/);
+    expect(roomSource).not.toMatch(/\bDraftLobby\b/);
   });
 
   it('documents the deployment, archive, and close-out requirements', () => {
-    const sourceOfTruth = read(
-      'docs/superpowers/specs/2026-06-13-draft-room-source-of-truth.md'
-    );
+    const sourceOfTruth = read('docs/superpowers/specs/2026-06-13-draft-room-source-of-truth.md');
 
     expect(sourceOfTruth).toContain('Live draft room route: `src/app/(app)/drafts/[id]/page.tsx`');
     expect(sourceOfTruth).toContain('Live room shell: `src/components/draft/UnifiedDraftRoom.tsx`');


### PR DESCRIPTION
## Summary

- Adds a focused regression guard for the current live draft room surface.
- Prevents the legacy `DraftLobby` component from being reintroduced into `/drafts/[id]` or `UnifiedDraftRoom`.
- Preserves the useful intent from old draft lobby reliability PRs without copying stale branch diffs or changing unused runtime code.

## Verification

- `npm exec -- prettier --check tests/unit/draftRoomRuntimeSurface.test.ts`
- `npm exec -- eslint tests/unit/draftRoomRuntimeSurface.test.ts`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/draftRoomRuntimeSurface.test.ts --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

- Test-only change.
- No runtime code changed.
- No protected, local, generated, database, env, Firebase, or secret files touched.
- The local `prisma/dev.db` stash was left untouched.

## Summary by Sourcery

Tests:
- Extend draft room runtime surface tests to assert the live draft route and unified draft room do not import or render the legacy DraftLobby component.