### PR TITLE
fix: validate league creation timezone

### DIFF
--- a/src/app/(app)/leagues/new/page.tsx
+++ b/src/app/(app)/leagues/new/page.tsx
@@ -1,11 +1,17 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { CalendarClock, ChevronLeft, Loader2, Settings2, ShieldCheck, Trophy } from 'lucide-react';
 
 import { useAuth } from '@/AuthContext';
 import { fetchApi } from '@/lib/api';
+import {
+  COMMON_TIMEZONES,
+  datetimeLocalToUtc,
+  getBrowserTimeZone,
+  isValidTimeZone,
+} from '@/lib/timezone';
 import { AppLayout } from '@/components/navigation';
 import { normalizeCreateLeagueResponse } from '@/server/leagues/createLeagueContract';
 import { REAL_DATA_NINE_CATEGORY_PRESET } from '@/types/fantasyCategories';
@@ -17,6 +23,7 @@ export default function NewLeaguePage() {
   const [teamCount, setTeamCount] = useState(12);
   const [scoringFormat, setScoringFormat] = useState('nine-category');
   const [draftDate, setDraftDate] = useState('');
+  const [timeZone, setTimeZone] = useState('UTC');
   const [draftType, setDraftType] = useState('snake');
   const [pickOrder, setPickOrder] = useState('random');
   const [waiverRule, setWaiverRule] = useState('weekly');
@@ -24,6 +31,21 @@ export default function NewLeaguePage() {
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const { user } = useAuth();
+
+  useEffect(() => {
+    const browserTimeZone = getBrowserTimeZone();
+    if (isValidTimeZone(browserTimeZone)) {
+      setTimeZone(browserTimeZone);
+    }
+  }, []);
+
+  const timeZoneOptions = useMemo(() => {
+    if (COMMON_TIMEZONES.some((option) => option.value === timeZone)) {
+      return COMMON_TIMEZONES;
+    }
+
+    return [{ value: timeZone, label: `${timeZone} (detected)`, offset: '' }, ...COMMON_TIMEZONES];
+  }, [timeZone]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -43,7 +65,8 @@ export default function NewLeaguePage() {
           privacy: 'private',
           scoringFormat,
           categories: [...REAL_DATA_NINE_CATEGORY_PRESET],
-          draftDate: draftDate ? new Date(draftDate).toISOString() : undefined,
+          draftDate: draftDate ? datetimeLocalToUtc(draftDate, timeZone).toISOString() : undefined,
+          timeZone,
           draftType,
           pickOrder,
           waiverRule,
@@ -159,6 +182,27 @@ export default function NewLeaguePage() {
                   onChange={(e) => setDraftDate(e.target.value)}
                   className="mt-2 h-11 w-full rounded-2xl border border-[color:var(--league-border)] bg-[color:var(--league-page)] px-3 text-sm font-medium text-[color:var(--league-text)] outline-none transition focus:border-[color:var(--league-primary)] focus:ring-2 focus:ring-[color:var(--league-primary)]/20"
                 />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="timeZone"
+                  className="text-sm font-semibold text-[color:var(--league-text)]"
+                >
+                  Time zone
+                </label>
+                <select
+                  id="timeZone"
+                  value={timeZone}
+                  onChange={(e) => setTimeZone(e.target.value)}
+                  className="mt-2 h-11 w-full rounded-2xl border border-[color:var(--league-border)] bg-[color:var(--league-page)] px-3 text-sm font-semibold text-[color:var(--league-text)] outline-none transition focus:border-[color:var(--league-primary)] focus:ring-2 focus:ring-[color:var(--league-primary)]/20"
+                >
+                  {timeZoneOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
               </div>
 
               <div className="grid gap-4 sm:grid-cols-3">

--- a/src/app/api/leagues/route.ts
+++ b/src/app/api/leagues/route.ts
@@ -107,6 +107,7 @@ export async function POST(req: NextRequest) {
       },
       createdAt: now,
       status: 'preseason',
+      timeZone: normalized.timeZone,
       ...(body.description && { description: body.description }),
       ...(body.draftDate && { draftDate: body.draftDate }),
       ...(body.draftType && { draftType: body.draftType }),

--- a/src/server/leagues/createLeagueContract.ts
+++ b/src/server/leagues/createLeagueContract.ts
@@ -9,6 +9,7 @@ export interface CreateLeagueInput {
   privacy?: string;
   type?: string;
   visibility?: string;
+  timeZone?: string;
 }
 
 export interface NormalizedCreateLeagueInput {
@@ -16,6 +17,21 @@ export interface NormalizedCreateLeagueInput {
   maxTeams: number;
   categories: FantasyCategoryKey[];
   visibility: 'PUBLIC' | 'PRIVATE';
+  timeZone: string;
+}
+
+function normalizeTimeZone(timeZone: unknown): string {
+  if (typeof timeZone !== 'string' || !timeZone.trim()) {
+    return 'UTC';
+  }
+
+  const trimmed = timeZone.trim();
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: trimmed });
+    return trimmed;
+  } catch {
+    return 'UTC';
+  }
 }
 
 export function normalizeCreateLeagueInput(input: CreateLeagueInput): NormalizedCreateLeagueInput {
@@ -33,6 +49,7 @@ export function normalizeCreateLeagueInput(input: CreateLeagueInput): Normalized
     maxTeams,
     categories,
     visibility,
+    timeZone: normalizeTimeZone(input.timeZone),
   };
 }
 

--- a/src/types/leagues.ts
+++ b/src/types/leagues.ts
@@ -39,6 +39,7 @@ export interface League {
   status: LeagueStatus;
   description?: string;
   draftDate?: string; // ISO timestamp
+  timeZone?: string; // IANA timezone name for league scheduling
   draftType?: DraftTypeOption;
   pickOrder?: DraftPickOrder;
   waiverRule?: WaiverResetPolicy;
@@ -80,6 +81,7 @@ export interface CreateLeagueRequest {
   tradeSettings?: Partial<TradeSettings>;
   waiverWire?: Partial<WaiverWireSettings>;
   draftDate?: string;
+  timeZone?: string;
   draftType?: DraftTypeOption;
   pickOrder?: DraftPickOrder;
   waiverRule?: WaiverResetPolicy;

--- a/tests/unit/leagueCreateContract.test.ts
+++ b/tests/unit/leagueCreateContract.test.ts
@@ -20,6 +20,29 @@ describe('league creation contract', () => {
       maxTeams: 12,
       categories: [...REAL_DATA_NINE_CATEGORY_PRESET],
       visibility: 'PRIVATE',
+      timeZone: 'UTC',
+    });
+  });
+
+  it('keeps valid league creation time zones', () => {
+    expect(
+      normalizeCreateLeagueInput({
+        name: 'Test Lab Alpha',
+        timeZone: 'Australia/Melbourne',
+      })
+    ).toMatchObject({
+      timeZone: 'Australia/Melbourne',
+    });
+  });
+
+  it('defaults invalid league creation time zones to UTC', () => {
+    expect(
+      normalizeCreateLeagueInput({
+        name: 'Test Lab Alpha',
+        timeZone: 'Mars/Olympus_Mons',
+      })
+    ).toMatchObject({
+      timeZone: 'UTC',
     });
   });
 

--- a/tests/unit/leagueCreateRoute.test.ts
+++ b/tests/unit/leagueCreateRoute.test.ts
@@ -1,0 +1,127 @@
+import type { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authMocks = vi.hoisted(() => ({
+  getUserIdFromRequest: vi.fn(),
+}));
+
+const firestoreMocks = vi.hoisted(() => ({
+  batch: vi.fn(),
+  collection: vi.fn(),
+}));
+
+const membershipMocks = vi.hoisted(() => ({
+  queueLeagueMembershipSet: vi.fn(),
+}));
+
+vi.mock('@/lib/serverAuth', () => ({
+  getUserIdFromRequest: authMocks.getUserIdFromRequest,
+}));
+
+vi.mock('../../src/lib/serverAuth', () => ({
+  getUserIdFromRequest: authMocks.getUserIdFromRequest,
+}));
+
+vi.mock('@/lib/firebaseAdmin', () => ({
+  adminDb: {
+    batch: firestoreMocks.batch,
+    collection: firestoreMocks.collection,
+  },
+}));
+
+vi.mock('../../src/lib/firebaseAdmin', () => ({
+  adminDb: {
+    batch: firestoreMocks.batch,
+    collection: firestoreMocks.collection,
+  },
+}));
+
+vi.mock('@/lib/leagueMembership', () => ({
+  queueLeagueMembershipSet: membershipMocks.queueLeagueMembershipSet,
+}));
+
+vi.mock('../../src/lib/leagueMembership', () => ({
+  queueLeagueMembershipSet: membershipMocks.queueLeagueMembershipSet,
+}));
+
+describe('league creation route timezone handling', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    authMocks.getUserIdFromRequest.mockResolvedValue('owner-user');
+    membershipMocks.queueLeagueMembershipSet.mockReturnValue('league-1_owner-user');
+  });
+
+  it('persists a valid IANA time zone for created leagues', async () => {
+    const { batch } = mockLeagueCreateFirestore();
+
+    const { POST } = await import('../../src/app/api/leagues/route');
+    const response = await POST(
+      jsonRequest('/api/leagues', {
+        name: 'Timezone Keepers',
+        maxTeams: 12,
+        categories: ['goals', 'marks', 'tackles'],
+        timeZone: 'Australia/Melbourne',
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(batch.set).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'league-1' }),
+      expect.objectContaining({ timeZone: 'Australia/Melbourne' })
+    );
+  });
+
+  it('defaults invalid create-route time zones to UTC before persistence', async () => {
+    const { batch } = mockLeagueCreateFirestore();
+
+    const { POST } = await import('../../src/app/api/leagues/route');
+    const response = await POST(
+      jsonRequest('/api/leagues', {
+        name: 'Fallback Keepers',
+        maxTeams: 12,
+        categories: ['goals', 'marks', 'tackles'],
+        timeZone: 'Mars/Olympus_Mons',
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(batch.set).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'league-1' }),
+      expect.objectContaining({ timeZone: 'UTC' })
+    );
+  });
+});
+
+function mockLeagueCreateFirestore() {
+  const batch = {
+    commit: vi.fn().mockResolvedValue(undefined),
+    set: vi.fn(),
+  };
+  const get = vi.fn().mockResolvedValue({ empty: true });
+  const limit = vi.fn(() => ({ get }));
+  const where = vi.fn(() => ({ limit }));
+  const doc = vi.fn(() => ({ id: 'league-1' }));
+
+  firestoreMocks.batch.mockReturnValue(batch);
+  firestoreMocks.collection.mockImplementation((collectionName: string) => {
+    if (collectionName === 'leagues') {
+      return { doc, where };
+    }
+
+    throw new Error(`Unexpected collection access: ${collectionName}`);
+  });
+
+  return { batch, doc, get, limit, where };
+}
+
+function jsonRequest(path: string, body: unknown): NextRequest {
+  return new Request(`https://statly.test${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}


### PR DESCRIPTION
## Summary

- Adds validated timezone normalization to the league creation contract, defaulting invalid or missing values to `UTC`.
- Persists the normalized timezone when creating leagues through `POST /api/leagues`.
- Adds a timezone selector to the active new-league form and converts `datetime-local` draft input using the selected timezone.
- Adds focused regression coverage for contract normalization and route persistence.

## Verification

- `npm exec -- prettier --check 'src/app/(app)/leagues/new/page.tsx' src/app/api/leagues/route.ts src/server/leagues/createLeagueContract.ts src/types/leagues.ts tests/unit/leagueCreateContract.test.ts tests/unit/leagueCreateRoute.test.ts`
- `npm exec -- eslint 'src/app/(app)/leagues/new/page.tsx' src/app/api/leagues/route.ts src/server/leagues/createLeagueContract.ts src/types/leagues.ts tests/unit/leagueCreateContract.test.ts tests/unit/leagueCreateRoute.test.ts`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/leagueCreateContract.test.ts tests/unit/leagueCreateRoute.test.ts --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

- Rebuilt from current `main`; old #238 was used as historical evidence only.
- No protected, local, generated, database, env, Firebase, or secret files touched.
- No database-backed browser/local smoke was needed for this contract/API/form boundary.

## Summary by Sourcery

Normalize and persist league time zones across the creation flow and update the UI to capture and convert draft dates using the selected IANA time zone.

New Features:
- Add time zone selection to the new league creation form, defaulting to the detected browser time zone and including common options.
- Include a timeZone field on league and create-league request types to support time zone–aware scheduling.

Bug Fixes:
- Ensure invalid or missing timeZone values in league creation requests are normalized to UTC before persistence.

Enhancements:
- Normalize league creation time zones using Intl-based validation in the createLeagueContract and store the normalized value in created league documents.

Tests:
- Add unit tests for league creation contract time zone normalization and for the leagues API route to verify correct time zone persistence and UTC fallback behavior.