### PR TITLE
test: add player data temp db simulation contract

### DIFF
--- a/docs/codex/player-data-convergence-brief.md
+++ b/docs/codex/player-data-convergence-brief.md
@@ -58,6 +58,7 @@ ladder steps:
 | Phase 3 tracked-data guard          | Completed | `tests/unit/playerDataConvergenceTrackedData.test.ts` verifies tracked data remains identity-converged.                      |
 | Phase 4 pure action planner         | Completed | `src/server/playerDataConvergencePlanner.ts` converts diagnostics into non-writing recommendations.                          |
 | Phase 4b tracked-data planner guard | Completed | `tests/unit/playerDataConvergenceTrackedData.test.ts` verifies warning-only tracked data stays safe for read-only follow-up. |
+| Phase 5 temp DB simulation contract | Completed | `src/server/playerDataConvergenceTempDbSimulation.ts` projects dry-run evidence into non-writing temp DB simulation gates.   |
 
 The current tracked-data warning is narrow and understood: four
 `player_stats_2025.json` rows have all nine real-data category values as `null`.
@@ -257,6 +258,11 @@ Expected UAT result on current tracked data:
 - `dryRunSummary.safeForWriteApply` is `false`;
 - `dryRunSummary.proposedRepairCount` is `0`;
 - `dryRunSummary.skippedNullStatSourceEvidence` is `4`;
+- `simulation.status` is `readyForTempDbSimulation`;
+- `simulation.safeForTempDbSimulation` is `true`;
+- `simulation.safeForWritePlanning` is `false`;
+- `simulation.safeForWriteApply` is `false`;
+- `simulation.proposedWriteCount` is `0`;
 - skipped source evidence lists Tobie Travaglia, Nathan Fyfe, Lachlan McNeil,
   and Mitchell Duncan.
 

--- a/src/server/playerDataConvergenceTempDbSimulation.ts
+++ b/src/server/playerDataConvergenceTempDbSimulation.ts
@@ -1,0 +1,172 @@
+import type {
+  PlayerDataConvergenceDryRunBlocker,
+  PlayerDataConvergenceDryRunPlan,
+} from '@/server/playerDataConvergenceDryRunPlan';
+
+export type PlayerDataConvergenceTempDbSimulationStatus = 'readyForTempDbSimulation' | 'blocked';
+
+export type PlayerDataConvergenceTempDbSimulationStepKind =
+  | 'validateTempDatabaseContract'
+  | 'validateDiagnosticEvidence'
+  | 'classifySkippedSourceEvidence'
+  | 'confirmNoRepairCandidates'
+  | 'holdBeforeWriteApply';
+
+export type PlayerDataConvergenceTempDbSimulationStepStatus = 'ready' | 'blocked' | 'notApplicable';
+
+export type PlayerDataConvergenceTempDbSimulationStep = {
+  kind: PlayerDataConvergenceTempDbSimulationStepKind;
+  status: PlayerDataConvergenceTempDbSimulationStepStatus;
+  message: string;
+  evidence?: Record<string, unknown>;
+};
+
+export type PlayerDataConvergenceTempDbSimulation = {
+  status: PlayerDataConvergenceTempDbSimulationStatus;
+  safeForTempDbSimulation: boolean;
+  safeForWritePlanning: false;
+  safeForWriteApply: false;
+  proposedWriteCount: 0;
+  skippedRepairCount: number;
+  blockers: PlayerDataConvergenceDryRunBlocker[];
+  steps: PlayerDataConvergenceTempDbSimulationStep[];
+  approvalGates: string[];
+  stopConditions: string[];
+  recommendedNextAction: string;
+};
+
+function step(
+  kind: PlayerDataConvergenceTempDbSimulationStepKind,
+  status: PlayerDataConvergenceTempDbSimulationStepStatus,
+  message: string,
+  evidence?: Record<string, unknown>
+): PlayerDataConvergenceTempDbSimulationStep {
+  return evidence ? { kind, status, message, evidence } : { kind, status, message };
+}
+
+function tempDatabaseStep(
+  dryRunPlan: PlayerDataConvergenceDryRunPlan
+): PlayerDataConvergenceTempDbSimulationStep {
+  return step(
+    'validateTempDatabaseContract',
+    dryRunPlan.blockers.length === 0 ? 'ready' : 'blocked',
+    dryRunPlan.blockers.length === 0
+      ? 'The temp database contract is ready for a non-writing simulation.'
+      : 'The temp database contract has blockers that must be resolved before simulation.',
+    {
+      statlyVerifyDb: dryRunPlan.tempDatabase.statlyVerifyDb,
+      databaseUrl: dryRunPlan.tempDatabase.databaseUrl,
+      safeForTempDbDryRun: dryRunPlan.safeForTempDbDryRun,
+    }
+  );
+}
+
+function diagnosticStep(
+  dryRunPlan: PlayerDataConvergenceDryRunPlan
+): PlayerDataConvergenceTempDbSimulationStep {
+  const evidence = dryRunPlan.evidence;
+  const hasBlockingIdentityEvidence =
+    evidence.ambiguousNameMatches > 0 || evidence.unmatchedSourceRecords > 0;
+
+  return step(
+    'validateDiagnosticEvidence',
+    hasBlockingIdentityEvidence ? 'blocked' : 'ready',
+    hasBlockingIdentityEvidence
+      ? 'Blocking identity evidence must be resolved before temp DB simulation.'
+      : 'Diagnostic evidence is safe for a non-writing temp DB simulation.',
+    {
+      ambiguousNameMatches: evidence.ambiguousNameMatches,
+      unmatchedSourceRecords: evidence.unmatchedSourceRecords,
+      matchedRecordsByNormalizedNameTeam: evidence.matchedRecordsByNormalizedNameTeam,
+    }
+  );
+}
+
+function skippedSourceEvidenceStep(
+  dryRunPlan: PlayerDataConvergenceDryRunPlan
+): PlayerDataConvergenceTempDbSimulationStep {
+  return step(
+    'classifySkippedSourceEvidence',
+    dryRunPlan.evidence.skippedNullStatSourceEvidence > 0 ? 'ready' : 'notApplicable',
+    dryRunPlan.evidence.skippedNullStatSourceEvidence > 0
+      ? 'All-null stat rows are classified as skipped source evidence, not repair candidates.'
+      : 'No all-null stat source rows require skipped-evidence classification.',
+    {
+      skippedNullStatSourceEvidence: dryRunPlan.evidence.skippedNullStatSourceEvidence,
+      missingExpectedCategoryValues: dryRunPlan.evidence.missingExpectedCategoryValues,
+    }
+  );
+}
+
+function repairCandidateStep(
+  dryRunPlan: PlayerDataConvergenceDryRunPlan
+): PlayerDataConvergenceTempDbSimulationStep {
+  return step(
+    'confirmNoRepairCandidates',
+    dryRunPlan.evidence.proposedRepairCount === 0 ? 'ready' : 'blocked',
+    dryRunPlan.evidence.proposedRepairCount === 0
+      ? 'The simulation has no repair candidates and will not plan writes.'
+      : 'Repair candidates require a separate approved write-planning task.',
+    {
+      proposedRepairCount: dryRunPlan.evidence.proposedRepairCount,
+      skippedRepairCount: dryRunPlan.evidence.skippedRepairCount,
+    }
+  );
+}
+
+function holdBeforeApplyStep(
+  dryRunPlan: PlayerDataConvergenceDryRunPlan
+): PlayerDataConvergenceTempDbSimulationStep {
+  return step(
+    'holdBeforeWriteApply',
+    'blocked',
+    'Write apply remains blocked even when temp DB simulation evidence is ready.',
+    {
+      safeForWritePlanning: dryRunPlan.safeForWritePlanning,
+      safeForWriteApply: dryRunPlan.safeForWriteApply,
+    }
+  );
+}
+
+export function planPlayerDataConvergenceTempDbSimulation(
+  dryRunPlan: PlayerDataConvergenceDryRunPlan
+): PlayerDataConvergenceTempDbSimulation {
+  const steps = [
+    tempDatabaseStep(dryRunPlan),
+    diagnosticStep(dryRunPlan),
+    skippedSourceEvidenceStep(dryRunPlan),
+    repairCandidateStep(dryRunPlan),
+    holdBeforeApplyStep(dryRunPlan),
+  ];
+  const hasSimulationBlocker = steps
+    .filter((item) => item.kind !== 'holdBeforeWriteApply')
+    .some((item) => item.status === 'blocked');
+  const safeForTempDbSimulation =
+    dryRunPlan.safeForTempDbDryRun &&
+    dryRunPlan.evidence.proposedRepairCount === 0 &&
+    !hasSimulationBlocker;
+
+  return {
+    status: safeForTempDbSimulation ? 'readyForTempDbSimulation' : 'blocked',
+    safeForTempDbSimulation,
+    safeForWritePlanning: false,
+    safeForWriteApply: false,
+    proposedWriteCount: 0,
+    skippedRepairCount: dryRunPlan.evidence.skippedRepairCount,
+    blockers: dryRunPlan.blockers,
+    steps,
+    approvalGates: [
+      ...dryRunPlan.approvalGates,
+      'Convert simulation steps into executable database writes.',
+      'Persist player identity, stats, rankings, or category mappings.',
+    ],
+    stopConditions: [
+      ...dryRunPlan.stopConditions,
+      'Any simulation step proposes a nonzero write count.',
+      'Any future implementation tries to make holdBeforeWriteApply ready automatically.',
+    ],
+    recommendedNextAction: safeForTempDbSimulation
+      ? 'Use this simulation evidence for UAT only; request a separate approved task before any write-capable dry-run.'
+      : 'Resolve simulation blockers before attempting any temp DB simulation or write-capable work.',
+  };
+}

--- a/src/server/playerDataConvergenceTrackedDryRun.ts
+++ b/src/server/playerDataConvergenceTrackedDryRun.ts
@@ -3,6 +3,7 @@ import { REAL_DATA_NINE_CATEGORY_PRESET } from '@/types/fantasyCategories';
 import { diagnosePlayerDataConvergence } from '@/server/playerDataConvergenceDiagnostic';
 import { planPlayerDataConvergenceTempDbDryRun } from '@/server/playerDataConvergenceDryRunPlan';
 import { planPlayerDataConvergenceActions } from '@/server/playerDataConvergencePlanner';
+import { planPlayerDataConvergenceTempDbSimulation } from '@/server/playerDataConvergenceTempDbSimulation';
 
 export type RawPlayerStatRow = Record<string, unknown>;
 
@@ -73,6 +74,7 @@ export function buildPlayerDataConvergenceTrackedDryRunReport({
     databaseUrl,
     repositoryRoot,
   });
+  const simulation = planPlayerDataConvergenceTempDbSimulation(dryRunPlan);
   const runtimeBlockers = tempDatabaseFileExists
     ? []
     : [
@@ -111,6 +113,18 @@ export function buildPlayerDataConvergenceTrackedDryRunReport({
     },
     skippedSourceEvidence,
     dryRunPlan,
+    simulation: {
+      status: simulation.status,
+      safeForTempDbSimulation: simulation.safeForTempDbSimulation,
+      safeForWritePlanning: simulation.safeForWritePlanning,
+      safeForWriteApply: simulation.safeForWriteApply,
+      proposedWriteCount: simulation.proposedWriteCount,
+      skippedRepairCount: simulation.skippedRepairCount,
+      steps: simulation.steps,
+      approvalGates: simulation.approvalGates,
+      stopConditions: simulation.stopConditions,
+      recommendedNextAction: simulation.recommendedNextAction,
+    },
     runtimeChecks: {
       tempDatabaseFileExists,
       blockers: runtimeBlockers,

--- a/tests/unit/playerDataConvergenceTempDbSimulation.test.ts
+++ b/tests/unit/playerDataConvergenceTempDbSimulation.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import {
+  diagnosePlayerDataConvergence,
+  type CanonicalPlayerRow,
+  type PlayerDataSourceRecord,
+} from '@/server/playerDataConvergenceDiagnostic';
+import { planPlayerDataConvergenceTempDbDryRun } from '@/server/playerDataConvergenceDryRunPlan';
+import { planPlayerDataConvergenceActions } from '@/server/playerDataConvergencePlanner';
+import { planPlayerDataConvergenceTempDbSimulation } from '@/server/playerDataConvergenceTempDbSimulation';
+
+const expectedCategories = ['goals', 'inside50s', 'effectiveDisposals'] as const;
+const tempDb = '/tmp/statly-verify-20260621030303.db';
+
+function completeStats(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    goals: 1,
+    inside50s: 2,
+    effectiveDisposals: 3,
+    ...overrides,
+  };
+}
+
+function nullStats(): Record<string, null> {
+  return {
+    goals: null,
+    inside50s: null,
+    effectiveDisposals: null,
+  };
+}
+
+function dryRunPlan(input: {
+  canonicalPlayers: CanonicalPlayerRow[];
+  sourceRecords: PlayerDataSourceRecord[];
+  statlyVerifyDb?: string | null;
+  databaseUrl?: string | null;
+  repositoryRoot?: string | null;
+}) {
+  const diagnostic = diagnosePlayerDataConvergence({
+    canonicalPlayers: input.canonicalPlayers,
+    sourceRecords: input.sourceRecords,
+    expectedCategoryKeys: expectedCategories,
+  });
+  const convergencePlan = planPlayerDataConvergenceActions({
+    diagnostic,
+    expectedCategoryKeys: expectedCategories,
+  });
+
+  return planPlayerDataConvergenceTempDbDryRun({
+    diagnostic,
+    convergencePlan,
+    statlyVerifyDb: input.statlyVerifyDb ?? tempDb,
+    databaseUrl: input.databaseUrl ?? `file://${input.statlyVerifyDb ?? tempDb}`,
+    repositoryRoot: input.repositoryRoot,
+  });
+}
+
+function simulation(input: Parameters<typeof dryRunPlan>[0]) {
+  return planPlayerDataConvergenceTempDbSimulation(dryRunPlan(input));
+}
+
+describe('player data convergence temp DB simulation contract', () => {
+  it('is ready for temp DB simulation when dry-run evidence is safe and non-writing', () => {
+    const result = simulation({
+      canonicalPlayers: [{ id: 'caleb_daniel', name: 'Caleb Daniel', club: 'North Melbourne' }],
+      sourceRecords: [
+        { player_uid: 'caleb_daniel', player_name: 'Caleb Daniel', stats: completeStats() },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      status: 'readyForTempDbSimulation',
+      safeForTempDbSimulation: true,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+      proposedWriteCount: 0,
+      skippedRepairCount: 0,
+    });
+    expect(result.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'validateTempDatabaseContract',
+          status: 'ready',
+        }),
+        expect.objectContaining({
+          kind: 'confirmNoRepairCandidates',
+          status: 'ready',
+          evidence: expect.objectContaining({ proposedRepairCount: 0 }),
+        }),
+        expect.objectContaining({
+          kind: 'holdBeforeWriteApply',
+          status: 'blocked',
+        }),
+      ])
+    );
+    expect(result.approvalGates).toContain(
+      'Convert simulation steps into executable database writes.'
+    );
+  });
+
+  it('classifies all-null stat rows as skipped evidence without creating writes', () => {
+    const result = simulation({
+      canonicalPlayers: [
+        { id: 'tobie_travaglia_st_kilda', name: 'Tobie Travaglia', club: 'St Kilda' },
+      ],
+      sourceRecords: [
+        { player_name: 'Tobie Travaglia', team: 'St Kilda', stats: completeStats(nullStats()) },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      status: 'readyForTempDbSimulation',
+      safeForTempDbSimulation: true,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+      proposedWriteCount: 0,
+      skippedRepairCount: 1,
+    });
+    expect(result.steps).toContainEqual(
+      expect.objectContaining({
+        kind: 'classifySkippedSourceEvidence',
+        status: 'ready',
+        evidence: expect.objectContaining({
+          skippedNullStatSourceEvidence: 1,
+          missingExpectedCategoryValues: 3,
+        }),
+      })
+    );
+  });
+
+  it('blocks simulation when temp database validation is unsafe', () => {
+    const result = simulation({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+      ],
+      statlyVerifyDb: tempDb,
+      databaseUrl: 'file:///Users/robert/Developer/Statly/prisma/dev.db',
+      repositoryRoot: '/Users/robert/Developer/Statly',
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.safeForTempDbSimulation).toBe(false);
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'protectedDevDatabasePath' }),
+        expect.objectContaining({ kind: 'databaseUrlMustNotPointInsideRepository' }),
+      ])
+    );
+    expect(result.steps).toContainEqual(
+      expect.objectContaining({
+        kind: 'validateTempDatabaseContract',
+        status: 'blocked',
+      })
+    );
+  });
+
+  it('blocks simulation when identity evidence requires product decisions', () => {
+    const result = simulation({
+      canonicalPlayers: [
+        { id: 'sam_reid_sydney', name: 'Sam Reid', club: 'Sydney' },
+        { id: 'sam_reid_gws', name: 'Sam Reid', club: 'GWS' },
+      ],
+      sourceRecords: [{ player_name: 'Sam Reid', stats: completeStats() }],
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.safeForTempDbSimulation).toBe(false);
+    expect(result.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'validateDiagnosticEvidence',
+          status: 'blocked',
+        }),
+        expect.objectContaining({
+          kind: 'holdBeforeWriteApply',
+          status: 'blocked',
+        }),
+      ])
+    );
+  });
+
+  it('blocks simulation if a future dry-run plan exposes repair candidates', () => {
+    const basePlan = dryRunPlan({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+      ],
+    });
+    const result = planPlayerDataConvergenceTempDbSimulation({
+      ...basePlan,
+      evidence: {
+        ...basePlan.evidence,
+        proposedRepairCount: 1,
+      },
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.safeForTempDbSimulation).toBe(false);
+    expect(result.proposedWriteCount).toBe(0);
+    expect(result.steps).toContainEqual(
+      expect.objectContaining({
+        kind: 'confirmNoRepairCandidates',
+        status: 'blocked',
+      })
+    );
+  });
+
+  it('stays a pure planner without DB, filesystem, or apply runner imports', () => {
+    const source = readFileSync('src/server/playerDataConvergenceTempDbSimulation.ts', 'utf8');
+
+    expect(source).not.toMatch(/@\/lib\/prisma|firebase|Firestore|node:fs|from 'fs'/);
+    expect(source).not.toMatch(/\bapplyPlayerData|\bwritePlayerData|\brunPlayerData/);
+    expect(source).toContain('safeForWritePlanning: false');
+    expect(source).toContain('safeForWriteApply: false');
+  });
+});

--- a/tests/unit/playerDataConvergenceTrackedDryRun.test.ts
+++ b/tests/unit/playerDataConvergenceTrackedDryRun.test.ts
@@ -76,6 +76,13 @@ describe('tracked player data convergence dry-run report', () => {
           proposedRepairCount: 0,
         },
       },
+      simulation: {
+        status: 'readyForTempDbSimulation',
+        safeForTempDbSimulation: true,
+        safeForWritePlanning: false,
+        safeForWriteApply: false,
+        proposedWriteCount: 0,
+      },
       runtimeChecks: {
         tempDatabaseFileExists: true,
         blockers: [],
@@ -156,5 +163,12 @@ describe('tracked player data convergence dry-run report', () => {
         expect.objectContaining({ kind: 'databaseUrlMustNotPointInsideRepository' }),
       ])
     );
+    expect(report.simulation).toMatchObject({
+      status: 'blocked',
+      safeForTempDbSimulation: false,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+      proposedWriteCount: 0,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a pure player data temp DB simulation contract over the existing dry-run plan.
- Adds simulation readiness to the current `player-data:dry-run` UAT JSON report.
- Keeps write planning and write apply explicitly blocked with zero proposed writes.
- Adds focused unit coverage for ready, blocked, protected DB, all-null source evidence, and architecture/no-writer cases.
- Updates the player data convergence brief with the new UAT acceptance fields.

## Verification

- `npm exec -- prettier --check src/server/playerDataConvergenceTempDbSimulation.ts src/server/playerDataConvergenceTrackedDryRun.ts tests/unit/playerDataConvergenceTempDbSimulation.test.ts tests/unit/playerDataConvergenceTrackedDryRun.test.ts docs/codex/player-data-convergence-brief.md`
- `npm exec -- eslint src/server/playerDataConvergenceTempDbSimulation.ts src/server/playerDataConvergenceTrackedDryRun.ts tests/unit/playerDataConvergenceTempDbSimulation.test.ts tests/unit/playerDataConvergenceTrackedDryRun.test.ts`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/playerDataConvergenceTempDbSimulation.test.ts tests/unit/playerDataConvergenceTrackedDryRun.test.ts tests/unit/playerDataConvergenceDryRunPlan.test.ts tests/unit/playerDataConvergenceTrackedData.test.ts --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Manual `/tmp/statly-verify-*.db` UAT command passed with `simulation.status=readyForTempDbSimulation` and `simulation.proposedWriteCount=0`.
- Council Decision 2 returned COMMIT.

## Notes

- No Prisma, Firestore, runner, package script, schema, or product runtime behavior changes.
- No `prisma/dev.db`, secrets, env files, Firebase exports, generated files, dataconnect local data, or local stashes touched.
- Write-capable convergence remains blocked pending a separate approved task.
