### PR TITLE
docs: add Statly automation pack

### DIFF
--- a/docs/codex/automations/README.md
+++ b/docs/codex/automations/README.md
@@ -1,0 +1,95 @@
+# Statly Automation Pack
+
+## Purpose
+
+This directory defines the documentation-only automation setup for five
+high-impact Statly loops:
+
+1. PR Babysitter
+2. Protected File Drift Monitor
+3. Completion Contract
+4. Ticket-to-PR-Ready
+5. Temp DB Quality Streak
+
+These are copy-paste Codex automation prompts and permission models. They do not
+install automations, add dependencies, change runtime code, create package
+scripts, or enable fully autonomous repository maintenance.
+
+## Shared Rules
+
+All automations must follow:
+
+- `AGENTS.md`
+- `.agents/skills/pr-babysitter/SKILL.md`
+- `.agents/skills/repository-cleanup-loop/SKILL.md`
+- `.agents/skills/completion-contract-loop/SKILL.md`
+- `.agents/skills/ticket-to-pr-ready-loop/SKILL.md`
+- `.agents/skills/quality-streak-loop/SKILL.md`
+- `docs/codex/agent-loop-operating-model.md`
+- `docs/codex/loop-library-adoption.md`
+- `docs/codex/temporary-database-verification.md`
+
+## Protected Files
+
+No automation may touch:
+
+- `prisma/dev.db`
+- `.env` or `.env.*`
+- secrets or `serviceAccountKey.json`
+- Firebase exports
+- generated files, including `functions/lib`
+- dataconnect local data
+- `node_modules`
+- `dist`
+- `coverage`
+- `test-results`
+- local stashes
+
+## Permission Summary
+
+| Automation                   | Permission level           | Can start now?                  | Automatic writes?                           |
+| ---------------------------- | -------------------------- | ------------------------------- | ------------------------------------------- |
+| PR Babysitter                | PR-attached                | Yes                             | Only in-scope must-fix PR feedback          |
+| Protected File Drift Monitor | Read-only                  | Yes                             | No                                          |
+| Completion Contract          | Read-only / blocker        | Yes                             | No                                          |
+| Ticket-to-PR-Ready           | Task-attached writer       | Yes, for approved bounded tasks | One narrow PR only                          |
+| Temp DB Quality Streak       | Verification-only at first | Partially                       | No, until one manual temp DB smoke succeeds |
+
+## Immediate Automations
+
+These can start immediately:
+
+- PR Babysitter, because it is attached to an existing PR and cannot merge,
+  close, or broaden scope automatically.
+- Protected File Drift Monitor, because it is read-only.
+- Completion Contract, because it only classifies evidence and blocks unsupported
+  completion claims.
+- Ticket-to-PR-Ready, when the user attaches it to one approved bounded task.
+
+## Deferred Automation
+
+Temp DB Quality Streak is not fully enabled yet.
+
+It must remain non-writing until one manual local smoke succeeds using a
+disposable database under `/tmp/statly-verify-*.db`. If a command ignores
+`DATABASE_URL`, tries to use `prisma/dev.db`, or produces protected artifacts,
+the automation must stop and report residual risk.
+
+## Must Never Happen Automatically
+
+- Merging PRs.
+- Closing PRs.
+- Deleting branches.
+- Dropping, popping, applying, or editing stashes.
+- Restoring or deleting protected files.
+- Touching `prisma/dev.db`.
+- Adding dependencies.
+- Adding package scripts.
+- Creating broad cleanup or feature PRs.
+- Claiming completion without evidence.
+
+## Expected Use
+
+Each page in this directory contains a copy-paste prompt. Paste the prompt into a
+new Codex task, fill in the bracketed fields, and keep the automation scoped to
+the named PR, task, branch, or verification target.

--- a/docs/codex/automations/completion-contract.md
+++ b/docs/codex/automations/completion-contract.md
@@ -1,0 +1,124 @@
+# Completion Contract Automation
+
+## Purpose
+
+Prevent unsupported completion claims. This automation compares requested done
+criteria against evidence and classifies each criterion as proved, weak, missing,
+contradicted, blocked, or parked.
+
+## When To Run
+
+- Before final reports.
+- Before PR body verification claims.
+- Before saying work is complete, fixed, ready, or merged.
+- After checks finish.
+- When browser/API/local smoke was skipped.
+
+## Cadence
+
+- At the end of every implementation task.
+- After PR babysitting.
+- Before closing a thread or handing off follow-up work.
+
+## Permission Level
+
+Read-only / blocker.
+
+Allowed:
+
+- Inspect local status, diffs, checks, and command outputs.
+- Compare evidence to the user's done criteria.
+- Mark missing evidence as residual risk.
+- Block completion claims.
+
+## Prohibited Actions
+
+- Do not edit files.
+- Do not invent evidence.
+- Do not run broad extra checks unless the task already approved them.
+- Do not claim completion when evidence is weak, missing, or contradicted.
+
+## Protected-File Restrictions
+
+Never touch protected paths listed in `docs/codex/automations/README.md`.
+
+## Stop Conditions
+
+- A done criterion has no evidence.
+- Evidence contradicts the claim.
+- Verification would mutate protected state.
+- Local status includes unexpected dirty files.
+- The task is parked rather than complete.
+
+## Copy-Paste Codex Automation Prompt
+
+```text
+Use Plan mode first.
+
+Use:
+- AGENTS.md
+- .agents/skills/completion-contract-loop/SKILL.md
+- docs/codex/agent-loop-operating-model.md
+- docs/codex/loop-library-adoption.md
+
+Task:
+Run the Completion Contract automation for [TASK_OR_PR].
+
+Permission level:
+Read-only / blocker. Do not edit files.
+
+Done criteria to verify:
+[PASTE_DONE_CRITERIA]
+
+Evidence available:
+[PASTE_COMMANDS_CHECKS_PR_STATUS_OR_NOTES]
+
+Classify each criterion as:
+- proved
+- weak
+- missing
+- contradicted
+- blocked
+- parked
+
+Report:
+- evidence for each proved criterion
+- residual risk for weak or skipped checks
+- exact blocker for missing or contradicted evidence
+- whether completion may be claimed
+
+Never:
+- invent evidence
+- claim completion without evidence
+- edit files
+- touch protected/local/generated files
+- touch local stashes
+```
+
+## Expected Report Format
+
+```text
+Completion decision: [claim allowed / blocked / parked]
+
+Criteria:
+- [criterion]: [proved / weak / missing / contradicted / blocked / parked]
+  Evidence: [command, PR status, file diff, browser/API result, or none]
+  Residual risk: [none or note]
+
+Protected files: [untouched / risk]
+Local status: [clean / dirty]
+Next action: [claim completion / run missing check / park / ask user]
+```
+
+## Requires Human Approval
+
+- Expanding scope to satisfy missing evidence.
+- Running stateful browser/API checks that may mutate data.
+- Converting a parked task into implementation.
+
+## Must Never Happen Automatically
+
+- Claim completion without proof.
+- Treat passing council output as verification.
+- Edit runtime or docs from final-report mode.
+- Touch protected files or local stashes.

--- a/docs/codex/automations/pr-babysitter.md
+++ b/docs/codex/automations/pr-babysitter.md
@@ -1,0 +1,145 @@
+# PR Babysitter Automation
+
+## Purpose
+
+Keep one Statly PR moving without broadening scope. This automation inspects
+checks, review comments, changed files, and merge blockers. It may fix only
+must-fix review comments that are inside the existing PR boundary.
+
+## When To Run
+
+- After opening a PR.
+- After CI starts or finishes.
+- After CodeRabbit, Sourcery, DeepSource, GitGuardian, CodeFactor, or a human
+  reviewer comments.
+- Before asking a human to merge.
+
+## Cadence
+
+- On PR creation.
+- After every new commit to the PR.
+- After every review-bot pass.
+- Before merge readiness is reported.
+
+## Permission Level
+
+PR-attached.
+
+Allowed:
+
+- Inspect the named PR.
+- Inspect CI/check status and review comments.
+- Inspect the PR diff against `main`.
+- Fix must-fix comments only inside the existing PR scope.
+- Push a follow-up commit only after the normal Statly checks and Council
+  Decision 2.
+
+## Prohibited Actions
+
+- Do not merge automatically.
+- Do not close PRs automatically.
+- Do not broaden scope.
+- Do not start feature work.
+- Do not edit files outside the existing PR boundary unless a must-fix comment
+  proves the boundary file is required.
+- Do not delete branches.
+
+## Protected-File Restrictions
+
+Never touch protected paths listed in `docs/codex/automations/README.md`.
+
+## Stop Conditions
+
+- A must-fix comment would broaden the PR.
+- A required fix touches protected files.
+- Checks fail for unclear infrastructure reasons.
+- Local status contains unrelated dirty files.
+- The PR is no longer based on current `main` and needs human merge/rebase
+  judgment.
+
+## Copy-Paste Codex Automation Prompt
+
+```text
+Use Plan mode first.
+
+Use:
+- AGENTS.md
+- .agents/skills/pr-babysitter/SKILL.md
+- .agents/skills/completion-contract-loop/SKILL.md
+- docs/codex/agent-loop-operating-model.md
+- docs/codex/loop-library-adoption.md
+
+Task:
+Run the PR Babysitter automation for PR [PR_NUMBER_OR_URL].
+
+Permission level:
+PR-attached. Do not merge. Do not close. Do not broaden scope.
+
+Inspect:
+- PR title/body
+- base/head branches
+- changed files
+- CI/check status
+- CodeRabbit comments
+- Sourcery comments
+- DeepSource/GitGuardian/CodeFactor status
+- PR diff against main
+- local branch status if relevant
+
+Classify findings:
+- must fix before merge
+- optional but safe
+- ignore/noise
+- residual risk
+
+If must-fix comments exist:
+- show the narrow edit plan first
+- edit only files already in the PR boundary unless clearly required
+- run targeted verification for touched files
+- run git diff --check
+- run Council Decision 2 before commit
+- push only the reviewed fix
+
+If no must-fix comments exist:
+- report ready for human merge consideration
+- do not edit files
+
+Never:
+- merge automatically
+- close automatically
+- delete branches
+- touch protected/local/generated files
+- touch local stashes
+```
+
+## Expected Report Format
+
+```text
+PR: [number/title]
+Status: [ready / needs fix / blocked / residual risk]
+Checks: [pass/fail/pending summary]
+Review bots: [CodeRabbit/Sourcery/DeepSource/GitGuardian/CodeFactor]
+Must-fix findings: [none or list]
+Optional findings: [none or list]
+Residual risk: [none or list]
+Files changed by babysitter: [none or list]
+Verification run: [commands]
+Next human action: [merge / review / rerun / decide scope]
+```
+
+## Requires Human Approval
+
+- Merging.
+- Closing.
+- Broadening scope.
+- Rebase/merge conflict resolution.
+- Touching files outside the PR boundary.
+
+## Must Never Happen Automatically
+
+- Merge a PR.
+- Close a PR.
+- Delete a branch.
+- Touch protected files.
+- Touch local stashes.
+- Convert optional suggestions into scope expansion.

--- a/docs/codex/automations/protected-file-drift-monitor.md
+++ b/docs/codex/automations/protected-file-drift-monitor.md
@@ -1,0 +1,120 @@
+# Protected File Drift Monitor Automation
+
+## Purpose
+
+Detect protected-file drift before it reaches a PR, commit, merge, or final
+completion claim. This automation is read-only and reports risk only.
+
+## When To Run
+
+- Before commit.
+- Before PR creation.
+- Before merge.
+- After local smoke or browser/API verification.
+- Any time protected local state is mentioned.
+
+## Cadence
+
+- At the start and end of risky runtime tasks.
+- After running any command that may create, seed, migrate, build, or test.
+- Before every final report that claims protected files were untouched.
+
+## Permission Level
+
+Read-only.
+
+Allowed:
+
+- Inspect `git status`.
+- Inspect protected path status.
+- List local stashes.
+- Report protected-file risk.
+
+## Prohibited Actions
+
+- Do not restore files.
+- Do not stash files.
+- Do not delete files.
+- Do not edit files.
+- Do not close PRs.
+- Do not merge PRs.
+- Do not delete branches.
+
+## Protected-File Restrictions
+
+Never touch protected paths listed in `docs/codex/automations/README.md`.
+
+## Stop Conditions
+
+- A protected path appears dirty.
+- A command would need to inspect secrets.
+- A command would mutate protected files.
+- Local status includes unexpected files.
+
+## Copy-Paste Codex Automation Prompt
+
+```text
+Use Plan mode first.
+
+Use:
+- AGENTS.md
+- .agents/skills/repository-cleanup-loop/SKILL.md
+- .agents/skills/completion-contract-loop/SKILL.md
+- docs/codex/agent-loop-operating-model.md
+- docs/codex/loop-library-adoption.md
+
+Task:
+Run the Protected File Drift Monitor automation.
+
+Permission level:
+Read-only. Do not edit, restore, stash, delete, close, merge, or push anything.
+
+Inspect:
+- git status --short --branch
+- git status --short -- prisma/dev.db
+- git status --short -- .env .env.* serviceAccountKey.json
+- git status --short -- functions/lib dataconnect node_modules dist coverage test-results
+- git stash list | head -5
+
+Report:
+- current branch
+- whether protected paths are clean
+- whether local stashes were untouched
+- any unexpected dirty files
+- stop condition if any protected path appears
+
+Never:
+- restore files
+- stash files
+- delete files
+- edit files
+- touch local stashes
+- touch protected/local/generated files
+```
+
+## Expected Report Format
+
+```text
+Branch: [branch]
+Workspace status: [clean / dirty]
+Protected path status: [clean / risk]
+Protected paths with changes: [none or list]
+Local stash status: [untouched, top stash shown]
+Stop condition: [none or reason]
+Next action: [continue / stop and ask user]
+```
+
+## Requires Human Approval
+
+- Any cleanup action.
+- Any restore action.
+- Any stash action.
+- Any branch deletion.
+- Any protected-file edit.
+
+## Must Never Happen Automatically
+
+- Restore, stash, delete, or edit files.
+- Apply or drop stashes.
+- Close or merge PRs.
+- Hide protected drift by cleaning it up silently.

--- a/docs/codex/automations/temp-db-quality-streak.md
+++ b/docs/codex/automations/temp-db-quality-streak.md
@@ -1,0 +1,139 @@
+# Temp DB Quality Streak Automation
+
+## Purpose
+
+Run repeatable Statly quality checks that need a disposable database without
+mutating protected local state. This automation is verification-only at first.
+
+## When To Run
+
+- A PR needs browser/API/local smoke that creates or mutates data.
+- A previous PR skipped full local smoke because `prisma/dev.db` was protected.
+- A risky runtime PR needs repeated quality evidence against safe fixtures.
+
+## Cadence
+
+- After one manual temp DB smoke succeeds.
+- Before merging runtime PRs that need local browser/API evidence.
+- During flaky or stateful verification follow-up.
+
+## Permission Level
+
+Test/verification only at first.
+
+Allowed now:
+
+- Plan the quality streak.
+- Inspect safe check configs.
+- Use `/tmp/statly-verify-*.db` for read-only or explicitly safe verification.
+- Report skipped checks and residual risk.
+
+Deferred:
+
+- Writing smoke flows remain disabled until one manual temp DB smoke succeeds.
+
+## Prohibited Actions
+
+- Do not mutate protected local state.
+- Do not use `prisma/dev.db`.
+- Do not continue if `DATABASE_URL` is ignored.
+- Do not add package scripts.
+- Do not change runtime code.
+- Do not treat a failed smoke as permission to broaden scope.
+
+## Protected-File Restrictions
+
+Never touch protected paths listed in `docs/codex/automations/README.md`.
+
+## Stop Conditions
+
+- `DATABASE_URL` is missing.
+- `DATABASE_URL` points inside the repository.
+- A script prints, reads, or writes `prisma/dev.db`.
+- `git status --short -- prisma/dev.db` shows a change.
+- Generated files, Firebase exports, dataconnect local data, `coverage`, or
+  `test-results` appear.
+- A command asks for real secrets or production credentials.
+
+## Copy-Paste Codex Automation Prompt
+
+```text
+Use Plan mode first.
+
+Use:
+- AGENTS.md
+- .agents/skills/quality-streak-loop/SKILL.md
+- .agents/skills/completion-contract-loop/SKILL.md
+- docs/codex/temporary-database-verification.md
+- docs/codex/agent-loop-operating-model.md
+- docs/codex/loop-library-adoption.md
+
+Task:
+Run the Temp DB Quality Streak automation for [PR_OR_BRANCH].
+
+Permission level:
+Verification-only. Remain non-writing until one manual temp DB smoke has already succeeded.
+
+Before running:
+- confirm git status --short --branch
+- confirm git status --short -- prisma/dev.db has no output
+- set STATLY_VERIFY_DB to /tmp/statly-verify-*.db
+- set DATABASE_URL=file://${STATLY_VERIFY_DB}
+- confirm DATABASE_URL does not point inside the repo
+- define the check streak and stop conditions
+
+Allowed checks:
+[LIST_SAFE_COMMANDS]
+
+Stop immediately if:
+- DATABASE_URL is ignored
+- prisma/dev.db changes
+- protected/generated/local files appear
+- secrets are required
+- the check needs product/runtime changes
+
+Report:
+- temp DB path
+- commands run
+- pass/fail results
+- confirmation prisma/dev.db was unchanged
+- skipped checks and residual risk
+
+Never:
+- mutate protected local state
+- touch local stashes
+- add scripts or dependencies
+- edit runtime code
+- continue after a stop condition
+```
+
+## Expected Report Format
+
+```text
+Target: [PR/branch]
+Mode: [planning only / read-only verification / manual temp smoke verified]
+Temp DB path: [/tmp/statly-verify-*.db or none]
+Commands: [list]
+Results: [pass/fail/skipped]
+prisma/dev.db status before: [clean/risk]
+prisma/dev.db status after: [clean/risk]
+Protected artifacts: [none or list]
+Residual risk: [none or list]
+Next action: [continue / stop / manual smoke required]
+```
+
+## Requires Human Approval
+
+- Enabling write-capable smoke runs.
+- Running long local full-stack smoke.
+- Expanding verification into implementation.
+- Keeping or deleting temporary artifacts.
+
+## Must Never Happen Automatically
+
+- Mutate `prisma/dev.db`.
+- Touch local stashes.
+- Add package scripts.
+- Add dependencies.
+- Delete existing files or branches.
+- Continue after `DATABASE_URL` or protected-file drift fails.

--- a/docs/codex/automations/ticket-to-pr-ready.md
+++ b/docs/codex/automations/ticket-to-pr-ready.md
@@ -1,0 +1,134 @@
+# Ticket-to-PR-Ready Automation
+
+## Purpose
+
+Turn one approved Statly ticket, issue, stale PR intent, or user prompt into one
+narrow PR from current `main`.
+
+## When To Run
+
+- A user approves one bounded implementation task.
+- A stale PR has useful intent but should be rebuilt from current `main`.
+- A bug has a reproducible or clearly identified failing path.
+
+## Cadence
+
+- One run per bounded task.
+- Do not start a second task until the current PR is merged, closed, or
+  explicitly parked.
+
+## Permission Level
+
+Task-attached writer.
+
+Allowed:
+
+- Inspect current code, docs, tests, and historical PRs as evidence.
+- Reproduce or clearly identify the failing path.
+- Implement one approved bounded task.
+- Add focused tests and docs needed for that task.
+- Open one narrow PR.
+
+## Prohibited Actions
+
+- Do not mix unrelated work.
+- Do not rebase, cherry-pick, or merge old branches.
+- Do not copy broad diffs from old PRs.
+- Do not start from a non-main base.
+- Do not add dependencies.
+- Do not delete branches.
+
+## Protected-File Restrictions
+
+Never touch protected paths listed in `docs/codex/automations/README.md`.
+
+## Stop Conditions
+
+- No failing or uncertain path can be identified.
+- The fix requires broad product judgment.
+- The edit boundary spans unrelated product areas.
+- Verification would mutate `prisma/dev.db`.
+- A required change touches protected files.
+- Local status becomes unexpectedly dirty.
+
+## Copy-Paste Codex Automation Prompt
+
+```text
+Use Plan mode first.
+
+Use:
+- AGENTS.md
+- .agents/skills/ticket-to-pr-ready-loop/SKILL.md
+- .agents/skills/completion-contract-loop/SKILL.md
+- .agents/skills/quality-streak-loop/SKILL.md where relevant
+- docs/codex/agent-loop-operating-model.md
+- docs/codex/loop-library-adoption.md
+- docs/codex/temporary-database-verification.md where relevant
+
+Task:
+Run the Ticket-to-PR-Ready automation for [TASK_NAME].
+
+Historical evidence only:
+[OLD_PRS_OR_DOCS]
+
+Goal:
+[ONE_BOUND_TASK_GOAL]
+
+Before editing:
+- confirm current main and clean status
+- identify active files/routes/components/services
+- reproduce or clearly identify the failing/uncertain path
+- identify the smallest implementation boundary
+- show proposed file list
+- show edit plan
+- identify tests and verification
+- run Council Decision 1 for substantive runtime/test work
+
+Implementation:
+- edit only the approved boundary
+- add focused regression coverage
+- run targeted verification
+- run git diff --check
+- run Council Decision 2 before commit
+- open one narrow PR
+
+Never:
+- mix unrelated work
+- copy broad old diffs
+- touch protected/local/generated files
+- touch local stashes
+- mutate prisma/dev.db
+- add dependencies
+```
+
+## Expected Report Format
+
+```text
+Task: [name]
+Decision: [PR opened / parked / blocked]
+Failing or uncertain path: [path]
+Edit boundary: [files]
+Changed files: [files]
+Verification: [commands and results]
+PR: [URL or not created]
+Residual risk: [none or list]
+Protected files: [untouched / risk]
+Next action: [babysit PR / merge after checks / split / ask user]
+```
+
+## Requires Human Approval
+
+- Starting the task.
+- Broadening scope.
+- Touching files outside the approved boundary.
+- Merging the resulting PR.
+- Closing superseded source PRs.
+
+## Must Never Happen Automatically
+
+- Start new feature work without a bounded task.
+- Merge or close PRs.
+- Delete branches.
+- Touch protected files.
+- Touch local stashes.
+- Claim success without verification.


### PR DESCRIPTION
## Summary

- Adds documentation for the first Statly automation pack.
- Covers PR Babysitter, Protected File Drift Monitor, Completion Contract, Ticket-to-PR-Ready, and Temp DB Quality Streak.
- Defines purpose, cadence, permission model, prohibited actions, protected-file restrictions, stop conditions, expected report format, and copy-paste Codex prompts.
- Keeps automations bounded and explicit rather than enabling broad autonomous repository maintenance.

## Verification

- `npm exec -- prettier --check docs/codex/automations/*.md`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

- Documentation-only change.
- No runtime code changed.
- No package scripts or dependencies changed.
- No protected, local, generated, database, env, Firebase, or secret files touched.
- Local `prisma/dev.db` stash was not touched.

## Summary by Sourcery

Add documentation for the Statly automation pack covering five bounded automation loops and their permission models.

Documentation:
- Document PR Babysitter automation, including purpose, cadence, permissions, prohibitions, stop conditions, prompts, and reporting format.
- Document Protected File Drift Monitor automation as a read-only safeguard for protected paths and local stashes.
- Document Completion Contract automation for evidence-based completion claims and residual risk reporting.
- Document Ticket-to-PR-Ready automation for turning a bounded task into a narrow PR from current main with strict scope limits.
- Document Temp DB Quality Streak automation for disposable-database verification with strict protections around prisma/dev.db and local state.
- Introduce a shared Statly Automation Pack README detailing common rules, protected files, and permission summary across all automations.