### PR TITLE
feat: add player data convergence runner

### DIFF
--- a/Scripts/player-data-convergence-runner.ts
+++ b/Scripts/player-data-convergence-runner.ts
@@ -35,6 +35,40 @@ function prismaExecutor(prisma: PrismaClient): PlayerDataConvergenceTempDbExecut
   };
 }
 
+function validateTempDatabaseUrl(databaseUrl: string, statlyVerifyDb: string): string {
+  const trimmedUrl = databaseUrl.trim();
+  const trimmedPath = statlyVerifyDb.trim();
+
+  if (!trimmedUrl || !trimmedPath) {
+    throw new Error(
+      'DATABASE_URL and STATLY_VERIFY_DB must both point to a /tmp/statly-verify-*.db file.'
+    );
+  }
+
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(trimmedUrl);
+  } catch {
+    throw new Error('DATABASE_URL must be a valid file:// URL for the temp verification DB.');
+  }
+
+  const urlPath = decodeURIComponent(parsedUrl.pathname);
+
+  if (
+    parsedUrl.protocol !== 'file:' ||
+    !trimmedPath.startsWith('/tmp/statly-verify-') ||
+    !trimmedPath.endsWith('.db') ||
+    urlPath !== trimmedPath
+  ) {
+    throw new Error(
+      'DATABASE_URL must be file:///tmp/statly-verify-*.db and match STATLY_VERIFY_DB.'
+    );
+  }
+
+  return trimmedUrl;
+}
+
 async function buildReport() {
   const repositoryRoot = process.cwd();
   const statlyVerifyDb = process.env.STATLY_VERIFY_DB ?? '';
@@ -55,8 +89,11 @@ async function buildReport() {
 }
 
 async function main(): Promise<void> {
-  const databaseUrl = process.env.DATABASE_URL ?? '';
   const report = await buildReport();
+  const databaseUrl = validateTempDatabaseUrl(
+    report.dryRunPlan.tempDatabase.databaseUrl,
+    report.dryRunPlan.tempDatabase.statlyVerifyDb
+  );
   let preview = null;
   let applySimulation = null;
 

--- a/Scripts/player-data-convergence-runner.ts
+++ b/Scripts/player-data-convergence-runner.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env tsx
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { PrismaClient } from '@prisma/client';
+
+import { getPlayers } from '@/lib/data';
+import { summarizePlayerDataConvergenceRunner } from '@/server/playerDataConvergenceRunner';
+import { runPlayerDataConvergenceTempDbApplySimulation } from '@/server/playerDataConvergenceTempDbApplySimulation';
+import {
+  buildPlayerDataConvergenceTrackedDryRunReport,
+  type RawPlayerStatRow,
+} from '@/server/playerDataConvergenceTrackedDryRun';
+import {
+  runPlayerDataConvergenceTempDbPreview,
+  type PlayerDataConvergenceTempDbExecutor,
+} from '@/server/playerDataConvergenceTempDbRunner';
+
+async function fileExists(filePath: string): Promise<boolean> {
+  if (!filePath) return false;
+
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+function prismaExecutor(prisma: PrismaClient): PlayerDataConvergenceTempDbExecutor {
+  return {
+    execute: (sql, params = []) => prisma.$executeRawUnsafe(sql, ...params),
+    query: (sql, params = []) => prisma.$queryRawUnsafe(sql, ...params),
+  };
+}
+
+async function buildReport() {
+  const repositoryRoot = process.cwd();
+  const statlyVerifyDb = process.env.STATLY_VERIFY_DB ?? '';
+  const databaseUrl = process.env.DATABASE_URL ?? '';
+  const rawStatRows = JSON.parse(
+    await fs.readFile(path.join(repositoryRoot, 'player_stats_2025.json'), 'utf8')
+  ) as RawPlayerStatRow[];
+  const players = await getPlayers();
+
+  return buildPlayerDataConvergenceTrackedDryRunReport({
+    players,
+    rawStatRows,
+    statlyVerifyDb,
+    databaseUrl,
+    repositoryRoot,
+    tempDatabaseFileExists: await fileExists(statlyVerifyDb),
+  });
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL ?? '';
+  const report = await buildReport();
+  let preview = null;
+  let applySimulation = null;
+
+  if (report.status === 'readyForUat') {
+    const prisma = new PrismaClient({
+      datasources: {
+        db: {
+          url: databaseUrl,
+        },
+      },
+    });
+
+    try {
+      const executor = prismaExecutor(prisma);
+      preview = await runPlayerDataConvergenceTempDbPreview({
+        report,
+        executor,
+      });
+
+      if (preview.status === 'previewWritten') {
+        applySimulation = await runPlayerDataConvergenceTempDbApplySimulation({
+          report,
+          applyPlan: report.applyPlan,
+          executor,
+        });
+      }
+    } finally {
+      await prisma.$disconnect();
+    }
+  }
+
+  const runner = summarizePlayerDataConvergenceRunner({
+    report,
+    preview,
+    applySimulation,
+  });
+
+  process.stdout.write(`${JSON.stringify(runner, null, 2)}\n`);
+
+  if (runner.status !== 'readyForUat') {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error('[player-data-convergence-runner] Failed', error);
+  process.exit(1);
+});

--- a/docs/codex/player-data-convergence-brief.md
+++ b/docs/codex/player-data-convergence-brief.md
@@ -62,6 +62,7 @@ ladder steps:
 | Phase 6 temp DB preview runner      | Completed | `player-data:temp-db-runner` writes preview/audit evidence only to disposable `/tmp/statly-verify-*.db` tables.              |
 | Phase 7 pure apply plan             | Completed | `src/server/playerDataConvergenceApplyPlan.ts` converts evidence into explicit zero-repair apply plans for current data.     |
 | Phase 8 temp DB apply simulation    | Completed | `player-data:temp-db-apply-simulation` applies the zero-mutation plan to temp-only product-shaped simulation tables.         |
+| Phase 9 non-durable runner          | Completed | `player-data:runner` orchestrates dry-run, temp DB preview, and temp DB apply simulation into one concise UAT summary.       |
 
 The current tracked-data warning is narrow and understood: four
 `player_stats_2025.json` rows have all nine real-data category values as `null`.
@@ -76,6 +77,8 @@ The current safety position is:
   rows as skipped source evidence;
 - the current temp-DB apply simulation proves that zero-mutation plan without
   touching durable product data;
+- the non-durable runner now provides one command for the approved temp DB UAT
+  ladder;
 - write-capable convergence remains unsafe without a separate approved plan;
 - no Prisma product write path, Firestore write path, local JSON write path, or
   durable repair workflow exists yet.
@@ -356,6 +359,44 @@ Expected UAT result on current tracked data:
 If the apply simulation reports `blocked`, stop. Do not add durable apply
 behavior or product mutations until the blockers are resolved in a separate
 approved task.
+
+### Consolidated Runner UAT Command
+
+The consolidated runner is the current top-level UAT command. It runs the
+tracked dry-run, temp DB preview, and temp DB apply simulation, then prints a
+concise summary. It does not add durable apply behavior and keeps product writes
+blocked.
+
+```bash
+export STATLY_VERIFY_DB="/tmp/statly-verify-$(date +%Y%m%d%H%M%S).db"
+export DATABASE_URL="file://${STATLY_VERIFY_DB}"
+: > "$STATLY_VERIFY_DB"
+npm --silent run player-data:runner
+rm -f "$STATLY_VERIFY_DB"
+```
+
+Expected UAT result on current tracked data:
+
+- top-level `status` is `readyForUat`;
+- `safeForProductWrites` is `false`;
+- `safeForProductApply` is `false`;
+- `summary.matchedRecordsByNormalizedNameTeam` is `7544`;
+- `summary.multiRowSourceEvidence` is `614`;
+- `summary.skippedNullStatSourceEvidence` is `4`;
+- `summary.proposedRepairCount` is `0`;
+- `summary.productMutationCount` is `0`;
+- `summary.appliedMutationCount` is `0`;
+- `summary.previewEvidenceRows` is `4`;
+- `summary.beforeProductRows` is `0`;
+- `summary.afterProductRows` is `0`;
+- `acceptance.dryRunReady`, `acceptance.previewWritten`, and
+  `acceptance.applySimulationApplied` are `true`;
+- `acceptance.productApplyBlocked` is `true`;
+- `blockers` is empty.
+
+If the consolidated runner reports `blocked`, stop. Use the reported stage and
+blocker kind to fix the earlier dry-run, preview, or apply-simulation rung
+before considering any durable apply work.
 
 ## Source-Of-Truth Map
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "player-data:dry-run": "tsx Scripts/player-data-convergence-dry-run.ts",
     "player-data:temp-db-runner": "tsx Scripts/player-data-convergence-temp-db-runner.ts",
     "player-data:temp-db-apply-simulation": "tsx Scripts/player-data-convergence-temp-db-apply-simulation.ts",
+    "player-data:runner": "tsx Scripts/player-data-convergence-runner.ts",
     "db:check": "tsx Scripts/check-database.ts",
     "firestore:smoke": "tsx Scripts/firestore-smoke.ts",
     "test:unit": "vitest run --config vitest.config.unit.ts",

--- a/src/server/playerDataConvergenceRunner.ts
+++ b/src/server/playerDataConvergenceRunner.ts
@@ -79,9 +79,21 @@ function previewBlockers(
     ];
   }
 
-  return preview.blockers.map((blocker: PlayerDataConvergenceTempDbRunnerBlocker) =>
+  const blockers = preview.blockers.map((blocker: PlayerDataConvergenceTempDbRunnerBlocker) =>
     runnerBlocker('preview', blocker.kind, blocker.message)
   );
+
+  if (preview.status !== 'previewWritten' && blockers.length === 0) {
+    blockers.push(
+      runnerBlocker(
+        'preview',
+        'previewStatusInvalid',
+        `The temp DB preview stage finished with status "${preview.status}".`
+      )
+    );
+  }
+
+  return blockers;
 }
 
 function applySimulationBlockers(
@@ -97,10 +109,22 @@ function applySimulationBlockers(
     ];
   }
 
-  return applySimulation.blockers.map(
+  const blockers = applySimulation.blockers.map(
     (blocker: PlayerDataConvergenceTempDbApplySimulationBlocker) =>
       runnerBlocker('applySimulation', blocker.kind, blocker.message)
   );
+
+  if (applySimulation.status !== 'simulationApplied' && blockers.length === 0) {
+    blockers.push(
+      runnerBlocker(
+        'applySimulation',
+        'applySimulationStatusInvalid',
+        `The temp DB apply simulation stage finished with status "${applySimulation.status}".`
+      )
+    );
+  }
+
+  return blockers;
 }
 
 function dryRunBlockers(

--- a/src/server/playerDataConvergenceRunner.ts
+++ b/src/server/playerDataConvergenceRunner.ts
@@ -1,0 +1,193 @@
+import type {
+  PlayerDataConvergenceTempDbApplySimulationBlocker,
+  PlayerDataConvergenceTempDbApplySimulationResult,
+} from '@/server/playerDataConvergenceTempDbApplySimulation';
+import type { PlayerDataConvergenceTrackedDryRunReport } from '@/server/playerDataConvergenceTrackedDryRun';
+import type {
+  PlayerDataConvergenceTempDbPreviewResult,
+  PlayerDataConvergenceTempDbRunnerBlocker,
+} from '@/server/playerDataConvergenceTempDbRunner';
+
+export type PlayerDataConvergenceRunnerStatus = 'readyForUat' | 'blocked';
+
+export type PlayerDataConvergenceRunnerStage = 'dryRun' | 'preview' | 'applySimulation';
+
+export type PlayerDataConvergenceRunnerBlocker = {
+  stage: PlayerDataConvergenceRunnerStage;
+  kind: string;
+  message: string;
+};
+
+export type PlayerDataConvergenceRunnerInput = {
+  report: PlayerDataConvergenceTrackedDryRunReport;
+  preview: PlayerDataConvergenceTempDbPreviewResult | null;
+  applySimulation: PlayerDataConvergenceTempDbApplySimulationResult | null;
+};
+
+export type PlayerDataConvergenceRunnerResult = {
+  mode: 'player-data-convergence-runner';
+  status: PlayerDataConvergenceRunnerStatus;
+  safeForProductWrites: false;
+  safeForProductApply: false;
+  tempDatabase: string;
+  summary: {
+    totalCanonicalPlayers: number;
+    totalSourceStatRecords: number;
+    matchedRecordsByNormalizedNameTeam: number;
+    ambiguousNameMatches: number;
+    unmatchedSourceRecords: number;
+    multiRowSourceEvidence: number;
+    skippedNullStatSourceEvidence: number;
+    proposedRepairCount: number;
+    productMutationCount: number;
+    appliedMutationCount: number;
+    previewEvidenceRows: number;
+    beforeProductRows: number;
+    afterProductRows: number;
+  };
+  acceptance: {
+    dryRunReady: boolean;
+    previewWritten: boolean;
+    applySimulationApplied: boolean;
+    noProductRepairs: boolean;
+    noProductMutations: boolean;
+    productApplyBlocked: boolean;
+    tempDatabasePresent: boolean;
+  };
+  blockers: PlayerDataConvergenceRunnerBlocker[];
+  recommendedNextAction: string;
+};
+
+function runnerBlocker(
+  stage: PlayerDataConvergenceRunnerStage,
+  kind: string,
+  message: string
+): PlayerDataConvergenceRunnerBlocker {
+  return { stage, kind, message };
+}
+
+function previewBlockers(
+  preview: PlayerDataConvergenceTempDbPreviewResult | null
+): PlayerDataConvergenceRunnerBlocker[] {
+  if (!preview) {
+    return [
+      runnerBlocker(
+        'preview',
+        'previewNotRun',
+        'The temp DB preview stage did not run because an earlier stage was blocked.'
+      ),
+    ];
+  }
+
+  return preview.blockers.map((blocker: PlayerDataConvergenceTempDbRunnerBlocker) =>
+    runnerBlocker('preview', blocker.kind, blocker.message)
+  );
+}
+
+function applySimulationBlockers(
+  applySimulation: PlayerDataConvergenceTempDbApplySimulationResult | null
+): PlayerDataConvergenceRunnerBlocker[] {
+  if (!applySimulation) {
+    return [
+      runnerBlocker(
+        'applySimulation',
+        'applySimulationNotRun',
+        'The temp DB apply simulation stage did not run because an earlier stage was blocked.'
+      ),
+    ];
+  }
+
+  return applySimulation.blockers.map(
+    (blocker: PlayerDataConvergenceTempDbApplySimulationBlocker) =>
+      runnerBlocker('applySimulation', blocker.kind, blocker.message)
+  );
+}
+
+function dryRunBlockers(
+  report: PlayerDataConvergenceTrackedDryRunReport
+): PlayerDataConvergenceRunnerBlocker[] {
+  const blockers: PlayerDataConvergenceRunnerBlocker[] = [];
+
+  if (report.status !== 'readyForUat') {
+    blockers.push(
+      runnerBlocker('dryRun', 'dryRunNotReady', 'The tracked dry-run report is not ready for UAT.')
+    );
+  }
+
+  for (const blocker of report.dryRunPlan.blockers) {
+    blockers.push(runnerBlocker('dryRun', blocker.kind, blocker.message));
+  }
+
+  for (const blocker of report.runtimeChecks.blockers) {
+    blockers.push(runnerBlocker('dryRun', blocker.kind, blocker.message));
+  }
+
+  return blockers;
+}
+
+function multiRowSourceEvidenceCount(report: PlayerDataConvergenceTrackedDryRunReport): number {
+  return (
+    report.applyPlan.skippedEvidence.find((item) => item.kind === 'multiRowSourceEvidence')
+      ?.count ?? 0
+  );
+}
+
+export function summarizePlayerDataConvergenceRunner({
+  report,
+  preview,
+  applySimulation,
+}: PlayerDataConvergenceRunnerInput): PlayerDataConvergenceRunnerResult {
+  const blockers = [
+    ...dryRunBlockers(report),
+    ...previewBlockers(preview),
+    ...applySimulationBlockers(applySimulation),
+  ];
+  const acceptance = {
+    dryRunReady: report.status === 'readyForUat',
+    previewWritten: preview?.status === 'previewWritten',
+    applySimulationApplied: applySimulation?.status === 'simulationApplied',
+    noProductRepairs: report.dryRunSummary.proposedRepairCount === 0,
+    noProductMutations:
+      report.applyPlan.productMutationCount === 0 &&
+      (applySimulation?.appliedMutationCount ?? 0) === 0,
+    productApplyBlocked:
+      !report.applyPlan.safeForProductApply && !(applySimulation?.safeForProductApply ?? false),
+    tempDatabasePresent: report.runtimeChecks.tempDatabaseFileExists,
+  };
+  const status =
+    blockers.length === 0 &&
+    acceptance.dryRunReady &&
+    acceptance.previewWritten &&
+    acceptance.applySimulationApplied
+      ? 'readyForUat'
+      : 'blocked';
+
+  return {
+    mode: 'player-data-convergence-runner',
+    status,
+    safeForProductWrites: false,
+    safeForProductApply: false,
+    tempDatabase: report.dryRunPlan.tempDatabase.statlyVerifyDb,
+    summary: {
+      totalCanonicalPlayers: report.diagnostic.totalCanonicalPlayers,
+      totalSourceStatRecords: report.diagnostic.totalSourceStatRecords,
+      matchedRecordsByNormalizedNameTeam: report.diagnostic.matchedRecordsByNormalizedNameTeam,
+      ambiguousNameMatches: report.diagnostic.ambiguousNameMatches,
+      unmatchedSourceRecords: report.diagnostic.unmatchedSourceRecords,
+      multiRowSourceEvidence: multiRowSourceEvidenceCount(report),
+      skippedNullStatSourceEvidence: report.dryRunSummary.skippedNullStatSourceEvidence,
+      proposedRepairCount: report.dryRunSummary.proposedRepairCount,
+      productMutationCount: report.applyPlan.productMutationCount,
+      appliedMutationCount: applySimulation?.appliedMutationCount ?? 0,
+      previewEvidenceRows: preview?.previewEvidenceRows ?? 0,
+      beforeProductRows: applySimulation?.beforeProductRows ?? 0,
+      afterProductRows: applySimulation?.afterProductRows ?? 0,
+    },
+    acceptance,
+    blockers,
+    recommendedNextAction:
+      status === 'readyForUat'
+        ? 'Runner UAT is complete for the current non-durable path; request a separate approved task before any durable apply mode.'
+        : 'Resolve runner blockers before attempting any durable player-data convergence work.',
+  };
+}

--- a/tests/unit/playerDataConvergenceRunner.test.ts
+++ b/tests/unit/playerDataConvergenceRunner.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PlayerDataConvergenceApplyPlan } from '@/server/playerDataConvergenceApplyPlan';
+import { summarizePlayerDataConvergenceRunner } from '@/server/playerDataConvergenceRunner';
+import type { PlayerDataConvergenceTempDbApplySimulationResult } from '@/server/playerDataConvergenceTempDbApplySimulation';
+import type { PlayerDataConvergenceTrackedDryRunReport } from '@/server/playerDataConvergenceTrackedDryRun';
+import type { PlayerDataConvergenceTempDbPreviewResult } from '@/server/playerDataConvergenceTempDbRunner';
+
+const tempDb = '/tmp/statly-verify-20260622010101.db';
+
+function applyPlan(
+  overrides: Partial<PlayerDataConvergenceApplyPlan> = {}
+): PlayerDataConvergenceApplyPlan {
+  return {
+    status: 'requiresReview',
+    safeForTempDbApplySimulation: true,
+    safeForProductApply: false,
+    requiresProductDecision: false,
+    productMutationCount: 0,
+    skippedEvidenceCount: 618,
+    productMutations: [],
+    skippedEvidence: [
+      {
+        kind: 'multiRowSourceEvidence',
+        message: 'multi-row evidence',
+        count: 614,
+      },
+      {
+        kind: 'nullStatSourceEvidence',
+        message: 'null stat evidence',
+        count: 4,
+      },
+    ],
+    blockers: [],
+    approvalGates: [],
+    stopConditions: [],
+    recommendedNextAction: 'simulate only',
+    ...overrides,
+  };
+}
+
+function report(
+  overrides: Partial<PlayerDataConvergenceTrackedDryRunReport> = {}
+): PlayerDataConvergenceTrackedDryRunReport {
+  return {
+    mode: 'player-data-convergence-temp-db-dry-run-uat',
+    status: 'readyForUat',
+    diagnostic: {
+      totalCanonicalPlayers: 642,
+      totalSourceStatRecords: 7544,
+      totalRankingRecords: 0,
+      matchedRecordsByDirectId: 0,
+      matchedRecordsByCanonicalId: 0,
+      matchedRecordsByNormalizedNameTeam: 7544,
+      unmatchedCanonicalPlayers: 0,
+      unmatchedSourceRecords: 0,
+      ambiguousNameMatches: 0,
+      duplicateSourceIdentities: 614,
+      missingExpectedCategoryValues: 36,
+      deprecatedCategoryKeys: 0,
+      severity: 'warning',
+    },
+    planner: {
+      status: 'readOnlyFollowUpSafe',
+      safeForNextReadOnlyDryRun: true,
+      safeForWritePlanning: false,
+      requiresProductDecision: false,
+    },
+    dryRunSummary: {
+      status: 'readyForTempDbDryRun',
+      safeForTempDbDryRun: true,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+      proposedRepairCount: 0,
+      skippedNullStatSourceEvidence: 4,
+      skippedRepairCount: 618,
+    },
+    skippedSourceEvidence: null,
+    dryRunPlan: {
+      status: 'readyForTempDbDryRun',
+      safeForTempDbDryRun: true,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+      requiresProductDecision: false,
+      tempDatabase: {
+        statlyVerifyDb: tempDb,
+        databaseUrl: `file://${tempDb}`,
+        precreateRequired: true,
+        cleanupCommand: 'rm -f "$STATLY_VERIFY_DB"',
+      },
+      evidence: {
+        totalCanonicalPlayers: 642,
+        totalSourceStatRecords: 7544,
+        totalRankingRecords: 0,
+        matchedRecordsByDirectId: 0,
+        matchedRecordsByCanonicalId: 0,
+        matchedRecordsByNormalizedNameTeam: 7544,
+        ambiguousNameMatches: 0,
+        unmatchedCanonicalPlayers: 0,
+        unmatchedSourceRecords: 0,
+        duplicateSourceIdentities: 614,
+        missingExpectedCategoryValues: 36,
+        deprecatedCategoryKeys: 0,
+        skippedNullStatSourceEvidence: 4,
+        proposedRepairCount: 0,
+        skippedRepairCount: 618,
+      },
+      blockers: [],
+      approvalGates: [],
+      stopConditions: [],
+      recommendedNextAction: 'runner only',
+    },
+    applyPlan: applyPlan(),
+    simulation: {
+      status: 'readyForTempDbSimulation',
+      safeForTempDbSimulation: true,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+      proposedWriteCount: 0,
+      skippedRepairCount: 618,
+      steps: [],
+      approvalGates: [],
+      stopConditions: [],
+      recommendedNextAction: 'runner only',
+    },
+    runtimeChecks: {
+      tempDatabaseFileExists: true,
+      blockers: [],
+    },
+    trackedDataWarnings: {
+      allNullStatRowsAreSkippedSourceEvidence: 4,
+      proposedRepairCount: 0,
+      safeForWritePlanning: false,
+      safeForWriteApply: false,
+    },
+    ...overrides,
+  } as PlayerDataConvergenceTrackedDryRunReport;
+}
+
+function preview(
+  overrides: Partial<PlayerDataConvergenceTempDbPreviewResult> = {}
+): PlayerDataConvergenceTempDbPreviewResult {
+  return {
+    status: 'previewWritten',
+    tempDatabase: tempDb,
+    safeForProductWrites: false,
+    previewTables: [
+      'player_data_convergence_preview_runs',
+      'player_data_convergence_preview_evidence',
+    ],
+    previewRunId: 'preview-run',
+    previewEvidenceRows: 4,
+    blockers: [],
+    acceptance: {
+      statusReadyForUat: true,
+      simulationReady: true,
+      proposedWriteCountZero: true,
+      writeApplyBlocked: true,
+      tempDatabasePresent: true,
+    },
+    ...overrides,
+  };
+}
+
+function applySimulation(
+  overrides: Partial<PlayerDataConvergenceTempDbApplySimulationResult> = {}
+): PlayerDataConvergenceTempDbApplySimulationResult {
+  return {
+    status: 'simulationApplied',
+    tempDatabase: tempDb,
+    safeForProductApply: false,
+    simulationTables: [
+      'player_data_convergence_apply_simulation_runs',
+      'player_data_convergence_apply_simulation_mutations',
+      'player_data_convergence_apply_simulated_players',
+    ],
+    productShapeTable: 'player_data_convergence_apply_simulated_players',
+    simulationRunId: 'apply-simulation-run',
+    plannedMutationCount: 0,
+    appliedMutationCount: 0,
+    beforeProductRows: 0,
+    afterProductRows: 0,
+    blockers: [],
+    acceptance: {
+      statusReadyForUat: true,
+      applyPlanReady: true,
+      zeroProductMutations: true,
+      productApplyBlocked: true,
+      tempDatabasePresent: true,
+    },
+    ...overrides,
+  };
+}
+
+describe('player data convergence runner summary', () => {
+  it('summarizes the current non-durable runner path as ready for UAT', () => {
+    const result = summarizePlayerDataConvergenceRunner({
+      report: report(),
+      preview: preview(),
+      applySimulation: applySimulation(),
+    });
+
+    expect(result).toMatchObject({
+      mode: 'player-data-convergence-runner',
+      status: 'readyForUat',
+      safeForProductWrites: false,
+      safeForProductApply: false,
+      tempDatabase: tempDb,
+      summary: {
+        matchedRecordsByNormalizedNameTeam: 7544,
+        multiRowSourceEvidence: 614,
+        skippedNullStatSourceEvidence: 4,
+        proposedRepairCount: 0,
+        productMutationCount: 0,
+        appliedMutationCount: 0,
+        previewEvidenceRows: 4,
+        beforeProductRows: 0,
+        afterProductRows: 0,
+      },
+      acceptance: {
+        dryRunReady: true,
+        previewWritten: true,
+        applySimulationApplied: true,
+        noProductRepairs: true,
+        noProductMutations: true,
+        productApplyBlocked: true,
+        tempDatabasePresent: true,
+      },
+      blockers: [],
+    });
+  });
+
+  it('blocks when preview or apply simulation stages do not run', () => {
+    const result = summarizePlayerDataConvergenceRunner({
+      report: report(),
+      preview: null,
+      applySimulation: null,
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ stage: 'preview', kind: 'previewNotRun' }),
+        expect.objectContaining({
+          stage: 'applySimulation',
+          kind: 'applySimulationNotRun',
+        }),
+      ])
+    );
+  });
+});

--- a/tests/unit/playerDataConvergenceRunner.test.ts
+++ b/tests/unit/playerDataConvergenceRunner.test.ts
@@ -248,4 +248,23 @@ describe('player data convergence runner summary', () => {
       ])
     );
   });
+
+  it('blocks with explicit stage blockers when preview or apply simulation statuses are invalid', () => {
+    const result = summarizePlayerDataConvergenceRunner({
+      report: report(),
+      preview: preview({ status: 'blocked' }),
+      applySimulation: applySimulation({ status: 'blocked' }),
+    });
+
+    expect(result.status).toBe('blocked');
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ stage: 'preview', kind: 'previewStatusInvalid' }),
+        expect.objectContaining({
+          stage: 'applySimulation',
+          kind: 'applySimulationStatusInvalid',
+        }),
+      ])
+    );
+  });
 });

--- a/tests/unit/playerDataConvergenceRunnerScript.test.ts
+++ b/tests/unit/playerDataConvergenceRunnerScript.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+describe('player data convergence runner script architecture', () => {
+  it('orchestrates the approved temp DB stages without hard-coding protected state', () => {
+    const source = readFileSync('Scripts/player-data-convergence-runner.ts', 'utf8');
+
+    expect(source).toContain('buildPlayerDataConvergenceTrackedDryRunReport');
+    expect(source).toContain('runPlayerDataConvergenceTempDbPreview');
+    expect(source).toContain('runPlayerDataConvergenceTempDbApplySimulation');
+    expect(source).toContain('summarizePlayerDataConvergenceRunner');
+    expect(source).toContain('process.env.STATLY_VERIFY_DB');
+    expect(source).toContain('process.env.DATABASE_URL');
+    expect(source).toContain('datasources');
+    expect(source).not.toMatch(/prisma\/dev\.db|serviceAccountKey|firebase-admin|Firestore/);
+  });
+
+  it('exposes a runner package script without migration, seed, firebase, or apply flags', () => {
+    const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(packageJson.scripts['player-data:runner']).toBe(
+      'tsx Scripts/player-data-convergence-runner.ts'
+    );
+    expect(packageJson.scripts['player-data:runner']).not.toMatch(
+      /--apply|migrate|seed|firebase|dev\.db/
+    );
+  });
+});

--- a/tests/unit/playerDataConvergenceRunnerScript.test.ts
+++ b/tests/unit/playerDataConvergenceRunnerScript.test.ts
@@ -16,6 +16,18 @@ describe('player data convergence runner script architecture', () => {
     expect(source).not.toMatch(/prisma\/dev\.db|serviceAccountKey|firebase-admin|Firestore/);
   });
 
+  it('validates the planned temp DB URL before constructing the Prisma datasource', () => {
+    const source = readFileSync('Scripts/player-data-convergence-runner.ts', 'utf8');
+
+    expect(source).toContain('validateTempDatabaseUrl');
+    expect(source).toContain('report.dryRunPlan.tempDatabase.databaseUrl');
+    expect(source).toContain('report.dryRunPlan.tempDatabase.statlyVerifyDb');
+    expect(source).toContain('/tmp/statly-verify-');
+    expect(source).toContain('DATABASE_URL must be file:///tmp/statly-verify-*.db');
+    expect(source).toMatch(/url:\s*databaseUrl/);
+    expect(source).not.toMatch(/url:\s*process\.env\.DATABASE_URL/);
+  });
+
   it('exposes a runner package script without migration, seed, firebase, or apply flags', () => {
     const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as {
       scripts: Record<string, string>;


### PR DESCRIPTION
## Summary

- Adds a consolidated non-durable player data convergence runner.
- Orchestrates the existing tracked dry-run, temp DB preview, and temp DB apply simulation stages.
- Emits a concise UAT summary instead of the full nested diagnostic report.
- Keeps product writes and product apply disabled.
- Documents the new `player-data:runner` UAT command in the convergence brief.

## Verification

- `npm exec -- prettier --check src/server/playerDataConvergenceRunner.ts Scripts/player-data-convergence-runner.ts tests/unit/playerDataConvergenceRunner.test.ts tests/unit/playerDataConvergenceRunnerScript.test.ts docs/codex/player-data-convergence-brief.md package.json`
- `npm exec -- eslint src/server/playerDataConvergenceRunner.ts Scripts/player-data-convergence-runner.ts tests/unit/playerDataConvergenceRunner.test.ts tests/unit/playerDataConvergenceRunnerScript.test.ts`
- `npm exec -- vitest run --config vitest.config.unit.ts tests/unit/playerDataConvergenceRunner.test.ts tests/unit/playerDataConvergenceRunnerScript.test.ts tests/unit/playerDataConvergenceTempDbRunner.test.ts tests/unit/playerDataConvergenceTempDbApplySimulation.test.ts --coverage.enabled=false`
- `npm run typecheck`
- `git diff --check`
- Consolidated temp DB runner UAT passed:
  - top-level `status`: `readyForUat`
  - `multiRowSourceEvidence`: `614`
  - `skippedNullStatSourceEvidence`: `4`
  - `proposedRepairCount`: `0`
  - `productMutationCount`: `0`
  - `appliedMutationCount`: `0`
  - `previewEvidenceRows`: `4`
  - temp DB cleanup succeeded
  - protected main `prisma/dev.db` stat was unchanged
- Council Decision 2 returned COMMIT.

## Notes

- This is not a durable apply runner.
- No Prisma product tables, Firestore, local JSON, rankings, generated files, or protected local data are written.
- Implemented in an isolated worktree because the primary checkout has unrelated local/user changes including `prisma/dev.db`.

## Summary by Sourcery

Introduce a non-durable consolidated player-data convergence runner that orchestrates existing dry-run, temp DB preview, and temp DB apply simulation into a single UAT entrypoint.

New Features:
- Add a player-data convergence runner module that summarizes dry-run, temp DB preview, and apply simulation results into a concise UAT status report.
- Expose a new `player-data:runner` npm script and CLI entrypoint for the consolidated non-durable convergence workflow.

Documentation:
- Document the consolidated `player-data:runner` UAT command, expected outputs, and its role in the temp DB convergence ladder.

Tests:
- Add unit coverage for the runner summary logic and the player-data convergence runner script behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `npm run player-data:runner` command to execute a consolidated player data convergence orchestration that combines dry-run reporting, temporary database preview, and apply simulation operations, producing a unified UAT summary with acceptance status and recommended next actions.

* **Documentation**
  * Updated player data convergence documentation describing the new Phase 9 runner orchestrator and consolidated UAT command, including detailed specifications for expected output contract and acceptance criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->