### PR TITLE
fix: preserve invite code onboarding

### DIFF
--- a/src/app/(app)/leagues/join/page.tsx
+++ b/src/app/(app)/leagues/join/page.tsx
@@ -8,6 +8,26 @@ import { CalendarPlus, CheckCircle2, ChevronLeft, KeyRound, Loader2, UserPlus } 
 import { useAuth } from '@/AuthContext';
 import { fetchApi } from '@/lib/api';
 import { AppLayout } from '@/components/navigation';
+import { LEAGUE_CONSTRAINTS } from '@/types/leagues';
+
+function normalizeInviteCode(value: string): string {
+  return value
+    .replace(/[^a-z0-9]/gi, '')
+    .toUpperCase()
+    .slice(0, LEAGUE_CONSTRAINTS.code.length);
+}
+
+function trimInviteTeamName(value: string): string {
+  return value.slice(0, LEAGUE_CONSTRAINTS.teamName.maxLength);
+}
+
+function buildJoinReturnPath(code: string, teamName: string): string {
+  const params = new URLSearchParams();
+  if (code) params.set('code', code);
+  if (teamName) params.set('team', teamName);
+  const query = params.toString();
+  return query ? `/leagues/join?${query}` : '/leagues/join';
+}
 
 export default function JoinLeaguePage() {
   const [code, setCode] = useState('');
@@ -27,12 +47,18 @@ export default function JoinLeaguePage() {
     const urlCode = searchParams?.get('code');
     const urlTeam = searchParams?.get('team');
     if (urlCode) {
-      setCode(urlCode.toUpperCase());
+      setCode(normalizeInviteCode(urlCode));
     }
     if (urlTeam) {
-      setTeamName(urlTeam);
+      setTeamName(trimInviteTeamName(urlTeam));
     }
   }, [searchParams]);
+
+  const searchCode = normalizeInviteCode(searchParams?.get('code') || '');
+  const searchTeamName = trimInviteTeamName(searchParams?.get('team') || '');
+  const loginHref = `/login?next=${encodeURIComponent(
+    buildJoinReturnPath(code || searchCode, teamName || searchTeamName)
+  )}`;
 
   const handleJoinLeague = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -54,7 +80,7 @@ export default function JoinLeaguePage() {
       const result = await fetchApi('leagues/join', {
         method: 'POST',
         body: JSON.stringify({
-          code: code.trim().toUpperCase(),
+          code: normalizeInviteCode(code),
           teamName: teamName.trim() || undefined,
         }),
         headers: {
@@ -98,7 +124,7 @@ export default function JoinLeaguePage() {
               Log in to accept an invite code and attach your team to a league.
             </p>
             <Link
-              href="/login"
+              href={loginHref}
               className="mt-5 inline-flex h-11 w-full items-center justify-center rounded-full bg-[color:var(--league-primary)] px-5 text-sm font-semibold text-[color:var(--league-primary-foreground)] transition hover:bg-[color:var(--league-primary-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--league-primary)] focus-visible:ring-offset-2"
             >
               Log in
@@ -188,7 +214,7 @@ export default function JoinLeaguePage() {
                   id="code"
                   type="text"
                   value={code}
-                  onChange={(e) => setCode(e.target.value.toUpperCase())}
+                  onChange={(e) => setCode(normalizeInviteCode(e.target.value))}
                   placeholder="ABC123"
                   maxLength={8}
                   className="mt-2 h-12 w-full rounded-2xl border border-[color:var(--league-border)] bg-[color:var(--league-page)] px-3 text-center font-mono text-lg font-semibold tracking-[0.2em] text-[color:var(--league-text)] outline-none transition placeholder:tracking-normal placeholder:text-[color:var(--league-text-muted)] focus:border-[color:var(--league-primary)] focus:ring-2 focus:ring-[color:var(--league-primary)]/20"

--- a/src/app/api/leagues/join/route.ts
+++ b/src/app/api/leagues/join/route.ts
@@ -14,6 +14,10 @@ import { REAL_DATA_NINE_CATEGORY_PRESET } from '@/types/fantasyCategories';
 
 export const runtime = 'nodejs';
 
+function normalizeInviteCode(code: string): string {
+  return code.replace(/[^a-z0-9]/gi, '').toUpperCase();
+}
+
 // POST /api/leagues/join - Join league by code
 export async function POST(req: NextRequest) {
   const userId = await getUserIdFromRequest(req);
@@ -30,12 +34,20 @@ export async function POST(req: NextRequest) {
         { status: 400 }
       );
     }
+    const normalizedCode = normalizeInviteCode(code);
+
+    if (!normalizedCode) {
+      return NextResponse.json(
+        { success: false, error: 'League code is required' },
+        { status: 400 }
+      );
+    }
 
     // Find league by code
-    console.log('🔍 Looking for league with code:', code.toUpperCase());
+    console.log('🔍 Looking for league with code:', normalizedCode);
 
     // For testing purposes, accept "123ABC" as a test code
-    if (code.toUpperCase() === '123ABC') {
+    if (normalizedCode === '123ABC') {
       console.log('🧪 Using test mode for code 123ABC');
 
       // Create a mock league for testing
@@ -80,7 +92,7 @@ export async function POST(req: NextRequest) {
 
     const leagueSnapshot = await adminDb
       .collection('leagues')
-      .where('code', '==', code.toUpperCase())
+      .where('code', '==', normalizedCode)
       .limit(1)
       .get();
 
@@ -94,7 +106,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(
         {
           success: false,
-          error: `League with code "${code.toUpperCase()}" not found.`,
+          error: `League with code "${normalizedCode}" not found.`,
         },
         { status: 400 }
       );

--- a/tests/unit/joinLeaguePage.test.tsx
+++ b/tests/unit/joinLeaguePage.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authMocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+}));
+
+const navigationMocks = vi.hoisted(() => ({
+  useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+vi.mock('@/AuthContext', () => ({
+  useAuth: authMocks.useAuth,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: navigationMocks.useRouter,
+  useSearchParams: navigationMocks.useSearchParams,
+}));
+
+vi.mock('@/components/navigation', () => ({
+  AppLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import JoinLeaguePage from '../../src/app/(app)/leagues/join/page';
+
+describe('JoinLeaguePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMocks.useAuth.mockReturnValue({ user: null });
+    navigationMocks.useRouter.mockReturnValue({ push: vi.fn(), replace: vi.fn() });
+  });
+
+  it('preserves normalized invite code and team name through login', () => {
+    navigationMocks.useSearchParams.mockReturnValue(
+      new URLSearchParams({ code: 'ab12-cd34', team: 'Robbo Rockets' })
+    );
+
+    render(<JoinLeaguePage />);
+
+    const loginHref = screen.getByRole('link', { name: 'Log in' }).getAttribute('href');
+    expect(loginHref).toBeTruthy();
+
+    const loginUrl = new URL(loginHref ?? '', 'https://statly.test');
+    const next = loginUrl.searchParams.get('next');
+    expect(next).toBeTruthy();
+
+    const nextUrl = new URL(next ?? '', 'https://statly.test');
+    expect(nextUrl.pathname).toBe('/leagues/join');
+    expect(nextUrl.searchParams.get('code')).toBe('AB12CD34');
+    expect(nextUrl.searchParams.get('team')).toBe('Robbo Rockets');
+  });
+});

--- a/tests/unit/leagueMembershipRoutes.test.ts
+++ b/tests/unit/leagueMembershipRoutes.test.ts
@@ -189,11 +189,12 @@ describe('league membership route Firestore architecture', () => {
 
     const { POST: joinLeague } = await import('../../src/app/api/leagues/join/route');
     const response = await joinLeague(
-      jsonRequest('/api/leagues/join', { code: 'keeper', teamName: 'New Team' })
+      jsonRequest('/api/leagues/join', { code: 'kee-per', teamName: 'New Team' })
     );
     const body = await response.json();
 
     expect(response.status).toBe(201);
+    expect(leaguesCollection.where).toHaveBeenCalledWith('code', '==', 'KEEPER');
     expect(body.data.member).toMatchObject({
       id: 'league-1_joining-user',
       leagueId: 'league-1',


### PR DESCRIPTION
## Summary

- Rebuilds the useful onboarding intent from current `main` as a narrow invite-code reliability fix.
- Normalizes invite codes to uppercase alphanumeric values in the join page before display/submission.
- Preserves normalized code and team name through the logged-out login `next` URL.
- Normalizes invite codes in `POST /api/leagues/join` before test-mode and Firestore lookup.
- Adds focused regression coverage for formatted-code API lookup and logged-out login return preservation.

## Verification

- `npm exec -- prettier --check 'src/app/(app)/leagues/join/page.tsx' src/app/api/leagues/join/route.ts tests/unit/leagueMembershipRoutes.test.ts tests/unit/joinLeaguePage.test.tsx`
- `npm exec -- eslint 'src/app/(app)/leagues/join/page.tsx' src/app/api/leagues/join/route.ts tests/unit/leagueMembershipRoutes.test.ts tests/unit/joinLeaguePage.test.tsx`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/leagueMembershipRoutes.test.ts tests/unit/joinLeaguePage.test.tsx --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

- Rebuilt from current `main`; old #408, #194, and #197 were used as historical evidence only.
- The broader commissioner wizard from #194 and draft lobby chat/checklist from #197 are intentionally parked for separate scoped tasks.
- No Prisma, database, env, secret, Firebase export, generated, protected, or local stash files touched.

## Summary by Sourcery

Normalize and preserve invite codes and team names throughout the league join flow to improve reliability of onboarding from invite links.

Bug Fixes:
- Ensure invite codes are normalized before submission and API lookup so formatted or mixed-case codes are accepted consistently.
- Preserve invite code and team name through the logged-out login redirect so users return to a prefilled join league form after logging in.

Enhancements:
- Align invite code and team name length handling on the join page with shared league constraints.
- Introduce helper utilities for invite code normalization, team name trimming, and join-return path construction on the join page.

Tests:
- Add unit coverage for the join league API to verify normalized invite code lookups against Firestore and test-mode codes.
- Add unit tests for the join league page to cover invite code formatting and logged-out login return behavior.