### PR TITLE
docs: document temp db precreation

### DIFF
--- a/docs/codex/temporary-database-verification.md
+++ b/docs/codex/temporary-database-verification.md
@@ -48,11 +48,17 @@ Use a disposable SQLite database under `/tmp`:
 ```bash
 export STATLY_VERIFY_DB="/tmp/statly-verify-$(date +%Y%m%d%H%M%S).db"
 export DATABASE_URL="file://${STATLY_VERIFY_DB}"
+: > "$STATLY_VERIFY_DB"
 echo "STATLY_VERIFY_DB=${STATLY_VERIFY_DB}"
 ```
 
 Do not use `file:./prisma/dev.db`, `file:prisma/dev.db`, or any path inside the
 repository for destructive smoke verification.
+
+The explicit `: > "$STATLY_VERIFY_DB"` step creates an empty SQLite file before
+Prisma schema setup. This avoids a generic Prisma schema-engine error observed
+when `db push` or `migrate deploy` targets a missing absolute `/tmp` database
+file.
 
 ## Local Full-Stack Smoke
 
@@ -65,6 +71,7 @@ Terminal 1:
 ```bash
 export STATLY_VERIFY_DB="/tmp/statly-verify-$(date +%Y%m%d%H%M%S).db"
 export DATABASE_URL="file://${STATLY_VERIFY_DB}"
+: > "$STATLY_VERIFY_DB"
 echo "STATLY_VERIFY_DB=${STATLY_VERIFY_DB}"
 npm run dev:full:local
 ```


### PR DESCRIPTION
## Summary

- Documents that temporary SQLite verification DB files must be pre-created before Prisma schema setup.
- Adds the proven `: > "$STATLY_VERIFY_DB"` step to the temporary database verification runbook.
- Explains the v1 blocker: Prisma `db push` and `migrate deploy` target the `/tmp` DB correctly but can fail with a generic schema-engine error when the absolute SQLite file does not already exist.

## Verification

- `npm exec -- prettier --check docs/codex/temporary-database-verification.md`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

- Documentation-only change.
- No runtime code changed.
- No package scripts, Prisma schema, env files, generated files, local databases, or stashes touched.
- `prisma/dev.db` remained unchanged.

## Summary by Sourcery

Document precreation of temporary SQLite verification databases to avoid Prisma schema-engine errors when targeting /tmp databases.

Documentation:
- Add a step to the temporary database verification runbook to precreate the SQLite file with ': > "$STATLY_VERIFY_DB"'.
- Explain that precreating the /tmp SQLite file prevents generic Prisma schema-engine errors when running 'db push' or 'migrate deploy' against a non-existent absolute database path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated runbook documentation for temporary database verification processes with improved setup instructions. Added explicit steps for creating disposable SQLite database files before Prisma initialization to prevent initialization errors and enhance reliability of verification workflows across local full-stack smoke testing and other verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->