### PR TITLE
feat: add player data dry run UAT harness

### DIFF
--- a/Scripts/player-data-convergence-dry-run.ts
+++ b/Scripts/player-data-convergence-dry-run.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env tsx
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { getPlayers } from '@/lib/data';
+import {
+  buildPlayerDataConvergenceTrackedDryRunReport,
+  type RawPlayerStatRow,
+} from '@/server/playerDataConvergenceTrackedDryRun';
+
+async function fileExists(filePath: string): Promise<boolean> {
+  if (!filePath) return false;
+
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  const repositoryRoot = process.cwd();
+  const statlyVerifyDb = process.env.STATLY_VERIFY_DB ?? '';
+  const databaseUrl = process.env.DATABASE_URL ?? '';
+  const rawStatRows = JSON.parse(
+    await fs.readFile(path.join(repositoryRoot, 'player_stats_2025.json'), 'utf8')
+  ) as RawPlayerStatRow[];
+  const players = await getPlayers();
+  const report = buildPlayerDataConvergenceTrackedDryRunReport({
+    players,
+    rawStatRows,
+    statlyVerifyDb,
+    databaseUrl,
+    repositoryRoot,
+    tempDatabaseFileExists: await fileExists(statlyVerifyDb),
+  });
+
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+
+  if (report.status !== 'readyForUat') {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error('[player-data-convergence-dry-run] Failed', error);
+  process.exit(1);
+});

--- a/docs/codex/player-data-convergence-brief.md
+++ b/docs/codex/player-data-convergence-brief.md
@@ -232,6 +232,37 @@ Before any later PR proposes an apply path, it must provide:
 Write-capable convergence remains blocked until a separate PR satisfies this
 evidence contract and receives explicit approval for the apply boundary.
 
+### Current UAT Command
+
+The current acceptance surface is a dry-run harness only. It validates the temp
+DB contract, reads tracked player fixture data, builds convergence diagnostics,
+and prints structured JSON without creating a runner or applying repairs.
+
+```bash
+export STATLY_VERIFY_DB="/tmp/statly-verify-$(date +%Y%m%d%H%M%S).db"
+export DATABASE_URL="file://${STATLY_VERIFY_DB}"
+: > "$STATLY_VERIFY_DB"
+npm --silent run player-data:dry-run
+rm -f "$STATLY_VERIFY_DB"
+```
+
+Expected UAT result on current tracked data:
+
+- `status` is `readyForUat`;
+- `diagnostic.matchedRecordsByNormalizedNameTeam` is `7544`;
+- `diagnostic.unmatchedSourceRecords` is `0`;
+- `diagnostic.ambiguousNameMatches` is `0`;
+- `planner.safeForNextReadOnlyDryRun` is `true`;
+- `planner.safeForWritePlanning` is `false`;
+- `dryRunSummary.safeForWriteApply` is `false`;
+- `dryRunSummary.proposedRepairCount` is `0`;
+- `dryRunSummary.skippedNullStatSourceEvidence` is `4`;
+- skipped source evidence lists Tobie Travaglia, Nathan Fyfe, Lachlan McNeil,
+  and Mitchell Duncan.
+
+If the command reports `blocked`, do not proceed to any write-capable work.
+Resolve the reported blockers first.
+
 ## Source-Of-Truth Map
 
 | Concern                                           | Current owner                                                              | Canonical source                                           | Notes                                                                                               |

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "prisma:seed": "prisma db seed",
     "init-firebase-db": "tsx Scripts/initialize-firebase-db.ts",
     "check:etl": "tsx Scripts/check-etl-setup.ts",
+    "player-data:dry-run": "tsx Scripts/player-data-convergence-dry-run.ts",
     "db:check": "tsx Scripts/check-database.ts",
     "firestore:smoke": "tsx Scripts/firestore-smoke.ts",
     "test:unit": "vitest run --config vitest.config.unit.ts",

--- a/src/server/playerDataConvergenceTrackedDryRun.ts
+++ b/src/server/playerDataConvergenceTrackedDryRun.ts
@@ -1,0 +1,125 @@
+import type { Player } from '@/types/players';
+import { REAL_DATA_NINE_CATEGORY_PRESET } from '@/types/fantasyCategories';
+import { diagnosePlayerDataConvergence } from '@/server/playerDataConvergenceDiagnostic';
+import { planPlayerDataConvergenceTempDbDryRun } from '@/server/playerDataConvergenceDryRunPlan';
+import { planPlayerDataConvergenceActions } from '@/server/playerDataConvergencePlanner';
+
+export type RawPlayerStatRow = Record<string, unknown>;
+
+export type PlayerDataConvergenceTrackedDryRunInput = {
+  players: readonly Player[];
+  rawStatRows: readonly RawPlayerStatRow[];
+  statlyVerifyDb?: string | null;
+  databaseUrl?: string | null;
+  repositoryRoot?: string | null;
+  tempDatabaseFileExists?: boolean;
+};
+
+export type PlayerDataConvergenceTrackedDryRunReport = ReturnType<
+  typeof buildPlayerDataConvergenceTrackedDryRunReport
+>;
+
+const rawStatCategoryKeys: Record<(typeof REAL_DATA_NINE_CATEGORY_PRESET)[number], string> = {
+  goals: 'G',
+  tackles: 'T',
+  inside50s: 'I50',
+  intercepts: 'ITC',
+  contestedMarks: 'CM',
+  rebound50s: 'R50',
+  contestedPossessions: 'CP',
+  effectiveDisposals: 'ED',
+  scoreInvolvements: 'SI',
+};
+
+function sourceRecordFromRawRow(row: RawPlayerStatRow) {
+  return {
+    player_name: typeof row.Player === 'string' ? row.Player : undefined,
+    team: typeof row.Team === 'string' ? row.Team : undefined,
+    stats: Object.fromEntries(
+      REAL_DATA_NINE_CATEGORY_PRESET.map((category) => [
+        category,
+        row[rawStatCategoryKeys[category]],
+      ])
+    ),
+  };
+}
+
+export function buildPlayerDataConvergenceTrackedDryRunReport({
+  players,
+  rawStatRows,
+  statlyVerifyDb,
+  databaseUrl,
+  repositoryRoot,
+  tempDatabaseFileExists = false,
+}: PlayerDataConvergenceTrackedDryRunInput) {
+  const diagnostic = diagnosePlayerDataConvergence({
+    canonicalPlayers: players.map((player) => ({
+      id: player.id,
+      name: player.name,
+      team: player.team,
+      position: player.position,
+    })),
+    sourceRecords: rawStatRows.map(sourceRecordFromRawRow),
+    expectedCategoryKeys: [...REAL_DATA_NINE_CATEGORY_PRESET],
+  });
+  const convergencePlan = planPlayerDataConvergenceActions({
+    diagnostic,
+    expectedCategoryKeys: [...REAL_DATA_NINE_CATEGORY_PRESET],
+  });
+  const dryRunPlan = planPlayerDataConvergenceTempDbDryRun({
+    diagnostic,
+    convergencePlan,
+    statlyVerifyDb,
+    databaseUrl,
+    repositoryRoot,
+  });
+  const runtimeBlockers = tempDatabaseFileExists
+    ? []
+    : [
+        {
+          kind: 'tempDatabaseFileMissing' as const,
+          message:
+            'Pre-create STATLY_VERIFY_DB before running UAT, for example with : > "$STATLY_VERIFY_DB".',
+        },
+      ];
+  const status =
+    dryRunPlan.status === 'readyForTempDbDryRun' && runtimeBlockers.length === 0
+      ? 'readyForUat'
+      : 'blocked';
+  const skippedSourceEvidence =
+    convergencePlan.actions.find((action) => action.kind === 'skippedNullStatSourceEvidence') ??
+    null;
+
+  return {
+    mode: 'player-data-convergence-temp-db-dry-run-uat',
+    status,
+    diagnostic: diagnostic.summary,
+    planner: {
+      status: convergencePlan.status,
+      safeForNextReadOnlyDryRun: convergencePlan.safeForNextReadOnlyDryRun,
+      safeForWritePlanning: convergencePlan.safeForWritePlanning,
+      requiresProductDecision: convergencePlan.requiresProductDecision,
+    },
+    dryRunSummary: {
+      status: dryRunPlan.status,
+      safeForTempDbDryRun: dryRunPlan.safeForTempDbDryRun,
+      safeForWritePlanning: dryRunPlan.safeForWritePlanning,
+      safeForWriteApply: dryRunPlan.safeForWriteApply,
+      proposedRepairCount: dryRunPlan.evidence.proposedRepairCount,
+      skippedNullStatSourceEvidence: dryRunPlan.evidence.skippedNullStatSourceEvidence,
+      skippedRepairCount: dryRunPlan.evidence.skippedRepairCount,
+    },
+    skippedSourceEvidence,
+    dryRunPlan,
+    runtimeChecks: {
+      tempDatabaseFileExists,
+      blockers: runtimeBlockers,
+    },
+    trackedDataWarnings: {
+      allNullStatRowsAreSkippedSourceEvidence: dryRunPlan.evidence.skippedNullStatSourceEvidence,
+      proposedRepairCount: dryRunPlan.evidence.proposedRepairCount,
+      safeForWritePlanning: dryRunPlan.safeForWritePlanning,
+      safeForWriteApply: dryRunPlan.safeForWriteApply,
+    },
+  };
+}

--- a/tests/unit/playerDataConvergenceTrackedDryRun.test.ts
+++ b/tests/unit/playerDataConvergenceTrackedDryRun.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPlayerDataConvergenceTrackedDryRunReport } from '@/server/playerDataConvergenceTrackedDryRun';
+import type { Player } from '@/types/players';
+
+const tempDb = '/tmp/statly-verify-20260621020202.db';
+
+function player(overrides: Partial<Player> = {}): Player {
+  return {
+    id: 'caleb-daniel-north-melbourne',
+    name: 'Caleb Daniel',
+    team: 'North Melbourne',
+    position: 'DEF',
+    stats: {},
+    ...overrides,
+  } as Player;
+}
+
+function rawRow(overrides: Record<string, unknown> = {}) {
+  return {
+    Player: 'Caleb Daniel',
+    Team: 'North Melbourne',
+    G: 1,
+    T: 2,
+    I50: 3,
+    ITC: 4,
+    CM: 5,
+    R50: 6,
+    CP: 7,
+    ED: 8,
+    SI: 9,
+    ...overrides,
+  };
+}
+
+describe('tracked player data convergence dry-run report', () => {
+  it('returns a UAT-ready report for tracked evidence and safe temp DB facts', () => {
+    const report = buildPlayerDataConvergenceTrackedDryRunReport({
+      players: [player()],
+      rawStatRows: [rawRow()],
+      statlyVerifyDb: tempDb,
+      databaseUrl: `file://${tempDb}`,
+      repositoryRoot: '/Users/robert/Developer/Statly',
+      tempDatabaseFileExists: true,
+    });
+
+    expect(report).toMatchObject({
+      mode: 'player-data-convergence-temp-db-dry-run-uat',
+      status: 'readyForUat',
+      diagnostic: {
+        totalCanonicalPlayers: 1,
+        totalSourceStatRecords: 1,
+        matchedRecordsByNormalizedNameTeam: 1,
+        severity: 'ok',
+      },
+      planner: {
+        status: 'allClear',
+        safeForNextReadOnlyDryRun: true,
+        safeForWritePlanning: false,
+        requiresProductDecision: false,
+      },
+      dryRunSummary: {
+        status: 'readyForTempDbDryRun',
+        safeForTempDbDryRun: true,
+        safeForWritePlanning: false,
+        safeForWriteApply: false,
+        proposedRepairCount: 0,
+      },
+      dryRunPlan: {
+        status: 'readyForTempDbDryRun',
+        safeForTempDbDryRun: true,
+        safeForWritePlanning: false,
+        safeForWriteApply: false,
+        evidence: {
+          matchedRecordsByNormalizedNameTeam: 1,
+          proposedRepairCount: 0,
+        },
+      },
+      runtimeChecks: {
+        tempDatabaseFileExists: true,
+        blockers: [],
+      },
+    });
+  });
+
+  it('blocks UAT when the temp DB file has not been pre-created', () => {
+    const report = buildPlayerDataConvergenceTrackedDryRunReport({
+      players: [player()],
+      rawStatRows: [rawRow()],
+      statlyVerifyDb: tempDb,
+      databaseUrl: `file://${tempDb}`,
+      repositoryRoot: '/Users/robert/Developer/Statly',
+      tempDatabaseFileExists: false,
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.runtimeChecks.blockers).toContainEqual(
+      expect.objectContaining({ kind: 'tempDatabaseFileMissing' })
+    );
+  });
+
+  it('keeps all-null tracked stat rows as skipped evidence, not repairs', () => {
+    const report = buildPlayerDataConvergenceTrackedDryRunReport({
+      players: [
+        player({ id: 'tobie-travaglia-st-kilda', name: 'Tobie Travaglia', team: 'St Kilda' }),
+      ],
+      rawStatRows: [
+        rawRow({
+          Player: 'Tobie Travaglia',
+          Team: 'St Kilda',
+          G: null,
+          T: null,
+          I50: null,
+          ITC: null,
+          CM: null,
+          R50: null,
+          CP: null,
+          ED: null,
+          SI: null,
+        }),
+      ],
+      statlyVerifyDb: tempDb,
+      databaseUrl: `file://${tempDb}`,
+      repositoryRoot: '/Users/robert/Developer/Statly',
+      tempDatabaseFileExists: true,
+    });
+
+    expect(report.status).toBe('readyForUat');
+    expect(report.skippedSourceEvidence).toMatchObject({
+      kind: 'skippedNullStatSourceEvidence',
+      count: 1,
+      sourceIdentities: ['tobie travaglia|st kilda'],
+    });
+    expect(report.trackedDataWarnings).toMatchObject({
+      allNullStatRowsAreSkippedSourceEvidence: 1,
+      proposedRepairCount: 0,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+    });
+  });
+
+  it('blocks UAT when DATABASE_URL points at protected prisma/dev.db', () => {
+    const report = buildPlayerDataConvergenceTrackedDryRunReport({
+      players: [player()],
+      rawStatRows: [rawRow()],
+      statlyVerifyDb: tempDb,
+      databaseUrl: 'file:///Users/robert/Developer/Statly/prisma/dev.db',
+      repositoryRoot: '/Users/robert/Developer/Statly',
+      tempDatabaseFileExists: true,
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.dryRunPlan.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'protectedDevDatabasePath' }),
+        expect.objectContaining({ kind: 'databaseUrlMustNotPointInsideRepository' }),
+      ])
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a UAT-ready player data convergence dry-run harness.
- Adds `npm run player-data:dry-run`, which validates caller-provided `STATLY_VERIFY_DB` and `DATABASE_URL`, reads tracked fixture/player data, and prints structured JSON.
- Adds a pure tracked-data dry-run report builder and fixture-only coverage.
- Documents the exact UAT command and expected acceptance output.
- Keeps write-capable convergence blocked: no apply path, no runner, no Prisma/Firestore writes, and proposed repairs remain zero.

## Verification

- `npm exec -- prettier --check Scripts/player-data-convergence-dry-run.ts src/server/playerDataConvergenceTrackedDryRun.ts tests/unit/playerDataConvergenceTrackedDryRun.test.ts docs/codex/player-data-convergence-brief.md package.json`
- `npm exec -- eslint Scripts/player-data-convergence-dry-run.ts src/server/playerDataConvergenceTrackedDryRun.ts tests/unit/playerDataConvergenceTrackedDryRun.test.ts`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/playerDataConvergenceTrackedDryRun.test.ts tests/unit/playerDataConvergenceDryRunPlan.test.ts tests/unit/playerDataConvergenceTrackedData.test.ts --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Manual temp DB UAT probe with `npm --silent run player-data:dry-run` returned `readyForUat` and left `prisma/dev.db` unchanged.
- Council Decision 2 returned COMMIT.

## UAT command

```bash
export STATLY_VERIFY_DB="/tmp/statly-verify-$(date +%Y%m%d%H%M%S).db"
export DATABASE_URL="file://${STATLY_VERIFY_DB}"
: > "$STATLY_VERIFY_DB"
npm --silent run player-data:dry-run
rm -f "$STATLY_VERIFY_DB"
```

## Notes

- Reads tracked `player_stats_2025.json` and local player directory data only.
- No database writes, Prisma access, Firestore access, apply path, schema change, runtime route, UI change, env file, secret, Firebase export, generated file, protected file, or stash touched.
- `prisma/dev.db` stat remained unchanged: `1781931534 421888 prisma/dev.db`.

## Summary by Sourcery

Introduce a UAT-focused player data convergence dry-run harness and wire it into the npm scripts.

New Features:
- Add a server-side builder that generates a structured player data convergence dry-run report from tracked players and stats without performing writes.
- Add a CLI script and npm script entry that reads tracked player stats, validates the temp DB configuration, and outputs JSON suitable for UAT verification.

Documentation:
- Document the current UAT dry-run command, expected diagnostic outputs, and guidance for handling blocked states.

Tests:
- Add unit coverage for the tracked dry-run report to ensure UAT readiness, safety checks for temp DB usage, and handling of null-stat evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `npm run player-data:dry-run` command to verify player data convergence status before processing updates. Generates reports indicating readiness for UAT or identifying blocking issues.

* **Documentation**
  * Added UAT command setup guide including environment configuration, expected output format, and action requirements.

* **Tests**
  * Added unit test suite for player data convergence dry-run verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->