### PR TITLE
docs: record player data convergence ladder status

### DIFF
--- a/docs/codex/player-data-convergence-brief.md
+++ b/docs/codex/player-data-convergence-brief.md
@@ -46,6 +46,41 @@ Current `main` does not have a player data convergence runner, a
 `converge:player-data` package script, or a current rollout protocol for applying
 player directory repairs.
 
+## Current Ladder Status
+
+As of June 21, 2026, the safe, non-writing player data convergence ladder has
+completed these steps:
+
+| Step                                | Status    | Evidence                                                                                                          |
+| ----------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
+| Phase 1 read-only diagnostic        | Completed | Current player identity, stats, ranking, and draft read-model ownership were inspected without mutating state.    |
+| Phase 2 pure diagnostic module      | Completed | `src/server/playerDataConvergenceDiagnostic.ts` and fixture tests compare in-memory player/stat/category records. |
+| Phase 3 tracked-data guard          | Completed | `tests/unit/playerDataConvergenceTrackedData.test.ts` verifies tracked data remains identity-converged.           |
+| Phase 4 pure action planner         | Completed | `src/server/playerDataConvergencePlanner.ts` converts diagnostics into non-writing recommendations.               |
+| Phase 4b tracked-data planner guard | Completed | The tracked-data guard verifies warning-only tracked data stays safe for read-only follow-up.                     |
+
+The current tracked-data warning is narrow and understood: four
+`player_stats_2025.json` rows have all nine real-data category values as `null`.
+Those rows are skipped source evidence and a source-data coverage warning, not
+player identity repair candidates.
+
+The current safety position is:
+
+- identity convergence is good for tracked data;
+- the tracked-data shape is warning-only and safe for read-only follow-up;
+- write-capable convergence remains unsafe without a separate approved plan;
+- no runner, package script, Prisma write path, Firestore write path, or durable
+  repair workflow exists yet.
+
+The next possible phase is a temp-DB-only write dry-run design. That design must
+use `/tmp/statly-verify-*.db`, avoid production and protected local database
+writes, define rollback criteria, require human approval before any apply path,
+and still defer any durable runner until explicitly approved.
+
+Stop condition: do not implement write-capable convergence from this ladder
+status. Stop before adding apply behavior, repair behavior, package scripts,
+runners, Prisma writes, Firestore writes, or ranking mutations.
+
 ## Source-Of-Truth Map
 
 | Concern                                           | Current owner                                                              | Canonical source                                           | Notes                                                                                               |

--- a/docs/codex/player-data-convergence-brief.md
+++ b/docs/codex/player-data-convergence-brief.md
@@ -48,21 +48,21 @@ player directory repairs.
 
 ## Current Ladder Status
 
-As of June 21, 2026, the safe, non-writing player data convergence ladder has
-completed these steps:
+Current `main` has completed these safe, non-writing player data convergence
+ladder steps:
 
-| Step                                | Status    | Evidence                                                                                                          |
-| ----------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
-| Phase 1 read-only diagnostic        | Completed | Current player identity, stats, ranking, and draft read-model ownership were inspected without mutating state.    |
-| Phase 2 pure diagnostic module      | Completed | `src/server/playerDataConvergenceDiagnostic.ts` and fixture tests compare in-memory player/stat/category records. |
-| Phase 3 tracked-data guard          | Completed | `tests/unit/playerDataConvergenceTrackedData.test.ts` verifies tracked data remains identity-converged.           |
-| Phase 4 pure action planner         | Completed | `src/server/playerDataConvergencePlanner.ts` converts diagnostics into non-writing recommendations.               |
-| Phase 4b tracked-data planner guard | Completed | The tracked-data guard verifies warning-only tracked data stays safe for read-only follow-up.                     |
+| Step                                | Status    | Evidence                                                                                                                     |
+| ----------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Phase 1 read-only diagnostic        | Completed | Current player identity, stats, ranking, and draft read-model ownership were inspected without mutating state.               |
+| Phase 2 pure diagnostic module      | Completed | `src/server/playerDataConvergenceDiagnostic.ts` and fixture tests compare in-memory player/stat/category records.            |
+| Phase 3 tracked-data guard          | Completed | `tests/unit/playerDataConvergenceTrackedData.test.ts` verifies tracked data remains identity-converged.                      |
+| Phase 4 pure action planner         | Completed | `src/server/playerDataConvergencePlanner.ts` converts diagnostics into non-writing recommendations.                          |
+| Phase 4b tracked-data planner guard | Completed | `tests/unit/playerDataConvergenceTrackedData.test.ts` verifies warning-only tracked data stays safe for read-only follow-up. |
 
 The current tracked-data warning is narrow and understood: four
 `player_stats_2025.json` rows have all nine real-data category values as `null`.
-Those rows are skipped source evidence and a source-data coverage warning, not
-player identity repair candidates.
+Those rows are skipped, with source evidence and a source-data coverage warning,
+not player identity repair candidates.
 
 The current safety position is:
 


### PR DESCRIPTION
## Summary

- Records the completed player data convergence safety ladder.
- Documents that the pure diagnostic module, tracked-data diagnostic guard, pure planner, and tracked-data planner guard are complete.
- Captures the known tracked-data warning: four rows have all nine real-data category values as null.
- Clarifies that those rows are skipped source evidence, not repair candidates.
- Keeps write-capable convergence explicitly blocked pending a separate temp-DB-only dry-run plan with rollback criteria and human approval.

## Verification

- `npm exec -- prettier --check docs/codex/player-data-convergence-brief.md`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

- Documentation-only change.
- No runtime code changed.
- No tests changed.
- No runner, package script, Prisma, Firestore, route, component, database, protected, local, generated, env, Firebase, or secret files touched.
- `prisma/dev.db` and local stashes were not touched.

## Summary by Sourcery

Documentation:
- Add a ladder status section describing completed diagnostic, guard, and planner phases for player data convergence, current tracked-data warnings, and the safety position blocking write-capable convergence pending a temp-DB-only dry run.