### PR TITLE
feat: add player data convergence diagnostic

### DIFF
--- a/src/server/playerDataConvergenceDiagnostic.ts
+++ b/src/server/playerDataConvergenceDiagnostic.ts
@@ -244,135 +244,200 @@ function recommendNextAction(severity: PlayerDataConvergenceSeverity): string {
   return 'No convergence blockers detected in these in-memory fixtures; Phase 2 temp DB dry-run can be planned when real data is loaded safely.';
 }
 
+type CanonicalIndexes = ReturnType<typeof buildCanonicalIndexes>;
+
+type DiagnosticAccumulator = {
+  matches: PlayerDataRecordMatch[];
+  unmatchedSourceRecords: PlayerDataUnmatchedSourceRecord[];
+  ambiguousNameMatches: PlayerDataAmbiguousNameMatch[];
+  missingExpectedCategoryValues: PlayerDataMissingCategoryValue[];
+  deprecatedCategoryKeys: PlayerDataDeprecatedCategoryKey[];
+  sourceIdentityIndexes: Map<string, number[]>;
+  matchedCanonicalIds: Set<string>;
+  categoryCoverageCounts: Map<string, number>;
+};
+
+function createAccumulator(expectedCategoryKeys: readonly string[]): DiagnosticAccumulator {
+  return {
+    matches: [],
+    unmatchedSourceRecords: [],
+    ambiguousNameMatches: [],
+    missingExpectedCategoryValues: [],
+    deprecatedCategoryKeys: [],
+    sourceIdentityIndexes: new Map<string, number[]>(),
+    matchedCanonicalIds: new Set<string>(),
+    categoryCoverageCounts: new Map(expectedCategoryKeys.map((key) => [key, 0])),
+  };
+}
+
+function trackSourceIdentity(
+  sourceIdentityIndexes: Map<string, number[]>,
+  identity: string,
+  sourceIndex: number
+): void {
+  const identityIndexes = sourceIdentityIndexes.get(identity) ?? [];
+  identityIndexes.push(sourceIndex);
+  sourceIdentityIndexes.set(identity, identityIndexes);
+}
+
+function collectCategoryDiagnostics(
+  record: PlayerDataSourceRecord,
+  sourceIndex: number,
+  identity: string,
+  expectedCategoryKeys: readonly string[],
+  accumulator: DiagnosticAccumulator
+): void {
+  for (const category of expectedCategoryKeys) {
+    if (hasCategoryValue(record, category)) {
+      accumulator.categoryCoverageCounts.set(
+        category,
+        (accumulator.categoryCoverageCounts.get(category) ?? 0) + 1
+      );
+    } else {
+      accumulator.missingExpectedCategoryValues.push({
+        sourceIndex,
+        sourceIdentity: identity,
+        category,
+      });
+    }
+  }
+
+  for (const key of categoryKeys(record)) {
+    const suggestedKey = DEPRECATED_CATEGORY_KEYS[key];
+    if (suggestedKey && expectedCategoryKeys.includes(suggestedKey)) {
+      accumulator.deprecatedCategoryKeys.push({
+        sourceIndex,
+        sourceIdentity: identity,
+        key,
+        suggestedKey,
+      });
+    }
+  }
+}
+
+function findRecordMatch(
+  sourceId: string | undefined,
+  name: string | undefined,
+  team: string | undefined,
+  indexes: CanonicalIndexes
+): { player: CanonicalPlayerRow; method: PlayerDataMatchMethod } | undefined {
+  const directMatch = sourceId ? indexes.byDirectId.get(sourceId) : undefined;
+  if (directMatch) return { player: directMatch, method: 'directId' };
+
+  const canonicalId = sourceId ? buildCanonicalPlayerId(sourceId) : undefined;
+  const canonicalMatch = canonicalId ? indexes.byCanonicalId.get(canonicalId) : undefined;
+  if (canonicalMatch) return { player: canonicalMatch, method: 'canonicalId' };
+
+  const exactNameTeamKey = nameTeamKey(name, team);
+  const nameTeamMatch = exactNameTeamKey ? indexes.byNameTeam.get(exactNameTeamKey) : undefined;
+  if (nameTeamMatch) return { player: nameTeamMatch, method: 'nameTeam' };
+
+  return undefined;
+}
+
+function collectMatchDiagnostics(
+  record: PlayerDataSourceRecord,
+  sourceIndex: number,
+  identity: string,
+  indexes: CanonicalIndexes,
+  accumulator: DiagnosticAccumulator
+): void {
+  const sourceId = readSourceId(record);
+  const name = readSourceName(record);
+  const team = readTeam(record);
+  const match = findRecordMatch(sourceId, name, team, indexes);
+
+  if (match) {
+    accumulator.matches.push({
+      sourceIndex,
+      sourceIdentity: identity,
+      canonicalPlayerId: match.player.id,
+      method: match.method,
+    });
+    accumulator.matchedCanonicalIds.add(match.player.id);
+    return;
+  }
+
+  const nameCandidates = indexes.byName.get(normalizeText(name));
+  if (nameCandidates && nameCandidates.length > 1) {
+    accumulator.ambiguousNameMatches.push({
+      sourceIndex,
+      sourceIdentity: identity,
+      name: name ?? '',
+      team,
+      candidatePlayerIds: nameCandidates.map((player) => player.id),
+    });
+    return;
+  }
+
+  accumulator.unmatchedSourceRecords.push({ sourceIndex, sourceIdentity: identity, name, team });
+}
+
+function collectSourceRecordDiagnostics(
+  record: PlayerDataSourceRecord,
+  sourceIndex: number,
+  expectedCategoryKeys: readonly string[],
+  indexes: CanonicalIndexes,
+  accumulator: DiagnosticAccumulator
+): void {
+  const identity = sourceIdentity(record);
+  trackSourceIdentity(accumulator.sourceIdentityIndexes, identity, sourceIndex);
+  collectCategoryDiagnostics(record, sourceIndex, identity, expectedCategoryKeys, accumulator);
+  collectMatchDiagnostics(record, sourceIndex, identity, indexes, accumulator);
+}
+
 export function diagnosePlayerDataConvergence(
   input: PlayerDataConvergenceInput
 ): PlayerDataConvergenceDiagnostic {
   const indexes = buildCanonicalIndexes(input.canonicalPlayers);
   const sourceRecords = [...input.sourceRecords, ...(input.rankingRecords ?? [])];
   const totalRankingRecords = input.rankingRecords?.length ?? 0;
-  const matches: PlayerDataRecordMatch[] = [];
-  const unmatchedSourceRecords: PlayerDataUnmatchedSourceRecord[] = [];
-  const ambiguousNameMatches: PlayerDataAmbiguousNameMatch[] = [];
-  const missingExpectedCategoryValues: PlayerDataMissingCategoryValue[] = [];
-  const deprecatedCategoryKeys: PlayerDataDeprecatedCategoryKey[] = [];
-  const sourceIdentityIndexes = new Map<string, number[]>();
-  const matchedCanonicalIds = new Set<string>();
-  const categoryCoverageCounts = new Map(input.expectedCategoryKeys.map((key) => [key, 0]));
+  const accumulator = createAccumulator(input.expectedCategoryKeys);
 
   sourceRecords.forEach((record, sourceIndex) => {
-    const identity = sourceIdentity(record);
-    const sourceId = readSourceId(record);
-    const name = readSourceName(record);
-    const team = readTeam(record);
-    const identityIndexes = sourceIdentityIndexes.get(identity) ?? [];
-    identityIndexes.push(sourceIndex);
-    sourceIdentityIndexes.set(identity, identityIndexes);
-
-    for (const category of input.expectedCategoryKeys) {
-      if (hasCategoryValue(record, category)) {
-        categoryCoverageCounts.set(category, (categoryCoverageCounts.get(category) ?? 0) + 1);
-      } else {
-        missingExpectedCategoryValues.push({ sourceIndex, sourceIdentity: identity, category });
-      }
-    }
-
-    for (const key of categoryKeys(record)) {
-      const suggestedKey = DEPRECATED_CATEGORY_KEYS[key];
-      if (suggestedKey && input.expectedCategoryKeys.includes(suggestedKey)) {
-        deprecatedCategoryKeys.push({ sourceIndex, sourceIdentity: identity, key, suggestedKey });
-      }
-    }
-
-    const directMatch = sourceId ? indexes.byDirectId.get(sourceId) : undefined;
-    if (directMatch) {
-      matches.push({
-        sourceIndex,
-        sourceIdentity: identity,
-        canonicalPlayerId: directMatch.id,
-        method: 'directId',
-      });
-      matchedCanonicalIds.add(directMatch.id);
-      return;
-    }
-
-    const canonicalCandidates = [sourceId ? buildCanonicalPlayerId(sourceId) : undefined].filter(
-      (value): value is string => Boolean(value)
+    collectSourceRecordDiagnostics(
+      record,
+      sourceIndex,
+      input.expectedCategoryKeys,
+      indexes,
+      accumulator
     );
-    const canonicalMatch = canonicalCandidates
-      .map((candidate) => indexes.byCanonicalId.get(candidate))
-      .find((candidate): candidate is CanonicalPlayerRow => Boolean(candidate));
-
-    if (canonicalMatch) {
-      matches.push({
-        sourceIndex,
-        sourceIdentity: identity,
-        canonicalPlayerId: canonicalMatch.id,
-        method: 'canonicalId',
-      });
-      matchedCanonicalIds.add(canonicalMatch.id);
-      return;
-    }
-
-    const exactNameTeamKey = nameTeamKey(name, team);
-    const nameTeamMatch = exactNameTeamKey ? indexes.byNameTeam.get(exactNameTeamKey) : undefined;
-    if (nameTeamMatch) {
-      matches.push({
-        sourceIndex,
-        sourceIdentity: identity,
-        canonicalPlayerId: nameTeamMatch.id,
-        method: 'nameTeam',
-      });
-      matchedCanonicalIds.add(nameTeamMatch.id);
-      return;
-    }
-
-    const nameCandidates = indexes.byName.get(normalizeText(name));
-    if (nameCandidates && nameCandidates.length > 1) {
-      ambiguousNameMatches.push({
-        sourceIndex,
-        sourceIdentity: identity,
-        name: name ?? '',
-        team,
-        candidatePlayerIds: nameCandidates.map((player) => player.id),
-      });
-      return;
-    }
-
-    unmatchedSourceRecords.push({ sourceIndex, sourceIdentity: identity, name, team });
   });
 
-  const duplicateSourceIdentities = [...sourceIdentityIndexes.entries()]
+  const duplicateSourceIdentities = [...accumulator.sourceIdentityIndexes.entries()]
     .filter(([, indexes]) => indexes.length > 1)
     .map(([identity, indexes]) => ({ sourceIdentity: identity, sourceIndexes: indexes }));
   const unmatchedCanonicalPlayers = input.canonicalPlayers
-    .filter((player) => !matchedCanonicalIds.has(player.id))
+    .filter((player) => !accumulator.matchedCanonicalIds.has(player.id))
     .map((player) => ({
       canonicalPlayerId: player.id,
       name: player.name,
       team: readTeam(player),
     }));
   const categoryCoverage = input.expectedCategoryKeys.map((category) => {
-    const present = categoryCoverageCounts.get(category) ?? 0;
+    const present = accumulator.categoryCoverageCounts.get(category) ?? 0;
     return {
       category,
       present,
       missing: sourceRecords.length - present,
     };
   });
-  const matchedRecordsByDirectId = matches.filter((match) => match.method === 'directId').length;
-  const matchedRecordsByCanonicalId = matches.filter(
+  const matchedRecordsByDirectId = accumulator.matches.filter(
+    (match) => match.method === 'directId'
+  ).length;
+  const matchedRecordsByCanonicalId = accumulator.matches.filter(
     (match) => match.method === 'canonicalId'
   ).length;
-  const matchedRecordsByNormalizedNameTeam = matches.filter(
+  const matchedRecordsByNormalizedNameTeam = accumulator.matches.filter(
     (match) => match.method === 'nameTeam'
   ).length;
   const severity = severityFor({
-    ambiguousNameMatches: ambiguousNameMatches.length,
-    unmatchedSourceRecords: unmatchedSourceRecords.length,
+    ambiguousNameMatches: accumulator.ambiguousNameMatches.length,
+    unmatchedSourceRecords: accumulator.unmatchedSourceRecords.length,
     unmatchedCanonicalPlayers: unmatchedCanonicalPlayers.length,
     duplicateSourceIdentities: duplicateSourceIdentities.length,
-    missingExpectedCategoryValues: missingExpectedCategoryValues.length,
-    deprecatedCategoryKeys: deprecatedCategoryKeys.length,
+    missingExpectedCategoryValues: accumulator.missingExpectedCategoryValues.length,
+    deprecatedCategoryKeys: accumulator.deprecatedCategoryKeys.length,
   });
 
   return {
@@ -384,20 +449,20 @@ export function diagnosePlayerDataConvergence(
       matchedRecordsByCanonicalId,
       matchedRecordsByNormalizedNameTeam,
       unmatchedCanonicalPlayers: unmatchedCanonicalPlayers.length,
-      unmatchedSourceRecords: unmatchedSourceRecords.length,
-      ambiguousNameMatches: ambiguousNameMatches.length,
+      unmatchedSourceRecords: accumulator.unmatchedSourceRecords.length,
+      ambiguousNameMatches: accumulator.ambiguousNameMatches.length,
       duplicateSourceIdentities: duplicateSourceIdentities.length,
-      missingExpectedCategoryValues: missingExpectedCategoryValues.length,
-      deprecatedCategoryKeys: deprecatedCategoryKeys.length,
+      missingExpectedCategoryValues: accumulator.missingExpectedCategoryValues.length,
+      deprecatedCategoryKeys: accumulator.deprecatedCategoryKeys.length,
       severity,
     },
-    matches,
+    matches: accumulator.matches,
     unmatchedCanonicalPlayers,
-    unmatchedSourceRecords,
-    ambiguousNameMatches,
+    unmatchedSourceRecords: accumulator.unmatchedSourceRecords,
+    ambiguousNameMatches: accumulator.ambiguousNameMatches,
     duplicateSourceIdentities,
-    missingExpectedCategoryValues,
-    deprecatedCategoryKeys,
+    missingExpectedCategoryValues: accumulator.missingExpectedCategoryValues,
+    deprecatedCategoryKeys: accumulator.deprecatedCategoryKeys,
     categoryCoverage,
     recommendedNextAction: recommendNextAction(severity),
   };

--- a/src/server/playerDataConvergenceDiagnostic.ts
+++ b/src/server/playerDataConvergenceDiagnostic.ts
@@ -1,0 +1,404 @@
+import { buildCanonicalPlayerId } from '@/lib/playerIdentity';
+
+export type PlayerDataConvergenceSeverity = 'ok' | 'warning' | 'error';
+export type PlayerDataMatchMethod = 'directId' | 'canonicalId' | 'nameTeam';
+
+export type CanonicalPlayerRow = {
+  id: string;
+  name: string;
+  team?: string | null;
+  club?: string | null;
+  position?: string | null;
+};
+
+export type PlayerDataSourceRecord = {
+  id?: string | null;
+  playerId?: string | null;
+  player_uid?: string | null;
+  playerName?: string | null;
+  player_name?: string | null;
+  name?: string | null;
+  team?: string | null;
+  club?: string | null;
+  stats?: Record<string, unknown> | null;
+  categories?: Record<string, unknown> | null;
+  [key: string]: unknown;
+};
+
+export type PlayerDataConvergenceInput = {
+  canonicalPlayers: readonly CanonicalPlayerRow[];
+  sourceRecords: readonly PlayerDataSourceRecord[];
+  rankingRecords?: readonly PlayerDataSourceRecord[];
+  expectedCategoryKeys: readonly string[];
+};
+
+export type PlayerDataRecordMatch = {
+  sourceIndex: number;
+  sourceIdentity: string;
+  canonicalPlayerId: string;
+  method: PlayerDataMatchMethod;
+};
+
+export type PlayerDataUnmatchedCanonicalPlayer = {
+  canonicalPlayerId: string;
+  name: string;
+  team?: string;
+};
+
+export type PlayerDataUnmatchedSourceRecord = {
+  sourceIndex: number;
+  sourceIdentity: string;
+  name?: string;
+  team?: string;
+};
+
+export type PlayerDataAmbiguousNameMatch = {
+  sourceIndex: number;
+  sourceIdentity: string;
+  name: string;
+  team?: string;
+  candidatePlayerIds: string[];
+};
+
+export type PlayerDataDuplicateSourceIdentity = {
+  sourceIdentity: string;
+  sourceIndexes: number[];
+};
+
+export type PlayerDataMissingCategoryValue = {
+  sourceIndex: number;
+  sourceIdentity: string;
+  category: string;
+};
+
+export type PlayerDataDeprecatedCategoryKey = {
+  sourceIndex: number;
+  sourceIdentity: string;
+  key: string;
+  suggestedKey: string;
+};
+
+export type PlayerDataCategoryCoverage = {
+  category: string;
+  present: number;
+  missing: number;
+};
+
+export type PlayerDataConvergenceDiagnostic = {
+  summary: {
+    totalCanonicalPlayers: number;
+    totalSourceStatRecords: number;
+    totalRankingRecords: number;
+    matchedRecordsByDirectId: number;
+    matchedRecordsByCanonicalId: number;
+    matchedRecordsByNormalizedNameTeam: number;
+    unmatchedCanonicalPlayers: number;
+    unmatchedSourceRecords: number;
+    ambiguousNameMatches: number;
+    duplicateSourceIdentities: number;
+    missingExpectedCategoryValues: number;
+    deprecatedCategoryKeys: number;
+    severity: PlayerDataConvergenceSeverity;
+  };
+  matches: PlayerDataRecordMatch[];
+  unmatchedCanonicalPlayers: PlayerDataUnmatchedCanonicalPlayer[];
+  unmatchedSourceRecords: PlayerDataUnmatchedSourceRecord[];
+  ambiguousNameMatches: PlayerDataAmbiguousNameMatch[];
+  duplicateSourceIdentities: PlayerDataDuplicateSourceIdentity[];
+  missingExpectedCategoryValues: PlayerDataMissingCategoryValue[];
+  deprecatedCategoryKeys: PlayerDataDeprecatedCategoryKey[];
+  categoryCoverage: PlayerDataCategoryCoverage[];
+  recommendedNextAction: string;
+};
+
+const DEPRECATED_CATEGORY_KEYS: Record<string, string> = {
+  contested_marks: 'contestedMarks',
+  contested_possessions: 'contestedPossessions',
+  effective_disposals: 'effectiveDisposals',
+  goal_assists: 'goalAssists',
+  inside_50s: 'inside50s',
+  rebound_50s: 'rebound50s',
+  score_involvements: 'scoreInvolvements',
+};
+
+function normalizeText(value: string | null | undefined): string {
+  return String(value ?? '')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+function readTeam(row: { team?: string | null; club?: string | null }): string | undefined {
+  const team = row.team ?? row.club ?? undefined;
+  const normalized = normalizeText(team);
+  return normalized ? team?.trim() : undefined;
+}
+
+function readSourceName(record: PlayerDataSourceRecord): string | undefined {
+  const name = record.player_name ?? record.playerName ?? record.name ?? undefined;
+  const normalized = normalizeText(name);
+  return normalized ? name?.trim() : undefined;
+}
+
+function readSourceId(record: PlayerDataSourceRecord): string | undefined {
+  const id = record.playerId ?? record.player_uid ?? record.id ?? undefined;
+  const trimmed = String(id ?? '').trim();
+  return trimmed || undefined;
+}
+
+function nameTeamKey(name: string | undefined, team: string | undefined): string | undefined {
+  const normalizedName = normalizeText(name);
+  const normalizedTeam = normalizeText(team);
+  return normalizedName && normalizedTeam ? `${normalizedName}|${normalizedTeam}` : undefined;
+}
+
+function sourceIdentity(record: PlayerDataSourceRecord): string {
+  const directId = readSourceId(record);
+  if (directId) return directId;
+
+  const name = readSourceName(record);
+  const team = readTeam(record);
+  const nameAndTeam = nameTeamKey(name, team);
+  if (nameAndTeam) return nameAndTeam;
+  if (name) return buildCanonicalPlayerId(name);
+  return 'unknown_source_record';
+}
+
+function readCategoryValue(record: PlayerDataSourceRecord, category: string): unknown {
+  if (record.categories && category in record.categories) return record.categories[category];
+  if (record.stats && category in record.stats) return record.stats[category];
+  return record[category];
+}
+
+function hasCategoryValue(record: PlayerDataSourceRecord, category: string): boolean {
+  const value = readCategoryValue(record, category);
+  return value !== null && value !== undefined && value !== '';
+}
+
+function categoryKeys(record: PlayerDataSourceRecord): string[] {
+  const keys = new Set<string>();
+  for (const key of Object.keys(record)) keys.add(key);
+  for (const key of Object.keys(record.stats ?? {})) keys.add(key);
+  for (const key of Object.keys(record.categories ?? {})) keys.add(key);
+  return [...keys];
+}
+
+function buildCanonicalIndexes(canonicalPlayers: readonly CanonicalPlayerRow[]) {
+  const byDirectId = new Map<string, CanonicalPlayerRow>();
+  const byCanonicalId = new Map<string, CanonicalPlayerRow>();
+  const byNameTeam = new Map<string, CanonicalPlayerRow>();
+  const byName = new Map<string, CanonicalPlayerRow[]>();
+
+  for (const player of canonicalPlayers) {
+    byDirectId.set(player.id, player);
+    byCanonicalId.set(buildCanonicalPlayerId(player.id), player);
+    byCanonicalId.set(buildCanonicalPlayerId(player.name), player);
+
+    const team = readTeam(player);
+    const key = nameTeamKey(player.name, team);
+    if (key) byNameTeam.set(key, player);
+
+    const normalizedName = normalizeText(player.name);
+    if (!normalizedName) continue;
+    const candidates = byName.get(normalizedName) ?? [];
+    candidates.push(player);
+    byName.set(normalizedName, candidates);
+  }
+
+  return { byDirectId, byCanonicalId, byNameTeam, byName };
+}
+
+function severityFor(input: {
+  ambiguousNameMatches: number;
+  unmatchedSourceRecords: number;
+  unmatchedCanonicalPlayers: number;
+  duplicateSourceIdentities: number;
+  missingExpectedCategoryValues: number;
+  deprecatedCategoryKeys: number;
+}): PlayerDataConvergenceSeverity {
+  if (input.ambiguousNameMatches > 0 || input.unmatchedSourceRecords > 0) {
+    return 'error';
+  }
+
+  if (
+    input.unmatchedCanonicalPlayers > 0 ||
+    input.duplicateSourceIdentities > 0 ||
+    input.missingExpectedCategoryValues > 0 ||
+    input.deprecatedCategoryKeys > 0
+  ) {
+    return 'warning';
+  }
+
+  return 'ok';
+}
+
+function recommendNextAction(severity: PlayerDataConvergenceSeverity): string {
+  if (severity === 'error') {
+    return 'Resolve identity ambiguity and unmatched source records before any dry-run or write-capable convergence work.';
+  }
+
+  if (severity === 'warning') {
+    return 'Review warnings with source evidence, then run a temp DB dry-run only after deterministic repairs are defined.';
+  }
+
+  return 'No convergence blockers detected in these in-memory fixtures; Phase 2 temp DB dry-run can be planned when real data is loaded safely.';
+}
+
+export function diagnosePlayerDataConvergence(
+  input: PlayerDataConvergenceInput
+): PlayerDataConvergenceDiagnostic {
+  const indexes = buildCanonicalIndexes(input.canonicalPlayers);
+  const sourceRecords = [...input.sourceRecords, ...(input.rankingRecords ?? [])];
+  const totalRankingRecords = input.rankingRecords?.length ?? 0;
+  const matches: PlayerDataRecordMatch[] = [];
+  const unmatchedSourceRecords: PlayerDataUnmatchedSourceRecord[] = [];
+  const ambiguousNameMatches: PlayerDataAmbiguousNameMatch[] = [];
+  const missingExpectedCategoryValues: PlayerDataMissingCategoryValue[] = [];
+  const deprecatedCategoryKeys: PlayerDataDeprecatedCategoryKey[] = [];
+  const sourceIdentityIndexes = new Map<string, number[]>();
+  const matchedCanonicalIds = new Set<string>();
+  const categoryCoverageCounts = new Map(input.expectedCategoryKeys.map((key) => [key, 0]));
+
+  sourceRecords.forEach((record, sourceIndex) => {
+    const identity = sourceIdentity(record);
+    const sourceId = readSourceId(record);
+    const name = readSourceName(record);
+    const team = readTeam(record);
+    const identityIndexes = sourceIdentityIndexes.get(identity) ?? [];
+    identityIndexes.push(sourceIndex);
+    sourceIdentityIndexes.set(identity, identityIndexes);
+
+    for (const category of input.expectedCategoryKeys) {
+      if (hasCategoryValue(record, category)) {
+        categoryCoverageCounts.set(category, (categoryCoverageCounts.get(category) ?? 0) + 1);
+      } else {
+        missingExpectedCategoryValues.push({ sourceIndex, sourceIdentity: identity, category });
+      }
+    }
+
+    for (const key of categoryKeys(record)) {
+      const suggestedKey = DEPRECATED_CATEGORY_KEYS[key];
+      if (suggestedKey && input.expectedCategoryKeys.includes(suggestedKey)) {
+        deprecatedCategoryKeys.push({ sourceIndex, sourceIdentity: identity, key, suggestedKey });
+      }
+    }
+
+    const directMatch = sourceId ? indexes.byDirectId.get(sourceId) : undefined;
+    if (directMatch) {
+      matches.push({
+        sourceIndex,
+        sourceIdentity: identity,
+        canonicalPlayerId: directMatch.id,
+        method: 'directId',
+      });
+      matchedCanonicalIds.add(directMatch.id);
+      return;
+    }
+
+    const canonicalCandidates = [sourceId ? buildCanonicalPlayerId(sourceId) : undefined].filter(
+      (value): value is string => Boolean(value)
+    );
+    const canonicalMatch = canonicalCandidates
+      .map((candidate) => indexes.byCanonicalId.get(candidate))
+      .find((candidate): candidate is CanonicalPlayerRow => Boolean(candidate));
+
+    if (canonicalMatch) {
+      matches.push({
+        sourceIndex,
+        sourceIdentity: identity,
+        canonicalPlayerId: canonicalMatch.id,
+        method: 'canonicalId',
+      });
+      matchedCanonicalIds.add(canonicalMatch.id);
+      return;
+    }
+
+    const exactNameTeamKey = nameTeamKey(name, team);
+    const nameTeamMatch = exactNameTeamKey ? indexes.byNameTeam.get(exactNameTeamKey) : undefined;
+    if (nameTeamMatch) {
+      matches.push({
+        sourceIndex,
+        sourceIdentity: identity,
+        canonicalPlayerId: nameTeamMatch.id,
+        method: 'nameTeam',
+      });
+      matchedCanonicalIds.add(nameTeamMatch.id);
+      return;
+    }
+
+    const nameCandidates = indexes.byName.get(normalizeText(name));
+    if (nameCandidates && nameCandidates.length > 1) {
+      ambiguousNameMatches.push({
+        sourceIndex,
+        sourceIdentity: identity,
+        name: name ?? '',
+        team,
+        candidatePlayerIds: nameCandidates.map((player) => player.id),
+      });
+      return;
+    }
+
+    unmatchedSourceRecords.push({ sourceIndex, sourceIdentity: identity, name, team });
+  });
+
+  const duplicateSourceIdentities = [...sourceIdentityIndexes.entries()]
+    .filter(([, indexes]) => indexes.length > 1)
+    .map(([identity, indexes]) => ({ sourceIdentity: identity, sourceIndexes: indexes }));
+  const unmatchedCanonicalPlayers = input.canonicalPlayers
+    .filter((player) => !matchedCanonicalIds.has(player.id))
+    .map((player) => ({
+      canonicalPlayerId: player.id,
+      name: player.name,
+      team: readTeam(player),
+    }));
+  const categoryCoverage = input.expectedCategoryKeys.map((category) => {
+    const present = categoryCoverageCounts.get(category) ?? 0;
+    return {
+      category,
+      present,
+      missing: sourceRecords.length - present,
+    };
+  });
+  const matchedRecordsByDirectId = matches.filter((match) => match.method === 'directId').length;
+  const matchedRecordsByCanonicalId = matches.filter(
+    (match) => match.method === 'canonicalId'
+  ).length;
+  const matchedRecordsByNormalizedNameTeam = matches.filter(
+    (match) => match.method === 'nameTeam'
+  ).length;
+  const severity = severityFor({
+    ambiguousNameMatches: ambiguousNameMatches.length,
+    unmatchedSourceRecords: unmatchedSourceRecords.length,
+    unmatchedCanonicalPlayers: unmatchedCanonicalPlayers.length,
+    duplicateSourceIdentities: duplicateSourceIdentities.length,
+    missingExpectedCategoryValues: missingExpectedCategoryValues.length,
+    deprecatedCategoryKeys: deprecatedCategoryKeys.length,
+  });
+
+  return {
+    summary: {
+      totalCanonicalPlayers: input.canonicalPlayers.length,
+      totalSourceStatRecords: input.sourceRecords.length,
+      totalRankingRecords,
+      matchedRecordsByDirectId,
+      matchedRecordsByCanonicalId,
+      matchedRecordsByNormalizedNameTeam,
+      unmatchedCanonicalPlayers: unmatchedCanonicalPlayers.length,
+      unmatchedSourceRecords: unmatchedSourceRecords.length,
+      ambiguousNameMatches: ambiguousNameMatches.length,
+      duplicateSourceIdentities: duplicateSourceIdentities.length,
+      missingExpectedCategoryValues: missingExpectedCategoryValues.length,
+      deprecatedCategoryKeys: deprecatedCategoryKeys.length,
+      severity,
+    },
+    matches,
+    unmatchedCanonicalPlayers,
+    unmatchedSourceRecords,
+    ambiguousNameMatches,
+    duplicateSourceIdentities,
+    missingExpectedCategoryValues,
+    deprecatedCategoryKeys,
+    categoryCoverage,
+    recommendedNextAction: recommendNextAction(severity),
+  };
+}

--- a/tests/unit/playerDataConvergenceDiagnostic.test.ts
+++ b/tests/unit/playerDataConvergenceDiagnostic.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  diagnosePlayerDataConvergence,
+  type CanonicalPlayerRow,
+  type PlayerDataSourceRecord,
+} from '@/server/playerDataConvergenceDiagnostic';
+
+const expectedCategories = ['goals', 'inside50s', 'effectiveDisposals'] as const;
+
+function completeStats(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    goals: 1,
+    inside50s: 2,
+    effectiveDisposals: 3,
+    ...overrides,
+  };
+}
+
+function diagnose(input: {
+  canonicalPlayers: CanonicalPlayerRow[];
+  sourceRecords: PlayerDataSourceRecord[];
+  rankingRecords?: PlayerDataSourceRecord[];
+}) {
+  return diagnosePlayerDataConvergence({
+    ...input,
+    expectedCategoryKeys: expectedCategories,
+  });
+}
+
+describe('player data convergence diagnostic', () => {
+  it('matches source records by direct id', () => {
+    const result = diagnose({
+      canonicalPlayers: [{ id: 'caleb_daniel', name: 'Caleb Daniel', club: 'North Melbourne' }],
+      sourceRecords: [
+        { player_uid: 'caleb_daniel', player_name: 'Caleb Daniel', stats: completeStats() },
+      ],
+    });
+
+    expect(result.summary.matchedRecordsByDirectId).toBe(1);
+    expect(result.matches[0]).toMatchObject({
+      canonicalPlayerId: 'caleb_daniel',
+      method: 'directId',
+    });
+    expect(result.summary.severity).toBe('ok');
+  });
+
+  it('matches source records by canonical id without treating that as a direct match', () => {
+    const result = diagnose({
+      canonicalPlayers: [{ id: 'caleb_daniel', name: 'Caleb Daniel', club: 'North Melbourne' }],
+      sourceRecords: [
+        { player_uid: 'Caleb Daniel', player_name: 'Caleb Daniel', stats: completeStats() },
+      ],
+    });
+
+    expect(result.summary.matchedRecordsByDirectId).toBe(0);
+    expect(result.summary.matchedRecordsByCanonicalId).toBe(1);
+    expect(result.matches[0]).toMatchObject({
+      canonicalPlayerId: 'caleb_daniel',
+      method: 'canonicalId',
+    });
+  });
+
+  it('matches source records by normalized name and team', () => {
+    const result = diagnose({
+      canonicalPlayers: [{ id: 'tom_green', name: 'Tom Green', club: 'GWS' }],
+      sourceRecords: [{ player_name: '  TOM   GREEN ', team: 'gws', stats: completeStats() }],
+    });
+
+    expect(result.summary.matchedRecordsByNormalizedNameTeam).toBe(1);
+    expect(result.matches[0]).toMatchObject({
+      canonicalPlayerId: 'tom_green',
+      method: 'nameTeam',
+    });
+  });
+
+  it('reports ambiguous name matches instead of guessing', () => {
+    const result = diagnose({
+      canonicalPlayers: [
+        { id: 'sam_reid_sydney', name: 'Sam Reid', club: 'Sydney' },
+        { id: 'sam_reid_gws', name: 'Sam Reid', club: 'GWS' },
+      ],
+      sourceRecords: [{ player_name: 'Sam Reid', stats: completeStats() }],
+    });
+
+    expect(result.summary.ambiguousNameMatches).toBe(1);
+    expect(result.ambiguousNameMatches[0]).toMatchObject({
+      sourceIdentity: 'sam_reid',
+      candidatePlayerIds: ['sam_reid_sydney', 'sam_reid_gws'],
+    });
+    expect(result.summary.severity).toBe('error');
+  });
+
+  it('reports unmatched canonical players', () => {
+    const result = diagnose({
+      canonicalPlayers: [
+        { id: 'matched_player', name: 'Matched Player', club: 'Carlton' },
+        { id: 'missing_player', name: 'Missing Player', club: 'Richmond' },
+      ],
+      sourceRecords: [
+        { player_uid: 'matched_player', player_name: 'Matched Player', stats: completeStats() },
+      ],
+    });
+
+    expect(result.summary.unmatchedCanonicalPlayers).toBe(1);
+    expect(result.unmatchedCanonicalPlayers).toEqual([
+      { canonicalPlayerId: 'missing_player', name: 'Missing Player', team: 'Richmond' },
+    ]);
+    expect(result.summary.severity).toBe('warning');
+  });
+
+  it('reports unmatched source records', () => {
+    const result = diagnose({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'ghost_player', player_name: 'Ghost Player', stats: completeStats() },
+      ],
+    });
+
+    expect(result.summary.unmatchedSourceRecords).toBe(1);
+    expect(result.unmatchedSourceRecords[0]).toMatchObject({
+      sourceIdentity: 'ghost_player',
+      name: 'Ghost Player',
+    });
+    expect(result.summary.severity).toBe('error');
+  });
+
+  it('reports duplicate source identities', () => {
+    const result = diagnose({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+      ],
+    });
+
+    expect(result.summary.duplicateSourceIdentities).toBe(1);
+    expect(result.duplicateSourceIdentities).toEqual([
+      { sourceIdentity: 'known_player', sourceIndexes: [0, 1] },
+    ]);
+    expect(result.summary.severity).toBe('warning');
+  });
+
+  it('reports missing expected fantasy categories', () => {
+    const result = diagnose({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        {
+          player_uid: 'known_player',
+          player_name: 'Known Player',
+          stats: completeStats({ effectiveDisposals: undefined }),
+        },
+      ],
+    });
+
+    expect(result.summary.missingExpectedCategoryValues).toBe(1);
+    expect(result.missingExpectedCategoryValues).toEqual([
+      {
+        sourceIndex: 0,
+        sourceIdentity: 'known_player',
+        category: 'effectiveDisposals',
+      },
+    ]);
+    expect(result.categoryCoverage).toContainEqual({
+      category: 'effectiveDisposals',
+      present: 0,
+      missing: 1,
+    });
+  });
+
+  it('reports deprecated or stale category keys from ranking-like records', () => {
+    const result = diagnose({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+      ],
+      rankingRecords: [
+        {
+          player_uid: 'known_player',
+          player_name: 'Known Player',
+          categories: {
+            goals: 1,
+            inside_50s: 2,
+            effective_disposals: 3,
+          },
+        },
+      ],
+    });
+
+    expect(result.summary.totalRankingRecords).toBe(1);
+    expect(result.deprecatedCategoryKeys).toEqual(
+      expect.arrayContaining([
+        {
+          sourceIndex: 1,
+          sourceIdentity: 'known_player',
+          key: 'inside_50s',
+          suggestedKey: 'inside50s',
+        },
+        {
+          sourceIndex: 1,
+          sourceIdentity: 'known_player',
+          key: 'effective_disposals',
+          suggestedKey: 'effectiveDisposals',
+        },
+      ])
+    );
+    expect(result.summary.deprecatedCategoryKeys).toBe(2);
+  });
+
+  it('returns an all-clear result when identities and categories converge', () => {
+    const result = diagnose({
+      canonicalPlayers: [
+        { id: 'caleb_daniel', name: 'Caleb Daniel', club: 'North Melbourne' },
+        { id: 'tom_green', name: 'Tom Green', club: 'GWS' },
+      ],
+      sourceRecords: [
+        { player_uid: 'caleb_daniel', player_name: 'Caleb Daniel', stats: completeStats() },
+        { player_uid: 'tom_green', player_name: 'Tom Green', stats: completeStats() },
+      ],
+    });
+
+    expect(result.summary).toMatchObject({
+      totalCanonicalPlayers: 2,
+      totalSourceStatRecords: 2,
+      matchedRecordsByDirectId: 2,
+      unmatchedCanonicalPlayers: 0,
+      unmatchedSourceRecords: 0,
+      ambiguousNameMatches: 0,
+      duplicateSourceIdentities: 0,
+      missingExpectedCategoryValues: 0,
+      deprecatedCategoryKeys: 0,
+      severity: 'ok',
+    });
+    expect(result.recommendedNextAction).toContain('No convergence blockers detected');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a pure in-memory player data convergence diagnostic.
- Accepts canonical player rows, source stat records, optional ranking-like records, and expected category keys.
- Reports direct ID, canonical ID, normalized name/team matches, unmatched records, ambiguous names, duplicate identities, missing expected categories, stale snake_case category keys, category coverage, severity, and recommended next action.
- Keeps the diagnostic side-effect free with no Prisma, Firestore, local JSON, runner, package script, route, or component changes.

## Verification

- `npm exec -- prettier --check src/server/playerDataConvergenceDiagnostic.ts tests/unit/playerDataConvergenceDiagnostic.test.ts`
- `npm exec -- eslint src/server/playerDataConvergenceDiagnostic.ts tests/unit/playerDataConvergenceDiagnostic.test.ts`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/playerDataConvergenceDiagnostic.test.ts --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

- No runtime code changed.
- No database reads or writes.
- No protected, local, generated, env, Firebase, or secret files touched.
- `prisma/dev.db` and local stashes were not touched.
- Real-data coverage is intentionally deferred to the next phase: a bounded temp-DB/read-only dry-run.

## Summary by Sourcery

Introduce an in-memory diagnostic for assessing convergence between canonical player data and source stat/ranking records.

New Features:
- Add a pure utility to compute player identity matches, mismatches, and category coverage across canonical and source player datasets.
- Report convergence metrics including match counts by method, unmatched and ambiguous records, duplicate identities, and deprecated vs expected stat categories.
- Provide a severity classification and recommended next action based on diagnostic findings.

Tests:
- Add unit tests covering matching strategies, ambiguity handling, category coverage reporting, deprecated key detection, and all-clear scenarios for the new diagnostic.