### PR TITLE
test: add player data apply plan

### DIFF
--- a/docs/codex/player-data-convergence-brief.md
+++ b/docs/codex/player-data-convergence-brief.md
@@ -60,6 +60,7 @@ ladder steps:
 | Phase 4b tracked-data planner guard | Completed | `tests/unit/playerDataConvergenceTrackedData.test.ts` verifies warning-only tracked data stays safe for read-only follow-up. |
 | Phase 5 temp DB simulation contract | Completed | `src/server/playerDataConvergenceTempDbSimulation.ts` projects dry-run evidence into non-writing temp DB simulation gates.   |
 | Phase 6 temp DB preview runner      | Completed | `player-data:temp-db-runner` writes preview/audit evidence only to disposable `/tmp/statly-verify-*.db` tables.              |
+| Phase 7 pure apply plan             | Completed | `src/server/playerDataConvergenceApplyPlan.ts` converts evidence into explicit zero-repair apply plans for current data.     |
 
 The current tracked-data warning is narrow and understood: four
 `player_stats_2025.json` rows have all nine real-data category values as `null`.
@@ -70,9 +71,11 @@ The current safety position is:
 
 - identity convergence is good for tracked data;
 - the tracked-data shape is warning-only and safe for read-only follow-up;
+- the current apply plan has zero product mutations and preserves null stat
+  rows as skipped source evidence;
 - write-capable convergence remains unsafe without a separate approved plan;
-- no runner, package script, Prisma write path, Firestore write path, or durable
-  repair workflow exists yet.
+- no Prisma product write path, Firestore write path, local JSON write path, or
+  durable repair workflow exists yet.
 
 The next possible phase is a temp-DB-only write dry-run design. That design must
 use `/tmp/statly-verify-*.db`, avoid production and protected local database

--- a/src/server/playerDataConvergenceApplyPlan.ts
+++ b/src/server/playerDataConvergenceApplyPlan.ts
@@ -1,0 +1,250 @@
+import type { PlayerDataConvergenceDiagnostic } from '@/server/playerDataConvergenceDiagnostic';
+import type {
+  PlayerDataConvergenceAction,
+  PlayerDataConvergencePlan,
+} from '@/server/playerDataConvergencePlanner';
+
+export type PlayerDataConvergenceApplyPlanStatus =
+  | 'noProductRepairs'
+  | 'blocked'
+  | 'requiresReview';
+
+export type PlayerDataConvergenceApplyPlanBlockerKind =
+  | 'plannerBlocked'
+  | 'plannerUnsafeForReadOnlyFollowUp'
+  | 'ambiguousNameMatches'
+  | 'unmatchedSourceRecords'
+  | 'unsafeForWritePlanning'
+  | 'productDecisionRequired';
+
+export type PlayerDataConvergenceApplyPlanBlocker = {
+  kind: PlayerDataConvergenceApplyPlanBlockerKind;
+  message: string;
+  count?: number;
+};
+
+export type PlayerDataConvergenceSkippedEvidenceKind =
+  | 'nullStatSourceEvidence'
+  | 'duplicateSourceIdentity'
+  | 'missingCategoryValue'
+  | 'staleCategoryKey'
+  | 'unmatchedCanonicalPlayer';
+
+export type PlayerDataConvergenceSkippedEvidence = {
+  kind: PlayerDataConvergenceSkippedEvidenceKind;
+  message: string;
+  count: number;
+  sourceIndexes?: number[];
+  sourceIdentities?: string[];
+  categories?: string[];
+};
+
+export type PlayerDataConvergenceProductMutationKind =
+  | 'createPlayer'
+  | 'updatePlayerIdentity'
+  | 'updatePlayerClub'
+  | 'updatePlayerPosition'
+  | 'updateCategoryMapping';
+
+export type PlayerDataConvergenceProductMutation = {
+  kind: PlayerDataConvergenceProductMutationKind;
+  playerId?: string;
+  reason: string;
+};
+
+export type PlayerDataConvergenceApplyPlan = {
+  status: PlayerDataConvergenceApplyPlanStatus;
+  safeForTempDbApplySimulation: boolean;
+  safeForProductApply: false;
+  requiresProductDecision: boolean;
+  productMutationCount: number;
+  skippedEvidenceCount: number;
+  productMutations: PlayerDataConvergenceProductMutation[];
+  skippedEvidence: PlayerDataConvergenceSkippedEvidence[];
+  blockers: PlayerDataConvergenceApplyPlanBlocker[];
+  approvalGates: string[];
+  stopConditions: string[];
+  recommendedNextAction: string;
+};
+
+export type PlayerDataConvergenceApplyPlanInput = {
+  diagnostic: PlayerDataConvergenceDiagnostic;
+  convergencePlan: PlayerDataConvergencePlan;
+};
+
+function blocker(
+  kind: PlayerDataConvergenceApplyPlanBlockerKind,
+  message: string,
+  count?: number
+): PlayerDataConvergenceApplyPlanBlocker {
+  return count === undefined ? { kind, message } : { kind, message, count };
+}
+
+function toSkippedEvidence(
+  action: PlayerDataConvergenceAction
+): PlayerDataConvergenceSkippedEvidence | undefined {
+  if (!action.count || action.count < 1) return undefined;
+
+  if (action.kind === 'skippedNullStatSourceEvidence') {
+    return {
+      kind: 'nullStatSourceEvidence',
+      message:
+        'Rows with all expected stat categories missing are skipped source evidence, not product repair candidates.',
+      count: action.count,
+      sourceIndexes: action.sourceIndexes,
+      sourceIdentities: action.sourceIdentities,
+      categories: action.categories,
+    };
+  }
+
+  if (action.kind === 'duplicateSourceIdentityReviewRequired') {
+    return {
+      kind: 'duplicateSourceIdentity',
+      message: 'Duplicate source identities need source-quality review before apply planning.',
+      count: action.count,
+      sourceIdentities: action.sourceIdentities,
+    };
+  }
+
+  if (action.kind === 'missingExpectedCategoryValueReviewRequired') {
+    return {
+      kind: 'missingCategoryValue',
+      message: 'Missing category values need source coverage review before apply planning.',
+      count: action.count,
+      sourceIndexes: action.sourceIndexes,
+      sourceIdentities: action.sourceIdentities,
+      categories: action.categories,
+    };
+  }
+
+  if (action.kind === 'staleCategoryKeyMappingReviewRequired') {
+    return {
+      kind: 'staleCategoryKey',
+      message: 'Stale category keys need explicit mapping review before apply planning.',
+      count: action.count,
+      sourceIndexes: action.sourceIndexes,
+      sourceIdentities: action.sourceIdentities,
+      categories: action.categories,
+    };
+  }
+
+  if (action.kind === 'identityReviewRequired') {
+    return {
+      kind: 'unmatchedCanonicalPlayer',
+      message: 'Canonical players without source evidence need review before apply planning.',
+      count: action.count,
+      sourceIdentities: action.sourceIdentities,
+    };
+  }
+
+  return undefined;
+}
+
+function applyPlanBlockers({
+  diagnostic,
+  convergencePlan,
+}: PlayerDataConvergenceApplyPlanInput): PlayerDataConvergenceApplyPlanBlocker[] {
+  const blockers: PlayerDataConvergenceApplyPlanBlocker[] = [];
+
+  if (convergencePlan.status === 'blocked') {
+    blockers.push(
+      blocker(
+        'plannerBlocked',
+        'The convergence planner is blocked and cannot produce an apply plan.'
+      )
+    );
+  }
+
+  if (!convergencePlan.safeForNextReadOnlyDryRun) {
+    blockers.push(
+      blocker(
+        'plannerUnsafeForReadOnlyFollowUp',
+        'The diagnostic evidence is not safe for the next read-only follow-up.'
+      )
+    );
+  }
+
+  if (diagnostic.ambiguousNameMatches.length > 0) {
+    blockers.push(
+      blocker(
+        'ambiguousNameMatches',
+        'Ambiguous name matches require a product/data decision before apply planning.',
+        diagnostic.ambiguousNameMatches.length
+      )
+    );
+  }
+
+  if (diagnostic.unmatchedSourceRecords.length > 0) {
+    blockers.push(
+      blocker(
+        'unmatchedSourceRecords',
+        'Unmatched source records must not create or update players automatically.',
+        diagnostic.unmatchedSourceRecords.length
+      )
+    );
+  }
+
+  if (convergencePlan.actions.some((action) => action.kind === 'unsafeForWritePlanning')) {
+    blockers.push(
+      blocker(
+        'unsafeForWritePlanning',
+        'The planner marked this evidence unsafe for write planning.'
+      )
+    );
+  }
+
+  if (convergencePlan.requiresProductDecision) {
+    blockers.push(
+      blocker(
+        'productDecisionRequired',
+        'A product/data decision is required before any apply plan can proceed.'
+      )
+    );
+  }
+
+  return blockers;
+}
+
+export function planPlayerDataConvergenceApply({
+  diagnostic,
+  convergencePlan,
+}: PlayerDataConvergenceApplyPlanInput): PlayerDataConvergenceApplyPlan {
+  const blockers = applyPlanBlockers({ diagnostic, convergencePlan });
+  const skippedEvidence = convergencePlan.actions
+    .map(toSkippedEvidence)
+    .filter((item): item is PlayerDataConvergenceSkippedEvidence => Boolean(item));
+  const productMutations: PlayerDataConvergenceProductMutation[] = [];
+  const productMutationCount = productMutations.length;
+  const skippedEvidenceCount = skippedEvidence.reduce((total, item) => total + item.count, 0);
+  const hasReviewOnlyEvidence = skippedEvidence.length > 0;
+  const status: PlayerDataConvergenceApplyPlanStatus =
+    blockers.length > 0 ? 'blocked' : hasReviewOnlyEvidence ? 'requiresReview' : 'noProductRepairs';
+
+  return {
+    status,
+    safeForTempDbApplySimulation: blockers.length === 0 && productMutationCount === 0,
+    safeForProductApply: false,
+    requiresProductDecision: convergencePlan.requiresProductDecision,
+    productMutationCount,
+    skippedEvidenceCount,
+    productMutations,
+    skippedEvidence,
+    blockers,
+    approvalGates: [
+      'Add a deterministic product mutation kind.',
+      'Run a temp-DB apply simulation.',
+      'Promote temp-DB apply simulation into durable product apply.',
+      'Write Prisma Player rows, Firestore stats, local JSON, rankings, or category mappings.',
+    ],
+    stopConditions: [
+      'Any ambiguous name match or unmatched source record is present.',
+      'Any proposed mutation requires player merge, split, create, delete, or category product judgment.',
+      'Any apply path points at prisma/dev.db or a database outside /tmp/statly-verify-*.db during simulation.',
+      'Any future implementation tries to make safeForProductApply true by default.',
+    ],
+    recommendedNextAction:
+      blockers.length > 0
+        ? 'Resolve blockers before temp-DB apply simulation.'
+        : 'Use this zero-repair apply plan as input to a temp-DB apply simulation; do not perform product writes.',
+  };
+}

--- a/tests/unit/playerDataConvergenceApplyPlan.test.ts
+++ b/tests/unit/playerDataConvergenceApplyPlan.test.ts
@@ -1,0 +1,182 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  diagnosePlayerDataConvergence,
+  type CanonicalPlayerRow,
+  type PlayerDataSourceRecord,
+} from '@/server/playerDataConvergenceDiagnostic';
+import { planPlayerDataConvergenceApply } from '@/server/playerDataConvergenceApplyPlan';
+import { planPlayerDataConvergenceActions } from '@/server/playerDataConvergencePlanner';
+
+const expectedCategories = ['goals', 'inside50s', 'effectiveDisposals'] as const;
+
+function completeStats(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    goals: 1,
+    inside50s: 2,
+    effectiveDisposals: 3,
+    ...overrides,
+  };
+}
+
+function nullStats(): Record<string, null> {
+  return {
+    goals: null,
+    inside50s: null,
+    effectiveDisposals: null,
+  };
+}
+
+function applyPlan(input: {
+  canonicalPlayers: CanonicalPlayerRow[];
+  sourceRecords: PlayerDataSourceRecord[];
+  rankingRecords?: PlayerDataSourceRecord[];
+}) {
+  const diagnostic = diagnosePlayerDataConvergence({
+    ...input,
+    expectedCategoryKeys: expectedCategories,
+  });
+  const convergencePlan = planPlayerDataConvergenceActions({
+    diagnostic,
+    expectedCategoryKeys: expectedCategories,
+  });
+
+  return planPlayerDataConvergenceApply({ diagnostic, convergencePlan });
+}
+
+describe('player data convergence apply plan', () => {
+  it('produces zero product repairs for clean converged evidence', () => {
+    const result = applyPlan({
+      canonicalPlayers: [{ id: 'caleb_daniel', name: 'Caleb Daniel', club: 'North Melbourne' }],
+      sourceRecords: [
+        { player_uid: 'caleb_daniel', player_name: 'Caleb Daniel', stats: completeStats() },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      status: 'noProductRepairs',
+      safeForTempDbApplySimulation: true,
+      safeForProductApply: false,
+      requiresProductDecision: false,
+      productMutationCount: 0,
+      skippedEvidenceCount: 0,
+      productMutations: [],
+      blockers: [],
+    });
+  });
+
+  it('keeps all-null stat rows as skipped evidence instead of product repairs', () => {
+    const result = applyPlan({
+      canonicalPlayers: [
+        { id: 'tobie_travaglia_st_kilda', name: 'Tobie Travaglia', club: 'St Kilda' },
+      ],
+      sourceRecords: [
+        { player_name: 'Tobie Travaglia', team: 'St Kilda', stats: completeStats(nullStats()) },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      status: 'requiresReview',
+      safeForTempDbApplySimulation: true,
+      safeForProductApply: false,
+      productMutationCount: 0,
+      skippedEvidenceCount: 1,
+      productMutations: [],
+      blockers: [],
+    });
+    expect(result.skippedEvidence).toContainEqual(
+      expect.objectContaining({
+        kind: 'nullStatSourceEvidence',
+        count: 1,
+        sourceIdentities: ['tobie travaglia|st kilda'],
+        categories: ['goals', 'inside50s', 'effectiveDisposals'],
+      })
+    );
+  });
+
+  it('blocks ambiguous names instead of proposing identity repairs', () => {
+    const result = applyPlan({
+      canonicalPlayers: [
+        { id: 'sam_reid_sydney', name: 'Sam Reid', club: 'Sydney' },
+        { id: 'sam_reid_gws', name: 'Sam Reid', club: 'GWS' },
+      ],
+      sourceRecords: [{ player_name: 'Sam Reid', stats: completeStats() }],
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.safeForTempDbApplySimulation).toBe(false);
+    expect(result.productMutationCount).toBe(0);
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'plannerBlocked' }),
+        expect.objectContaining({ kind: 'ambiguousNameMatches', count: 1 }),
+        expect.objectContaining({ kind: 'productDecisionRequired' }),
+      ])
+    );
+  });
+
+  it('blocks unmatched source records instead of creating players', () => {
+    const result = applyPlan({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'ghost_player', player_name: 'Ghost Player', stats: completeStats() },
+      ],
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.productMutationCount).toBe(0);
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'unmatchedSourceRecords', count: 1 }),
+        expect.objectContaining({ kind: 'unsafeForWritePlanning' }),
+      ])
+    );
+  });
+
+  it('classifies stale category keys as skipped review evidence', () => {
+    const result = applyPlan({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+      ],
+      rankingRecords: [
+        {
+          player_uid: 'known_player',
+          player_name: 'Known Player',
+          categories: {
+            goals: 1,
+            inside_50s: 2,
+            effective_disposals: 3,
+          },
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      status: 'requiresReview',
+      productMutationCount: 0,
+    });
+    expect(result.skippedEvidenceCount).toBeGreaterThanOrEqual(2);
+    expect(result.skippedEvidence).toContainEqual(
+      expect.objectContaining({
+        kind: 'staleCategoryKey',
+        count: 2,
+        categories: ['inside_50s', 'effective_disposals'],
+      })
+    );
+  });
+
+  it('stays pure and does not import database or runner dependencies', () => {
+    const source = readFileSync('src/server/playerDataConvergenceApplyPlan.ts', 'utf8');
+    const imports = source
+      .split('\n')
+      .filter((line) => line.startsWith('import '))
+      .join('\n');
+
+    expect(imports).not.toMatch(/@\/lib\/prisma|@prisma\/client|firebase|Firestore|node:fs/);
+    expect(source).not.toMatch(/\$executeRaw|\$queryRaw|INSERT INTO|UPDATE|DELETE FROM/);
+    expect(source).toContain('safeForProductApply: false');
+  });
+});

--- a/tests/unit/playerDataConvergenceTrackedApplyPlan.test.ts
+++ b/tests/unit/playerDataConvergenceTrackedApplyPlan.test.ts
@@ -1,0 +1,85 @@
+import { promises as fs } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { getPlayers } from '@/lib/data';
+import { diagnosePlayerDataConvergence } from '@/server/playerDataConvergenceDiagnostic';
+import { planPlayerDataConvergenceApply } from '@/server/playerDataConvergenceApplyPlan';
+import { planPlayerDataConvergenceActions } from '@/server/playerDataConvergencePlanner';
+import { REAL_DATA_NINE_CATEGORY_PRESET } from '@/types/fantasyCategories';
+
+type RawStatRow = Record<string, unknown>;
+
+const rawStatCategoryKeys: Record<(typeof REAL_DATA_NINE_CATEGORY_PRESET)[number], string> = {
+  goals: 'G',
+  tackles: 'T',
+  inside50s: 'I50',
+  intercepts: 'ITC',
+  contestedMarks: 'CM',
+  rebound50s: 'R50',
+  contestedPossessions: 'CP',
+  effectiveDisposals: 'ED',
+  scoreInvolvements: 'SI',
+};
+
+async function loadRawStatRows(): Promise<RawStatRow[]> {
+  return JSON.parse(await fs.readFile('player_stats_2025.json', 'utf8')) as RawStatRow[];
+}
+
+function sourceRecordFromRawRow(row: RawStatRow) {
+  return {
+    player_name: typeof row.Player === 'string' ? row.Player : undefined,
+    team: typeof row.Team === 'string' ? row.Team : undefined,
+    stats: Object.fromEntries(
+      REAL_DATA_NINE_CATEGORY_PRESET.map((category) => [
+        category,
+        row[rawStatCategoryKeys[category]],
+      ])
+    ),
+  };
+}
+
+describe('tracked player data convergence apply plan', () => {
+  it('produces zero product repairs and keeps null stat rows as skipped evidence', async () => {
+    const rawRows = await loadRawStatRows();
+    const players = await getPlayers();
+    const diagnostic = diagnosePlayerDataConvergence({
+      canonicalPlayers: players.map((player) => ({
+        id: player.id,
+        name: player.name,
+        team: player.team,
+        position: player.position,
+      })),
+      sourceRecords: rawRows.map(sourceRecordFromRawRow),
+      expectedCategoryKeys: [...REAL_DATA_NINE_CATEGORY_PRESET],
+    });
+    const convergencePlan = planPlayerDataConvergenceActions({
+      diagnostic,
+      expectedCategoryKeys: [...REAL_DATA_NINE_CATEGORY_PRESET],
+    });
+    const applyPlan = planPlayerDataConvergenceApply({ diagnostic, convergencePlan });
+
+    expect(applyPlan).toMatchObject({
+      status: 'requiresReview',
+      safeForTempDbApplySimulation: true,
+      safeForProductApply: false,
+      requiresProductDecision: false,
+      productMutationCount: 0,
+      productMutations: [],
+      blockers: [],
+    });
+    expect(applyPlan.skippedEvidence).toContainEqual(
+      expect.objectContaining({
+        kind: 'nullStatSourceEvidence',
+        count: 4,
+        sourceIndexes: [2920, 6140, 6209, 6324],
+        sourceIdentities: expect.arrayContaining([
+          'tobie travaglia|st kilda',
+          'nathan fyfe|fremantle',
+          'lachlan mcneil|western bulldogs',
+          'mitchell duncan|geelong',
+        ]),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a pure player data convergence apply-plan module.
- Converts diagnostic/planner evidence into explicit product mutations, skipped evidence, blockers, approval gates, and stop conditions.
- Keeps current tracked data at zero product mutations while classifying the four all-null stat rows as skipped source evidence.
- Adds fixture coverage for clean, null-stat, ambiguous, unmatched, stale-category, and purity cases.
- Adds tracked-data coverage proving current data has zero product repairs.
- Updates the convergence brief with Phase 7 status.

## Verification

- `npm exec -- prettier --check src/server/playerDataConvergenceApplyPlan.ts tests/unit/playerDataConvergenceApplyPlan.test.ts tests/unit/playerDataConvergenceTrackedApplyPlan.test.ts docs/codex/player-data-convergence-brief.md`
- `npm exec -- eslint src/server/playerDataConvergenceApplyPlan.ts tests/unit/playerDataConvergenceApplyPlan.test.ts tests/unit/playerDataConvergenceTrackedApplyPlan.test.ts`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/playerDataConvergenceApplyPlan.test.ts tests/unit/playerDataConvergenceTrackedApplyPlan.test.ts tests/unit/playerDataConvergencePlanner.test.ts tests/unit/playerDataConvergenceTrackedData.test.ts --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Council Decision 2 returned COMMIT.

## Notes

- Pure in-memory planning only.
- No runner, package script, Prisma, Firestore, local JSON, schema, product runtime, or durable apply behavior changed.
- No `prisma/dev.db`, env files, secrets, generated files, dataconnect local data, or local stashes touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated player data convergence design brief with Phase 7 completion status and refined safety position assessment.

* **Tests**
  * Added comprehensive unit test coverage for data convergence apply plan validation across multiple scenarios, including edge cases and real-world data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->