### PR TITLE
test: add player data dry run plan builder

### DIFF
--- a/src/server/playerDataConvergenceDryRunPlan.ts
+++ b/src/server/playerDataConvergenceDryRunPlan.ts
@@ -1,0 +1,300 @@
+import type { PlayerDataConvergenceDiagnostic } from '@/server/playerDataConvergenceDiagnostic';
+import type {
+  PlayerDataConvergenceActionKind,
+  PlayerDataConvergencePlan,
+} from '@/server/playerDataConvergencePlanner';
+
+export type PlayerDataConvergenceDryRunBlockerKind =
+  | 'missingTempDatabasePath'
+  | 'missingDatabaseUrl'
+  | 'databaseUrlMustBeFileUrl'
+  | 'databaseUrlMustMatchTempDatabasePath'
+  | 'tempDatabaseMustUseTmpStatlyVerifyPath'
+  | 'databaseUrlMustNotPointInsideRepository'
+  | 'protectedDevDatabasePath'
+  | 'diagnosticUnsafeForDryRun'
+  | 'productDecisionRequired';
+
+export type PlayerDataConvergenceDryRunBlocker = {
+  kind: PlayerDataConvergenceDryRunBlockerKind;
+  message: string;
+};
+
+export type PlayerDataConvergenceDryRunEvidence = {
+  totalCanonicalPlayers: number;
+  totalSourceStatRecords: number;
+  totalRankingRecords: number;
+  matchedRecordsByDirectId: number;
+  matchedRecordsByCanonicalId: number;
+  matchedRecordsByNormalizedNameTeam: number;
+  ambiguousNameMatches: number;
+  unmatchedCanonicalPlayers: number;
+  unmatchedSourceRecords: number;
+  duplicateSourceIdentities: number;
+  missingExpectedCategoryValues: number;
+  deprecatedCategoryKeys: number;
+  skippedNullStatSourceEvidence: number;
+  proposedRepairCount: number;
+  skippedRepairCount: number;
+};
+
+export type PlayerDataConvergenceDryRunPlanStatus = 'readyForTempDbDryRun' | 'blocked';
+
+export type PlayerDataConvergenceDryRunPlan = {
+  status: PlayerDataConvergenceDryRunPlanStatus;
+  safeForTempDbDryRun: boolean;
+  safeForWritePlanning: false;
+  safeForWriteApply: false;
+  requiresProductDecision: boolean;
+  tempDatabase: {
+    statlyVerifyDb: string;
+    databaseUrl: string;
+    precreateRequired: true;
+    cleanupCommand: string;
+  };
+  evidence: PlayerDataConvergenceDryRunEvidence;
+  blockers: PlayerDataConvergenceDryRunBlocker[];
+  approvalGates: string[];
+  stopConditions: string[];
+  recommendedNextAction: string;
+};
+
+export type PlayerDataConvergenceDryRunPlanInput = {
+  diagnostic: PlayerDataConvergenceDiagnostic;
+  convergencePlan: PlayerDataConvergencePlan;
+  statlyVerifyDb?: string | null;
+  databaseUrl?: string | null;
+  repositoryRoot?: string | null;
+};
+
+const TMP_VERIFY_DB_PATTERN = /^\/tmp\/statly-verify-[^/]+\.db$/;
+
+const APPROVAL_GATES = [
+  'Add an apply function.',
+  'Add a CLI or package script.',
+  'Run any write-capable command, even against /tmp.',
+  'Promote dry-run planning to temp apply simulation.',
+  'Write Prisma player rows outside a disposable temp database.',
+  'Touch Firestore, production, shared, or developer data.',
+  'Change category mappings used by rankings or fantasy scoring.',
+] as const;
+
+const STOP_CONDITIONS = [
+  'DATABASE_URL is missing, non-file://, outside /tmp, inside the repo, or points at prisma/dev.db.',
+  'A command references, reads, or mutates prisma/dev.db.',
+  'A command asks for .env, real secrets, production credentials, Firebase exports, or service account files.',
+  'Generated files, dataconnect local data, coverage, dist, or test-results appear.',
+  'An ambiguous name match or unmatched source record is present.',
+  'Product judgment is required to merge, split, create, or delete players.',
+  'A proposed repair is not explainable from diagnostic evidence.',
+  'The work requires package scripts, Prisma schema changes, Firestore writes, ranking mutations, local JSON edits, fixture rewrites, branches, or stashes.',
+] as const;
+
+function trim(value: string | null | undefined): string {
+  return String(value ?? '').trim();
+}
+
+function normalizedRepositoryRoot(repositoryRoot: string | null | undefined): string | undefined {
+  const root = trim(repositoryRoot).replace(/\/+$/, '');
+  return root || undefined;
+}
+
+function fileUrlFor(path: string): string {
+  return `file://${path}`;
+}
+
+function actionCount(
+  convergencePlan: PlayerDataConvergencePlan,
+  kind: PlayerDataConvergenceActionKind
+): number {
+  return convergencePlan.actions
+    .filter((action) => action.kind === kind)
+    .reduce((total, action) => total + (action.count ?? 0), 0);
+}
+
+function blocker(
+  kind: PlayerDataConvergenceDryRunBlockerKind,
+  message: string
+): PlayerDataConvergenceDryRunBlocker {
+  return { kind, message };
+}
+
+function validateTempDatabase(input: PlayerDataConvergenceDryRunPlanInput) {
+  const blockers: PlayerDataConvergenceDryRunBlocker[] = [];
+  const statlyVerifyDb = trim(input.statlyVerifyDb);
+  const databaseUrl = trim(input.databaseUrl);
+  const repoRoot = normalizedRepositoryRoot(input.repositoryRoot);
+
+  if (!statlyVerifyDb) {
+    blockers.push(
+      blocker(
+        'missingTempDatabasePath',
+        'STATLY_VERIFY_DB must be provided before planning a temp DB dry-run.'
+      )
+    );
+  }
+
+  if (!databaseUrl) {
+    blockers.push(
+      blocker('missingDatabaseUrl', 'DATABASE_URL must be provided before planning a dry-run.')
+    );
+  }
+
+  if (databaseUrl && !databaseUrl.startsWith('file://')) {
+    blockers.push(
+      blocker('databaseUrlMustBeFileUrl', 'DATABASE_URL must use a file:// SQLite URL.')
+    );
+  }
+
+  if (statlyVerifyDb && !TMP_VERIFY_DB_PATTERN.test(statlyVerifyDb)) {
+    blockers.push(
+      blocker(
+        'tempDatabaseMustUseTmpStatlyVerifyPath',
+        'STATLY_VERIFY_DB must match /tmp/statly-verify-*.db.'
+      )
+    );
+  }
+
+  if (statlyVerifyDb && databaseUrl && databaseUrl !== fileUrlFor(statlyVerifyDb)) {
+    blockers.push(
+      blocker(
+        'databaseUrlMustMatchTempDatabasePath',
+        'DATABASE_URL must equal file://${STATLY_VERIFY_DB}.'
+      )
+    );
+  }
+
+  if (
+    statlyVerifyDb.includes('prisma/dev.db') ||
+    databaseUrl.includes('prisma/dev.db') ||
+    databaseUrl.includes('/prisma/dev.db')
+  ) {
+    blockers.push(
+      blocker(
+        'protectedDevDatabasePath',
+        'The dry-run plan must never point at the protected prisma/dev.db database.'
+      )
+    );
+  }
+
+  if (
+    repoRoot &&
+    ((statlyVerifyDb && statlyVerifyDb.startsWith(`${repoRoot}/`)) ||
+      (databaseUrl && databaseUrl.startsWith(fileUrlFor(`${repoRoot}/`))))
+  ) {
+    blockers.push(
+      blocker(
+        'databaseUrlMustNotPointInsideRepository',
+        'The temp database must live outside the repository.'
+      )
+    );
+  }
+
+  return { statlyVerifyDb, databaseUrl, blockers };
+}
+
+function diagnosticBlockers({
+  diagnostic,
+  convergencePlan,
+}: Pick<PlayerDataConvergenceDryRunPlanInput, 'diagnostic' | 'convergencePlan'>) {
+  const blockers: PlayerDataConvergenceDryRunBlocker[] = [];
+
+  if (
+    diagnostic.summary.severity === 'error' ||
+    diagnostic.ambiguousNameMatches.length > 0 ||
+    diagnostic.unmatchedSourceRecords.length > 0 ||
+    convergencePlan.status === 'blocked' ||
+    !convergencePlan.safeForNextReadOnlyDryRun
+  ) {
+    blockers.push(
+      blocker(
+        'diagnosticUnsafeForDryRun',
+        'Resolve ambiguous identity or unmatched source evidence before temp DB dry-run planning.'
+      )
+    );
+  }
+
+  if (convergencePlan.requiresProductDecision) {
+    blockers.push(
+      blocker(
+        'productDecisionRequired',
+        'Product/data decisions must be resolved before dry-run planning.'
+      )
+    );
+  }
+
+  return blockers;
+}
+
+function dryRunEvidence(
+  diagnostic: PlayerDataConvergenceDiagnostic,
+  convergencePlan: PlayerDataConvergencePlan
+): PlayerDataConvergenceDryRunEvidence {
+  const skippedNullStatSourceEvidence = actionCount(
+    convergencePlan,
+    'skippedNullStatSourceEvidence'
+  );
+
+  return {
+    totalCanonicalPlayers: diagnostic.summary.totalCanonicalPlayers,
+    totalSourceStatRecords: diagnostic.summary.totalSourceStatRecords,
+    totalRankingRecords: diagnostic.summary.totalRankingRecords,
+    matchedRecordsByDirectId: diagnostic.summary.matchedRecordsByDirectId,
+    matchedRecordsByCanonicalId: diagnostic.summary.matchedRecordsByCanonicalId,
+    matchedRecordsByNormalizedNameTeam: diagnostic.summary.matchedRecordsByNormalizedNameTeam,
+    ambiguousNameMatches: diagnostic.summary.ambiguousNameMatches,
+    unmatchedCanonicalPlayers: diagnostic.summary.unmatchedCanonicalPlayers,
+    unmatchedSourceRecords: diagnostic.summary.unmatchedSourceRecords,
+    duplicateSourceIdentities: diagnostic.summary.duplicateSourceIdentities,
+    missingExpectedCategoryValues: diagnostic.summary.missingExpectedCategoryValues,
+    deprecatedCategoryKeys: diagnostic.summary.deprecatedCategoryKeys,
+    skippedNullStatSourceEvidence,
+    proposedRepairCount: 0,
+    skippedRepairCount:
+      diagnostic.summary.unmatchedCanonicalPlayers +
+      diagnostic.summary.unmatchedSourceRecords +
+      diagnostic.summary.ambiguousNameMatches +
+      diagnostic.summary.duplicateSourceIdentities +
+      diagnostic.summary.deprecatedCategoryKeys +
+      skippedNullStatSourceEvidence,
+  };
+}
+
+export function planPlayerDataConvergenceTempDbDryRun(
+  input: PlayerDataConvergenceDryRunPlanInput
+): PlayerDataConvergenceDryRunPlan {
+  const {
+    statlyVerifyDb,
+    databaseUrl,
+    blockers: tempDatabaseBlockers,
+  } = validateTempDatabase(input);
+  const blockers = [
+    ...tempDatabaseBlockers,
+    ...diagnosticBlockers({
+      diagnostic: input.diagnostic,
+      convergencePlan: input.convergencePlan,
+    }),
+  ];
+  const safeForTempDbDryRun = blockers.length === 0;
+
+  return {
+    status: safeForTempDbDryRun ? 'readyForTempDbDryRun' : 'blocked',
+    safeForTempDbDryRun,
+    safeForWritePlanning: false,
+    safeForWriteApply: false,
+    requiresProductDecision: input.convergencePlan.requiresProductDecision,
+    tempDatabase: {
+      statlyVerifyDb,
+      databaseUrl,
+      precreateRequired: true,
+      cleanupCommand: 'rm -f "$STATLY_VERIFY_DB"',
+    },
+    evidence: dryRunEvidence(input.diagnostic, input.convergencePlan),
+    blockers,
+    approvalGates: [...APPROVAL_GATES],
+    stopConditions: [...STOP_CONDITIONS],
+    recommendedNextAction: safeForTempDbDryRun
+      ? 'Run a separately approved temp DB dry-run with structured evidence; do not add an apply path yet.'
+      : 'Resolve blockers before any temp DB dry-run or write-capable convergence work.',
+  };
+}

--- a/tests/unit/playerDataConvergenceDryRunPlan.test.ts
+++ b/tests/unit/playerDataConvergenceDryRunPlan.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  diagnosePlayerDataConvergence,
+  type CanonicalPlayerRow,
+  type PlayerDataSourceRecord,
+} from '@/server/playerDataConvergenceDiagnostic';
+import { planPlayerDataConvergenceTempDbDryRun } from '@/server/playerDataConvergenceDryRunPlan';
+import { planPlayerDataConvergenceActions } from '@/server/playerDataConvergencePlanner';
+
+const expectedCategories = ['goals', 'inside50s', 'effectiveDisposals'] as const;
+const tempDb = '/tmp/statly-verify-20260621010101.db';
+
+function completeStats(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    goals: 1,
+    inside50s: 2,
+    effectiveDisposals: 3,
+    ...overrides,
+  };
+}
+
+function nullStats(): Record<string, null> {
+  return {
+    goals: null,
+    inside50s: null,
+    effectiveDisposals: null,
+  };
+}
+
+function dryRunPlan(input: {
+  canonicalPlayers: CanonicalPlayerRow[];
+  sourceRecords: PlayerDataSourceRecord[];
+  statlyVerifyDb?: string | null;
+  databaseUrl?: string | null;
+  repositoryRoot?: string | null;
+}) {
+  const diagnostic = diagnosePlayerDataConvergence({
+    canonicalPlayers: input.canonicalPlayers,
+    sourceRecords: input.sourceRecords,
+    expectedCategoryKeys: expectedCategories,
+  });
+  const convergencePlan = planPlayerDataConvergenceActions({
+    diagnostic,
+    expectedCategoryKeys: expectedCategories,
+  });
+
+  return planPlayerDataConvergenceTempDbDryRun({
+    diagnostic,
+    convergencePlan,
+    statlyVerifyDb: input.statlyVerifyDb ?? tempDb,
+    databaseUrl: input.databaseUrl ?? `file://${input.statlyVerifyDb ?? tempDb}`,
+    repositoryRoot: input.repositoryRoot,
+  });
+}
+
+function blockerKinds(input: ReturnType<typeof dryRunPlan>): string[] {
+  return input.blockers.map((blocker) => blocker.kind);
+}
+
+describe('player data convergence temp DB dry-run plan', () => {
+  it('builds a ready non-writing temp DB plan for clean diagnostic evidence', () => {
+    const result = dryRunPlan({
+      canonicalPlayers: [{ id: 'caleb_daniel', name: 'Caleb Daniel', club: 'North Melbourne' }],
+      sourceRecords: [
+        { player_uid: 'caleb_daniel', player_name: 'Caleb Daniel', stats: completeStats() },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      status: 'readyForTempDbDryRun',
+      safeForTempDbDryRun: true,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+      requiresProductDecision: false,
+      tempDatabase: {
+        statlyVerifyDb: tempDb,
+        databaseUrl: `file://${tempDb}`,
+        precreateRequired: true,
+        cleanupCommand: 'rm -f "$STATLY_VERIFY_DB"',
+      },
+      evidence: {
+        totalCanonicalPlayers: 1,
+        totalSourceStatRecords: 1,
+        matchedRecordsByDirectId: 1,
+        matchedRecordsByCanonicalId: 0,
+        matchedRecordsByNormalizedNameTeam: 0,
+        proposedRepairCount: 0,
+      },
+    });
+    expect(result.blockers).toEqual([]);
+    expect(result.approvalGates).toContain('Add an apply function.');
+    expect(result.stopConditions).toContain(
+      'A command references, reads, or mutates prisma/dev.db.'
+    );
+  });
+
+  it('rejects temp database paths outside /tmp/statly-verify-*.db', () => {
+    const result = dryRunPlan({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+      ],
+      statlyVerifyDb: '/tmp/other.db',
+      databaseUrl: 'file:///tmp/other.db',
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.safeForTempDbDryRun).toBe(false);
+    expect(blockerKinds(result)).toContain('tempDatabaseMustUseTmpStatlyVerifyPath');
+  });
+
+  it('rejects DATABASE_URL values that do not match STATLY_VERIFY_DB', () => {
+    const result = dryRunPlan({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+      ],
+      statlyVerifyDb: tempDb,
+      databaseUrl: 'file:///tmp/statly-verify-other.db',
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(blockerKinds(result)).toContain('databaseUrlMustMatchTempDatabasePath');
+  });
+
+  it('rejects protected prisma dev database paths', () => {
+    const result = dryRunPlan({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+      ],
+      statlyVerifyDb: '/tmp/statly-verify-prisma-dev.db',
+      databaseUrl: 'file:///Users/robert/Developer/Statly/prisma/dev.db',
+      repositoryRoot: '/Users/robert/Developer/Statly',
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(blockerKinds(result)).toEqual(
+      expect.arrayContaining([
+        'databaseUrlMustMatchTempDatabasePath',
+        'protectedDevDatabasePath',
+        'databaseUrlMustNotPointInsideRepository',
+      ])
+    );
+  });
+
+  it('blocks dry-run planning when source evidence requires product decisions', () => {
+    const result = dryRunPlan({
+      canonicalPlayers: [
+        { id: 'sam_reid_sydney', name: 'Sam Reid', club: 'Sydney' },
+        { id: 'sam_reid_gws', name: 'Sam Reid', club: 'GWS' },
+      ],
+      sourceRecords: [{ player_name: 'Sam Reid', stats: completeStats() }],
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(blockerKinds(result)).toEqual(
+      expect.arrayContaining(['diagnosticUnsafeForDryRun', 'productDecisionRequired'])
+    );
+    expect(result.recommendedNextAction).toContain('Resolve blockers');
+    expect(result.requiresProductDecision).toBe(true);
+  });
+
+  it('keeps all-null stat rows as skipped source evidence, not proposed repairs', () => {
+    const result = dryRunPlan({
+      canonicalPlayers: [
+        { id: 'tobie_travaglia_st_kilda', name: 'Tobie Travaglia', club: 'St Kilda' },
+      ],
+      sourceRecords: [
+        { player_name: 'Tobie Travaglia', team: 'St Kilda', stats: completeStats(nullStats()) },
+      ],
+    });
+
+    expect(result.status).toBe('readyForTempDbDryRun');
+    expect(result.evidence).toMatchObject({
+      missingExpectedCategoryValues: 3,
+      skippedNullStatSourceEvidence: 1,
+      proposedRepairCount: 0,
+      skippedRepairCount: 1,
+    });
+    expect(result.safeForWritePlanning).toBe(false);
+    expect(result.safeForWriteApply).toBe(false);
+  });
+
+  it('keeps duplicate source identities review-only while allowing temp dry-run evidence', () => {
+    const result = dryRunPlan({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+      ],
+    });
+
+    expect(result.status).toBe('readyForTempDbDryRun');
+    expect(result.evidence).toMatchObject({
+      duplicateSourceIdentities: 1,
+      proposedRepairCount: 0,
+      skippedRepairCount: 1,
+    });
+    expect(result.safeForWritePlanning).toBe(false);
+    expect(result.safeForWriteApply).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a pure player data convergence temp DB dry-run plan builder.
- Validates caller-provided `STATLY_VERIFY_DB` and `DATABASE_URL` strings without reading env, files, Prisma, or Firestore.
- Summarizes diagnostic/planner evidence into a structured dry-run contract with proposed repair count fixed at zero.
- Keeps write planning/apply explicitly disabled while preserving approval gates and stop conditions.
- Adds fixture-only unit coverage for safe temp DB planning, unsafe DB paths, protected `prisma/dev.db` rejection, product-decision blockers, all-null stat rows, and duplicate source identities.

## Verification

- `npm exec -- prettier --check src/server/playerDataConvergenceDryRunPlan.ts tests/unit/playerDataConvergenceDryRunPlan.test.ts`
- `npm exec -- eslint src/server/playerDataConvergenceDryRunPlan.ts tests/unit/playerDataConvergenceDryRunPlan.test.ts`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/playerDataConvergenceDryRunPlan.test.ts --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

- Pure in-memory module and fixture tests only.
- No package scripts, runner, apply function, Prisma reads/writes, Firestore reads/writes, routes, runtime UI, schema changes, database files, protected files, env files, secrets, Firebase exports, generated files, or stashes touched.
- `safeForWritePlanning` and `safeForWriteApply` remain false by design.

## Summary by Sourcery

Introduce a read-only temp DB dry-run planning contract for player data convergence with strict safety guards and structured evidence output.

New Features:
- Add a player data convergence temp DB dry-run plan builder that validates temp database configuration and summarizes diagnostic evidence without enabling writes.

Tests:
- Add unit tests covering safe temp DB planning, invalid or unsafe database paths, protected prisma/dev.db rejection, product-decision blockers, all-null stat rows, and duplicate source identities.