### PR TITLE
feat: add player data temp db preview runner

### DIFF
--- a/Scripts/player-data-convergence-temp-db-runner.ts
+++ b/Scripts/player-data-convergence-temp-db-runner.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env tsx
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { PrismaClient } from '@prisma/client';
+
+import { getPlayers } from '@/lib/data';
+import {
+  buildPlayerDataConvergenceTrackedDryRunReport,
+  type RawPlayerStatRow,
+} from '@/server/playerDataConvergenceTrackedDryRun';
+import {
+  runPlayerDataConvergenceTempDbPreview,
+  type PlayerDataConvergenceTempDbExecutor,
+} from '@/server/playerDataConvergenceTempDbRunner';
+
+async function fileExists(filePath: string): Promise<boolean> {
+  if (!filePath) return false;
+
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+function prismaExecutor(prisma: PrismaClient): PlayerDataConvergenceTempDbExecutor {
+  return {
+    execute: (sql, params = []) => prisma.$executeRawUnsafe(sql, ...params),
+    query: (sql, params = []) => prisma.$queryRawUnsafe(sql, ...params),
+  };
+}
+
+async function buildReport() {
+  const repositoryRoot = process.cwd();
+  const statlyVerifyDb = process.env.STATLY_VERIFY_DB ?? '';
+  const databaseUrl = process.env.DATABASE_URL ?? '';
+  const rawStatRows = JSON.parse(
+    await fs.readFile(path.join(repositoryRoot, 'player_stats_2025.json'), 'utf8')
+  ) as RawPlayerStatRow[];
+  const players = await getPlayers();
+
+  return buildPlayerDataConvergenceTrackedDryRunReport({
+    players,
+    rawStatRows,
+    statlyVerifyDb,
+    databaseUrl,
+    repositoryRoot,
+    tempDatabaseFileExists: await fileExists(statlyVerifyDb),
+  });
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL ?? '';
+  const report = await buildReport();
+
+  if (report.status !== 'readyForUat') {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          mode: 'player-data-convergence-temp-db-runner',
+          status: 'blocked',
+          report,
+          preview: null,
+        },
+        null,
+        2
+      )}\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const prisma = new PrismaClient({
+    datasources: {
+      db: {
+        url: databaseUrl,
+      },
+    },
+  });
+
+  try {
+    const preview = await runPlayerDataConvergenceTempDbPreview({
+      report,
+      executor: prismaExecutor(prisma),
+    });
+
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          mode: 'player-data-convergence-temp-db-runner',
+          status: preview.status === 'previewWritten' ? 'readyForUat' : 'blocked',
+          report,
+          preview,
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    if (preview.status !== 'previewWritten') {
+      process.exitCode = 1;
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error('[player-data-convergence-temp-db-runner] Failed', error);
+  process.exit(1);
+});

--- a/docs/codex/player-data-convergence-brief.md
+++ b/docs/codex/player-data-convergence-brief.md
@@ -59,6 +59,7 @@ ladder steps:
 | Phase 4 pure action planner         | Completed | `src/server/playerDataConvergencePlanner.ts` converts diagnostics into non-writing recommendations.                          |
 | Phase 4b tracked-data planner guard | Completed | `tests/unit/playerDataConvergenceTrackedData.test.ts` verifies warning-only tracked data stays safe for read-only follow-up. |
 | Phase 5 temp DB simulation contract | Completed | `src/server/playerDataConvergenceTempDbSimulation.ts` projects dry-run evidence into non-writing temp DB simulation gates.   |
+| Phase 6 temp DB preview runner      | Completed | `player-data:temp-db-runner` writes preview/audit evidence only to disposable `/tmp/statly-verify-*.db` tables.              |
 
 The current tracked-data warning is narrow and understood: four
 `player_stats_2025.json` rows have all nine real-data category values as `null`.
@@ -268,6 +269,41 @@ Expected UAT result on current tracked data:
 
 If the command reports `blocked`, do not proceed to any write-capable work.
 Resolve the reported blockers first.
+
+### Temp DB Preview Runner UAT Command
+
+The preview runner is the first real runner boundary. It writes audit evidence
+only to preview tables inside the disposable temp DB. It does not write Statly
+product tables, Prisma `Player` rows, Firestore, local JSON, rankings, fixtures,
+or generated files.
+
+```bash
+export STATLY_VERIFY_DB="/tmp/statly-verify-$(date +%Y%m%d%H%M%S).db"
+export DATABASE_URL="file://${STATLY_VERIFY_DB}"
+: > "$STATLY_VERIFY_DB"
+npm --silent run player-data:temp-db-runner
+rm -f "$STATLY_VERIFY_DB"
+```
+
+Expected UAT result on current tracked data:
+
+- top-level `status` is `readyForUat`;
+- `preview.status` is `previewWritten`;
+- `preview.safeForProductWrites` is `false`;
+- `preview.previewTables` lists only
+  `player_data_convergence_preview_runs` and
+  `player_data_convergence_preview_evidence`;
+- `preview.previewEvidenceRows` is `4`;
+- `preview.acceptance.statusReadyForUat` is `true`;
+- `preview.acceptance.simulationReady` is `true`;
+- `preview.acceptance.proposedWriteCountZero` is `true`;
+- `preview.acceptance.writeApplyBlocked` is `true`;
+- `preview.acceptance.tempDatabasePresent` is `true`;
+- nested `report.simulation.proposedWriteCount` remains `0`;
+- nested `report.simulation.safeForWriteApply` remains `false`.
+
+If the preview runner reports `blocked`, stop. Do not add product writes or
+apply behavior until the blockers are resolved in a separate approved task.
 
 ## Source-Of-Truth Map
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "init-firebase-db": "tsx Scripts/initialize-firebase-db.ts",
     "check:etl": "tsx Scripts/check-etl-setup.ts",
     "player-data:dry-run": "tsx Scripts/player-data-convergence-dry-run.ts",
+    "player-data:temp-db-runner": "tsx Scripts/player-data-convergence-temp-db-runner.ts",
     "db:check": "tsx Scripts/check-database.ts",
     "firestore:smoke": "tsx Scripts/firestore-smoke.ts",
     "test:unit": "vitest run --config vitest.config.unit.ts",

--- a/src/server/playerDataConvergenceTempDbRunner.ts
+++ b/src/server/playerDataConvergenceTempDbRunner.ts
@@ -1,0 +1,268 @@
+import type { PlayerDataConvergenceTrackedDryRunReport } from '@/server/playerDataConvergenceTrackedDryRun';
+
+export type PlayerDataConvergenceTempDbRunnerStatus = 'previewWritten' | 'blocked';
+
+export type PlayerDataConvergenceTempDbRunnerBlockerKind =
+  | 'dryRunNotReady'
+  | 'simulationNotReady'
+  | 'writePlanningEnabled'
+  | 'writeApplyEnabled'
+  | 'proposedWriteCountNonZero'
+  | 'tempDatabaseMissing'
+  | 'dryRunBlockersPresent'
+  | 'runtimeBlockersPresent';
+
+export type PlayerDataConvergenceTempDbRunnerBlocker = {
+  kind: PlayerDataConvergenceTempDbRunnerBlockerKind;
+  message: string;
+};
+
+export type PlayerDataConvergenceTempDbExecutor = {
+  execute(sql: string, params?: readonly unknown[]): Promise<unknown>;
+  query<T>(sql: string, params?: readonly unknown[]): Promise<T[]>;
+};
+
+export type PlayerDataConvergenceTempDbRunnerInput = {
+  report: PlayerDataConvergenceTrackedDryRunReport;
+  executor: PlayerDataConvergenceTempDbExecutor;
+  now?: Date;
+};
+
+export type PlayerDataConvergenceTempDbPreviewResult = {
+  status: PlayerDataConvergenceTempDbRunnerStatus;
+  tempDatabase: string;
+  safeForProductWrites: false;
+  previewTables: readonly string[];
+  previewRunId: string | null;
+  previewEvidenceRows: number;
+  blockers: PlayerDataConvergenceTempDbRunnerBlocker[];
+  acceptance: {
+    statusReadyForUat: boolean;
+    simulationReady: boolean;
+    proposedWriteCountZero: boolean;
+    writeApplyBlocked: boolean;
+    tempDatabasePresent: boolean;
+  };
+};
+
+type CountRow = {
+  count: bigint | number | string;
+};
+
+const PREVIEW_RUN_TABLE = 'player_data_convergence_preview_runs';
+const PREVIEW_EVIDENCE_TABLE = 'player_data_convergence_preview_evidence';
+const PREVIEW_TABLES = [PREVIEW_RUN_TABLE, PREVIEW_EVIDENCE_TABLE] as const;
+
+function blocker(
+  kind: PlayerDataConvergenceTempDbRunnerBlockerKind,
+  message: string
+): PlayerDataConvergenceTempDbRunnerBlocker {
+  return { kind, message };
+}
+
+function countValue(rows: readonly CountRow[]): number {
+  const value = rows[0]?.count ?? 0;
+  return Number(value);
+}
+
+function json(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function previewRunId(now: Date): string {
+  return `player-data-preview-${now.toISOString()}`;
+}
+
+export function validatePlayerDataConvergenceTempDbRunner(
+  report: PlayerDataConvergenceTrackedDryRunReport
+): PlayerDataConvergenceTempDbRunnerBlocker[] {
+  const blockers: PlayerDataConvergenceTempDbRunnerBlocker[] = [];
+
+  if (report.status !== 'readyForUat') {
+    blockers.push(
+      blocker('dryRunNotReady', 'The tracked dry-run report must be readyForUat before preview.')
+    );
+  }
+
+  if (
+    report.simulation.status !== 'readyForTempDbSimulation' ||
+    !report.simulation.safeForTempDbSimulation
+  ) {
+    blockers.push(
+      blocker('simulationNotReady', 'The temp DB simulation contract must be ready before preview.')
+    );
+  }
+
+  if (report.simulation.safeForWritePlanning || report.dryRunSummary.safeForWritePlanning) {
+    blockers.push(
+      blocker('writePlanningEnabled', 'Write planning must remain disabled for preview.')
+    );
+  }
+
+  if (report.simulation.safeForWriteApply || report.dryRunSummary.safeForWriteApply) {
+    blockers.push(blocker('writeApplyEnabled', 'Write apply must remain disabled for preview.'));
+  }
+
+  if (
+    report.simulation.proposedWriteCount !== 0 ||
+    report.dryRunSummary.proposedRepairCount !== 0
+  ) {
+    blockers.push(
+      blocker('proposedWriteCountNonZero', 'Preview requires zero proposed writes or repairs.')
+    );
+  }
+
+  if (!report.runtimeChecks.tempDatabaseFileExists) {
+    blockers.push(
+      blocker('tempDatabaseMissing', 'STATLY_VERIFY_DB must be pre-created before preview.')
+    );
+  }
+
+  if (report.dryRunPlan.blockers.length > 0) {
+    blockers.push(
+      blocker('dryRunBlockersPresent', 'Dry-run blockers must be resolved before preview.')
+    );
+  }
+
+  if (report.runtimeChecks.blockers.length > 0) {
+    blockers.push(
+      blocker('runtimeBlockersPresent', 'Runtime blockers must be resolved before preview.')
+    );
+  }
+
+  return blockers;
+}
+
+async function createPreviewTables(executor: PlayerDataConvergenceTempDbExecutor): Promise<void> {
+  await executor.execute(`
+    CREATE TABLE IF NOT EXISTS "${PREVIEW_RUN_TABLE}" (
+      "id" TEXT PRIMARY KEY,
+      "createdAt" TEXT NOT NULL,
+      "status" TEXT NOT NULL,
+      "tempDatabase" TEXT NOT NULL,
+      "safeForProductWrites" INTEGER NOT NULL,
+      "diagnosticJson" TEXT NOT NULL,
+      "simulationJson" TEXT NOT NULL
+    )
+  `);
+  await executor.execute(`
+    CREATE TABLE IF NOT EXISTS "${PREVIEW_EVIDENCE_TABLE}" (
+      "id" TEXT PRIMARY KEY,
+      "runId" TEXT NOT NULL,
+      "kind" TEXT NOT NULL,
+      "payloadJson" TEXT NOT NULL,
+      FOREIGN KEY ("runId") REFERENCES "${PREVIEW_RUN_TABLE}"("id") ON DELETE CASCADE
+    )
+  `);
+}
+
+async function insertPreviewRows({
+  executor,
+  report,
+  runId,
+  createdAt,
+}: {
+  executor: PlayerDataConvergenceTempDbExecutor;
+  report: PlayerDataConvergenceTrackedDryRunReport;
+  runId: string;
+  createdAt: string;
+}): Promise<void> {
+  await executor.execute(
+    `
+      INSERT INTO "${PREVIEW_RUN_TABLE}" (
+        "id",
+        "createdAt",
+        "status",
+        "tempDatabase",
+        "safeForProductWrites",
+        "diagnosticJson",
+        "simulationJson"
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `,
+    [
+      runId,
+      createdAt,
+      report.status,
+      report.dryRunPlan.tempDatabase.statlyVerifyDb,
+      0,
+      json(report.diagnostic),
+      json(report.simulation),
+    ]
+  );
+
+  const evidenceRows = [
+    ['dryRunSummary', report.dryRunSummary],
+    ['skippedSourceEvidence', report.skippedSourceEvidence],
+    ['runtimeChecks', report.runtimeChecks],
+    ['trackedDataWarnings', report.trackedDataWarnings],
+  ] as const;
+
+  for (const [kind, payload] of evidenceRows) {
+    await executor.execute(
+      `
+        INSERT INTO "${PREVIEW_EVIDENCE_TABLE}" (
+          "id",
+          "runId",
+          "kind",
+          "payloadJson"
+        )
+        VALUES (?, ?, ?, ?)
+      `,
+      [`${runId}:${kind}`, runId, kind, json(payload)]
+    );
+  }
+}
+
+export async function runPlayerDataConvergenceTempDbPreview({
+  report,
+  executor,
+  now = new Date(),
+}: PlayerDataConvergenceTempDbRunnerInput): Promise<PlayerDataConvergenceTempDbPreviewResult> {
+  const blockers = validatePlayerDataConvergenceTempDbRunner(report);
+  const acceptance = {
+    statusReadyForUat: report.status === 'readyForUat',
+    simulationReady: report.simulation.status === 'readyForTempDbSimulation',
+    proposedWriteCountZero: report.simulation.proposedWriteCount === 0,
+    writeApplyBlocked:
+      !report.simulation.safeForWriteApply && !report.dryRunSummary.safeForWriteApply,
+    tempDatabasePresent: report.runtimeChecks.tempDatabaseFileExists,
+  };
+
+  if (blockers.length > 0) {
+    return {
+      status: 'blocked',
+      tempDatabase: report.dryRunPlan.tempDatabase.statlyVerifyDb,
+      safeForProductWrites: false,
+      previewTables: PREVIEW_TABLES,
+      previewRunId: null,
+      previewEvidenceRows: 0,
+      blockers,
+      acceptance,
+    };
+  }
+
+  const runId = previewRunId(now);
+  await createPreviewTables(executor);
+  await insertPreviewRows({
+    executor,
+    report,
+    runId,
+    createdAt: now.toISOString(),
+  });
+  const rows = await executor.query<CountRow>(
+    `SELECT COUNT(*) AS "count" FROM "${PREVIEW_EVIDENCE_TABLE}" WHERE "runId" = ?`,
+    [runId]
+  );
+
+  return {
+    status: 'previewWritten',
+    tempDatabase: report.dryRunPlan.tempDatabase.statlyVerifyDb,
+    safeForProductWrites: false,
+    previewTables: PREVIEW_TABLES,
+    previewRunId: runId,
+    previewEvidenceRows: countValue(rows),
+    blockers: [],
+    acceptance,
+  };
+}

--- a/tests/unit/playerDataConvergenceTempDbRunner.test.ts
+++ b/tests/unit/playerDataConvergenceTempDbRunner.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PlayerDataConvergenceTrackedDryRunReport } from '@/server/playerDataConvergenceTrackedDryRun';
+import {
+  runPlayerDataConvergenceTempDbPreview,
+  validatePlayerDataConvergenceTempDbRunner,
+  type PlayerDataConvergenceTempDbExecutor,
+} from '@/server/playerDataConvergenceTempDbRunner';
+
+const tempDb = '/tmp/statly-verify-20260621040404.db';
+
+function readyReport(
+  overrides: Partial<PlayerDataConvergenceTrackedDryRunReport> = {}
+): PlayerDataConvergenceTrackedDryRunReport {
+  return {
+    mode: 'player-data-convergence-temp-db-dry-run-uat',
+    status: 'readyForUat',
+    diagnostic: {
+      totalCanonicalPlayers: 1,
+      totalSourceStatRecords: 1,
+      totalRankingRecords: 0,
+      matchedRecordsByDirectId: 0,
+      matchedRecordsByCanonicalId: 0,
+      matchedRecordsByNormalizedNameTeam: 1,
+      unmatchedCanonicalPlayers: 0,
+      unmatchedSourceRecords: 0,
+      ambiguousNameMatches: 0,
+      duplicateSourceIdentities: 0,
+      missingExpectedCategoryValues: 0,
+      deprecatedCategoryKeys: 0,
+      severity: 'ok',
+    },
+    planner: {
+      status: 'allClear',
+      safeForNextReadOnlyDryRun: true,
+      safeForWritePlanning: false,
+      requiresProductDecision: false,
+    },
+    dryRunSummary: {
+      status: 'readyForTempDbDryRun',
+      safeForTempDbDryRun: true,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+      proposedRepairCount: 0,
+      skippedNullStatSourceEvidence: 0,
+      skippedRepairCount: 0,
+    },
+    skippedSourceEvidence: null,
+    dryRunPlan: {
+      status: 'readyForTempDbDryRun',
+      safeForTempDbDryRun: true,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+      requiresProductDecision: false,
+      tempDatabase: {
+        statlyVerifyDb: tempDb,
+        databaseUrl: `file://${tempDb}`,
+        precreateRequired: true,
+        cleanupCommand: 'rm -f "$STATLY_VERIFY_DB"',
+      },
+      evidence: {
+        totalCanonicalPlayers: 1,
+        totalSourceStatRecords: 1,
+        totalRankingRecords: 0,
+        matchedRecordsByDirectId: 0,
+        matchedRecordsByCanonicalId: 0,
+        matchedRecordsByNormalizedNameTeam: 1,
+        ambiguousNameMatches: 0,
+        unmatchedCanonicalPlayers: 0,
+        unmatchedSourceRecords: 0,
+        duplicateSourceIdentities: 0,
+        missingExpectedCategoryValues: 0,
+        deprecatedCategoryKeys: 0,
+        skippedNullStatSourceEvidence: 0,
+        proposedRepairCount: 0,
+        skippedRepairCount: 0,
+      },
+      blockers: [],
+      approvalGates: [],
+      stopConditions: [],
+      recommendedNextAction: 'preview only',
+    },
+    simulation: {
+      status: 'readyForTempDbSimulation',
+      safeForTempDbSimulation: true,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+      proposedWriteCount: 0,
+      skippedRepairCount: 0,
+      steps: [],
+      approvalGates: [],
+      stopConditions: [],
+      recommendedNextAction: 'preview only',
+    },
+    runtimeChecks: {
+      tempDatabaseFileExists: true,
+      blockers: [],
+    },
+    trackedDataWarnings: {
+      allNullStatRowsAreSkippedSourceEvidence: 0,
+      proposedRepairCount: 0,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+    },
+    ...overrides,
+  } as PlayerDataConvergenceTrackedDryRunReport;
+}
+
+function executor(): PlayerDataConvergenceTempDbExecutor & {
+  executedSql: string[];
+  queries: string[];
+} {
+  const executedSql: string[] = [];
+  const queries: string[] = [];
+
+  return {
+    executedSql,
+    queries,
+    execute: vi.fn(async (sql: string) => {
+      executedSql.push(sql);
+      return 1;
+    }),
+    query: vi.fn(async (sql: string) => {
+      queries.push(sql);
+      return [{ count: 4 }];
+    }),
+  };
+}
+
+describe('player data convergence temp DB runner', () => {
+  it('writes only preview evidence tables for a ready report', async () => {
+    const fakeExecutor = executor();
+    const result = await runPlayerDataConvergenceTempDbPreview({
+      report: readyReport(),
+      executor: fakeExecutor,
+      now: new Date('2026-06-21T01:00:00.000Z'),
+    });
+    const combinedSql = [...fakeExecutor.executedSql, ...fakeExecutor.queries].join('\n');
+
+    expect(result).toMatchObject({
+      status: 'previewWritten',
+      tempDatabase: tempDb,
+      safeForProductWrites: false,
+      previewRunId: 'player-data-preview-2026-06-21T01:00:00.000Z',
+      previewEvidenceRows: 4,
+      blockers: [],
+      acceptance: {
+        statusReadyForUat: true,
+        simulationReady: true,
+        proposedWriteCountZero: true,
+        writeApplyBlocked: true,
+        tempDatabasePresent: true,
+      },
+    });
+    expect(result.previewTables).toEqual([
+      'player_data_convergence_preview_runs',
+      'player_data_convergence_preview_evidence',
+    ]);
+    expect(combinedSql).toContain('player_data_convergence_preview_runs');
+    expect(combinedSql).toContain('player_data_convergence_preview_evidence');
+    expect(combinedSql).not.toMatch(/\b(Player|Pick|LeagueRosterPlayer|LeagueRoster)\b/);
+  });
+
+  it('blocks when the dry-run report is not UAT-ready', () => {
+    const result = validatePlayerDataConvergenceTempDbRunner(readyReport({ status: 'blocked' }));
+
+    expect(result).toContainEqual(expect.objectContaining({ kind: 'dryRunNotReady' }));
+  });
+
+  it('blocks when write planning or apply becomes enabled', () => {
+    const result = validatePlayerDataConvergenceTempDbRunner(
+      readyReport({
+        simulation: {
+          ...readyReport().simulation,
+          safeForWritePlanning: true as false,
+          safeForWriteApply: true as false,
+        },
+      })
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'writePlanningEnabled' }),
+        expect.objectContaining({ kind: 'writeApplyEnabled' }),
+      ])
+    );
+  });
+
+  it('blocks when proposed writes or repairs are nonzero', () => {
+    const result = validatePlayerDataConvergenceTempDbRunner(
+      readyReport({
+        dryRunSummary: {
+          ...readyReport().dryRunSummary,
+          proposedRepairCount: 1,
+        },
+        simulation: {
+          ...readyReport().simulation,
+          proposedWriteCount: 1 as 0,
+        },
+      })
+    );
+
+    expect(result).toContainEqual(expect.objectContaining({ kind: 'proposedWriteCountNonZero' }));
+  });
+
+  it('does not execute SQL when blocked', async () => {
+    const fakeExecutor = executor();
+    const result = await runPlayerDataConvergenceTempDbPreview({
+      report: readyReport({
+        runtimeChecks: {
+          tempDatabaseFileExists: false,
+          blockers: [],
+        },
+      }),
+      executor: fakeExecutor,
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.blockers).toContainEqual(
+      expect.objectContaining({ kind: 'tempDatabaseMissing' })
+    );
+    expect(fakeExecutor.execute).not.toHaveBeenCalled();
+    expect(fakeExecutor.query).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/playerDataConvergenceTempDbRunnerScript.test.ts
+++ b/tests/unit/playerDataConvergenceTempDbRunnerScript.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+describe('player data convergence temp DB runner script architecture', () => {
+  it('uses the temp DB runner and does not hard-code protected local state', () => {
+    const source = readFileSync('Scripts/player-data-convergence-temp-db-runner.ts', 'utf8');
+
+    expect(source).toContain('runPlayerDataConvergenceTempDbPreview');
+    expect(source).toContain('process.env.STATLY_VERIFY_DB');
+    expect(source).toContain('process.env.DATABASE_URL');
+    expect(source).not.toMatch(/prisma\/dev\.db|serviceAccountKey|firebase-admin|Firestore/);
+  });
+
+  it('keeps product writes outside the package-script runner name', () => {
+    const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(packageJson.scripts['player-data:temp-db-runner']).toBe(
+      'tsx Scripts/player-data-convergence-temp-db-runner.ts'
+    );
+    expect(packageJson.scripts['player-data:temp-db-runner']).not.toMatch(
+      /migrate|seed|firebase|dev\.db/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a guarded player data temp DB preview runner.
- Adds `player-data:temp-db-runner` for UAT against `/tmp/statly-verify-*.db`.
- Writes only preview/audit evidence tables inside the disposable temp DB.
- Keeps product writes, write planning, write apply, Firestore, local JSON, rankings, and Prisma product tables blocked.
- Adds focused unit and architecture coverage for runner safety and blocker behavior.
- Documents the new preview runner UAT command and acceptance criteria.

## Verification

- `npm exec -- prettier --check src/server/playerDataConvergenceTempDbRunner.ts Scripts/player-data-convergence-temp-db-runner.ts tests/unit/playerDataConvergenceTempDbRunner.test.ts tests/unit/playerDataConvergenceTempDbRunnerScript.test.ts docs/codex/player-data-convergence-brief.md package.json`
- `npm exec -- eslint src/server/playerDataConvergenceTempDbRunner.ts Scripts/player-data-convergence-temp-db-runner.ts tests/unit/playerDataConvergenceTempDbRunner.test.ts tests/unit/playerDataConvergenceTempDbRunnerScript.test.ts`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/playerDataConvergenceTempDbRunner.test.ts tests/unit/playerDataConvergenceTempDbRunnerScript.test.ts tests/unit/playerDataConvergenceTempDbSimulation.test.ts tests/unit/playerDataConvergenceTrackedDryRun.test.ts tests/unit/playerDataConvergenceDryRunPlan.test.ts tests/unit/playerDataConvergenceTrackedData.test.ts --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Manual `/tmp/statly-verify-*.db` UAT passed with `preview.status=previewWritten`, `preview.safeForProductWrites=false`, and `preview.previewEvidenceRows=4`.
- Council Decision 2 returned COMMIT.

## Notes

- This is the first real runner boundary, but it writes only temp DB preview/audit evidence.
- No Prisma product tables, Firestore, local JSON, rankings, schema, env files, generated files, `prisma/dev.db`, or local stashes were touched.
- Durable product apply remains blocked pending a separate approved task.
