### PR TITLE
feat: add player data convergence planner

### DIFF
--- a/src/server/playerDataConvergencePlanner.ts
+++ b/src/server/playerDataConvergencePlanner.ts
@@ -29,11 +29,7 @@ export type PlayerDataConvergenceAction = {
   categories?: string[];
 };
 
-export type PlayerDataConvergencePlanStatus =
-  | 'allClear'
-  | 'readOnlyFollowUpSafe'
-  | 'reviewRequired'
-  | 'blocked';
+export type PlayerDataConvergencePlanStatus = 'allClear' | 'readOnlyFollowUpSafe' | 'blocked';
 
 export type PlayerDataConvergencePlan = {
   status: PlayerDataConvergencePlanStatus;
@@ -45,10 +41,10 @@ export type PlayerDataConvergencePlan = {
 
 export type PlayerDataConvergencePlannerInput = {
   diagnostic: PlayerDataConvergenceDiagnostic;
-  expectedCategoryKeys?: readonly string[];
+  expectedCategoryKeys: readonly string[];
 };
 
-function unique(values: Iterable<string>): string[] {
+function unique<T>(values: Iterable<T>): T[] {
   return [...new Set(values)];
 }
 
@@ -130,7 +126,7 @@ function missingCategoryAction(
     'Some source rows are missing expected category values; review source coverage before defining any repair plan.',
     {
       count: missingValues.length,
-      sourceIndexes: unique(missingValues.map((value) => String(value.sourceIndex))).map(Number),
+      sourceIndexes: unique(missingValues.map((value) => value.sourceIndex)),
       sourceIdentities: unique(missingValues.map((value) => value.sourceIdentity)),
       categories: unique(missingValues.map((value) => value.category)),
     }
@@ -146,7 +142,7 @@ function staleCategoryAction(
     'Deprecated or stale category keys need explicit mapping review before they can be used in convergence work.',
     {
       count: deprecatedKeys.length,
-      sourceIndexes: unique(deprecatedKeys.map((value) => String(value.sourceIndex))).map(Number),
+      sourceIndexes: unique(deprecatedKeys.map((value) => value.sourceIndex)),
       sourceIdentities: unique(deprecatedKeys.map((value) => value.sourceIdentity)),
       categories: unique(deprecatedKeys.map((value) => value.key)),
     }
@@ -236,7 +232,7 @@ function planStatus(
 
 export function planPlayerDataConvergenceActions({
   diagnostic,
-  expectedCategoryKeys = [],
+  expectedCategoryKeys,
 }: PlayerDataConvergencePlannerInput): PlayerDataConvergencePlan {
   const actions: PlayerDataConvergenceAction[] = [];
   const { skippedNullStatSourceEvidence, partialMissingCategoryValues } =

--- a/src/server/playerDataConvergencePlanner.ts
+++ b/src/server/playerDataConvergencePlanner.ts
@@ -1,0 +1,312 @@
+import type {
+  PlayerDataConvergenceDiagnostic,
+  PlayerDataDeprecatedCategoryKey,
+  PlayerDataMissingCategoryValue,
+} from '@/server/playerDataConvergenceDiagnostic';
+
+export type PlayerDataConvergenceActionKind =
+  | 'noActionRequired'
+  | 'skippedNullStatSourceEvidence'
+  | 'identityReviewRequired'
+  | 'ambiguousNameReviewRequired'
+  | 'sourceRecordReviewRequired'
+  | 'duplicateSourceIdentityReviewRequired'
+  | 'staleCategoryKeyMappingReviewRequired'
+  | 'missingExpectedCategoryValueReviewRequired'
+  | 'unsafeForWritePlanning'
+  | 'safeForNextReadOnlyDryRun'
+  | 'blockedPendingProductDecision';
+
+export type PlayerDataConvergenceActionSeverity = 'info' | 'warning' | 'error';
+
+export type PlayerDataConvergenceAction = {
+  kind: PlayerDataConvergenceActionKind;
+  severity: PlayerDataConvergenceActionSeverity;
+  message: string;
+  count?: number;
+  sourceIndexes?: number[];
+  sourceIdentities?: string[];
+  categories?: string[];
+};
+
+export type PlayerDataConvergencePlanStatus =
+  | 'allClear'
+  | 'readOnlyFollowUpSafe'
+  | 'reviewRequired'
+  | 'blocked';
+
+export type PlayerDataConvergencePlan = {
+  status: PlayerDataConvergencePlanStatus;
+  safeForNextReadOnlyDryRun: boolean;
+  safeForWritePlanning: boolean;
+  requiresProductDecision: boolean;
+  actions: PlayerDataConvergenceAction[];
+};
+
+export type PlayerDataConvergencePlannerInput = {
+  diagnostic: PlayerDataConvergenceDiagnostic;
+  expectedCategoryKeys?: readonly string[];
+};
+
+function unique(values: Iterable<string>): string[] {
+  return [...new Set(values)];
+}
+
+function groupMissingValuesBySourceIndex(
+  missingValues: readonly PlayerDataMissingCategoryValue[]
+): Map<number, PlayerDataMissingCategoryValue[]> {
+  const grouped = new Map<number, PlayerDataMissingCategoryValue[]>();
+
+  for (const value of missingValues) {
+    const values = grouped.get(value.sourceIndex) ?? [];
+    values.push(value);
+    grouped.set(value.sourceIndex, values);
+  }
+
+  return grouped;
+}
+
+function splitMissingCategoryValues(
+  missingValues: readonly PlayerDataMissingCategoryValue[],
+  expectedCategoryKeys: readonly string[]
+): {
+  skippedNullStatSourceEvidence: PlayerDataMissingCategoryValue[][];
+  partialMissingCategoryValues: PlayerDataMissingCategoryValue[];
+} {
+  const expectedCategories = new Set(expectedCategoryKeys);
+  const grouped = groupMissingValuesBySourceIndex(missingValues);
+  const skippedNullStatSourceEvidence: PlayerDataMissingCategoryValue[][] = [];
+  const partialMissingCategoryValues: PlayerDataMissingCategoryValue[] = [];
+
+  for (const values of grouped.values()) {
+    const missingCategories = new Set(values.map((value) => value.category));
+    const isAllNullStatEvidence =
+      expectedCategories.size > 0 &&
+      [...expectedCategories].every((category) => missingCategories.has(category));
+
+    if (isAllNullStatEvidence) {
+      skippedNullStatSourceEvidence.push(values);
+    } else {
+      partialMissingCategoryValues.push(...values);
+    }
+  }
+
+  return { skippedNullStatSourceEvidence, partialMissingCategoryValues };
+}
+
+function action(
+  kind: PlayerDataConvergenceActionKind,
+  severity: PlayerDataConvergenceActionSeverity,
+  message: string,
+  details: Omit<PlayerDataConvergenceAction, 'kind' | 'severity' | 'message'> = {}
+): PlayerDataConvergenceAction {
+  return { kind, severity, message, ...details };
+}
+
+function skippedNullStatAction(
+  skippedGroups: readonly PlayerDataMissingCategoryValue[][]
+): PlayerDataConvergenceAction {
+  const firstValues = skippedGroups.map((values) => values[0]).filter(Boolean);
+
+  return action(
+    'skippedNullStatSourceEvidence',
+    'warning',
+    'Source rows with all expected category values missing should be skipped as source evidence, not converted into identity repair candidates.',
+    {
+      count: skippedGroups.length,
+      sourceIndexes: firstValues.map((value) => value.sourceIndex),
+      sourceIdentities: unique(firstValues.map((value) => value.sourceIdentity)),
+      categories: unique(skippedGroups.flatMap((values) => values.map((value) => value.category))),
+    }
+  );
+}
+
+function missingCategoryAction(
+  missingValues: readonly PlayerDataMissingCategoryValue[]
+): PlayerDataConvergenceAction {
+  return action(
+    'missingExpectedCategoryValueReviewRequired',
+    'warning',
+    'Some source rows are missing expected category values; review source coverage before defining any repair plan.',
+    {
+      count: missingValues.length,
+      sourceIndexes: unique(missingValues.map((value) => String(value.sourceIndex))).map(Number),
+      sourceIdentities: unique(missingValues.map((value) => value.sourceIdentity)),
+      categories: unique(missingValues.map((value) => value.category)),
+    }
+  );
+}
+
+function staleCategoryAction(
+  deprecatedKeys: readonly PlayerDataDeprecatedCategoryKey[]
+): PlayerDataConvergenceAction {
+  return action(
+    'staleCategoryKeyMappingReviewRequired',
+    'warning',
+    'Deprecated or stale category keys need explicit mapping review before they can be used in convergence work.',
+    {
+      count: deprecatedKeys.length,
+      sourceIndexes: unique(deprecatedKeys.map((value) => String(value.sourceIndex))).map(Number),
+      sourceIdentities: unique(deprecatedKeys.map((value) => value.sourceIdentity)),
+      categories: unique(deprecatedKeys.map((value) => value.key)),
+    }
+  );
+}
+
+function appendIssueActions(
+  diagnostic: PlayerDataConvergenceDiagnostic,
+  actions: PlayerDataConvergenceAction[]
+): void {
+  if (diagnostic.ambiguousNameMatches.length > 0) {
+    actions.push(
+      action(
+        'ambiguousNameReviewRequired',
+        'error',
+        'Ambiguous name matches require manual identity review; the planner must not guess between candidates.',
+        {
+          count: diagnostic.ambiguousNameMatches.length,
+          sourceIndexes: diagnostic.ambiguousNameMatches.map((match) => match.sourceIndex),
+          sourceIdentities: unique(
+            diagnostic.ambiguousNameMatches.map((match) => match.sourceIdentity)
+          ),
+        }
+      )
+    );
+  }
+
+  if (diagnostic.unmatchedCanonicalPlayers.length > 0) {
+    actions.push(
+      action(
+        'identityReviewRequired',
+        'warning',
+        'Canonical players without source evidence need identity review before write planning.',
+        {
+          count: diagnostic.unmatchedCanonicalPlayers.length,
+          sourceIdentities: diagnostic.unmatchedCanonicalPlayers.map(
+            (player) => player.canonicalPlayerId
+          ),
+        }
+      )
+    );
+  }
+
+  if (diagnostic.unmatchedSourceRecords.length > 0) {
+    actions.push(
+      action(
+        'sourceRecordReviewRequired',
+        'error',
+        'Unmatched source records require source review; they must not create or repair players automatically.',
+        {
+          count: diagnostic.unmatchedSourceRecords.length,
+          sourceIndexes: diagnostic.unmatchedSourceRecords.map((record) => record.sourceIndex),
+          sourceIdentities: unique(
+            diagnostic.unmatchedSourceRecords.map((record) => record.sourceIdentity)
+          ),
+        }
+      )
+    );
+  }
+
+  if (diagnostic.duplicateSourceIdentities.length > 0) {
+    actions.push(
+      action(
+        'duplicateSourceIdentityReviewRequired',
+        'warning',
+        'Duplicate source identities need source-quality review before any convergence plan consumes them.',
+        {
+          count: diagnostic.duplicateSourceIdentities.length,
+          sourceIdentities: unique(
+            diagnostic.duplicateSourceIdentities.map((entry) => entry.sourceIdentity)
+          ),
+        }
+      )
+    );
+  }
+}
+
+function planStatus(
+  actions: readonly PlayerDataConvergenceAction[],
+  unsafeForWritePlanning: boolean,
+  requiresProductDecision: boolean
+): PlayerDataConvergencePlanStatus {
+  if (requiresProductDecision || unsafeForWritePlanning) return 'blocked';
+  if (actions.some((item) => item.severity === 'warning')) return 'readOnlyFollowUpSafe';
+  return 'allClear';
+}
+
+export function planPlayerDataConvergenceActions({
+  diagnostic,
+  expectedCategoryKeys = [],
+}: PlayerDataConvergencePlannerInput): PlayerDataConvergencePlan {
+  const actions: PlayerDataConvergenceAction[] = [];
+  const { skippedNullStatSourceEvidence, partialMissingCategoryValues } =
+    splitMissingCategoryValues(diagnostic.missingExpectedCategoryValues, expectedCategoryKeys);
+
+  appendIssueActions(diagnostic, actions);
+
+  if (skippedNullStatSourceEvidence.length > 0) {
+    actions.push(skippedNullStatAction(skippedNullStatSourceEvidence));
+  }
+
+  if (partialMissingCategoryValues.length > 0) {
+    actions.push(missingCategoryAction(partialMissingCategoryValues));
+  }
+
+  if (diagnostic.deprecatedCategoryKeys.length > 0) {
+    actions.push(staleCategoryAction(diagnostic.deprecatedCategoryKeys));
+  }
+
+  const requiresProductDecision = diagnostic.ambiguousNameMatches.length > 0;
+  const unsafeForWritePlanning =
+    diagnostic.summary.severity === 'error' ||
+    requiresProductDecision ||
+    diagnostic.unmatchedSourceRecords.length > 0;
+
+  if (unsafeForWritePlanning) {
+    actions.push(
+      action(
+        'unsafeForWritePlanning',
+        'error',
+        'This diagnostic is unsafe for write planning until blocking identity/source issues are resolved.'
+      )
+    );
+  }
+
+  if (requiresProductDecision) {
+    actions.push(
+      action(
+        'blockedPendingProductDecision',
+        'error',
+        'Ambiguous identity evidence requires an explicit product/data decision before implementation.'
+      )
+    );
+  }
+
+  if (actions.length === 0) {
+    actions.push(
+      action(
+        'noActionRequired',
+        'info',
+        'No player data convergence action is required for this diagnostic.'
+      )
+    );
+  }
+
+  if (!unsafeForWritePlanning) {
+    actions.push(
+      action(
+        'safeForNextReadOnlyDryRun',
+        'info',
+        'The next read-only dry-run can proceed with the current diagnostic evidence.'
+      )
+    );
+  }
+
+  return {
+    status: planStatus(actions, unsafeForWritePlanning, requiresProductDecision),
+    safeForNextReadOnlyDryRun: !unsafeForWritePlanning,
+    safeForWritePlanning: false,
+    requiresProductDecision,
+    actions,
+  };
+}

--- a/tests/unit/playerDataConvergencePlanner.test.ts
+++ b/tests/unit/playerDataConvergencePlanner.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  diagnosePlayerDataConvergence,
+  type CanonicalPlayerRow,
+  type PlayerDataSourceRecord,
+} from '@/server/playerDataConvergenceDiagnostic';
+import { planPlayerDataConvergenceActions } from '@/server/playerDataConvergencePlanner';
+
+const expectedCategories = ['goals', 'inside50s', 'effectiveDisposals'] as const;
+
+function completeStats(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    goals: 1,
+    inside50s: 2,
+    effectiveDisposals: 3,
+    ...overrides,
+  };
+}
+
+function diagnose(input: {
+  canonicalPlayers: CanonicalPlayerRow[];
+  sourceRecords: PlayerDataSourceRecord[];
+  rankingRecords?: PlayerDataSourceRecord[];
+}) {
+  return diagnosePlayerDataConvergence({
+    ...input,
+    expectedCategoryKeys: expectedCategories,
+  });
+}
+
+function plan(input: {
+  canonicalPlayers: CanonicalPlayerRow[];
+  sourceRecords: PlayerDataSourceRecord[];
+  rankingRecords?: PlayerDataSourceRecord[];
+}) {
+  return planPlayerDataConvergenceActions({
+    diagnostic: diagnose(input),
+    expectedCategoryKeys: expectedCategories,
+  });
+}
+
+function actionKinds(input: ReturnType<typeof plan>): string[] {
+  return input.actions.map((action) => action.kind);
+}
+
+describe('player data convergence planner', () => {
+  it('produces no repair action for a clean diagnostic', () => {
+    const result = plan({
+      canonicalPlayers: [{ id: 'caleb_daniel', name: 'Caleb Daniel', club: 'North Melbourne' }],
+      sourceRecords: [
+        { player_uid: 'caleb_daniel', player_name: 'Caleb Daniel', stats: completeStats() },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      status: 'allClear',
+      safeForNextReadOnlyDryRun: true,
+      safeForWritePlanning: false,
+      requiresProductDecision: false,
+    });
+    expect(actionKinds(result)).toEqual(['noActionRequired', 'safeForNextReadOnlyDryRun']);
+  });
+
+  it('classifies all-null stat rows as skipped source evidence instead of repair work', () => {
+    const result = plan({
+      canonicalPlayers: [
+        { id: 'tobie_travaglia_st_kilda', name: 'Tobie Travaglia', club: 'St Kilda' },
+        { id: 'nathan_fyfe_fremantle', name: 'Nathan Fyfe', club: 'Fremantle' },
+        { id: 'lachlan_mcneil_western_bulldogs', name: 'Lachlan McNeil', club: 'Western Bulldogs' },
+        { id: 'mitchell_duncan_geelong', name: 'Mitchell Duncan', club: 'Geelong' },
+      ],
+      sourceRecords: [
+        { player_name: 'Tobie Travaglia', team: 'St Kilda', stats: completeStats(nullStats()) },
+        { player_name: 'Nathan Fyfe', team: 'Fremantle', stats: completeStats(nullStats()) },
+        {
+          player_name: 'Lachlan McNeil',
+          team: 'Western Bulldogs',
+          stats: completeStats(nullStats()),
+        },
+        { player_name: 'Mitchell Duncan', team: 'Geelong', stats: completeStats(nullStats()) },
+      ],
+    });
+
+    const skippedAction = result.actions.find(
+      (action) => action.kind === 'skippedNullStatSourceEvidence'
+    );
+
+    expect(skippedAction).toMatchObject({
+      severity: 'warning',
+      count: 4,
+      sourceIndexes: [0, 1, 2, 3],
+      categories: ['goals', 'inside50s', 'effectiveDisposals'],
+    });
+    expect(actionKinds(result)).not.toContain('identityReviewRequired');
+    expect(actionKinds(result)).not.toContain('unsafeForWritePlanning');
+    expect(result.safeForNextReadOnlyDryRun).toBe(true);
+    expect(result.safeForWritePlanning).toBe(false);
+  });
+
+  it('blocks write planning for ambiguous name matches', () => {
+    const result = plan({
+      canonicalPlayers: [
+        { id: 'sam_reid_sydney', name: 'Sam Reid', club: 'Sydney' },
+        { id: 'sam_reid_gws', name: 'Sam Reid', club: 'GWS' },
+      ],
+      sourceRecords: [{ player_name: 'Sam Reid', stats: completeStats() }],
+    });
+
+    expect(actionKinds(result)).toEqual(
+      expect.arrayContaining([
+        'ambiguousNameReviewRequired',
+        'unsafeForWritePlanning',
+        'blockedPendingProductDecision',
+      ])
+    );
+    expect(result).toMatchObject({
+      status: 'blocked',
+      safeForNextReadOnlyDryRun: false,
+      safeForWritePlanning: false,
+      requiresProductDecision: true,
+    });
+  });
+
+  it('requires identity review for unmatched canonical players', () => {
+    const result = plan({
+      canonicalPlayers: [
+        { id: 'matched_player', name: 'Matched Player', club: 'Carlton' },
+        { id: 'missing_player', name: 'Missing Player', club: 'Richmond' },
+      ],
+      sourceRecords: [
+        { player_uid: 'matched_player', player_name: 'Matched Player', stats: completeStats() },
+      ],
+    });
+
+    expect(result.actions).toContainEqual(
+      expect.objectContaining({
+        kind: 'identityReviewRequired',
+        severity: 'warning',
+        count: 1,
+        sourceIdentities: ['missing_player'],
+      })
+    );
+    expect(result.safeForNextReadOnlyDryRun).toBe(true);
+  });
+
+  it('requires source review for unmatched source records', () => {
+    const result = plan({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'ghost_player', player_name: 'Ghost Player', stats: completeStats() },
+      ],
+    });
+
+    expect(actionKinds(result)).toEqual(
+      expect.arrayContaining(['sourceRecordReviewRequired', 'unsafeForWritePlanning'])
+    );
+    expect(result.safeForNextReadOnlyDryRun).toBe(false);
+  });
+
+  it('requires source-quality review for duplicate source identities', () => {
+    const result = plan({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+      ],
+    });
+
+    expect(result.actions).toContainEqual(
+      expect.objectContaining({
+        kind: 'duplicateSourceIdentityReviewRequired',
+        severity: 'warning',
+        count: 1,
+        sourceIdentities: ['known_player'],
+      })
+    );
+    expect(result.safeForNextReadOnlyDryRun).toBe(true);
+  });
+
+  it('requires mapping review for stale snake_case category keys', () => {
+    const result = plan({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+      ],
+      rankingRecords: [
+        {
+          player_uid: 'known_player',
+          player_name: 'Known Player',
+          categories: {
+            goals: 1,
+            inside_50s: 2,
+            effective_disposals: 3,
+          },
+        },
+      ],
+    });
+
+    expect(result.actions).toContainEqual(
+      expect.objectContaining({
+        kind: 'staleCategoryKeyMappingReviewRequired',
+        severity: 'warning',
+        count: 2,
+        categories: ['inside_50s', 'effective_disposals'],
+      })
+    );
+  });
+
+  it('warns on partial missing category values without automatic repair', () => {
+    const result = plan({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        {
+          player_uid: 'known_player',
+          player_name: 'Known Player',
+          stats: completeStats({ effectiveDisposals: undefined }),
+        },
+      ],
+    });
+
+    expect(result.actions).toContainEqual(
+      expect.objectContaining({
+        kind: 'missingExpectedCategoryValueReviewRequired',
+        severity: 'warning',
+        count: 1,
+        categories: ['effectiveDisposals'],
+      })
+    );
+    expect(actionKinds(result)).not.toContain('unsafeForWritePlanning');
+    expect(result.safeForWritePlanning).toBe(false);
+  });
+
+  it('marks severe diagnostics unsafe for write planning', () => {
+    const result = plan({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'ghost_player', player_name: 'Ghost Player', stats: completeStats() },
+      ],
+    });
+
+    expect(result.actions).toContainEqual(
+      expect.objectContaining({
+        kind: 'unsafeForWritePlanning',
+        severity: 'error',
+      })
+    );
+    expect(result.status).toBe('blocked');
+  });
+
+  it('keeps the tracked-data warning shape safe for read-only follow-up', () => {
+    const result = plan({
+      canonicalPlayers: [
+        { id: 'tobie_travaglia_st_kilda', name: 'Tobie Travaglia', club: 'St Kilda' },
+      ],
+      sourceRecords: [
+        { player_name: 'Tobie Travaglia', team: 'St Kilda', stats: completeStats(nullStats()) },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      status: 'readOnlyFollowUpSafe',
+      safeForNextReadOnlyDryRun: true,
+      safeForWritePlanning: false,
+      requiresProductDecision: false,
+    });
+    expect(actionKinds(result)).toEqual(
+      expect.arrayContaining(['skippedNullStatSourceEvidence', 'safeForNextReadOnlyDryRun'])
+    );
+  });
+});
+
+function nullStats(): Record<string, null> {
+  return {
+    goals: null,
+    inside50s: null,
+    effectiveDisposals: null,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a pure in-memory player data convergence action planner.
- Converts diagnostic output into non-writing recommendations for identity review, source-quality review, category mapping review, skipped source evidence, and follow-up safety.
- Treats all-null expected category rows as skipped source evidence rather than repair/write candidates.
- Keeps write-capable convergence planning disabled by default.

## Verification

- `npm exec -- prettier --check src/server/playerDataConvergencePlanner.ts tests/unit/playerDataConvergencePlanner.test.ts`
- `npm exec -- eslint src/server/playerDataConvergencePlanner.ts tests/unit/playerDataConvergencePlanner.test.ts`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/playerDataConvergencePlanner.test.ts --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

- Pure in-memory planner only.
- No runtime code changed.
- No Prisma, Firestore, database, runner, package script, route, or component changes.
- No protected, local, generated, env, Firebase, or secret files touched.
- `prisma/dev.db` and local stashes were not touched.

## Summary by Sourcery

Introduce a read-only, in-memory planner that translates player data convergence diagnostics into structured follow-up actions without enabling write planning.

New Features:
- Add a player data convergence planner that evaluates diagnostics and produces structured action plans with statuses and safety flags.

Tests:
- Add unit tests covering planner behavior for clean diagnostics, skipped null-stat evidence, ambiguous identities, unmatched records, duplicate identities, stale category keys, missing values, and safety flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added player data convergence planning with comprehensive safety assessments to detect naming conflicts, unmatched records, duplicate identities, and missing category data during data operations.

* **Tests**
  * Added comprehensive unit test suite validating convergence planning behavior across multiple diagnostic scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->