### PR TITLE
fix: make api health resilient locally

### DIFF
--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -78,13 +78,23 @@ vi.mock('@/lib/metrics', () => ({
 describe('Health API', () => {
   let mockRequest: NextRequest;
 
+  function useOptionalLocalRedisEnv() {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('REDIS_URL', undefined);
+    vi.stubEnv('REDIS_HOST', undefined);
+    vi.stubEnv('REDIS_PORT', undefined);
+    vi.stubEnv('REDIS_PASSWORD', undefined);
+  }
+
   beforeEach(() => {
     mockRequest = new NextRequest('http://localhost:3000/api/health');
     vi.clearAllMocks();
+    useOptionalLocalRedisEnv();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   describe('GET /api/health', () => {
@@ -132,6 +142,36 @@ describe('Health API', () => {
       expect(data.data.status).toBe('healthy');
       expect(data.data.services.memory.status).toBe('healthy');
     });
+
+    it('should stay operational but degraded when optional local Redis is unavailable', async () => {
+      const { redisClient } = await import('@/lib/redis');
+      vi.mocked(redisClient.isConnected).mockReturnValue(false);
+
+      const response = await GET(mockRequest);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data.status).toBe('degraded');
+      expect(data.data.services.redis.status).toBe('degraded');
+      expect(data.data.services.redis.error).toContain('Optional local Redis unavailable');
+    });
+
+    it('should treat development heap pressure as degraded instead of unhealthy', async () => {
+      vi.spyOn(process, 'memoryUsage').mockReturnValue({
+        rss: 100,
+        heapTotal: 100,
+        heapUsed: 95,
+        external: 0,
+        arrayBuffers: 0,
+      });
+
+      const response = await GET(mockRequest);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data.status).toBe('degraded');
+      expect(data.data.services.memory.status).toBe('degraded');
+    });
   });
 
   describe('HEAD /api/health', () => {
@@ -155,7 +195,20 @@ describe('Health API', () => {
       expect(data.services).toHaveProperty('metrics');
     });
 
-    it('should return 503 when Redis is not ready', async () => {
+    it('should return 200 when optional local Redis is not ready', async () => {
+      const { redisClient } = await import('@/lib/redis');
+      vi.mocked(redisClient.isConnected).mockReturnValue(false);
+
+      const response = await PATCH(mockRequest);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.ready).toBe(true);
+      expect(data.services.redis).toBe('degraded');
+    });
+
+    it('should return 503 when production Redis is not ready', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
       const { redisClient } = await import('@/lib/redis');
       vi.mocked(redisClient.isConnected).mockReturnValue(false);
 
@@ -164,6 +217,7 @@ describe('Health API', () => {
 
       expect(response.status).toBe(503);
       expect(data.ready).toBe(false);
+      expect(data.services.redis).toBe('unhealthy');
     });
   });
 
@@ -182,7 +236,8 @@ describe('Health API', () => {
       expect(data.data.services.database.status).toBe('unhealthy');
     });
 
-    it('should handle Redis errors gracefully', async () => {
+    it('should handle configured Redis errors gracefully', async () => {
+      vi.stubEnv('REDIS_URL', 'redis://localhost:6379');
       const { redisClient } = await import('@/lib/redis');
       vi.mocked(redisClient.ping).mockRejectedValue(new Error('Redis connection failed'));
 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -170,16 +170,14 @@ function checkMemory(): ServiceStatus {
 
   if (memoryUsagePercent >= 90) {
     status = isProductionEnvironment() ? 'unhealthy' : 'degraded';
-    error =
-      process.env.NODE_ENV === 'production'
-        ? 'High memory usage detected'
-        : `High memory usage: ${memoryUsagePercent.toFixed(1)}%`;
+    error = isProductionEnvironment()
+      ? 'High memory usage detected'
+      : `High memory usage: ${memoryUsagePercent.toFixed(1)}%`;
   } else if (memoryUsagePercent >= 75) {
     status = 'degraded';
-    error =
-      process.env.NODE_ENV === 'production'
-        ? 'Elevated memory usage'
-        : `Elevated memory usage: ${memoryUsagePercent.toFixed(1)}%`;
+    error = isProductionEnvironment()
+      ? 'Elevated memory usage'
+      : `Elevated memory usage: ${memoryUsagePercent.toFixed(1)}%`;
   } else {
     status = 'healthy';
   }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -29,6 +29,34 @@ interface ServiceStatus {
 
 const startTime = Date.now();
 
+function isProductionEnvironment(): boolean {
+  return process.env.NODE_ENV === 'production';
+}
+
+function isRedisExplicitlyConfigured(): boolean {
+  return Boolean(
+    process.env.REDIS_URL ||
+      process.env.REDIS_HOST ||
+      process.env.REDIS_PORT ||
+      process.env.REDIS_PASSWORD
+  );
+}
+
+function isRedisRequired(): boolean {
+  return isProductionEnvironment() || isRedisExplicitlyConfigured();
+}
+
+function redisFailureStatus(error: string, responseTime: number): ServiceStatus {
+  const required = isRedisRequired();
+
+  return {
+    status: required ? 'unhealthy' : 'degraded',
+    responseTime,
+    error: required ? error : `Optional local Redis unavailable: ${error}`,
+    lastChecked: new Date().toISOString(),
+  };
+}
+
 async function checkDatabase(): Promise<ServiceStatus> {
   const start = Date.now();
   try {
@@ -70,12 +98,7 @@ async function checkRedis(): Promise<ServiceStatus> {
   const start = Date.now();
   try {
     if (!redisClient.isConnected()) {
-      return {
-        status: 'unhealthy',
-        responseTime: Date.now() - start,
-        error: 'Redis not connected',
-        lastChecked: new Date().toISOString(),
-      };
+      return redisFailureStatus('Redis not connected', Date.now() - start);
     }
 
     // Test basic operations
@@ -99,17 +122,14 @@ async function checkRedis(): Promise<ServiceStatus> {
       lastChecked: new Date().toISOString(),
     };
   } catch (error) {
-    return {
-      status: 'unhealthy',
-      responseTime: Date.now() - start,
-      error:
-        process.env.NODE_ENV === 'production'
-          ? 'Cache service error'
-          : error instanceof Error
-            ? error.message
-            : 'Redis error',
-      lastChecked: new Date().toISOString(),
-    };
+    return redisFailureStatus(
+      process.env.NODE_ENV === 'production'
+        ? 'Cache service error'
+        : error instanceof Error
+          ? error.message
+          : 'Redis error',
+      Date.now() - start
+    );
   }
 }
 
@@ -149,7 +169,7 @@ function checkMemory(): ServiceStatus {
   let error: string | undefined;
 
   if (memoryUsagePercent >= 90) {
-    status = 'unhealthy';
+    status = isProductionEnvironment() ? 'unhealthy' : 'degraded';
     error =
       process.env.NODE_ENV === 'production'
         ? 'High memory usage detected'
@@ -287,8 +307,11 @@ export async function PATCH(req: NextRequest) {
     ]);
 
     // For readiness, we require all critical services to be healthy
-    const criticalServices = [database, redis, metricsCheck];
-    const isReady = criticalServices.every((service) => service.status === 'healthy');
+    const criticalServices = [database, metricsCheck];
+    const redisReady = isRedisRequired()
+      ? redis.status === 'healthy'
+      : redis.status !== 'unhealthy';
+    const isReady = criticalServices.every((service) => service.status === 'healthy') && redisReady;
 
     const status = isReady ? 200 : 503;
     tracer.complete(status, {


### PR DESCRIPTION
## Summary

- Rebuilds the useful API health resilience intent from current `main`.
- Treats unconfigured local Redis failures as `degraded` instead of `unhealthy`.
- Keeps production Redis and explicitly configured Redis strict.
- Treats development heap pressure at 90%+ as `degraded`, while production remains `unhealthy`.
- Keeps readiness strict for database and metrics health while allowing optional local Redis degradation.
- Adds focused regression coverage for local Redis resilience, production Redis failure, development heap pressure, and configured Redis errors.

## Verification

- `npm exec -- prettier --check src/app/api/health/route.ts src/app/api/health/route.test.ts`
- `npm exec -- eslint src/app/api/health/route.ts src/app/api/health/route.test.ts`
- `npm exec -- vitest run src/app/api/health/route.test.ts --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

- Rebuilt from current `main`; old #400 was used as historical evidence only.
- No protected, local, generated, database, env, Firebase, or secret files touched.
- Database-backed verification was not needed for this route-level health check change.

## Summary by Sourcery

Relax health and readiness behavior for optional local Redis and development heap pressure while preserving strictness for production and explicitly configured environments, and add targeted regression tests for these scenarios.

Bug Fixes:
- Make health endpoint treat missing local Redis as degraded instead of unhealthy while keeping production and explicitly configured Redis strict
- Adjust readiness checks so optional local Redis degradation does not fail readiness while required Redis still does

Enhancements:
- Adjust memory health check so high heap usage is degraded in development but remains unhealthy in production
- Add helper utilities to distinguish production vs optional Redis configuration and derive Redis failure status consistently

Tests:
- Expand health route tests to cover optional local Redis degradation, production Redis failures, development heap pressure behavior, and configured Redis error handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health endpoint reporting for optional Redis unavailability and memory pressure handling with environment-aware status differentiation.
  * Refined Kubernetes readiness probe logic to treat Redis as critical only when required.

* **Tests**
  * Expanded coverage for Redis unavailability, memory pressure, and environment-dependent health behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->