### PR TITLE
test: add player data temp db apply simulation

### DIFF
--- a/Scripts/player-data-convergence-temp-db-apply-simulation.ts
+++ b/Scripts/player-data-convergence-temp-db-apply-simulation.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env tsx
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { PrismaClient } from '@prisma/client';
+
+import { getPlayers } from '@/lib/data';
+import {
+  buildPlayerDataConvergenceTrackedDryRunReport,
+  type RawPlayerStatRow,
+} from '@/server/playerDataConvergenceTrackedDryRun';
+import { runPlayerDataConvergenceTempDbApplySimulation } from '@/server/playerDataConvergenceTempDbApplySimulation';
+import type { PlayerDataConvergenceTempDbExecutor } from '@/server/playerDataConvergenceTempDbRunner';
+
+async function fileExists(filePath: string): Promise<boolean> {
+  if (!filePath) return false;
+
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+function prismaExecutor(prisma: PrismaClient): PlayerDataConvergenceTempDbExecutor {
+  return {
+    execute: (sql, params = []) => prisma.$executeRawUnsafe(sql, ...params),
+    query: (sql, params = []) => prisma.$queryRawUnsafe(sql, ...params),
+  };
+}
+
+async function buildReport() {
+  const repositoryRoot = process.cwd();
+  const statlyVerifyDb = process.env.STATLY_VERIFY_DB ?? '';
+  const databaseUrl = process.env.DATABASE_URL ?? '';
+  const rawStatRows = JSON.parse(
+    await fs.readFile(path.join(repositoryRoot, 'player_stats_2025.json'), 'utf8')
+  ) as RawPlayerStatRow[];
+  const players = await getPlayers();
+
+  return buildPlayerDataConvergenceTrackedDryRunReport({
+    players,
+    rawStatRows,
+    statlyVerifyDb,
+    databaseUrl,
+    repositoryRoot,
+    tempDatabaseFileExists: await fileExists(statlyVerifyDb),
+  });
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL ?? '';
+  const report = await buildReport();
+
+  if (report.status !== 'readyForUat') {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          mode: 'player-data-convergence-temp-db-apply-simulation',
+          status: 'blocked',
+          report,
+          applySimulation: null,
+        },
+        null,
+        2
+      )}\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const prisma = new PrismaClient({
+    datasources: {
+      db: {
+        url: databaseUrl,
+      },
+    },
+  });
+
+  try {
+    const applySimulation = await runPlayerDataConvergenceTempDbApplySimulation({
+      report,
+      applyPlan: report.applyPlan,
+      executor: prismaExecutor(prisma),
+    });
+
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          mode: 'player-data-convergence-temp-db-apply-simulation',
+          status: applySimulation.status === 'simulationApplied' ? 'readyForUat' : 'blocked',
+          report,
+          applySimulation,
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    if (applySimulation.status !== 'simulationApplied') {
+      process.exitCode = 1;
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error('[player-data-convergence-temp-db-apply-simulation] Failed', error);
+  process.exit(1);
+});

--- a/docs/codex/player-data-convergence-brief.md
+++ b/docs/codex/player-data-convergence-brief.md
@@ -61,6 +61,7 @@ ladder steps:
 | Phase 5 temp DB simulation contract | Completed | `src/server/playerDataConvergenceTempDbSimulation.ts` projects dry-run evidence into non-writing temp DB simulation gates.   |
 | Phase 6 temp DB preview runner      | Completed | `player-data:temp-db-runner` writes preview/audit evidence only to disposable `/tmp/statly-verify-*.db` tables.              |
 | Phase 7 pure apply plan             | Completed | `src/server/playerDataConvergenceApplyPlan.ts` converts evidence into explicit zero-repair apply plans for current data.     |
+| Phase 8 temp DB apply simulation    | Completed | `player-data:temp-db-apply-simulation` applies the zero-mutation plan to temp-only product-shaped simulation tables.         |
 
 The current tracked-data warning is narrow and understood: four
 `player_stats_2025.json` rows have all nine real-data category values as `null`.
@@ -73,6 +74,8 @@ The current safety position is:
 - the tracked-data shape is warning-only and safe for read-only follow-up;
 - the current apply plan has zero product mutations and preserves null stat
   rows as skipped source evidence;
+- the current temp-DB apply simulation proves that zero-mutation plan without
+  touching durable product data;
 - write-capable convergence remains unsafe without a separate approved plan;
 - no Prisma product write path, Firestore write path, local JSON write path, or
   durable repair workflow exists yet.
@@ -307,6 +310,47 @@ Expected UAT result on current tracked data:
 
 If the preview runner reports `blocked`, stop. Do not add product writes or
 apply behavior until the blockers are resolved in a separate approved task.
+
+### Temp DB Apply Simulation UAT Command
+
+The apply simulation runner is the next temp-only rung. It consumes the current
+apply plan, creates product-shaped simulation tables inside the disposable temp
+DB, and proves the current plan applies zero product mutations. It does not
+write Statly product tables, Prisma `Player` rows, Firestore, local JSON,
+rankings, fixtures, generated files, or protected local data.
+
+```bash
+export STATLY_VERIFY_DB="/tmp/statly-verify-$(date +%Y%m%d%H%M%S).db"
+export DATABASE_URL="file://${STATLY_VERIFY_DB}"
+: > "$STATLY_VERIFY_DB"
+npm --silent run player-data:temp-db-apply-simulation
+rm -f "$STATLY_VERIFY_DB"
+```
+
+Expected UAT result on current tracked data:
+
+- top-level `status` is `readyForUat`;
+- `applySimulation.status` is `simulationApplied`;
+- `applySimulation.safeForProductApply` is `false`;
+- `applySimulation.simulationTables` lists only
+  `player_data_convergence_apply_simulation_runs`,
+  `player_data_convergence_apply_simulation_mutations`, and
+  `player_data_convergence_apply_simulated_players`;
+- `applySimulation.plannedMutationCount` is `0`;
+- `applySimulation.appliedMutationCount` is `0`;
+- `applySimulation.beforeProductRows` is `0`;
+- `applySimulation.afterProductRows` is `0`;
+- `applySimulation.acceptance.zeroProductMutations` is `true`;
+- `applySimulation.acceptance.productApplyBlocked` is `true`;
+- nested `report.applyPlan.safeForTempDbApplySimulation` is `true`;
+- nested `report.applyPlan.safeForProductApply` is `false`;
+- nested `report.applyPlan.productMutationCount` is `0`;
+- nested `report.applyPlan.skippedEvidence` includes the four all-null stat
+  source rows as skipped evidence.
+
+If the apply simulation reports `blocked`, stop. Do not add durable apply
+behavior or product mutations until the blockers are resolved in a separate
+approved task.
 
 ## Source-Of-Truth Map
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "check:etl": "tsx Scripts/check-etl-setup.ts",
     "player-data:dry-run": "tsx Scripts/player-data-convergence-dry-run.ts",
     "player-data:temp-db-runner": "tsx Scripts/player-data-convergence-temp-db-runner.ts",
+    "player-data:temp-db-apply-simulation": "tsx Scripts/player-data-convergence-temp-db-apply-simulation.ts",
     "db:check": "tsx Scripts/check-database.ts",
     "firestore:smoke": "tsx Scripts/firestore-smoke.ts",
     "test:unit": "vitest run --config vitest.config.unit.ts",

--- a/src/server/playerDataConvergenceTempDbApplySimulation.ts
+++ b/src/server/playerDataConvergenceTempDbApplySimulation.ts
@@ -1,0 +1,282 @@
+import type { PlayerDataConvergenceApplyPlan } from '@/server/playerDataConvergenceApplyPlan';
+import type { PlayerDataConvergenceTrackedDryRunReport } from '@/server/playerDataConvergenceTrackedDryRun';
+import type { PlayerDataConvergenceTempDbExecutor } from '@/server/playerDataConvergenceTempDbRunner';
+
+export type PlayerDataConvergenceTempDbApplySimulationStatus = 'simulationApplied' | 'blocked';
+
+export type PlayerDataConvergenceTempDbApplySimulationBlockerKind =
+  | 'dryRunNotReady'
+  | 'applyPlanNotReady'
+  | 'tempDbApplySimulationDisabled'
+  | 'productApplyEnabled'
+  | 'productMutationsPresent'
+  | 'tempDatabaseMissing'
+  | 'dryRunBlockersPresent'
+  | 'runtimeBlockersPresent';
+
+export type PlayerDataConvergenceTempDbApplySimulationBlocker = {
+  kind: PlayerDataConvergenceTempDbApplySimulationBlockerKind;
+  message: string;
+};
+
+export type PlayerDataConvergenceTempDbApplySimulationInput = {
+  report: PlayerDataConvergenceTrackedDryRunReport;
+  applyPlan: PlayerDataConvergenceApplyPlan;
+  executor: PlayerDataConvergenceTempDbExecutor;
+  now?: Date;
+};
+
+export type PlayerDataConvergenceTempDbApplySimulationResult = {
+  status: PlayerDataConvergenceTempDbApplySimulationStatus;
+  tempDatabase: string;
+  safeForProductApply: false;
+  simulationTables: readonly string[];
+  productShapeTable: string;
+  simulationRunId: string | null;
+  plannedMutationCount: number;
+  appliedMutationCount: number;
+  beforeProductRows: number;
+  afterProductRows: number;
+  blockers: PlayerDataConvergenceTempDbApplySimulationBlocker[];
+  acceptance: {
+    statusReadyForUat: boolean;
+    applyPlanReady: boolean;
+    zeroProductMutations: boolean;
+    productApplyBlocked: boolean;
+    tempDatabasePresent: boolean;
+  };
+};
+
+type CountRow = {
+  count: bigint | number | string;
+};
+
+const APPLY_RUN_TABLE = 'player_data_convergence_apply_simulation_runs';
+const APPLY_MUTATION_TABLE = 'player_data_convergence_apply_simulation_mutations';
+const APPLY_PRODUCT_SHAPE_TABLE = 'player_data_convergence_apply_simulated_players';
+const APPLY_SIMULATION_TABLES = [
+  APPLY_RUN_TABLE,
+  APPLY_MUTATION_TABLE,
+  APPLY_PRODUCT_SHAPE_TABLE,
+] as const;
+
+function blocker(
+  kind: PlayerDataConvergenceTempDbApplySimulationBlockerKind,
+  message: string
+): PlayerDataConvergenceTempDbApplySimulationBlocker {
+  return { kind, message };
+}
+
+function countValue(rows: readonly CountRow[]): number {
+  const value = rows[0]?.count ?? 0;
+  return Number(value);
+}
+
+function json(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function simulationRunId(now: Date): string {
+  return `player-data-apply-simulation-${now.toISOString()}`;
+}
+
+export function validatePlayerDataConvergenceTempDbApplySimulation({
+  report,
+  applyPlan,
+}: Pick<
+  PlayerDataConvergenceTempDbApplySimulationInput,
+  'report' | 'applyPlan'
+>): PlayerDataConvergenceTempDbApplySimulationBlocker[] {
+  const blockers: PlayerDataConvergenceTempDbApplySimulationBlocker[] = [];
+
+  if (report.status !== 'readyForUat') {
+    blockers.push(
+      blocker(
+        'dryRunNotReady',
+        'The tracked dry-run report must be readyForUat before apply simulation.'
+      )
+    );
+  }
+
+  if (applyPlan.status === 'blocked') {
+    blockers.push(
+      blocker('applyPlanNotReady', 'The apply plan must not be blocked before simulation.')
+    );
+  }
+
+  if (!applyPlan.safeForTempDbApplySimulation) {
+    blockers.push(
+      blocker(
+        'tempDbApplySimulationDisabled',
+        'The apply plan must explicitly allow temp-DB apply simulation.'
+      )
+    );
+  }
+
+  if (applyPlan.safeForProductApply) {
+    blockers.push(
+      blocker('productApplyEnabled', 'Product apply must remain disabled during simulation.')
+    );
+  }
+
+  if (applyPlan.productMutationCount !== 0 || applyPlan.productMutations.length !== 0) {
+    blockers.push(
+      blocker(
+        'productMutationsPresent',
+        'The first temp-DB apply simulation only accepts a zero-mutation apply plan.'
+      )
+    );
+  }
+
+  if (!report.runtimeChecks.tempDatabaseFileExists) {
+    blockers.push(
+      blocker('tempDatabaseMissing', 'STATLY_VERIFY_DB must be pre-created before simulation.')
+    );
+  }
+
+  if (report.dryRunPlan.blockers.length > 0) {
+    blockers.push(
+      blocker('dryRunBlockersPresent', 'Dry-run blockers must be resolved before simulation.')
+    );
+  }
+
+  if (report.runtimeChecks.blockers.length > 0) {
+    blockers.push(
+      blocker('runtimeBlockersPresent', 'Runtime blockers must be resolved before simulation.')
+    );
+  }
+
+  return blockers;
+}
+
+async function createApplySimulationTables(
+  executor: PlayerDataConvergenceTempDbExecutor
+): Promise<void> {
+  await executor.execute(`
+    CREATE TABLE IF NOT EXISTS "${APPLY_RUN_TABLE}" (
+      "id" TEXT PRIMARY KEY,
+      "createdAt" TEXT NOT NULL,
+      "status" TEXT NOT NULL,
+      "tempDatabase" TEXT NOT NULL,
+      "safeForProductApply" INTEGER NOT NULL,
+      "plannedMutationCount" INTEGER NOT NULL,
+      "applyPlanJson" TEXT NOT NULL
+    )
+  `);
+  await executor.execute(`
+    CREATE TABLE IF NOT EXISTS "${APPLY_MUTATION_TABLE}" (
+      "id" TEXT PRIMARY KEY,
+      "runId" TEXT NOT NULL,
+      "kind" TEXT NOT NULL,
+      "playerId" TEXT,
+      "payloadJson" TEXT NOT NULL,
+      FOREIGN KEY ("runId") REFERENCES "${APPLY_RUN_TABLE}"("id") ON DELETE CASCADE
+    )
+  `);
+  await executor.execute(`
+    CREATE TABLE IF NOT EXISTS "${APPLY_PRODUCT_SHAPE_TABLE}" (
+      "runId" TEXT NOT NULL,
+      "id" TEXT NOT NULL,
+      "name" TEXT NOT NULL,
+      "club" TEXT,
+      "position" TEXT,
+      "active" INTEGER NOT NULL DEFAULT 1,
+      PRIMARY KEY ("runId", "id"),
+      FOREIGN KEY ("runId") REFERENCES "${APPLY_RUN_TABLE}"("id") ON DELETE CASCADE
+    )
+  `);
+}
+
+async function countSimulatedProductRows({
+  executor,
+  runId,
+}: {
+  executor: PlayerDataConvergenceTempDbExecutor;
+  runId: string;
+}): Promise<number> {
+  const rows = await executor.query<CountRow>(
+    `SELECT COUNT(*) AS "count" FROM "${APPLY_PRODUCT_SHAPE_TABLE}" WHERE "runId" = ?`,
+    [runId]
+  );
+
+  return countValue(rows);
+}
+
+export async function runPlayerDataConvergenceTempDbApplySimulation({
+  report,
+  applyPlan,
+  executor,
+  now = new Date(),
+}: PlayerDataConvergenceTempDbApplySimulationInput): Promise<PlayerDataConvergenceTempDbApplySimulationResult> {
+  const blockers = validatePlayerDataConvergenceTempDbApplySimulation({ report, applyPlan });
+  const acceptance = {
+    statusReadyForUat: report.status === 'readyForUat',
+    applyPlanReady: applyPlan.status !== 'blocked' && applyPlan.safeForTempDbApplySimulation,
+    zeroProductMutations:
+      applyPlan.productMutationCount === 0 && applyPlan.productMutations.length === 0,
+    productApplyBlocked: !applyPlan.safeForProductApply,
+    tempDatabasePresent: report.runtimeChecks.tempDatabaseFileExists,
+  };
+
+  if (blockers.length > 0) {
+    return {
+      status: 'blocked',
+      tempDatabase: report.dryRunPlan.tempDatabase.statlyVerifyDb,
+      safeForProductApply: false,
+      simulationTables: APPLY_SIMULATION_TABLES,
+      productShapeTable: APPLY_PRODUCT_SHAPE_TABLE,
+      simulationRunId: null,
+      plannedMutationCount: applyPlan.productMutationCount,
+      appliedMutationCount: 0,
+      beforeProductRows: 0,
+      afterProductRows: 0,
+      blockers,
+      acceptance,
+    };
+  }
+
+  const runId = simulationRunId(now);
+  await createApplySimulationTables(executor);
+  const beforeProductRows = await countSimulatedProductRows({ executor, runId });
+
+  await executor.execute(
+    `
+      INSERT INTO "${APPLY_RUN_TABLE}" (
+        "id",
+        "createdAt",
+        "status",
+        "tempDatabase",
+        "safeForProductApply",
+        "plannedMutationCount",
+        "applyPlanJson"
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `,
+    [
+      runId,
+      now.toISOString(),
+      applyPlan.status,
+      report.dryRunPlan.tempDatabase.statlyVerifyDb,
+      0,
+      applyPlan.productMutationCount,
+      json(applyPlan),
+    ]
+  );
+
+  const afterProductRows = await countSimulatedProductRows({ executor, runId });
+
+  return {
+    status: 'simulationApplied',
+    tempDatabase: report.dryRunPlan.tempDatabase.statlyVerifyDb,
+    safeForProductApply: false,
+    simulationTables: APPLY_SIMULATION_TABLES,
+    productShapeTable: APPLY_PRODUCT_SHAPE_TABLE,
+    simulationRunId: runId,
+    plannedMutationCount: applyPlan.productMutationCount,
+    appliedMutationCount: 0,
+    beforeProductRows,
+    afterProductRows,
+    blockers: [],
+    acceptance,
+  };
+}

--- a/src/server/playerDataConvergenceTrackedDryRun.ts
+++ b/src/server/playerDataConvergenceTrackedDryRun.ts
@@ -1,6 +1,7 @@
 import type { Player } from '@/types/players';
 import { REAL_DATA_NINE_CATEGORY_PRESET } from '@/types/fantasyCategories';
 import { diagnosePlayerDataConvergence } from '@/server/playerDataConvergenceDiagnostic';
+import { planPlayerDataConvergenceApply } from '@/server/playerDataConvergenceApplyPlan';
 import { planPlayerDataConvergenceTempDbDryRun } from '@/server/playerDataConvergenceDryRunPlan';
 import { planPlayerDataConvergenceActions } from '@/server/playerDataConvergencePlanner';
 import { planPlayerDataConvergenceTempDbSimulation } from '@/server/playerDataConvergenceTempDbSimulation';
@@ -67,6 +68,7 @@ export function buildPlayerDataConvergenceTrackedDryRunReport({
     diagnostic,
     expectedCategoryKeys: [...REAL_DATA_NINE_CATEGORY_PRESET],
   });
+  const applyPlan = planPlayerDataConvergenceApply({ diagnostic, convergencePlan });
   const dryRunPlan = planPlayerDataConvergenceTempDbDryRun({
     diagnostic,
     convergencePlan,
@@ -113,6 +115,7 @@ export function buildPlayerDataConvergenceTrackedDryRunReport({
     },
     skippedSourceEvidence,
     dryRunPlan,
+    applyPlan,
     simulation: {
       status: simulation.status,
       safeForTempDbSimulation: simulation.safeForTempDbSimulation,

--- a/tests/unit/playerDataConvergenceTempDbApplySimulation.test.ts
+++ b/tests/unit/playerDataConvergenceTempDbApplySimulation.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PlayerDataConvergenceApplyPlan } from '@/server/playerDataConvergenceApplyPlan';
+import {
+  runPlayerDataConvergenceTempDbApplySimulation,
+  validatePlayerDataConvergenceTempDbApplySimulation,
+} from '@/server/playerDataConvergenceTempDbApplySimulation';
+import type { PlayerDataConvergenceTrackedDryRunReport } from '@/server/playerDataConvergenceTrackedDryRun';
+import type { PlayerDataConvergenceTempDbExecutor } from '@/server/playerDataConvergenceTempDbRunner';
+
+const tempDb = '/tmp/statly-verify-20260621060606.db';
+
+function applyPlan(
+  overrides: Partial<PlayerDataConvergenceApplyPlan> = {}
+): PlayerDataConvergenceApplyPlan {
+  return {
+    status: 'noProductRepairs',
+    safeForTempDbApplySimulation: true,
+    safeForProductApply: false,
+    requiresProductDecision: false,
+    productMutationCount: 0,
+    skippedEvidenceCount: 0,
+    productMutations: [],
+    skippedEvidence: [],
+    blockers: [],
+    approvalGates: [],
+    stopConditions: [],
+    recommendedNextAction: 'simulate only',
+    ...overrides,
+  };
+}
+
+function readyReport(
+  overrides: Partial<PlayerDataConvergenceTrackedDryRunReport> = {}
+): PlayerDataConvergenceTrackedDryRunReport {
+  const baseApplyPlan = applyPlan();
+
+  return {
+    mode: 'player-data-convergence-temp-db-dry-run-uat',
+    status: 'readyForUat',
+    diagnostic: {
+      totalCanonicalPlayers: 1,
+      totalSourceStatRecords: 1,
+      totalRankingRecords: 0,
+      matchedRecordsByDirectId: 0,
+      matchedRecordsByCanonicalId: 0,
+      matchedRecordsByNormalizedNameTeam: 1,
+      unmatchedCanonicalPlayers: 0,
+      unmatchedSourceRecords: 0,
+      ambiguousNameMatches: 0,
+      duplicateSourceIdentities: 0,
+      missingExpectedCategoryValues: 0,
+      deprecatedCategoryKeys: 0,
+      severity: 'ok',
+    },
+    planner: {
+      status: 'allClear',
+      safeForNextReadOnlyDryRun: true,
+      safeForWritePlanning: false,
+      requiresProductDecision: false,
+    },
+    dryRunSummary: {
+      status: 'readyForTempDbDryRun',
+      safeForTempDbDryRun: true,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+      proposedRepairCount: 0,
+      skippedNullStatSourceEvidence: 0,
+      skippedRepairCount: 0,
+    },
+    skippedSourceEvidence: null,
+    dryRunPlan: {
+      status: 'readyForTempDbDryRun',
+      safeForTempDbDryRun: true,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+      requiresProductDecision: false,
+      tempDatabase: {
+        statlyVerifyDb: tempDb,
+        databaseUrl: `file://${tempDb}`,
+        precreateRequired: true,
+        cleanupCommand: 'rm -f "$STATLY_VERIFY_DB"',
+      },
+      evidence: {
+        totalCanonicalPlayers: 1,
+        totalSourceStatRecords: 1,
+        totalRankingRecords: 0,
+        matchedRecordsByDirectId: 0,
+        matchedRecordsByCanonicalId: 0,
+        matchedRecordsByNormalizedNameTeam: 1,
+        ambiguousNameMatches: 0,
+        unmatchedCanonicalPlayers: 0,
+        unmatchedSourceRecords: 0,
+        duplicateSourceIdentities: 0,
+        missingExpectedCategoryValues: 0,
+        deprecatedCategoryKeys: 0,
+        skippedNullStatSourceEvidence: 0,
+        proposedRepairCount: 0,
+        skippedRepairCount: 0,
+      },
+      blockers: [],
+      approvalGates: [],
+      stopConditions: [],
+      recommendedNextAction: 'preview only',
+    },
+    applyPlan: baseApplyPlan,
+    simulation: {
+      status: 'readyForTempDbSimulation',
+      safeForTempDbSimulation: true,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+      proposedWriteCount: 0,
+      skippedRepairCount: 0,
+      steps: [],
+      approvalGates: [],
+      stopConditions: [],
+      recommendedNextAction: 'preview only',
+    },
+    runtimeChecks: {
+      tempDatabaseFileExists: true,
+      blockers: [],
+    },
+    trackedDataWarnings: {
+      allNullStatRowsAreSkippedSourceEvidence: 0,
+      proposedRepairCount: 0,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+    },
+    ...overrides,
+  } as PlayerDataConvergenceTrackedDryRunReport;
+}
+
+function executor(): PlayerDataConvergenceTempDbExecutor & {
+  executedSql: string[];
+  queries: string[];
+} {
+  const executedSql: string[] = [];
+  const queries: string[] = [];
+
+  return {
+    executedSql,
+    queries,
+    execute: vi.fn(async (sql: string) => {
+      executedSql.push(sql);
+      return 1;
+    }),
+    query: vi.fn(async (sql: string) => {
+      queries.push(sql);
+      return [{ count: 0 }];
+    }),
+  };
+}
+
+describe('player data convergence temp DB apply simulation', () => {
+  it('applies a zero-mutation plan to temp-only product-shaped tables', async () => {
+    const fakeExecutor = executor();
+    const result = await runPlayerDataConvergenceTempDbApplySimulation({
+      report: readyReport(),
+      applyPlan: applyPlan(),
+      executor: fakeExecutor,
+      now: new Date('2026-06-21T03:00:00.000Z'),
+    });
+    const combinedSql = [...fakeExecutor.executedSql, ...fakeExecutor.queries].join('\n');
+
+    expect(result).toMatchObject({
+      status: 'simulationApplied',
+      tempDatabase: tempDb,
+      safeForProductApply: false,
+      productShapeTable: 'player_data_convergence_apply_simulated_players',
+      simulationRunId: 'player-data-apply-simulation-2026-06-21T03:00:00.000Z',
+      plannedMutationCount: 0,
+      appliedMutationCount: 0,
+      beforeProductRows: 0,
+      afterProductRows: 0,
+      blockers: [],
+      acceptance: {
+        statusReadyForUat: true,
+        applyPlanReady: true,
+        zeroProductMutations: true,
+        productApplyBlocked: true,
+        tempDatabasePresent: true,
+      },
+    });
+    expect(result.simulationTables).toEqual([
+      'player_data_convergence_apply_simulation_runs',
+      'player_data_convergence_apply_simulation_mutations',
+      'player_data_convergence_apply_simulated_players',
+    ]);
+    expect(combinedSql).toContain('player_data_convergence_apply_simulation_runs');
+    expect(combinedSql).toContain('player_data_convergence_apply_simulation_mutations');
+    expect(combinedSql).toContain('player_data_convergence_apply_simulated_players');
+    expect(combinedSql).not.toMatch(/\b(Player|Pick|LeagueRosterPlayer|LeagueRoster)\b/);
+  });
+
+  it('blocks if the apply plan is blocked or not simulation-safe', () => {
+    const result = validatePlayerDataConvergenceTempDbApplySimulation({
+      report: readyReport(),
+      applyPlan: applyPlan({
+        status: 'blocked',
+        safeForTempDbApplySimulation: false,
+        blockers: [{ kind: 'plannerBlocked', message: 'blocked' }],
+      }),
+    });
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'applyPlanNotReady' }),
+        expect.objectContaining({ kind: 'tempDbApplySimulationDisabled' }),
+      ])
+    );
+  });
+
+  it('blocks if product apply or product mutations appear', () => {
+    const result = validatePlayerDataConvergenceTempDbApplySimulation({
+      report: readyReport(),
+      applyPlan: applyPlan({
+        safeForProductApply: true as false,
+        productMutationCount: 1,
+        productMutations: [{ kind: 'createPlayer', reason: 'not allowed' }],
+      }),
+    });
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'productApplyEnabled' }),
+        expect.objectContaining({ kind: 'productMutationsPresent' }),
+      ])
+    );
+  });
+
+  it('does not execute SQL when blocked', async () => {
+    const fakeExecutor = executor();
+    const result = await runPlayerDataConvergenceTempDbApplySimulation({
+      report: readyReport({
+        runtimeChecks: {
+          tempDatabaseFileExists: false,
+          blockers: [],
+        },
+      }),
+      applyPlan: applyPlan(),
+      executor: fakeExecutor,
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.blockers).toContainEqual(
+      expect.objectContaining({ kind: 'tempDatabaseMissing' })
+    );
+    expect(fakeExecutor.execute).not.toHaveBeenCalled();
+    expect(fakeExecutor.query).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/playerDataConvergenceTempDbApplySimulationScript.test.ts
+++ b/tests/unit/playerDataConvergenceTempDbApplySimulationScript.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+describe('player data convergence temp DB apply simulation script architecture', () => {
+  it('uses the temp DB apply simulation runner and does not hard-code protected local state', () => {
+    const source = readFileSync(
+      'Scripts/player-data-convergence-temp-db-apply-simulation.ts',
+      'utf8'
+    );
+
+    expect(source).toContain('runPlayerDataConvergenceTempDbApplySimulation');
+    expect(source).toContain('process.env.STATLY_VERIFY_DB');
+    expect(source).toContain('process.env.DATABASE_URL');
+    expect(source).toContain('datasources');
+    expect(source).not.toMatch(/prisma\/dev\.db|serviceAccountKey|firebase-admin|Firestore/);
+  });
+
+  it('exposes a temp DB apply simulation package script without setup or product writes', () => {
+    const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(packageJson.scripts['player-data:temp-db-apply-simulation']).toBe(
+      'tsx Scripts/player-data-convergence-temp-db-apply-simulation.ts'
+    );
+    expect(packageJson.scripts['player-data:temp-db-apply-simulation']).not.toMatch(
+      /migrate|seed|firebase|dev\.db/
+    );
+  });
+});

--- a/tests/unit/playerDataConvergenceTrackedDryRun.test.ts
+++ b/tests/unit/playerDataConvergenceTrackedDryRun.test.ts
@@ -76,6 +76,14 @@ describe('tracked player data convergence dry-run report', () => {
           proposedRepairCount: 0,
         },
       },
+      applyPlan: {
+        status: 'noProductRepairs',
+        safeForTempDbApplySimulation: true,
+        safeForProductApply: false,
+        productMutationCount: 0,
+        productMutations: [],
+        blockers: [],
+      },
       simulation: {
         status: 'readyForTempDbSimulation',
         safeForTempDbSimulation: true,
@@ -144,6 +152,21 @@ describe('tracked player data convergence dry-run report', () => {
       safeForWritePlanning: false,
       safeForWriteApply: false,
     });
+    expect(report.applyPlan).toMatchObject({
+      status: 'requiresReview',
+      safeForTempDbApplySimulation: true,
+      safeForProductApply: false,
+      productMutationCount: 0,
+      productMutations: [],
+      blockers: [],
+    });
+    expect(report.applyPlan.skippedEvidence).toContainEqual(
+      expect.objectContaining({
+        kind: 'nullStatSourceEvidence',
+        count: 1,
+        sourceIdentities: ['tobie travaglia|st kilda'],
+      })
+    );
   });
 
   it('blocks UAT when DATABASE_URL points at protected prisma/dev.db', () => {


### PR DESCRIPTION
## Summary

- Adds a temp-DB-only player data apply simulation runner.
- Consumes the existing pure apply plan and writes only disposable simulation tables under the caller-provided `/tmp/statly-verify-*.db` database.
- Keeps product apply hard-disabled with zero planned/applied product mutations.
- Adds tracked-report apply-plan evidence and focused regression/architecture coverage.
- Documents the new UAT command and expected acceptance fields in the player data convergence brief.

## Verification

- `npm exec -- prettier --check src/server/playerDataConvergenceTempDbApplySimulation.ts Scripts/player-data-convergence-temp-db-apply-simulation.ts src/server/playerDataConvergenceTrackedDryRun.ts tests/unit/playerDataConvergenceTempDbApplySimulation.test.ts tests/unit/playerDataConvergenceTempDbApplySimulationScript.test.ts tests/unit/playerDataConvergenceTrackedDryRun.test.ts docs/codex/player-data-convergence-brief.md package.json`
- `npm exec -- eslint src/server/playerDataConvergenceTempDbApplySimulation.ts Scripts/player-data-convergence-temp-db-apply-simulation.ts src/server/playerDataConvergenceTrackedDryRun.ts tests/unit/playerDataConvergenceTempDbApplySimulation.test.ts tests/unit/playerDataConvergenceTempDbApplySimulationScript.test.ts tests/unit/playerDataConvergenceTrackedDryRun.test.ts`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/playerDataConvergenceTempDbApplySimulation.test.ts tests/unit/playerDataConvergenceTempDbApplySimulationScript.test.ts tests/unit/playerDataConvergenceTrackedDryRun.test.ts tests/unit/playerDataConvergenceApplyPlan.test.ts tests/unit/playerDataConvergenceTrackedApplyPlan.test.ts --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Manual `/tmp/statly-verify-*.db` UAT passed:
  - top-level `status`: `readyForUat`
  - `applySimulation.status`: `simulationApplied`
  - planned/applied mutations: `0` / `0`
  - before/after product-shaped rows: `0` / `0`
  - skipped null stat rows: `4`
  - temp DB cleanup succeeded
  - `prisma/dev.db` stat remained unchanged
- Council Decision 2 returned COMMIT.

## Notes

- No durable product apply path is added.
- No Prisma product tables, Firestore, local JSON, rankings, generated files, or protected local data are written.
- No `prisma/dev.db`, env files, secrets, Firebase exports, generated files, or local stashes were touched.
