### PR TITLE
[codex] Fix draft stats season fallback

### DIFF
--- a/src/server/draft/readModels/draftPlayerReadModel.ts
+++ b/src/server/draft/readModels/draftPlayerReadModel.ts
@@ -319,19 +319,27 @@ export function getDraftStatSeasonOptions(
   requestedSeason?: number | null
 ): DraftStatSeasonOptions {
   const currentSeason = new Date().getFullYear();
-  const availableSeasonSet = new Set<number>([currentSeason]);
+  const availableSeasonSet = new Set<number>();
 
   for (const player of players) {
+    if (typeof player.statsSeason === 'number' && Number.isFinite(player.statsSeason)) {
+      availableSeasonSet.add(player.statsSeason);
+    }
+
     for (const season of player.availableStatSeasons ?? []) {
       if (Number.isFinite(season)) availableSeasonSet.add(season);
     }
   }
 
   const availableSeasons = Array.from(availableSeasonSet).sort((a, b) => b - a);
+  const fallbackSeason = availableSeasons[0] ?? currentSeason;
   const selectedSeason =
-    requestedSeason && availableSeasonSet.has(requestedSeason) ? requestedSeason : currentSeason;
+    requestedSeason && availableSeasonSet.has(requestedSeason) ? requestedSeason : fallbackSeason;
 
-  return { selectedSeason, availableSeasons };
+  return {
+    selectedSeason,
+    availableSeasons: availableSeasons.length > 0 ? availableSeasons : [fallbackSeason],
+  };
 }
 
 export function buildDraftPlayerStatsLookup(

--- a/tests/unit/server/draft/readModels/draftPlayerReadModel.test.ts
+++ b/tests/unit/server/draft/readModels/draftPlayerReadModel.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { getDraftStatSeasonOptions } from '@/server/draft/readModels/draftPlayerReadModel';
+import type { Player } from '@/types/players';
+
+function playerWithSeasons(id: string, availableStatSeasons: number[]): Player {
+  return {
+    id,
+    name: id,
+    team: 'GWS',
+    position: 'MID',
+    stats: {},
+    availableStatSeasons,
+  };
+}
+
+function playerWithStatsSeason(id: string, statsSeason: number): Player {
+  return {
+    id,
+    name: id,
+    team: 'GWS',
+    position: 'MID',
+    stats: {},
+    statsSeason,
+  };
+}
+
+describe('getDraftStatSeasonOptions', () => {
+  it('defaults to the newest season present in player stat data', () => {
+    const options = getDraftStatSeasonOptions([
+      playerWithSeasons('player-1', [2025]),
+      playerWithSeasons('player-2', [2024, 2023]),
+    ]);
+
+    expect(options).toEqual({
+      selectedSeason: 2025,
+      availableSeasons: [2025, 2024, 2023],
+    });
+  });
+
+  it('uses a requested season when that season is available', () => {
+    const options = getDraftStatSeasonOptions(
+      [playerWithSeasons('player-1', [2025, 2024])],
+      2024
+    );
+
+    expect(options).toEqual({
+      selectedSeason: 2024,
+      availableSeasons: [2025, 2024],
+    });
+  });
+
+  it('falls back to the newest available season when the requested season has no stats', () => {
+    const options = getDraftStatSeasonOptions(
+      [playerWithSeasons('player-1', [2025]), playerWithSeasons('player-2', [2025])],
+      2026
+    );
+
+    expect(options).toEqual({
+      selectedSeason: 2025,
+      availableSeasons: [2025],
+    });
+  });
+
+  it('uses statsSeason when a player does not expose availableStatSeasons', () => {
+    const options = getDraftStatSeasonOptions([playerWithStatsSeason('player-1', 2025)]);
+
+    expect(options).toEqual({
+      selectedSeason: 2025,
+      availableSeasons: [2025],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the live draft room player stats table showing dashes when the current calendar year has no stat data.

## Root cause

The draft player read model always injected the current calendar year into stat season options and selected it by default. In local/dev data, the available AFL stat season is 2025 while the current date is 2026, so draft player stat enrichment looked up a season with no stats.

## Changes

- Derive draft stat season options from real player stat seasons instead of always adding the calendar year.
- Include both `availableStatSeasons` and legacy `statsSeason` when deriving available seasons.
- Fall back to the calendar year only when no player stat seasons exist at all.
- Add focused unit coverage for default selection, valid requested seasons, unavailable requested seasons, and legacy `statsSeason` fallback.

## Verification

Clean branch verification from `codex/draft-stats-season-fallback`:

- `npm run test:unit -- tests/unit/server/draft/readModels/draftPlayerReadModel.test.ts` passed: 4 tests.
- `npm run typecheck -- --pretty false` passed.
- `npx eslint src/server/draft/readModels/draftPlayerReadModel.ts tests/unit/server/draft/readModels/draftPlayerReadModel.test.ts --quiet` passed.
- `git diff --check origin/main...HEAD -- src/server/draft/readModels/draftPlayerReadModel.ts tests/unit/server/draft/readModels/draftPlayerReadModel.test.ts` passed.

Earlier local behavior verification:

- Live API check returned `statSeason: 2025`, stats present, `statlyZBreakdownLength: 4`, and `missing: []`.
- Browser reload of the live draft room showed numeric League Stats values in the draft table.

## Notes

- This replacement PR supersedes closed draft PR #452, which was based on a polluted branch.
- No Prisma migration required.
- No Firebase, Socket.IO, worker, or ETL deployment required.
- Local `prisma/dev.db` runtime state remains excluded from the commit.

## Summary by Sourcery

Adjust draft player stat season selection to derive from actual player stat data and provide sensible fallbacks when no matching season exists.

Bug Fixes:
- Fix draft player stats selection so the live draft room shows stats instead of dashes when the current calendar year has no stat data.

Enhancements:
- Unify draft stat season selection to prioritize the newest available season from either availableStatSeasons or legacy statsSeason, with a calendar-year fallback only when no player seasons are present.

Tests:
- Add unit tests covering default season selection, honoring valid requested seasons, handling unavailable requested seasons, and using legacy statsSeason when available.