### PR TITLE
fix: sort realtime top picks

### DIFF
--- a/src/components/dashboard/TopPicksModule.client.tsx
+++ b/src/components/dashboard/TopPicksModule.client.tsx
@@ -17,13 +17,11 @@ export default function TopPicksModuleClient({ socket }: TopPicksModuleClientPro
   const { data: playerStats, loading, error, refetch } = usePlayerStatsETL('2025');
 
   // Derived data must be computed before any early returns to obey Hooks rules
-  const filteredPlayers = useMemo(
-    () =>
-      (playerStats ?? []).filter(
-        (player) => player.totalValue && !Number.isNaN(player.totalValue) && player.categories
-      ),
-    [playerStats]
-  );
+  const filteredPlayers = useMemo(() => {
+    return (playerStats ?? []).filter(
+      (player) => Number.isFinite(player.totalValue) && player.categories != null
+    );
+  }, [playerStats]);
 
   useEffect(() => {
     if (!socket) return;
@@ -125,7 +123,7 @@ function DataFocusedTopPicks({
   limit?: number;
 }) {
   const reduceMotion = useReducedMotion();
-  const topPlayers = players.slice(0, limit);
+  const topPlayers = [...players].sort((a, b) => b.totalValue - a.totalValue).slice(0, limit);
 
   return (
     <div
@@ -148,7 +146,7 @@ function DataFocusedTopPicks({
       <div className="space-y-3">
         {topPlayers.map((player, index) => (
           <motion.div
-            key={player.id}
+            key={player.player_id}
             initial={reduceMotion ? undefined : { opacity: 0, x: -20 }}
             animate={reduceMotion ? undefined : { opacity: 1, x: 0 }}
             transition={reduceMotion ? undefined : { delay: index * 0.1 }}
@@ -311,11 +309,11 @@ function comparePlayerStat(a: PlayerStat, b: PlayerStat): boolean {
   const bc = (b.categories ?? {}) as NonNullable<PlayerStat['categories']>;
 
   return (
-    a.id === b.id &&
+    a.player_id === b.player_id &&
     a.player_name === b.player_name &&
     a.team === b.team &&
     a.position === b.position &&
-    (a.totalValue || 0) === (b.totalValue || 0) &&
+    a.totalValue === b.totalValue &&
     a.round_number === b.round_number &&
     a.opposition === b.opposition &&
     (ac.goals || 0) === (bc.goals || 0) &&

--- a/tests/unit/TopPicksModule.test.tsx
+++ b/tests/unit/TopPicksModule.test.tsx
@@ -1,0 +1,108 @@
+import { act, render, screen, within } from '@testing-library/react';
+import type { Socket } from 'socket.io-client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PlayerStat } from '../../src/hooks/usePlayerStats';
+import TopPicksModuleClient from '../../src/components/dashboard/TopPicksModule.client';
+
+const playerStatsMocks = vi.hoisted(() => ({
+  usePlayerStatsETL: vi.fn(),
+}));
+
+vi.mock('../../src/hooks/usePlayerStats', () => ({
+  usePlayerStatsETL: playerStatsMocks.usePlayerStatsETL,
+}));
+
+vi.mock('@/hooks/usePlayerStats', () => ({
+  usePlayerStatsETL: playerStatsMocks.usePlayerStatsETL,
+}));
+
+describe('TopPicksModuleClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sorts top picks by total value and keeps zero-value players', () => {
+    playerStatsMocks.usePlayerStatsETL.mockReturnValue({
+      data: [
+        playerStat({ player_id: 'zero', player_name: 'Zero Value', totalValue: 0 }),
+        playerStat({ player_id: 'high', player_name: 'High Value', totalValue: 42 }),
+        playerStat({ player_id: 'mid', player_name: 'Mid Value', totalValue: 7 }),
+      ],
+      error: null,
+      loading: false,
+      refetch: vi.fn(),
+    });
+
+    render(<TopPicksModuleClient socket={null} />);
+
+    const rows = screen.getAllByRole('listitem');
+    expect(within(rows[0]).getByText('High Value')).toBeInTheDocument();
+    expect(within(rows[1]).getByText('Mid Value')).toBeInTheDocument();
+    expect(within(rows[2]).getByText('Zero Value')).toBeInTheDocument();
+  });
+
+  it('refetches when the top picks realtime event arrives', () => {
+    const refetch = vi.fn();
+    const socketHandlers = new Map<string, () => void>();
+    const socket = {
+      off: vi.fn(),
+      on: vi.fn((event: string, handler: () => void) => {
+        socketHandlers.set(event, handler);
+      }),
+    } as unknown as Socket;
+
+    playerStatsMocks.usePlayerStatsETL.mockReturnValue({
+      data: [playerStat({ player_id: 'high', player_name: 'High Value', totalValue: 42 })],
+      error: null,
+      loading: false,
+      refetch,
+    });
+
+    render(<TopPicksModuleClient socket={socket} />);
+
+    act(() => {
+      socketHandlers.get('top-picks:update')?.();
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(socket.on).toHaveBeenCalledWith('top-picks:update', expect.any(Function));
+  });
+});
+
+function playerStat(overrides: Partial<PlayerStat>): PlayerStat {
+  return {
+    behinds: 0,
+    categories: {
+      contestedMarks: 0,
+      contestedPossessions: 0,
+      effectiveDisposals: 0,
+      goals: 0,
+      inside50s: 0,
+      intercepts: 0,
+      rebound50s: 0,
+      scoreInvolvements: 0,
+      tackles: 0,
+    },
+    fantasy_points: 0,
+    goals: 0,
+    id: overrides.player_id ?? 'player-id',
+    match_id: 'match-1',
+    opposition: 'OPP',
+    perGameLog: {} as PlayerStat['perGameLog'],
+    player_id: 'player-id',
+    player_name: 'Player Name',
+    position: 'MID',
+    round_number: 1,
+    season: 2026,
+    tackles: 0,
+    team: 'STAT',
+    tenthCell: {
+      label: 'SI',
+      type: 'count',
+      value: 0,
+    },
+    totalValue: 0,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

- Rebuilds the useful dashboard/realtime intent from current `main` as a narrow top-picks correctness fix.
- Keeps valid `totalValue: 0` player rows in the realtime top-picks module.
- Sorts displayed top picks by `totalValue` before applying the display limit.
- Uses `player_id` as the stable player identity for render keys and memo comparison.
- Adds focused component coverage for sorting, zero-value retention, and `top-picks:update` refetch behavior.

## Verification

- `npm exec -- prettier --check src/components/dashboard/TopPicksModule.client.tsx tests/unit/TopPicksModule.test.tsx`
- `npm exec -- eslint src/components/dashboard/TopPicksModule.client.tsx tests/unit/TopPicksModule.test.tsx`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/TopPicksModule.test.tsx --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

- Rebuilt from current `main`; old #313 and #388 were used as historical evidence only.
- Current `main` already contains the core SocketProvider exposure/error-handling path from old #388.
- No socket server, dashboard shell, deployment, Prisma, database, env, secret, generated, or protected files touched.

## Summary by Sourcery

Fix realtime dashboard top picks ordering and player identity handling while adding focused test coverage.

Bug Fixes:
- Include players with zero totalValue in the realtime top picks list.
- Sort realtime top picks by totalValue before applying the display limit to ensure correct ordering.
- Use player_id as the stable identifier for top picks rendering and memoization comparisons.

Tests:
- Add unit tests covering top picks sorting, zero-totalValue player retention, and realtime top-picks:update refetch behavior.