### PR TITLE
test: clarify player data source evidence

### DIFF
--- a/docs/codex/player-data-convergence-brief.md
+++ b/docs/codex/player-data-convergence-brief.md
@@ -156,7 +156,8 @@ database queries or fallback assumptions. Every dry-run report must include:
 - ambiguous name matches;
 - unmatched canonical players;
 - unmatched source records;
-- duplicate source identities;
+- repeated source identities, reported by the planner as multi-row source
+  evidence when they already match canonical players;
 - missing expected category values;
 - stale or deprecated category keys;
 - skipped null-stat source evidence;
@@ -174,7 +175,7 @@ planner must skip or block:
 - ambiguous name matches;
 - unmatched source records;
 - unknown or malformed names;
-- duplicate source identities without a reviewed rule;
+- repeated matched source identities without a reviewed coverage rule;
 - stale category mappings without an explicit mapping decision;
 - partial missing category values;
 - rows where all expected category values are `null`;
@@ -182,6 +183,10 @@ planner must skip or block:
 
 The four currently tracked all-null stat rows remain skipped source evidence and
 must not become identity repair candidates.
+
+The currently tracked repeated source identities are also skipped source
+evidence. They represent multiple matched stat rows for the same player/team in
+the source data, not automatic player identity repairs.
 
 ### Human Approval Gates
 

--- a/src/server/playerDataConvergenceApplyPlan.ts
+++ b/src/server/playerDataConvergenceApplyPlan.ts
@@ -25,7 +25,7 @@ export type PlayerDataConvergenceApplyPlanBlocker = {
 
 export type PlayerDataConvergenceSkippedEvidenceKind =
   | 'nullStatSourceEvidence'
-  | 'duplicateSourceIdentity'
+  | 'multiRowSourceEvidence'
   | 'missingCategoryValue'
   | 'staleCategoryKey'
   | 'unmatchedCanonicalPlayer';
@@ -97,10 +97,11 @@ function toSkippedEvidence(
     };
   }
 
-  if (action.kind === 'duplicateSourceIdentityReviewRequired') {
+  if (action.kind === 'multiRowSourceEvidenceReviewRequired') {
     return {
-      kind: 'duplicateSourceIdentity',
-      message: 'Duplicate source identities need source-quality review before apply planning.',
+      kind: 'multiRowSourceEvidence',
+      message:
+        'Repeated matched source identities are skipped as multi-row source evidence, not product repair candidates.',
       count: action.count,
       sourceIdentities: action.sourceIdentities,
     };

--- a/src/server/playerDataConvergencePlanner.ts
+++ b/src/server/playerDataConvergencePlanner.ts
@@ -10,7 +10,7 @@ export type PlayerDataConvergenceActionKind =
   | 'identityReviewRequired'
   | 'ambiguousNameReviewRequired'
   | 'sourceRecordReviewRequired'
-  | 'duplicateSourceIdentityReviewRequired'
+  | 'multiRowSourceEvidenceReviewRequired'
   | 'staleCategoryKeyMappingReviewRequired'
   | 'missingExpectedCategoryValueReviewRequired'
   | 'unsafeForWritePlanning'
@@ -206,9 +206,9 @@ function appendIssueActions(
   if (diagnostic.duplicateSourceIdentities.length > 0) {
     actions.push(
       action(
-        'duplicateSourceIdentityReviewRequired',
+        'multiRowSourceEvidenceReviewRequired',
         'warning',
-        'Duplicate source identities need source-quality review before any convergence plan consumes them.',
+        'Repeated matched source identities are multi-row source evidence, not identity repair candidates; review source coverage before any write-capable plan consumes them.',
         {
           count: diagnostic.duplicateSourceIdentities.length,
           sourceIdentities: unique(

--- a/tests/unit/playerDataConvergenceApplyPlan.test.ts
+++ b/tests/unit/playerDataConvergenceApplyPlan.test.ts
@@ -168,6 +168,32 @@ describe('player data convergence apply plan', () => {
     );
   });
 
+  it('classifies repeated source rows as multi-row evidence, not product repairs', () => {
+    const result = applyPlan({
+      canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
+      sourceRecords: [
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+        { player_uid: 'known_player', player_name: 'Known Player', stats: completeStats() },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      status: 'requiresReview',
+      safeForTempDbApplySimulation: true,
+      safeForProductApply: false,
+      productMutationCount: 0,
+      productMutations: [],
+      blockers: [],
+    });
+    expect(result.skippedEvidence).toContainEqual(
+      expect.objectContaining({
+        kind: 'multiRowSourceEvidence',
+        count: 1,
+        sourceIdentities: ['known_player'],
+      })
+    );
+  });
+
   it('stays pure and does not import database or runner dependencies', () => {
     const source = readFileSync('src/server/playerDataConvergenceApplyPlan.ts', 'utf8');
     const imports = source

--- a/tests/unit/playerDataConvergencePlanner.test.ts
+++ b/tests/unit/playerDataConvergencePlanner.test.ts
@@ -158,7 +158,7 @@ describe('player data convergence planner', () => {
     expect(result.safeForNextReadOnlyDryRun).toBe(false);
   });
 
-  it('requires source-quality review for duplicate source identities', () => {
+  it('classifies repeated matched source identities as multi-row source evidence', () => {
     const result = plan({
       canonicalPlayers: [{ id: 'known_player', name: 'Known Player', club: 'Adelaide' }],
       sourceRecords: [
@@ -169,13 +169,14 @@ describe('player data convergence planner', () => {
 
     expect(result.actions).toContainEqual(
       expect.objectContaining({
-        kind: 'duplicateSourceIdentityReviewRequired',
+        kind: 'multiRowSourceEvidenceReviewRequired',
         severity: 'warning',
         count: 1,
         sourceIdentities: ['known_player'],
       })
     );
     expect(result.safeForNextReadOnlyDryRun).toBe(true);
+    expect(result.safeForWritePlanning).toBe(false);
   });
 
   it('requires mapping review for stale snake_case category keys', () => {

--- a/tests/unit/playerDataConvergenceTrackedApplyPlan.test.ts
+++ b/tests/unit/playerDataConvergenceTrackedApplyPlan.test.ts
@@ -81,5 +81,11 @@ describe('tracked player data convergence apply plan', () => {
         ]),
       })
     );
+    expect(applyPlan.skippedEvidence).toContainEqual(
+      expect.objectContaining({
+        kind: 'multiRowSourceEvidence',
+        count: 614,
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Reclassifies repeated matched player/stat source rows as multi-row source evidence instead of duplicate identity repair risk.
- Keeps product repair planning disabled with zero product mutations.
- Updates apply-plan output so UAT reports show `multiRowSourceEvidence` for the 614 repeated matched source identities.
- Updates focused planner/apply-plan tests and the convergence brief.

## Verification

- `npm exec -- prettier --check src/server/playerDataConvergencePlanner.ts src/server/playerDataConvergenceApplyPlan.ts tests/unit/playerDataConvergencePlanner.test.ts tests/unit/playerDataConvergenceApplyPlan.test.ts tests/unit/playerDataConvergenceTrackedApplyPlan.test.ts docs/codex/player-data-convergence-brief.md`
- `npm exec -- eslint src/server/playerDataConvergencePlanner.ts src/server/playerDataConvergenceApplyPlan.ts tests/unit/playerDataConvergencePlanner.test.ts tests/unit/playerDataConvergenceApplyPlan.test.ts tests/unit/playerDataConvergenceTrackedApplyPlan.test.ts`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/playerDataConvergencePlanner.test.ts tests/unit/playerDataConvergenceApplyPlan.test.ts tests/unit/playerDataConvergenceTrackedApplyPlan.test.ts tests/unit/playerDataConvergenceTrackedDryRun.test.ts --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Temp DB apply simulation UAT passed:
  - top-level `status`: `readyForUat`
  - `applySimulation.status`: `simulationApplied`
  - `multiRowSourceEvidence` count: `614`
  - product mutations: `0`
  - applied mutations: `0`
  - temp DB cleanup succeeded
  - protected main `prisma/dev.db` stat was unchanged
- Council Decision 2 returned COMMIT.

## Notes

- Implemented in an isolated worktree because the primary checkout has unrelated local/user changes including `prisma/dev.db`.
- No runtime routes/components changed.
- No database, generated, env, secret, Firebase, dependency, or stash files were touched.

## Summary by Sourcery

Clarify handling of repeated matched source identities in player data convergence so they are treated as multi-row source evidence rather than product repair candidates.

Enhancements:
- Rename planner/apply-plan action and evidence kinds from duplicate source identities to multi-row source evidence and adjust messaging to emphasize source coverage review over identity repair.
- Ensure planner output remains safe-only for read-only dry runs when repeated matched identities are present and blocks write-capable planning.
- Update convergence brief documentation to describe repeated matched source identities as multi-row source evidence and not automatic identity repairs.

Tests:
- Add and update planner, apply-plan, and tracked apply-plan tests to assert repeated matched source identities yield multi-row source evidence, zero product mutations, and the expected skipped evidence counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified terminology for repeated source identities and coverage rule handling in player data convergence

* **Changes**
  * Refactored classification of multi-row source evidence for improved clarity
  * Repeated matched source identities now require review before product application and are excluded from automatic repairs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->