### PR TITLE
[codex] Make draft player Z score column sortable

### DIFF
--- a/src/components/draft/PlayerGrid.tsx
+++ b/src/components/draft/PlayerGrid.tsx
@@ -3,7 +3,7 @@ import React, { useMemo, useCallback, useRef, useState, useEffect } from 'react'
 
 import Image from 'next/image';
 
-import { CheckCircle2, ListPlus, Star } from 'lucide-react';
+import { CheckCircle2, Info, ListPlus, Star } from 'lucide-react';
 
 import { getTeamAbbreviation, getTeamLogo } from '@/lib/teamLogos';
 import { FANTASY_CATEGORIES, type FantasyCategoryKey } from '@/types/fantasyCategories';
@@ -33,13 +33,15 @@ interface PlayerGridProps {
 }
 
 const PLAYER_COLUMN_WIDTH = 340;
-const PROFILE_COLUMN_WIDTH = 180;
+const Z_SCORE_COLUMN_WIDTH = 144;
 const STAT_COLUMN_WIDTH = 88;
 const ACTIONS_COLUMN_WIDTH = 236;
 const TABLE_VIEWPORT_HEIGHT = 680;
 const VIRTUALIZED_ROW_HEIGHT = 112;
 const VIRTUALIZED_ROW_OVERSCAN = 6;
 const VIRTUALIZED_ROW_THRESHOLD = 120;
+const STATLY_Z_DESCRIPTION =
+  "Combined Z score across this league's selected scoring categories.";
 const ACTION_BUTTON_BASE_CLASS =
   'inline-flex h-10 w-full justify-center items-center gap-1 rounded-md px-1.5 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
 const ACTION_BUTTON_DISABLED_CLASS =
@@ -111,8 +113,13 @@ function PlayerIdentityCell({
   isQueued,
   isWatched,
 }: PlayerIdentityCellProps): React.JSX.Element {
+  const showInjury = player.injuryStatus && player.injuryStatus !== 'healthy';
+
   return (
-    <th scope="row" className="px-4 py-4 font-normal sm:px-5">
+    <th
+      scope="row"
+      className="sticky left-0 z-[1] bg-card px-4 py-4 font-normal shadow-[1px_0_0_0_hsl(var(--border))] transition-colors group-hover:bg-muted/50 sm:px-5"
+    >
       <div className="flex min-w-0 items-center gap-3">
         <span className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-md border border-border bg-background p-1.5 shadow-sm">
           <Image
@@ -147,6 +154,11 @@ function PlayerIdentityCell({
                 Watchlist
               </span>
             )}
+            {showInjury && (
+              <span className="rounded-md border border-warning/40 bg-warning/15 px-2 py-0.5 font-medium text-warning-foreground">
+                {getInjuryLabel(player.injuryStatus)}
+              </span>
+            )}
           </div>
         </div>
       </div>
@@ -160,33 +172,14 @@ function getInjuryLabel(status: DraftPlayer['injuryStatus']): string {
   return 'Questionable';
 }
 
-function PlayerProfileCell({ player }: { player: DraftPlayer }): React.JSX.Element {
+function PlayerStatlyZCell({ player }: { player: DraftPlayer }): React.JSX.Element {
   const statlyZScore = typeof player.statlyZScore === 'number' ? player.statlyZScore : null;
-  const showInjury = player.injuryStatus && player.injuryStatus !== 'healthy';
 
   return (
-    <td className="px-4 py-4 align-middle">
-      <div className="min-w-0 space-y-2">
-        <div>
-          <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-            Statly Z
-          </div>
-          <div className="mt-1 text-lg font-semibold leading-none text-foreground">
-            {statlyZScore !== null ? statlyZScore.toFixed(2) : 'Pending'}
-          </div>
-        </div>
-        <div className="text-xs text-muted-foreground">
-          Combined Z score across this league&apos;s selected scoring categories.
-        </div>
-
-        {showInjury && (
-          <div>
-            <span className="inline-flex items-center rounded-md border border-warning/40 bg-warning/15 px-2 py-1 text-xs font-medium text-warning-foreground">
-              {getInjuryLabel(player.injuryStatus)}
-            </span>
-          </div>
-        )}
-      </div>
+    <td className="border-l border-border/60 px-4 py-4 text-center align-middle">
+      <span className="inline-flex min-w-16 justify-center text-lg font-semibold leading-none text-foreground tabular-nums">
+        {statlyZScore !== null ? statlyZScore.toFixed(2) : 'Pending'}
+      </span>
     </td>
   );
 }
@@ -353,7 +346,7 @@ function PlayerTableRow({
 }: PlayerTableRowProps): React.JSX.Element {
   const teamLogo = getTeamLogo(player.club);
   const teamAbbreviation = getTeamAbbreviation(player.club);
-  const rowClassName = `cursor-pointer transition-colors [content-visibility:auto] hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
+  const rowClassName = `group cursor-pointer transition-colors [content-visibility:auto] hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
     isFocused ? 'bg-accent/50 ring-2 ring-inset ring-ring' : ''
   } ${isSelected ? 'bg-primary/10' : ''}`;
 
@@ -378,7 +371,7 @@ function PlayerTableRow({
         isQueued={isQueued}
         isWatched={isWatched}
       />
-      <PlayerProfileCell player={player} />
+      <PlayerStatlyZCell player={player} />
       <PlayerStatCells player={player} visibleCategories={visibleCategories} />
       <PlayerRowActions
         player={player}
@@ -576,6 +569,8 @@ interface PlayerGridTableProps {
   canMakePick: boolean;
   pendingSelectionId: string | null;
   setScrollTop: (scrollTop: number) => void;
+  sortBy: PlayerGridSortKey;
+  onSortChange: (sort: PlayerGridSortKey) => void;
   onKeyDown: (event: React.KeyboardEvent, playerIndex: number) => void;
   onFocusChange: (index: number | null) => void;
   onSelect: (player: DraftPlayer) => void;
@@ -602,6 +597,8 @@ function PlayerGridTable({
   canMakePick,
   pendingSelectionId,
   setScrollTop,
+  sortBy,
+  onSortChange,
   onKeyDown,
   onFocusChange,
   onSelect,
@@ -626,11 +623,11 @@ function PlayerGridTable({
           aria-label="Available draft players"
         >
           <caption className="sr-only">
-            Available draft players with profile, league stats, and draft actions.
+            Available draft players with Statly Z, league stats, and draft actions.
           </caption>
           <colgroup>
             <col style={{ width: PLAYER_COLUMN_WIDTH }} />
-            <col style={{ width: PROFILE_COLUMN_WIDTH }} />
+            <col style={{ width: Z_SCORE_COLUMN_WIDTH }} />
             {visibleCategories.length > 0 ? (
               visibleCategories.map((category) => (
                 <col key={category} style={{ width: STAT_COLUMN_WIDTH }} />
@@ -645,16 +642,29 @@ function PlayerGridTable({
               <th
                 scope="col"
                 rowSpan={visibleCategories.length > 0 ? 2 : 1}
-                className="px-4 py-3 font-medium sm:px-5"
+                className="sticky left-0 z-20 bg-muted/95 px-4 py-3 font-medium shadow-[1px_0_0_0_hsl(var(--border))] sm:px-5"
               >
                 Player
               </th>
               <th
                 scope="col"
                 rowSpan={visibleCategories.length > 0 ? 2 : 1}
-                className="px-4 py-3 font-medium"
+                aria-sort={sortBy === 'statlyZ' ? 'descending' : 'none'}
+                className="border-l border-border/70 px-3 py-3 text-center font-medium"
               >
-                Profile
+                <button
+                  type="button"
+                  onClick={() => onSortChange('statlyZ')}
+                  className="mx-auto inline-flex items-center justify-center gap-1 rounded-md px-2 py-1 text-xs font-semibold uppercase text-foreground transition-colors hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-muted"
+                  aria-label="Sort by Statly Z"
+                  title={STATLY_Z_DESCRIPTION}
+                >
+                  <span>Statly Z</span>
+                  <Info
+                    className="h-3.5 w-3.5 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                </button>
               </th>
               <th
                 scope={visibleCategories.length > 0 ? 'colgroup' : 'col'}
@@ -798,7 +808,7 @@ export default function PlayerGrid({
   const statColumnCount = Math.max(visibleCategories.length, 1);
   const tableMinWidth =
     PLAYER_COLUMN_WIDTH +
-    PROFILE_COLUMN_WIDTH +
+    Z_SCORE_COLUMN_WIDTH +
     statColumnCount * STAT_COLUMN_WIDTH +
     ACTIONS_COLUMN_WIDTH;
   const shouldWindowRows = filteredPlayers.length > VIRTUALIZED_ROW_THRESHOLD;
@@ -973,6 +983,8 @@ export default function PlayerGrid({
         canMakePick={canMakePick}
         pendingSelectionId={pendingSelectionId}
         setScrollTop={setScrollTop}
+        sortBy={sortBy}
+        onSortChange={onSortChange}
         onKeyDown={handleKeyDown}
         onFocusChange={setFocusedRow}
         onSelect={handlePlayerSelect}

--- a/tests/unit/PlayerGrid.a11y.test.tsx
+++ b/tests/unit/PlayerGrid.a11y.test.tsx
@@ -98,7 +98,7 @@ describe('PlayerGrid accessibility', () => {
         .map((header) => header.textContent)
     ).toEqual([
       'Player',
-      'Profile',
+      'Statly Z',
       'League Stats',
       'Actions',
       'G',
@@ -113,8 +113,12 @@ describe('PlayerGrid accessibility', () => {
     ]);
 
     const playerRow = within(table).getByRole('row', { name: /marcus bontempelli/i });
-    expect(within(playerRow).getByText('Statly Z')).toBeInTheDocument();
     expect(within(playerRow).getByText('3.42')).toBeInTheDocument();
+    expect(within(playerRow).queryByText(/combined z score/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sort by Statly Z' })).toHaveAttribute(
+      'title',
+      "Combined Z score across this league's selected scoring categories."
+    );
     expect(within(playerRow).getByRole('cell', { name: 'Goals: 1.1' })).toBeInTheDocument();
     expect(within(playerRow).getByRole('cell', { name: 'Inside 50s: 4.2' })).toBeInTheDocument();
     expect(
@@ -190,9 +194,12 @@ describe('PlayerGrid accessibility', () => {
     expect(source).toContain('text-muted-foreground');
     expect(source).toContain('focus-visible:ring-ring');
     expect(source).toContain('const PLAYER_COLUMN_WIDTH = 340');
-    expect(source).toContain('const PROFILE_COLUMN_WIDTH = 180');
+    expect(source).toContain('const Z_SCORE_COLUMN_WIDTH = 144');
     expect(source).toContain('const STAT_COLUMN_WIDTH = 88');
     expect(source).toContain('const ACTIONS_COLUMN_WIDTH = 236');
+    expect(source).toContain('sticky left-0 z-20 bg-muted/95');
+    expect(source).toContain('sticky left-0 z-[1] bg-card');
+    expect(source).toContain("onClick={() => onSortChange('statlyZ')}");
     expect(source).toContain('grid grid-cols-3 items-center gap-2');
     expect(source).toContain('h-10 w-full justify-center');
     expect(source).toContain('inline-flex min-w-12 justify-center tabular-nums');


### PR DESCRIPTION
## Summary
- Moves Statly Z out of the player/profile cell into its own dedicated draft player table column.
- Adds a sortable Statly Z column header with a single info-hover explanation for the combined Z score.
- Makes the Player column sticky for horizontal category scrolling and updates focused accessibility coverage.

## Why
The player table repeated the Z-score explanation in every row and coupled the value to the profile area, making the category table harder to scan. This keeps the explanation at the column level and makes Statly Z sortable as its own table field.

## Validation
- `npm run typecheck:app`
- `npx vitest run --config vitest.config.unit.ts tests/unit/PlayerGrid.a11y.test.tsx`
- `npx eslint src/components/draft/PlayerGrid.tsx tests/unit/PlayerGrid.a11y.test.tsx`
- `git diff --check`

## Residual risk
- Browser QA of the live draft route was attempted locally, but the unauthenticated browser session could not render the live table because local client API calls returned 401. The table behavior is covered by focused component tests and type/lint checks.

## Summary by Sourcery

Make Statly Z a dedicated sortable column in the draft player grid and adjust layout and accessibility.

New Features:
- Add a dedicated Statly Z column with sortable header in the draft player table.

Enhancements:
- Make the Player column sticky for horizontal scrolling and visually align the Statly Z value as a numeric stat cell.
- Move injury status chips from the profile area into the main Player identity cell.
- Update accessibility tests and expectations for the new Statly Z column and sticky Player header.