### PR TITLE
Fix draft watchlist click reliability

### DIFF
--- a/src/components/DraftWatchlist.tsx
+++ b/src/components/DraftWatchlist.tsx
@@ -81,6 +81,188 @@ function getInjuryLabel(player: WatchlistRow['player']): string | null {
   return null;
 }
 
+function WatchlistPlayerMeta({ row }: { row: WatchlistRow }) {
+  const avgPoints = row.player.avgPoints ?? row.player.averagePoints;
+
+  return (
+    <div className="mt-1 flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+      <span className="rounded-md bg-muted px-1.5 py-0.5 font-medium text-muted-foreground">
+        {row.player.position}
+      </span>
+      <span className="truncate">{row.player.club}</span>
+      {typeof row.player.adp === 'number' && <span className="shrink-0">ADP {row.player.adp}</span>}
+      {typeof avgPoints === 'number' && <span className="shrink-0">{avgPoints.toFixed(1)} avg</span>}
+    </div>
+  );
+}
+
+function WatchlistPlayerSignals({ row }: { row: WatchlistRow }) {
+  const injuryLabel = getInjuryLabel(row.player);
+
+  if (!injuryLabel && !row.item.notes) return null;
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-1.5 text-xs text-muted-foreground">
+      {injuryLabel && (
+        <span className="inline-flex items-center gap-1 rounded-md border border-destructive/30 bg-destructive/10 px-1.5 py-0.5 text-destructive">
+          <AlertCircle className="h-3 w-3" aria-hidden="true" />
+          {injuryLabel}
+        </span>
+      )}
+      {row.item.notes && (
+        <span className="inline-flex items-center gap-1 rounded-md border border-border bg-muted px-1.5 py-0.5">
+          <Clock className="h-3 w-3" aria-hidden="true" />
+          {row.item.notes}
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface WatchlistRowActionsProps {
+  row: WatchlistRow;
+  canActOnPlayer: boolean;
+  canDraft: boolean;
+  isLoading: boolean;
+  isWatchlistPending: boolean;
+  onAddToQueue?: (player: DraftPlayer) => void | Promise<void>;
+  onDraftPlayer: (player: DraftPlayer) => void | Promise<void>;
+  onRemoveFromWatchlist: (playerId: string) => void | Promise<void>;
+}
+
+function WatchlistRowActions({
+  row,
+  canActOnPlayer,
+  canDraft,
+  isLoading,
+  isWatchlistPending,
+  onAddToQueue,
+  onDraftPlayer,
+  onRemoveFromWatchlist,
+}: WatchlistRowActionsProps) {
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-2">
+      {onAddToQueue && (
+        <button
+          type="button"
+          onClick={() => {
+            if (row.draftablePlayer) void onAddToQueue(row.draftablePlayer);
+          }}
+          disabled={!canActOnPlayer || row.isQueued || isLoading}
+          className="inline-flex h-8 items-center justify-center gap-1 rounded-md border border-primary/20 bg-primary/10 px-2 text-xs font-medium text-primary transition-colors hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label={
+            row.isQueued
+              ? `${row.player.name} is already in your draft queue`
+              : `Add ${row.player.name} to draft queue`
+          }
+        >
+          <ListPlus className="h-3.5 w-3.5" aria-hidden="true" />
+          {row.isQueued ? 'Queued' : 'Queue'}
+        </button>
+      )}
+
+      <button
+        type="button"
+        onClick={() => {
+          if (row.draftablePlayer) void onDraftPlayer(row.draftablePlayer);
+        }}
+        disabled={!canActOnPlayer || !canDraft || isLoading}
+        className="inline-flex h-8 items-center justify-center gap-1 rounded-md border border-[color:var(--draft-broadcast-red)] bg-[color:var(--draft-broadcast-red)] px-2 text-xs font-semibold text-white shadow-[0_0_18px_var(--draft-broadcast-red-glow)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+        aria-label={
+          canDraft
+            ? `Draft ${row.player.name}`
+            : `Cannot draft ${row.player.name} until you are on the clock`
+        }
+      >
+        <Zap className="h-3.5 w-3.5" aria-hidden="true" />
+        Draft
+      </button>
+
+      <button
+        type="button"
+        onClick={() => {
+          void onRemoveFromWatchlist(String(row.item.playerId));
+        }}
+        disabled={isWatchlistPending}
+        className="ml-auto inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+        aria-label={`Remove ${row.player.name} from watchlist`}
+      >
+        <Trash2 className="h-4 w-4" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
+
+interface WatchlistPlayerRowProps {
+  row: WatchlistRow;
+  canDraft: boolean;
+  isLoading: boolean;
+  pendingWatchlistIds: ReadonlySet<string>;
+  onAddToQueue?: (player: DraftPlayer) => void | Promise<void>;
+  onDraftPlayer: (player: DraftPlayer) => void | Promise<void>;
+  onRemoveFromWatchlist: (playerId: string) => void | Promise<void>;
+}
+
+function WatchlistPlayerRow({
+  row,
+  canDraft,
+  isLoading,
+  pendingWatchlistIds,
+  onAddToQueue,
+  onDraftPlayer,
+  onRemoveFromWatchlist,
+}: WatchlistPlayerRowProps) {
+  const availabilityLabel = getAvailabilityLabel(row);
+  const canActOnPlayer = Boolean(row.draftablePlayer) && !row.isDrafted && !row.isUnavailable;
+  const isWatchlistPending = pendingWatchlistIds.has(String(row.item.playerId));
+
+  return (
+    <li
+      className={cn(
+        'rounded-md border border-border bg-card px-3 py-2 text-card-foreground transition-colors',
+        canActOnPlayer && 'hover:bg-muted/60',
+        !canActOnPlayer && 'opacity-75'
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-xs font-semibold text-muted-foreground">
+          {row.order}
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-start justify-between gap-2">
+            <div className="min-w-0">
+              <h3 className="truncate text-sm font-semibold text-foreground">{row.player.name}</h3>
+              <WatchlistPlayerMeta row={row} />
+            </div>
+
+            <span
+              className={cn(
+                'shrink-0 rounded-md border px-1.5 py-0.5 text-[0.6875rem] font-semibold uppercase',
+                getAvailabilityClassName(row)
+              )}
+            >
+              {availabilityLabel}
+            </span>
+          </div>
+
+          <WatchlistPlayerSignals row={row} />
+          <WatchlistRowActions
+            row={row}
+            canActOnPlayer={canActOnPlayer}
+            canDraft={canDraft}
+            isLoading={isLoading}
+            isWatchlistPending={isWatchlistPending}
+            onAddToQueue={onAddToQueue}
+            onDraftPlayer={onDraftPlayer}
+            onRemoveFromWatchlist={onRemoveFromWatchlist}
+          />
+        </div>
+      </div>
+    </li>
+  );
+}
+
 export default function DraftWatchlist({
   players,
   draftedPlayerIds,
@@ -248,126 +430,17 @@ export default function DraftWatchlist({
           aria-label="Watchlisted players"
         >
           {filteredRows.map((row) => {
-            const availabilityLabel = getAvailabilityLabel(row);
-            const injuryLabel = getInjuryLabel(row.player);
-            const canActOnPlayer =
-              Boolean(row.draftablePlayer) && !row.isDrafted && !row.isUnavailable;
-            const avgPoints = row.player.avgPoints ?? row.player.averagePoints;
-            const isWatchlistPending = pendingWatchlistIds.has(String(row.item.playerId));
-
             return (
-              <li
+              <WatchlistPlayerRow
                 key={`${row.item.playerId}:${row.order}`}
-                className={cn(
-                  'rounded-md border border-border bg-card px-3 py-2 text-card-foreground transition-colors',
-                  canActOnPlayer && 'hover:bg-muted/60',
-                  !canActOnPlayer && 'opacity-75'
-                )}
-              >
-                <div className="flex items-start gap-2">
-                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-xs font-semibold text-muted-foreground">
-                    {row.order}
-                  </span>
-
-                  <div className="min-w-0 flex-1">
-                    <div className="flex min-w-0 items-start justify-between gap-2">
-                      <div className="min-w-0">
-                        <h3 className="truncate text-sm font-semibold text-foreground">
-                          {row.player.name}
-                        </h3>
-                        <div className="mt-1 flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-                          <span className="rounded-md bg-muted px-1.5 py-0.5 font-medium text-muted-foreground">
-                            {row.player.position}
-                          </span>
-                          <span className="truncate">{row.player.club}</span>
-                          {typeof row.player.adp === 'number' && (
-                            <span className="shrink-0">ADP {row.player.adp}</span>
-                          )}
-                          {typeof avgPoints === 'number' && (
-                            <span className="shrink-0">{avgPoints.toFixed(1)} avg</span>
-                          )}
-                        </div>
-                      </div>
-
-                      <span
-                        className={cn(
-                          'shrink-0 rounded-md border px-1.5 py-0.5 text-[0.6875rem] font-semibold uppercase',
-                          getAvailabilityClassName(row)
-                        )}
-                      >
-                        {availabilityLabel}
-                      </span>
-                    </div>
-
-                    {(injuryLabel || row.item.notes) && (
-                      <div className="mt-2 flex flex-wrap gap-1.5 text-xs text-muted-foreground">
-                        {injuryLabel && (
-                          <span className="inline-flex items-center gap-1 rounded-md border border-destructive/30 bg-destructive/10 px-1.5 py-0.5 text-destructive">
-                            <AlertCircle className="h-3 w-3" aria-hidden="true" />
-                            {injuryLabel}
-                          </span>
-                        )}
-                        {row.item.notes && (
-                          <span className="inline-flex items-center gap-1 rounded-md border border-border bg-muted px-1.5 py-0.5">
-                            <Clock className="h-3 w-3" aria-hidden="true" />
-                            {row.item.notes}
-                          </span>
-                        )}
-                      </div>
-                    )}
-
-                    <div className="mt-3 flex flex-wrap items-center gap-2">
-                      {onAddToQueue && (
-                        <button
-                          type="button"
-                          onClick={() => {
-                            if (row.draftablePlayer) void onAddToQueue(row.draftablePlayer);
-                          }}
-                          disabled={!canActOnPlayer || row.isQueued || isLoading}
-                          className="inline-flex h-8 items-center justify-center gap-1 rounded-md border border-primary/20 bg-primary/10 px-2 text-xs font-medium text-primary transition-colors hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-                          aria-label={
-                            row.isQueued
-                              ? `${row.player.name} is already in your draft queue`
-                              : `Add ${row.player.name} to draft queue`
-                          }
-                        >
-                          <ListPlus className="h-3.5 w-3.5" aria-hidden="true" />
-                          {row.isQueued ? 'Queued' : 'Queue'}
-                        </button>
-                      )}
-
-                      <button
-                        type="button"
-                        onClick={() => {
-                          if (row.draftablePlayer) void onDraftPlayer(row.draftablePlayer);
-                        }}
-                        disabled={!canActOnPlayer || !canDraft || isLoading}
-                        className="inline-flex h-8 items-center justify-center gap-1 rounded-md border border-[color:var(--draft-broadcast-red)] bg-[color:var(--draft-broadcast-red)] px-2 text-xs font-semibold text-white shadow-[0_0_18px_var(--draft-broadcast-red-glow)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label={
-                          canDraft
-                            ? `Draft ${row.player.name}`
-                            : `Cannot draft ${row.player.name} until you are on the clock`
-                        }
-                      >
-                        <Zap className="h-3.5 w-3.5" aria-hidden="true" />
-                        Draft
-                      </button>
-
-                      <button
-                        type="button"
-                        onClick={() => {
-                          void onRemoveFromWatchlist(String(row.item.playerId));
-                        }}
-                        disabled={isWatchlistPending}
-                        className="ml-auto inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label={`Remove ${row.player.name} from watchlist`}
-                      >
-                        <Trash2 className="h-4 w-4" aria-hidden="true" />
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </li>
+                row={row}
+                canDraft={canDraft}
+                isLoading={isLoading}
+                pendingWatchlistIds={pendingWatchlistIds}
+                onAddToQueue={onAddToQueue}
+                onDraftPlayer={onDraftPlayer}
+                onRemoveFromWatchlist={onRemoveFromWatchlist}
+              />
             );
           })}
         </ol>

--- a/src/components/DraftWatchlist.tsx
+++ b/src/components/DraftWatchlist.tsx
@@ -29,6 +29,7 @@ interface WatchlistProps {
   watchlistItems: WatchlistItem[];
   onAddToQueue?: (player: DraftPlayer) => void | Promise<void>;
   queuedPlayerIds?: string[];
+  pendingWatchlistPlayerIds?: string[];
   onRemoveFromWatchlist: (playerId: string) => void | Promise<void>;
   isLoading?: boolean;
 }
@@ -89,6 +90,7 @@ export default function DraftWatchlist({
   watchlistItems,
   onAddToQueue,
   queuedPlayerIds = [],
+  pendingWatchlistPlayerIds = [],
   onRemoveFromWatchlist,
   isLoading = false,
 }: WatchlistProps) {
@@ -102,6 +104,10 @@ export default function DraftWatchlist({
   const queuedIds = useMemo(
     () => new Set(queuedPlayerIds.map((id) => String(id))),
     [queuedPlayerIds]
+  );
+  const pendingWatchlistIds = useMemo(
+    () => new Set(pendingWatchlistPlayerIds.map((id) => String(id))),
+    [pendingWatchlistPlayerIds]
   );
   const playerById = useMemo(
     () => new Map(players.map((player) => [String(player.id), player])),
@@ -247,6 +253,7 @@ export default function DraftWatchlist({
             const canActOnPlayer =
               Boolean(row.draftablePlayer) && !row.isDrafted && !row.isUnavailable;
             const avgPoints = row.player.avgPoints ?? row.player.averagePoints;
+            const isWatchlistPending = pendingWatchlistIds.has(String(row.item.playerId));
 
             return (
               <li
@@ -351,7 +358,7 @@ export default function DraftWatchlist({
                         onClick={() => {
                           void onRemoveFromWatchlist(String(row.item.playerId));
                         }}
-                        disabled={isLoading}
+                        disabled={isWatchlistPending}
                         className="ml-auto inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                         aria-label={`Remove ${row.player.name} from watchlist`}
                       >

--- a/src/components/DraftWatchlist.tsx
+++ b/src/components/DraftWatchlist.tsx
@@ -1,39 +1,83 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
-import { X, Zap, AlertCircle, Clock, TrendingUp } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { AlertCircle, Bookmark, Clock, ListPlus, Search, Trash2, Zap } from 'lucide-react';
 
-interface DraftPlayer {
-  id: string;
-  name: string;
-  position: string;
-  club: string;
-  // Add additional stats that might be available
-  avgPoints?: number;
-  lastGamePoints?: number;
-  byeWeek?: number;
-  injuryStatus?: 'healthy' | 'questionable' | 'injured' | 'out';
-}
+import type { DraftPlayer } from '@/types/draft';
+import { cn } from '@/lib/utils';
 
 interface WatchlistItem {
   playerId: string;
-  rank: number;
+  priority?: number;
+  rank?: number;
   addedAt: string;
   notes?: string;
+  player?: {
+    id: string;
+    name: string;
+    position: string;
+    club: string;
+  };
 }
 
 interface WatchlistProps {
   players: DraftPlayer[];
   draftedPlayerIds: string[];
-  onDraftPlayer: (player: DraftPlayer) => void;
+  onDraftPlayer: (player: DraftPlayer) => void | Promise<void>;
   canDraft: boolean;
   className?: string;
-  // Add watchlist state as props
   watchlistItems: WatchlistItem[];
   onAddToQueue?: (player: DraftPlayer) => void | Promise<void>;
   queuedPlayerIds?: string[];
-  onRemoveFromWatchlist: (playerId: string) => void;
+  onRemoveFromWatchlist: (playerId: string) => void | Promise<void>;
   isLoading?: boolean;
+}
+
+type WatchlistRow = {
+  item: WatchlistItem;
+  player: Pick<DraftPlayer, 'id' | 'name' | 'position' | 'club'> &
+    Partial<
+      Pick<DraftPlayer, 'avgPoints' | 'averagePoints' | 'adp' | 'injuryStatus' | 'isAvailable'>
+    >;
+  draftablePlayer: DraftPlayer | null;
+  order: number;
+  isDrafted: boolean;
+  isUnavailable: boolean;
+  isQueued: boolean;
+};
+
+function getWatchlistOrder(item: WatchlistItem, index: number): number {
+  const explicitOrder = item.priority ?? item.rank;
+
+  return typeof explicitOrder === 'number' && Number.isFinite(explicitOrder)
+    ? explicitOrder
+    : index + 1;
+}
+
+function getAvailabilityLabel(row: WatchlistRow): string {
+  if (row.isDrafted) return 'Drafted';
+  if (row.isUnavailable) return 'Unavailable';
+
+  return 'Available';
+}
+
+function getAvailabilityClassName(row: WatchlistRow): string {
+  if (row.isDrafted) {
+    return 'border-destructive/30 bg-destructive/10 text-destructive';
+  }
+
+  if (row.isUnavailable) {
+    return 'border-[color:var(--draft-broadcast-yellow)]/50 bg-[color:var(--draft-broadcast-yellow-soft)] text-foreground';
+  }
+
+  return 'border-[color:var(--draft-broadcast-green)]/40 bg-[color:var(--draft-broadcast-green-soft)] text-foreground';
+}
+
+function getInjuryLabel(player: WatchlistRow['player']): string | null {
+  if (player.injuryStatus === 'injured' || player.injuryStatus === 'out') return 'Injured';
+  if (player.injuryStatus === 'questionable') return 'Questionable';
+
+  return null;
 }
 
 export default function DraftWatchlist({
@@ -41,337 +85,286 @@ export default function DraftWatchlist({
   draftedPlayerIds,
   onDraftPlayer,
   canDraft,
-  className = '',
+  className,
   watchlistItems,
+  onAddToQueue,
+  queuedPlayerIds = [],
   onRemoveFromWatchlist,
+  isLoading = false,
 }: WatchlistProps) {
   const [showAvailableOnly, setShowAvailableOnly] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
 
-  console.log('DraftWatchlist: Received watchlist items:', watchlistItems);
-
-  // Get watchlisted players with their data (filter out drafted players by default)
-  const watchlistedPlayers = watchlistItems
-    .map((item) => {
-      const player = players.find((p) => p.id === item.playerId);
-      if (!player) return null;
-      return { ...player, watchlistItem: item };
-    })
-    .filter(Boolean)
-    .filter((player) => {
-      // Always filter out drafted players unless explicitly showing all
-      const isDrafted = draftedPlayerIds.includes(player!.id);
-      if (isDrafted && showAvailableOnly) {
-        return false;
-      }
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase();
-        return (
-          player!.name.toLowerCase().includes(query) ||
-          player!.club.toLowerCase().includes(query) ||
-          player!.position.toLowerCase().includes(query)
-        );
-      }
-      return true;
-    })
-    .sort((a, b) => a!.watchlistItem.rank - b!.watchlistItem.rank);
-
-  // Remove player from watchlist
-  const removeFromWatchlist = useCallback(
-    (playerId: string) => {
-      onRemoveFromWatchlist(playerId);
-    },
-    [onRemoveFromWatchlist]
+  const draftedIds = useMemo(
+    () => new Set(draftedPlayerIds.map((id) => String(id))),
+    [draftedPlayerIds]
+  );
+  const queuedIds = useMemo(
+    () => new Set(queuedPlayerIds.map((id) => String(id))),
+    [queuedPlayerIds]
+  );
+  const playerById = useMemo(
+    () => new Map(players.map((player) => [String(player.id), player])),
+    [players]
   );
 
-  // Get player availability status
-  const getAvailabilityStatus = (player: DraftPlayer) => {
-    if (draftedPlayerIds.includes(player.id)) {
-      return { status: 'drafted', color: 'bg-red-500', label: 'Drafted' };
-    }
-    return { status: 'available', color: 'bg-green-500', label: 'Available' };
-  };
+  const rows = useMemo<WatchlistRow[]>(() => {
+    const watchlistRows: WatchlistRow[] = [];
 
-  // Get injury status styling
-  const getInjuryStatus = (player: DraftPlayer) => {
-    switch (player.injuryStatus) {
-      case 'injured':
-      case 'out':
-        return { color: 'text-red-600', icon: AlertCircle, label: 'Injured' };
-      case 'questionable':
-        return { color: 'text-orange-600', icon: AlertCircle, label: 'Questionable' };
-      default:
-        return null;
-    }
-  };
+    watchlistItems.forEach((item, index) => {
+      const playerId = String(item.playerId);
+      const draftablePlayer = playerById.get(playerId) ?? null;
+      const fallbackPlayer = item.player;
 
-  // Check if it's bye week
-  const isByeWeek = (player: DraftPlayer) => {
-    // This would need to be calculated based on current week
-    // For now, just using the byeWeek property if available
-    return player.byeWeek === 12; // Example current week
-  };
+      if (!draftablePlayer && !fallbackPlayer) return;
 
-  const availableCount = watchlistedPlayers.filter((p) => !draftedPlayerIds.includes(p!.id)).length;
-  const draftedCount = watchlistedPlayers.filter((p) => draftedPlayerIds.includes(p!.id)).length;
+      const player: WatchlistRow['player'] = draftablePlayer ?? {
+        id: fallbackPlayer?.id ?? playerId,
+        name: fallbackPlayer?.name ?? 'Unknown player',
+        position: fallbackPlayer?.position ?? 'NA',
+        club: fallbackPlayer?.club ?? 'Unknown club',
+        isAvailable: false,
+      };
+      const isDrafted = draftedIds.has(String(player.id)) || Boolean(draftablePlayer?.draftedBy);
+      const isUnavailable = !isDrafted && draftablePlayer?.isAvailable === false;
+
+      watchlistRows.push({
+        item,
+        player,
+        draftablePlayer,
+        order: getWatchlistOrder(item, index),
+        isDrafted,
+        isUnavailable,
+        isQueued: queuedIds.has(String(player.id)),
+      });
+    });
+
+    return watchlistRows.sort(
+      (a, b) => a.order - b.order || a.player.name.localeCompare(b.player.name)
+    );
+  }, [draftedIds, playerById, queuedIds, watchlistItems]);
+
+  const filteredRows = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+
+    return rows.filter((row) => {
+      if (showAvailableOnly && (row.isDrafted || row.isUnavailable)) return false;
+      if (!query) return true;
+
+      return (
+        row.player.name.toLowerCase().includes(query) ||
+        row.player.position.toLowerCase().includes(query) ||
+        row.player.club.toLowerCase().includes(query)
+      );
+    });
+  }, [rows, searchQuery, showAvailableOnly]);
+
+  const availableCount = rows.filter((row) => !row.isDrafted && !row.isUnavailable).length;
+  const draftedCount = rows.filter((row) => row.isDrafted).length;
+  const unavailableCount = rows.filter((row) => row.isUnavailable).length;
+  const emptyTitle = rows.length === 0 ? 'No players in watchlist' : 'No matching players';
+  const emptyDetail =
+    rows.length === 0
+      ? 'Use the player market to add players you want to monitor.'
+      : 'Adjust the watchlist search or availability filter.';
 
   return (
-    <div className={`bg-white rounded-lg border h-full flex flex-col ${className}`}>
-      {/* Header */}
-      <div className="p-4 border-b bg-gradient-to-r from-yellow-50 to-amber-50">
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="font-bold text-lg flex items-center gap-2">
-            <svg
-              className="w-5 h-5 text-blue-600"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-              xmlns="http://www.w3.org/2000/svg"
+    <section className={cn('flex min-h-0 flex-1 flex-col gap-3', className)} aria-label="Watchlist">
+      <div className="rounded-md border border-border bg-background p-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h2 className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <Bookmark className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+              Watchlist
+            </h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {rows.length === 0 ? 'Track draft targets.' : `${rows.length} watched players`}
+            </p>
+          </div>
+
+          <div className="flex shrink-0 flex-wrap justify-end gap-1 text-[0.6875rem] font-semibold">
+            <span
+              className={cn(
+                'rounded-md border px-1.5 py-0.5',
+                'border-[color:var(--draft-broadcast-green)]/40 bg-[color:var(--draft-broadcast-green-soft)] text-foreground'
+              )}
             >
-              <path d="M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z" />
-            </svg>
-            My Watchlist
-          </h3>
-          <div className="flex items-center gap-2 text-sm">
-            <span className="bg-green-100 text-green-800 px-2 py-1 rounded-full">
               {availableCount} available
             </span>
-            <span className="bg-red-100 text-red-800 px-2 py-1 rounded-full">
+            <span className="rounded-md border border-destructive/30 bg-destructive/10 px-1.5 py-0.5 text-destructive">
               {draftedCount} drafted
             </span>
+            {unavailableCount > 0 && (
+              <span className="rounded-md border border-[color:var(--draft-broadcast-yellow)]/50 bg-[color:var(--draft-broadcast-yellow-soft)] px-1.5 py-0.5 text-foreground">
+                {unavailableCount} unavailable
+              </span>
+            )}
           </div>
         </div>
 
-        {/* Search and Filters */}
-        <div className="flex gap-3">
-          <div className="flex-1">
-            <input
-              type="text"
-              placeholder="Search watchlist..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full px-3 py-2 border rounded-md text-sm"
+        <div className="mt-3 grid gap-2">
+          <label className="relative block">
+            <span className="sr-only">Search watchlist</span>
+            <Search
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              aria-hidden="true"
             />
-          </div>
-          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="Search watchlist..."
+              className="h-10 w-full rounded-md border border-input bg-[color:var(--draft-broadcast-field)] py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+          </label>
+
+          <label className="inline-flex w-fit items-center gap-2 text-xs font-medium text-muted-foreground">
             <input
               type="checkbox"
               checked={showAvailableOnly}
-              onChange={(e) => setShowAvailableOnly(e.target.checked)}
-              className="rounded"
+              onChange={(event) => setShowAvailableOnly(event.target.checked)}
+              className="h-4 w-4 rounded border-border bg-background text-primary focus:ring-ring"
             />
             Available only
           </label>
         </div>
       </div>
 
-      {/* Watchlist Content */}
-      <div className="flex-1 overflow-y-auto">
-        {watchlistedPlayers.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">
-            <svg
-              className="w-12 h-12 mx-auto mb-3 opacity-50"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path d="M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z" />
-            </svg>
-            <p className="text-lg font-medium mb-1">No players in watchlist</p>
-            <p className="text-sm">
-              {searchQuery
-                ? 'No watchlisted players match your search'
-                : 'Add players to your watchlist from the Available Players tab'}
-            </p>
-          </div>
-        ) : (
-          <div className="min-h-full">
-            {watchlistedPlayers.map((player) => {
-              if (!player) return null;
+      {filteredRows.length === 0 ? (
+        <div className="flex min-h-52 flex-1 flex-col items-center justify-center rounded-md border border-dashed border-border bg-muted/30 px-4 py-8 text-center">
+          <Bookmark className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
+          <p className="mt-3 text-sm font-semibold text-foreground">{emptyTitle}</p>
+          <p className="mt-1 max-w-52 text-xs leading-5 text-muted-foreground">{emptyDetail}</p>
+        </div>
+      ) : (
+        <ol
+          className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pr-1"
+          aria-label="Watchlisted players"
+        >
+          {filteredRows.map((row) => {
+            const availabilityLabel = getAvailabilityLabel(row);
+            const injuryLabel = getInjuryLabel(row.player);
+            const canActOnPlayer =
+              Boolean(row.draftablePlayer) && !row.isDrafted && !row.isUnavailable;
+            const avgPoints = row.player.avgPoints ?? row.player.averagePoints;
 
-              const availability = getAvailabilityStatus(player);
-              const injury = getInjuryStatus(player);
-              const isBye = isByeWeek(player);
-              const isDrafted = draftedPlayerIds.includes(player.id);
+            return (
+              <li
+                key={`${row.item.playerId}:${row.order}`}
+                className={cn(
+                  'rounded-md border border-border bg-card px-3 py-2 text-card-foreground transition-colors',
+                  canActOnPlayer && 'hover:bg-muted/60',
+                  !canActOnPlayer && 'opacity-75'
+                )}
+              >
+                <div className="flex items-start gap-2">
+                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-xs font-semibold text-muted-foreground">
+                    {row.order}
+                  </span>
 
-              return (
-                <div
-                  key={player.id}
-                  className={`m-2 p-4 rounded-lg border transition-all ${
-                    isDrafted
-                      ? 'bg-gray-50 border-gray-300 opacity-75'
-                      : 'bg-white border-gray-200 hover:border-gray-300 hover:shadow-md'
-                  }`}
-                >
-                  <div className="flex items-start gap-3">
-                    {/* Rank Number */}
-                    <div
-                      className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
-                        isDrafted ? 'bg-gray-300 text-gray-500' : 'bg-blue-100 text-blue-800'
-                      }`}
-                    >
-                      {player.watchlistItem.rank}
-                    </div>
-
-                    {/* Player Info */}
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
-                        <h4
-                          className={`font-bold truncate ${isDrafted ? 'text-gray-500' : 'text-gray-900'}`}
-                        >
-                          {player.name}
-                        </h4>
-                        <div className={`w-2 h-2 rounded-full ${availability.color}`} />
-                        {injury && <injury.icon className={`w-4 h-4 ${injury.color}`} />}
-                        {isBye && <Clock className="w-4 h-4 text-orange-600" />}
-                        {isDrafted && (
-                          <span className="text-xs bg-red-100 text-red-800 px-2 py-0.5 rounded">
-                            DRAFTED
+                  <div className="min-w-0 flex-1">
+                    <div className="flex min-w-0 items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <h3 className="truncate text-sm font-semibold text-foreground">
+                          {row.player.name}
+                        </h3>
+                        <div className="mt-1 flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+                          <span className="rounded-md bg-muted px-1.5 py-0.5 font-medium text-muted-foreground">
+                            {row.player.position}
                           </span>
-                        )}
-                      </div>
-
-                      <div className="flex items-center gap-4 text-sm text-gray-600 mb-2">
-                        <span className="font-medium">{player.position}</span>
-                        <span>{player.club}</span>
-                        {player.avgPoints && (
-                          <span className="flex items-center gap-1">
-                            <TrendingUp className="w-3 h-3" />
-                            {player.avgPoints.toFixed(1)} avg
-                          </span>
-                        )}
-                      </div>
-
-                      {/* Quick Stats */}
-                      {(player.lastGamePoints || player.avgPoints) && (
-                        <div className="flex items-center gap-3 text-xs text-gray-500">
-                          {player.lastGamePoints && <span>Last: {player.lastGamePoints} pts</span>}
-                          {player.byeWeek && <span>Bye: Week {player.byeWeek}</span>}
+                          <span className="truncate">{row.player.club}</span>
+                          {typeof row.player.adp === 'number' && (
+                            <span className="shrink-0">ADP {row.player.adp}</span>
+                          )}
+                          {typeof avgPoints === 'number' && (
+                            <span className="shrink-0">{avgPoints.toFixed(1)} avg</span>
+                          )}
                         </div>
-                      )}
+                      </div>
+
+                      <span
+                        className={cn(
+                          'shrink-0 rounded-md border px-1.5 py-0.5 text-[0.6875rem] font-semibold uppercase',
+                          getAvailabilityClassName(row)
+                        )}
+                      >
+                        {availabilityLabel}
+                      </span>
                     </div>
 
-                    {/* Action Buttons */}
-                    <div className="flex items-center gap-2 flex-shrink-0">
-                      {!isDrafted && canDraft && (
+                    {(injuryLabel || row.item.notes) && (
+                      <div className="mt-2 flex flex-wrap gap-1.5 text-xs text-muted-foreground">
+                        {injuryLabel && (
+                          <span className="inline-flex items-center gap-1 rounded-md border border-destructive/30 bg-destructive/10 px-1.5 py-0.5 text-destructive">
+                            <AlertCircle className="h-3 w-3" aria-hidden="true" />
+                            {injuryLabel}
+                          </span>
+                        )}
+                        {row.item.notes && (
+                          <span className="inline-flex items-center gap-1 rounded-md border border-border bg-muted px-1.5 py-0.5">
+                            <Clock className="h-3 w-3" aria-hidden="true" />
+                            {row.item.notes}
+                          </span>
+                        )}
+                      </div>
+                    )}
+
+                    <div className="mt-3 flex flex-wrap items-center gap-2">
+                      {onAddToQueue && (
                         <button
-                          onClick={() => onDraftPlayer(player)}
-                          className="bg-blue-600 text-white px-3 py-1 rounded text-sm font-medium hover:bg-blue-700 transition-colors flex items-center gap-1"
-                          title="Draft this player now"
+                          type="button"
+                          onClick={() => {
+                            if (row.draftablePlayer) void onAddToQueue(row.draftablePlayer);
+                          }}
+                          disabled={!canActOnPlayer || row.isQueued || isLoading}
+                          className="inline-flex h-8 items-center justify-center gap-1 rounded-md border border-primary/20 bg-primary/10 px-2 text-xs font-medium text-primary transition-colors hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                          aria-label={
+                            row.isQueued
+                              ? `${row.player.name} is already in your draft queue`
+                              : `Add ${row.player.name} to draft queue`
+                          }
                         >
-                          <Zap className="w-3 h-3" />
-                          Draft
+                          <ListPlus className="h-3.5 w-3.5" aria-hidden="true" />
+                          {row.isQueued ? 'Queued' : 'Queue'}
                         </button>
                       )}
 
                       <button
-                        onClick={() => removeFromWatchlist(player.id)}
-                        className="text-gray-400 hover:text-red-600 transition-colors p-1"
-                        title="Remove from watchlist"
+                        type="button"
+                        onClick={() => {
+                          if (row.draftablePlayer) void onDraftPlayer(row.draftablePlayer);
+                        }}
+                        disabled={!canActOnPlayer || !canDraft || isLoading}
+                        className="inline-flex h-8 items-center justify-center gap-1 rounded-md border border-[color:var(--draft-broadcast-red)] bg-[color:var(--draft-broadcast-red)] px-2 text-xs font-semibold text-white shadow-[0_0_18px_var(--draft-broadcast-red-glow)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                        aria-label={
+                          canDraft
+                            ? `Draft ${row.player.name}`
+                            : `Cannot draft ${row.player.name} until you are on the clock`
+                        }
                       >
-                        <X className="w-4 h-4" />
+                        <Zap className="h-3.5 w-3.5" aria-hidden="true" />
+                        Draft
+                      </button>
+
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void onRemoveFromWatchlist(String(row.item.playerId));
+                        }}
+                        disabled={isLoading}
+                        className="ml-auto inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                        aria-label={`Remove ${row.player.name} from watchlist`}
+                      >
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
                       </button>
                     </div>
                   </div>
                 </div>
-              );
-            })}
-          </div>
-        )}
-      </div>
-
-      {/* Footer */}
-      {watchlistedPlayers.length > 0 && (
-        <div className="p-3 border-t bg-gray-50 text-center text-xs text-gray-500">
-          {watchlistedPlayers.length} players • Drag to reorder • Click 🔖 to add more players
-        </div>
+              </li>
+            );
+          })}
+        </ol>
       )}
-    </div>
+    </section>
   );
 }
-
-// Export function to add to watchlist from other components
-export const useWatchlist = () => {
-  const [watchlistItems, setWatchlistItems] = useState<WatchlistItem[]>([]);
-
-  useEffect(() => {
-    const saved = localStorage.getItem('draft-watchlist');
-    if (saved) {
-      try {
-        setWatchlistItems(JSON.parse(saved));
-      } catch (error) {
-        console.error('Failed to load watchlist:', error);
-      }
-    }
-  }, []);
-
-  // Auto-save to localStorage whenever watchlistItems changes
-  useEffect(() => {
-    console.log('useWatchlist hook: Saving to localStorage:', watchlistItems);
-    localStorage.setItem('draft-watchlist', JSON.stringify(watchlistItems));
-  }, [watchlistItems]);
-
-  const isInWatchlist = useCallback(
-    (playerId: string) => {
-      const isInList = watchlistItems.some((item) => item.playerId === playerId);
-      console.log('useWatchlist: isInWatchlist check for', playerId, ':', isInList);
-      return isInList;
-    },
-    [watchlistItems]
-  );
-
-  const addToWatchlist = useCallback(
-    (playerId: string) => {
-      console.log('useWatchlist: Adding to watchlist:', playerId);
-      const isAlreadyWatched = watchlistItems.some((item) => item.playerId === playerId);
-      if (isAlreadyWatched) {
-        console.log('useWatchlist: Player already in watchlist');
-        return false;
-      }
-
-      const newRank = Math.max(0, ...watchlistItems.map((item) => item.rank)) + 1;
-      const newItem: WatchlistItem = {
-        playerId,
-        rank: newRank,
-        addedAt: new Date().toISOString(),
-      };
-
-      console.log('useWatchlist: Adding new item:', newItem);
-      setWatchlistItems((prev) => {
-        const updated = [...prev, newItem];
-        console.log('useWatchlist: Updated watchlist items:', updated);
-        return updated;
-      });
-      return true;
-    },
-    [watchlistItems]
-  );
-
-  const removeFromWatchlist = useCallback((playerId: string) => {
-    setWatchlistItems((prev) => prev.filter((item) => item.playerId !== playerId));
-    return true;
-  }, []);
-
-  const toggleWatchlist = useCallback(
-    (playerId: string) => {
-      if (isInWatchlist(playerId)) {
-        return removeFromWatchlist(playerId);
-      } else {
-        return addToWatchlist(playerId);
-      }
-    },
-    [isInWatchlist, addToWatchlist, removeFromWatchlist]
-  );
-
-  const getWatchlistPlayerIds = useCallback(() => {
-    return watchlistItems.map((item) => item.playerId);
-  }, [watchlistItems]);
-
-  return {
-    watchlistItems,
-    isInWatchlist,
-    addToWatchlist,
-    removeFromWatchlist,
-    toggleWatchlist,
-    getWatchlistPlayerIds,
-  };
-};

--- a/src/components/draft/PlayerGrid.tsx
+++ b/src/components/draft/PlayerGrid.tsx
@@ -27,6 +27,7 @@ interface PlayerGridProps {
   canMakePick: boolean;
   queuedPlayerIds: string[];
   watchedPlayerIds: string[];
+  pendingWatchlistPlayerIds?: string[];
   selectedCategories: FantasyCategoryKey[];
   searchQuery: string;
   onSearchChange: (query: string) => void;
@@ -238,6 +239,7 @@ interface PlayerRowActionsProps {
   isWatched: boolean;
   isQueued: boolean;
   isLoading: boolean;
+  isWatchlistPending: boolean;
   selectionInFlight: boolean;
   canMakePick: boolean;
   pendingSelectionId: string | null;
@@ -251,6 +253,7 @@ function PlayerRowActions({
   isWatched,
   isQueued,
   isLoading,
+  isWatchlistPending,
   selectionInFlight,
   canMakePick,
   pendingSelectionId,
@@ -259,6 +262,7 @@ function PlayerRowActions({
   onSelect,
 }: PlayerRowActionsProps): React.JSX.Element {
   const actionDisabled = isLoading || selectionInFlight;
+  const watchlistDisabled = isWatchlistPending;
   const queueDisabled = actionDisabled || isQueued;
   const selectDisabled = !canMakePick || actionDisabled;
 
@@ -271,8 +275,8 @@ function PlayerRowActions({
             event.stopPropagation();
             onToggleWatchlist(player);
           }}
-          disabled={actionDisabled}
-          className={getWatchActionClass(actionDisabled, isWatched)}
+          disabled={watchlistDisabled}
+          className={getWatchActionClass(watchlistDisabled, isWatched)}
           aria-label={`${isWatched ? 'Remove' : 'Add'} ${player.name} ${isWatched ? 'from' : 'to'} watchlist`}
         >
           <Star className="h-4 w-4" aria-hidden="true" fill={isWatched ? 'currentColor' : 'none'} />
@@ -319,6 +323,7 @@ interface PlayerTableRowProps {
   isQueued: boolean;
   isWatched: boolean;
   isLoading: boolean;
+  isWatchlistPending: boolean;
   selectionInFlight: boolean;
   canMakePick: boolean;
   pendingSelectionId: string | null;
@@ -339,6 +344,7 @@ function PlayerTableRow({
   isQueued,
   isWatched,
   isLoading,
+  isWatchlistPending,
   selectionInFlight,
   canMakePick,
   pendingSelectionId,
@@ -384,6 +390,7 @@ function PlayerTableRow({
         isWatched={isWatched}
         isQueued={isQueued}
         isLoading={isLoading}
+        isWatchlistPending={isWatchlistPending}
         selectionInFlight={selectionInFlight}
         canMakePick={canMakePick}
         pendingSelectionId={pendingSelectionId}
@@ -602,6 +609,7 @@ interface PlayerGridTableProps {
   selectedPlayerId: string | null;
   queuedIds: ReadonlySet<string>;
   watchedIds: ReadonlySet<string>;
+  pendingWatchlistIds: ReadonlySet<string>;
   isLoading: boolean;
   selectionInFlight: boolean;
   canMakePick: boolean;
@@ -625,6 +633,7 @@ function PlayerGridTable({
   selectedPlayerId,
   queuedIds,
   watchedIds,
+  pendingWatchlistIds,
   isLoading,
   selectionInFlight,
   canMakePick,
@@ -744,6 +753,7 @@ function PlayerGridTable({
                   isSelected={selectedPlayerId === player.id}
                   isQueued={queuedIds.has(player.id)}
                   isWatched={watchedIds.has(player.id)}
+                  isWatchlistPending={pendingWatchlistIds.has(player.id)}
                   isLoading={isLoading}
                   selectionInFlight={selectionInFlight}
                   canMakePick={canMakePick}
@@ -788,6 +798,7 @@ export default function PlayerGrid({
   canMakePick,
   queuedPlayerIds,
   watchedPlayerIds,
+  pendingWatchlistPlayerIds = [],
   selectedCategories,
   searchQuery,
   onSearchChange,
@@ -811,6 +822,10 @@ export default function PlayerGrid({
   const searchInputRef = useRef<HTMLInputElement>(null);
   const queuedIds = useMemo(() => new Set(queuedPlayerIds), [queuedPlayerIds]);
   const watchedIds = useMemo(() => new Set(watchedPlayerIds), [watchedPlayerIds]);
+  const pendingWatchlistIds = useMemo(
+    () => new Set(pendingWatchlistPlayerIds),
+    [pendingWatchlistPlayerIds]
+  );
   const visibleCategories = useMemo(
     () => selectedCategories.filter((category) => FANTASY_CATEGORIES[category]),
     [selectedCategories]
@@ -962,6 +977,7 @@ export default function PlayerGrid({
         selectedPlayerId={selectedPlayerId}
         queuedIds={queuedIds}
         watchedIds={watchedIds}
+        pendingWatchlistIds={pendingWatchlistIds}
         isLoading={isLoading}
         selectionInFlight={selectionInFlight}
         canMakePick={canMakePick}

--- a/src/components/draft/UnifiedDraftRoom.tsx
+++ b/src/components/draft/UnifiedDraftRoom.tsx
@@ -501,6 +501,7 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
       watchlistItems={watchlistItems}
       onAddToQueue={handleAddWatchlistPlayerToQueue}
       queuedPlayerIds={queuePlayerIds}
+      pendingWatchlistPlayerIds={draft.pendingWatchlistPlayerIds}
       onRemoveFromWatchlist={draft.removeFromWatchlist}
       isLoading={draft.isSaving}
     />
@@ -690,6 +691,7 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
                   canMakePick={draft.canMakePick}
                   queuedPlayerIds={me?.queue || []}
                   watchedPlayerIds={watchlistItems.map((item) => item.playerId)}
+                  pendingWatchlistPlayerIds={draft.pendingWatchlistPlayerIds}
                   selectedCategories={selectedCategories}
                   searchQuery={searchQuery}
                   onSearchChange={setSearchQuery}

--- a/src/contexts/DraftContext.tsx
+++ b/src/contexts/DraftContext.tsx
@@ -194,6 +194,58 @@ function normalizeParticipants(raw: unknown): DraftParticipant[] {
   return toArray<any>(raw).map(normalizeParticipant);
 }
 
+function normalizeWatchlistItem(
+  raw: unknown,
+  fallbackPlayer?: DraftPlayer,
+  fallbackPriority = 0
+): DraftWatchlistItem | null {
+  const source = asRecord(raw);
+  const playerSource = asRecord(firstPresent(source.player, fallbackPlayer));
+  const playerId = firstPresent(source.playerId, playerSource.id, fallbackPlayer?.id);
+
+  if (!playerId) return null;
+
+  const priority = Number(firstPresent(source.priority, source.rank, fallbackPriority));
+  const normalizedPriority = Number.isFinite(priority) ? priority : fallbackPriority;
+
+  return {
+    id: String(firstPresent(source.id, `watchlist-${playerId}`)),
+    playerId: String(playerId),
+    priority: normalizedPriority,
+    rank: normalizedPriority,
+    addedAt: String(firstPresent(source.addedAt, source.createdAt, new Date().toISOString())),
+    notes: source.notes ?? undefined,
+    createdAt: source.createdAt,
+    updatedAt: source.updatedAt,
+    player: {
+      id: String(firstPresent(playerSource.id, playerId)),
+      name: String(firstPresent(playerSource.name, fallbackPlayer?.name, 'Unknown Player')),
+      position: String(firstPresent(playerSource.position, fallbackPlayer?.position, 'NA')),
+      club: String(firstPresent(playerSource.club, fallbackPlayer?.club, '')),
+    },
+  };
+}
+
+function sortWatchlistItems(items: DraftWatchlistItem[]): DraftWatchlistItem[] {
+  return items
+    .slice()
+    .sort((a, b) => Number(a?.rank ?? a?.priority ?? 0) - Number(b?.rank ?? b?.priority ?? 0));
+}
+
+function mergeWatchlistItem(
+  items: DraftWatchlistItem[],
+  itemToMerge: DraftWatchlistItem
+): DraftWatchlistItem[] {
+  const mergedByPlayerId = new Map<string, DraftWatchlistItem>();
+
+  for (const item of items) {
+    mergedByPlayerId.set(String(item.playerId), item);
+  }
+  mergedByPlayerId.set(String(itemToMerge.playerId), itemToMerge);
+
+  return sortWatchlistItems(Array.from(mergedByPlayerId.values()));
+}
+
 function participantQueueIncluded(raw: unknown): boolean {
   return toArray<any>(raw).some((participant) => {
     const member = participant?.member ?? participant;
@@ -1161,16 +1213,13 @@ export function DraftProvider({
             rank?: number;
             addedAt?: string;
           }
-        >(res?.data?.watchlist ?? res?.watchlist)
-          .map((item) => ({
-            ...item,
-            rank: Number(item.rank ?? item.priority ?? 0),
-            addedAt: item.addedAt ?? item.createdAt ?? new Date().toISOString(),
-          }))
-          .sort((a, b) => Number(a?.rank ?? 0) - Number(b?.rank ?? 0));
+        >(res?.data?.watchlist ?? res?.watchlist).flatMap((item) => {
+          const normalized = normalizeWatchlistItem(item);
+          return normalized ? [normalized] : [];
+        });
 
         if (!isMounted.current) return;
-        dispatch({ type: 'SET_WATCHLIST', items });
+        dispatch({ type: 'SET_WATCHLIST', items: sortWatchlistItems(items) });
       } catch {
         // Watchlist hydration is best-effort; keep the room usable if it fails.
       }
@@ -1558,7 +1607,7 @@ export function DraftProvider({
         const nextPriority =
           Math.max(0, ...state.watchlistItems.map((item) => Number(item.priority ?? 0))) + 1;
 
-        await fetchApi(`drafts/${draftId}/watchlist`, {
+        const res = await fetchApi(`drafts/${draftId}/watchlist`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -1568,7 +1617,20 @@ export function DraftProvider({
           }),
         });
 
-        await hydrateMyWatchlist(memberId);
+        const persistedItem = normalizeWatchlistItem(
+          res?.data?.watchlistItem ?? res?.watchlistItem,
+          player,
+          nextPriority
+        );
+
+        if (persistedItem) {
+          dispatch({
+            type: 'SET_WATCHLIST',
+            items: mergeWatchlistItem(state.watchlistItems, persistedItem),
+          });
+        } else {
+          await hydrateMyWatchlist(memberId);
+        }
       } catch (err: any) {
         if (isMounted.current) {
           dispatch({

--- a/src/contexts/DraftContext.tsx
+++ b/src/contexts/DraftContext.tsx
@@ -87,6 +87,7 @@ interface DraftState {
   statSeason: number | null;
   statSeasons: number[];
   watchlistItems: DraftWatchlistItem[];
+  pendingWatchlistPlayerIds: string[];
   liveState: DraftLiveState;
   connection: { status: ConnectionStatus; latencyMs?: number; lastEventAt?: number };
   isLoading: boolean;
@@ -244,6 +245,22 @@ function mergeWatchlistItem(
   mergedByPlayerId.set(String(itemToMerge.playerId), itemToMerge);
 
   return sortWatchlistItems(Array.from(mergedByPlayerId.values()));
+}
+
+function removeWatchlistItem(
+  items: DraftWatchlistItem[],
+  playerId: string
+): DraftWatchlistItem[] {
+  return items.filter((item) => String(item.playerId) !== String(playerId));
+}
+
+function setPendingPlayerId(ids: string[], playerId: string, pending: boolean): string[] {
+  const id = String(playerId);
+  const exists = ids.some((entry) => String(entry) === id);
+
+  if (pending) return exists ? ids : [...ids, id];
+
+  return ids.filter((entry) => String(entry) !== id);
 }
 
 function participantQueueIncluded(raw: unknown): boolean {
@@ -713,6 +730,8 @@ type Action =
   | { type: 'SET_STAT_SEASON'; season: number }
   | { type: 'SET_WATCHLIST'; items: DraftWatchlistItem[] }
   | { type: 'MERGE_WATCHLIST_ITEM'; item: DraftWatchlistItem }
+  | { type: 'REMOVE_WATCHLIST_ITEM'; playerId: string }
+  | { type: 'SET_WATCHLIST_PENDING'; playerId: string; pending: boolean }
   | { type: 'SET_PERSISTED_PICKS'; picks: DraftPick[] }
   | { type: 'APPLY_DELTAS'; deltas: DraftDelta[] }
   | { type: 'SET_CONNECTION'; status: ConnectionStatus; latencyMs?: number }
@@ -970,6 +989,21 @@ function reducer(state: DraftState, action: Action): DraftState {
         watchlistItems: mergeWatchlistItem(state.watchlistItems, action.item),
         error: null,
       };
+    case 'REMOVE_WATCHLIST_ITEM':
+      return {
+        ...state,
+        watchlistItems: removeWatchlistItem(state.watchlistItems, action.playerId),
+        error: null,
+      };
+    case 'SET_WATCHLIST_PENDING':
+      return {
+        ...state,
+        pendingWatchlistPlayerIds: setPendingPlayerId(
+          state.pendingWatchlistPlayerIds,
+          action.playerId,
+          action.pending
+        ),
+      };
     case 'SET_PERSISTED_PICKS':
       return applyPersistedPicksState(state, action.picks);
     case 'APPLY_DELTAS': {
@@ -1091,6 +1125,7 @@ export function DraftProvider({
       statSeason: snap.statSeason,
       statSeasons: snap.statSeasons,
       watchlistItems: [],
+      pendingWatchlistPlayerIds: [],
       liveState: snap.liveState,
       connection: { status: 'disconnected', lastEventAt: snap.ts },
       isLoading: !initialSnapshot,
@@ -1588,6 +1623,7 @@ export function DraftProvider({
 
   const addToWatchlist = useCallback(
     async (playerId: string) => {
+      const normalizedPlayerId = String(playerId);
       const player = state.availablePlayers.find((entry) => String(entry.id) === String(playerId));
       if (!player) {
         dispatch({
@@ -1605,15 +1641,32 @@ export function DraftProvider({
         return;
       }
 
-      if (state.watchlistItems.some((item) => String(item.playerId) === String(playerId))) {
+      if (
+        state.pendingWatchlistPlayerIds.some((id) => String(id) === normalizedPlayerId) ||
+        state.watchlistItems.some((item) => String(item.playerId) === normalizedPlayerId)
+      ) {
         return;
       }
 
-      dispatch({ type: 'SET_SAVING', saving: true });
-      try {
-        const nextPriority =
-          Math.max(0, ...state.watchlistItems.map((item) => Number(item.priority ?? 0))) + 1;
+      const nextPriority =
+        Math.max(0, ...state.watchlistItems.map((item) => Number(item.priority ?? 0))) + 1;
+      const optimisticItem = normalizeWatchlistItem(
+        {
+          id: `optimistic-watchlist-${normalizedPlayerId}`,
+          playerId: normalizedPlayerId,
+          priority: nextPriority,
+          addedAt: new Date().toISOString(),
+        },
+        player,
+        nextPriority
+      );
 
+      dispatch({ type: 'SET_WATCHLIST_PENDING', playerId: normalizedPlayerId, pending: true });
+      if (optimisticItem) {
+        dispatch({ type: 'MERGE_WATCHLIST_ITEM', item: optimisticItem });
+      }
+
+      try {
         const res = await fetchApi(`drafts/${draftId}/watchlist`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -1645,15 +1698,30 @@ export function DraftProvider({
             error: err?.message ?? 'Failed to add player to watchlist',
           });
         }
+        dispatch({ type: 'REMOVE_WATCHLIST_ITEM', playerId: normalizedPlayerId });
       } finally {
-        if (isMounted.current) dispatch({ type: 'SET_SAVING', saving: false });
+        if (isMounted.current) {
+          dispatch({
+            type: 'SET_WATCHLIST_PENDING',
+            playerId: normalizedPlayerId,
+            pending: false,
+          });
+        }
       }
     },
-    [draftId, hydrateMyWatchlist, memberId, state.availablePlayers, state.watchlistItems]
+    [
+      draftId,
+      hydrateMyWatchlist,
+      memberId,
+      state.availablePlayers,
+      state.pendingWatchlistPlayerIds,
+      state.watchlistItems,
+    ]
   );
 
   const removeFromWatchlist = useCallback(
     async (playerId: string) => {
+      const normalizedPlayerId = String(playerId);
       if (!memberId) {
         dispatch({
           type: 'SET_ERROR',
@@ -1662,17 +1730,22 @@ export function DraftProvider({
         return;
       }
 
-      dispatch({ type: 'SET_SAVING', saving: true });
+      if (state.pendingWatchlistPlayerIds.some((id) => String(id) === normalizedPlayerId)) {
+        return;
+      }
+
+      const existingItem = state.watchlistItems.find(
+        (item) => String(item.playerId) === normalizedPlayerId
+      );
+      if (!existingItem) return;
+
+      dispatch({ type: 'SET_WATCHLIST_PENDING', playerId: normalizedPlayerId, pending: true });
+      dispatch({ type: 'REMOVE_WATCHLIST_ITEM', playerId: normalizedPlayerId });
       try {
         await fetchApi(
           `drafts/${draftId}/watchlist?memberId=${encodeURIComponent(memberId)}&playerId=${encodeURIComponent(playerId)}`,
           { method: 'DELETE' }
         );
-
-        dispatch({
-          type: 'SET_WATCHLIST',
-          items: state.watchlistItems.filter((item) => String(item.playerId) !== String(playerId)),
-        });
       } catch (err: any) {
         if (isMounted.current) {
           dispatch({
@@ -1680,15 +1753,26 @@ export function DraftProvider({
             error: err?.message ?? 'Failed to remove player from watchlist',
           });
         }
+        dispatch({ type: 'MERGE_WATCHLIST_ITEM', item: existingItem });
       } finally {
-        if (isMounted.current) dispatch({ type: 'SET_SAVING', saving: false });
+        if (isMounted.current) {
+          dispatch({
+            type: 'SET_WATCHLIST_PENDING',
+            playerId: normalizedPlayerId,
+            pending: false,
+          });
+        }
       }
     },
-    [draftId, memberId, state.watchlistItems]
+    [draftId, memberId, state.pendingWatchlistPlayerIds, state.watchlistItems]
   );
 
   const toggleWatchlist = useCallback(
     async (playerId: string) => {
+      if (state.pendingWatchlistPlayerIds.some((id) => String(id) === String(playerId))) {
+        return;
+      }
+
       if (state.watchlistItems.some((item) => String(item.playerId) === String(playerId))) {
         await removeFromWatchlist(playerId);
         return;
@@ -1696,7 +1780,7 @@ export function DraftProvider({
 
       await addToWatchlist(playerId);
     },
-    [addToWatchlist, removeFromWatchlist, state.watchlistItems]
+    [addToWatchlist, removeFromWatchlist, state.pendingWatchlistPlayerIds, state.watchlistItems]
   );
 
   const isInWatchlist = useCallback(

--- a/src/contexts/DraftContext.tsx
+++ b/src/contexts/DraftContext.tsx
@@ -712,6 +712,7 @@ type Action =
     }
   | { type: 'SET_STAT_SEASON'; season: number }
   | { type: 'SET_WATCHLIST'; items: DraftWatchlistItem[] }
+  | { type: 'MERGE_WATCHLIST_ITEM'; item: DraftWatchlistItem }
   | { type: 'SET_PERSISTED_PICKS'; picks: DraftPick[] }
   | { type: 'APPLY_DELTAS'; deltas: DraftDelta[] }
   | { type: 'SET_CONNECTION'; status: ConnectionStatus; latencyMs?: number }
@@ -961,6 +962,12 @@ function reducer(state: DraftState, action: Action): DraftState {
       return {
         ...state,
         watchlistItems: action.items,
+        error: null,
+      };
+    case 'MERGE_WATCHLIST_ITEM':
+      return {
+        ...state,
+        watchlistItems: mergeWatchlistItem(state.watchlistItems, action.item),
         error: null,
       };
     case 'SET_PERSISTED_PICKS':
@@ -1625,8 +1632,8 @@ export function DraftProvider({
 
         if (persistedItem) {
           dispatch({
-            type: 'SET_WATCHLIST',
-            items: mergeWatchlistItem(state.watchlistItems, persistedItem),
+            type: 'MERGE_WATCHLIST_ITEM',
+            item: persistedItem,
           });
         } else {
           await hydrateMyWatchlist(memberId);

--- a/src/providers/SocketProvider.tsx
+++ b/src/providers/SocketProvider.tsx
@@ -13,6 +13,8 @@ interface Props {
 }
 
 const SocketContext = createContext<Socket | null>(null);
+const SOCKET_AUTH_RETRY_DELAY_MS = 250;
+const SOCKET_AUTH_RETRY_ATTEMPTS = 16;
 
 function isSocketDisabled(): boolean {
   return process.env.NEXT_PUBLIC_SOCKET_DISABLED === 'true';
@@ -31,6 +33,28 @@ export async function resolveSocketAuthToken(uid: string): Promise<string | null
   return null;
 }
 
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+async function resolveSocketAuthTokenWithRetry(
+  uid: string,
+  isCancelled: () => boolean
+): Promise<string | null> {
+  for (let attempt = 0; attempt < SOCKET_AUTH_RETRY_ATTEMPTS; attempt += 1) {
+    if (isCancelled()) return null;
+
+    const token = await resolveSocketAuthToken(uid);
+    if (token || isCancelled()) return token;
+
+    await wait(SOCKET_AUTH_RETRY_DELAY_MS);
+  }
+
+  return resolveSocketAuthToken(uid);
+}
+
 export function SocketProvider({ uid, children }: Props): React.JSX.Element {
   const [socket, setSocket] = useState<Socket | null>(null);
 
@@ -47,7 +71,7 @@ export function SocketProvider({ uid, children }: Props): React.JSX.Element {
 
     const connectSocket = async () => {
       try {
-        const token = await resolveSocketAuthToken(uid);
+        const token = await resolveSocketAuthTokenWithRetry(uid, () => cancelled);
         if (cancelled) {
           return;
         }

--- a/tests/unit/DraftContext.initialFetch.test.tsx
+++ b/tests/unit/DraftContext.initialFetch.test.tsx
@@ -540,6 +540,11 @@ describe('DraftProvider initial hydration', () => {
       expect(resolvePlayer3Add).toBeDefined();
     });
 
+    expect(screen.getByTestId('watchlist-count')).toHaveTextContent('3');
+    expect(screen.getByTestId('watchlist-order')).toHaveTextContent(
+      'player-1,player-2,player-3'
+    );
+
     act(() => {
       resolvePlayer2Add?.();
       resolvePlayer3Add?.();

--- a/tests/unit/DraftContext.initialFetch.test.tsx
+++ b/tests/unit/DraftContext.initialFetch.test.tsx
@@ -33,8 +33,15 @@ function DraftStateProbe() {
       <div data-testid="player-count">{draft.availablePlayers.length}</div>
       <div data-testid="pick-count">{draft.picks.length}</div>
       <div data-testid="pick-order">{draft.picks.map((pick) => pick.id).join(',')}</div>
+      <div data-testid="watchlist-count">{draft.watchlistItems.length}</div>
+      <div data-testid="watchlist-order">
+        {draft.watchlistItems.map((item) => item.playerId).join(',')}
+      </div>
       <button type="button" onClick={() => void draft.makePick('player-1')}>
         Pick player 1
+      </button>
+      <button type="button" onClick={() => void draft.toggleWatchlist('player-2')}>
+        Toggle player 2 watchlist
       </button>
     </div>
   );
@@ -256,6 +263,126 @@ describe('DraftProvider initial hydration', () => {
     );
 
     expect(screen.getByTestId('pick-order')).toHaveTextContent('pick-1,pick-2');
+  });
+
+  it('retains existing watchlist items when adding another player', async () => {
+    fetchApi.mockImplementation(async (endpoint: string, options?: RequestInit) => {
+      if (endpoint === 'drafts/draft-1') {
+        return {
+          success: true,
+          data: {
+            id: 'draft-1',
+            name: 'Watchlist Draft',
+            leagueId: 'league-1',
+            status: 'LIVE',
+            currentPick: 1,
+            totalPicks: 24,
+            round: 1,
+            direction: 'FORWARD',
+            participants: [
+              {
+                slot: 1,
+                member: {
+                  id: 'member-1',
+                  userId: 'statly-dev-tester',
+                  displayName: 'Tester',
+                },
+              },
+            ],
+            selectedCategories: [],
+            draftReadiness: null,
+            liveState: {},
+          },
+        };
+      }
+
+      if (endpoint === 'drafts/draft-1/players?page=1&pageSize=100') {
+        return {
+          success: true,
+          data: {
+            players: [
+              {
+                id: 'player-1',
+                name: 'Player One',
+                position: 'MID',
+                club: 'Sydney',
+                statlyZScore: 1,
+              },
+              {
+                id: 'player-2',
+                name: 'Player Two',
+                position: 'DEF',
+                club: 'Richmond',
+                statlyZScore: 2,
+              },
+            ],
+            pagination: { hasMore: false },
+          },
+        };
+      }
+
+      if (endpoint === 'drafts/draft-1/watchlist?memberId=member-1') {
+        return {
+          success: true,
+          data: {
+            watchlist: [
+              {
+                id: 'watchlist-1',
+                playerId: 'player-1',
+                priority: 1,
+                rank: 1,
+                addedAt: '2026-06-13T10:00:00.000Z',
+                player: {
+                  id: 'player-1',
+                  name: 'Player One',
+                  position: 'MID',
+                  club: 'Sydney',
+                },
+              },
+            ],
+          },
+        };
+      }
+
+      if (endpoint === 'drafts/draft-1/watchlist' && options?.method === 'POST') {
+        return {
+          success: true,
+          data: {
+            watchlistItem: {
+              id: 'watchlist-2',
+              playerId: 'player-2',
+              priority: 2,
+              createdAt: '2026-06-13T10:01:00.000Z',
+              player: {
+                id: 'player-2',
+                name: 'Player Two',
+                position: 'DEF',
+                club: 'Richmond',
+              },
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    render(
+      <DraftProvider draftId="draft-1" userId="statly-dev-tester">
+        <DraftStateProbe />
+      </DraftProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('watchlist-order')).toHaveTextContent('player-1');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle player 2 watchlist' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('watchlist-count')).toHaveTextContent('2');
+      expect(screen.getByTestId('watchlist-order')).toHaveTextContent('player-1,player-2');
+    });
   });
 
   it('hydrates an in-progress draft with persisted picks and authoritative deadline after refresh', async () => {

--- a/tests/unit/DraftContext.initialFetch.test.tsx
+++ b/tests/unit/DraftContext.initialFetch.test.tsx
@@ -43,6 +43,9 @@ function DraftStateProbe() {
       <button type="button" onClick={() => void draft.toggleWatchlist('player-2')}>
         Toggle player 2 watchlist
       </button>
+      <button type="button" onClick={() => void draft.toggleWatchlist('player-3')}>
+        Toggle player 3 watchlist
+      </button>
     </div>
   );
 }
@@ -382,6 +385,171 @@ describe('DraftProvider initial hydration', () => {
     await waitFor(() => {
       expect(screen.getByTestId('watchlist-count')).toHaveTextContent('2');
       expect(screen.getByTestId('watchlist-order')).toHaveTextContent('player-1,player-2');
+    });
+  });
+
+  it('retains rapid watchlist adds resolved from stale render state', async () => {
+    let resolvePlayer2Add: (() => void) | undefined;
+    let resolvePlayer3Add: (() => void) | undefined;
+
+    fetchApi.mockImplementation(async (endpoint: string, options?: RequestInit) => {
+      if (endpoint === 'drafts/draft-1') {
+        return {
+          success: true,
+          data: {
+            id: 'draft-1',
+            name: 'Watchlist Draft',
+            leagueId: 'league-1',
+            status: 'LIVE',
+            currentPick: 1,
+            totalPicks: 24,
+            round: 1,
+            direction: 'FORWARD',
+            participants: [
+              {
+                slot: 1,
+                member: {
+                  id: 'member-1',
+                  userId: 'statly-dev-tester',
+                  displayName: 'Tester',
+                },
+              },
+            ],
+            selectedCategories: [],
+            draftReadiness: null,
+            liveState: {},
+          },
+        };
+      }
+
+      if (endpoint === 'drafts/draft-1/players?page=1&pageSize=100') {
+        return {
+          success: true,
+          data: {
+            players: [
+              {
+                id: 'player-1',
+                name: 'Player One',
+                position: 'MID',
+                club: 'Sydney',
+                statlyZScore: 1,
+              },
+              {
+                id: 'player-2',
+                name: 'Player Two',
+                position: 'DEF',
+                club: 'Richmond',
+                statlyZScore: 2,
+              },
+              {
+                id: 'player-3',
+                name: 'Player Three',
+                position: 'FWD',
+                club: 'Brisbane',
+                statlyZScore: 3,
+              },
+            ],
+            pagination: { hasMore: false },
+          },
+        };
+      }
+
+      if (endpoint === 'drafts/draft-1/watchlist?memberId=member-1') {
+        return {
+          success: true,
+          data: {
+            watchlist: [
+              {
+                id: 'watchlist-1',
+                playerId: 'player-1',
+                priority: 1,
+                rank: 1,
+                addedAt: '2026-06-13T10:00:00.000Z',
+                player: {
+                  id: 'player-1',
+                  name: 'Player One',
+                  position: 'MID',
+                  club: 'Sydney',
+                },
+              },
+            ],
+          },
+        };
+      }
+
+      if (endpoint === 'drafts/draft-1/watchlist' && options?.method === 'POST') {
+        const payload = JSON.parse(String(options.body ?? '{}')) as { playerId?: string };
+
+        if (payload.playerId === 'player-2') {
+          await new Promise<void>((resolve) => {
+            resolvePlayer2Add = resolve;
+          });
+        }
+
+        if (payload.playerId === 'player-3') {
+          await new Promise<void>((resolve) => {
+            resolvePlayer3Add = resolve;
+          });
+        }
+
+        return {
+          success: true,
+          data: {
+            watchlistItem: {
+              id: `watchlist-${payload.playerId}`,
+              playerId: payload.playerId,
+              priority: payload.playerId === 'player-2' ? 2 : 3,
+              createdAt: '2026-06-13T10:01:00.000Z',
+              player:
+                payload.playerId === 'player-2'
+                  ? {
+                      id: 'player-2',
+                      name: 'Player Two',
+                      position: 'DEF',
+                      club: 'Richmond',
+                    }
+                  : {
+                      id: 'player-3',
+                      name: 'Player Three',
+                      position: 'FWD',
+                      club: 'Brisbane',
+                    },
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    render(
+      <DraftProvider draftId="draft-1" userId="statly-dev-tester">
+        <DraftStateProbe />
+      </DraftProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('watchlist-order')).toHaveTextContent('player-1');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle player 2 watchlist' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle player 3 watchlist' }));
+
+    await waitFor(() => {
+      expect(resolvePlayer2Add).toBeDefined();
+      expect(resolvePlayer3Add).toBeDefined();
+    });
+
+    act(() => {
+      resolvePlayer2Add?.();
+      resolvePlayer3Add?.();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('watchlist-count')).toHaveTextContent('3');
+      expect(screen.getByTestId('watchlist-order')).toHaveTextContent(
+        'player-1,player-2,player-3'
+      );
     });
   });
 

--- a/tests/unit/PlayerGrid.a11y.test.tsx
+++ b/tests/unit/PlayerGrid.a11y.test.tsx
@@ -170,6 +170,24 @@ describe('PlayerGrid accessibility', () => {
     });
   });
 
+  it('keeps unrelated watchlist buttons available while one player is pending', () => {
+    const twoPlayers = [players[0], { ...players[0], id: 'player-2', name: 'Adam Treloar' }];
+
+    render(
+      <PlayerGrid
+        {...defaultProps}
+        players={twoPlayers}
+        totalPlayers={twoPlayers.length}
+        pendingWatchlistPlayerIds={['player-1']}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Add Marcus Bontempelli to watchlist' })
+    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Add Adam Treloar to watchlist' })).not.toBeDisabled();
+  });
+
   it('renders large draft player pools without truncating available rows', () => {
     const largePool = Array.from({ length: 130 }, (_, index) => buildPlayer(index + 1));
 

--- a/tests/unit/SocketProvider.test.tsx
+++ b/tests/unit/SocketProvider.test.tsx
@@ -43,6 +43,7 @@ describe('SocketProvider', () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    vi.useRealTimers();
     authMock.currentUser = null;
     isDevelopmentAuthEnabled.mockReturnValue(false);
     process.env.NEXT_PUBLIC_SOCKET_URL = originalSocketUrl;
@@ -87,6 +88,33 @@ describe('SocketProvider', () => {
         'http://localhost:3002',
         expect.objectContaining({
           auth: { token: 'dev:dev-user' },
+        })
+      )
+    );
+  });
+
+  it('waits for Firebase auth restoration before creating the socket', async () => {
+    delete process.env.NEXT_PUBLIC_SOCKET_URL;
+    getIdToken.mockResolvedValue('restored-token');
+    authMock.currentUser = null;
+
+    render(
+      <SocketProvider uid="restored-user">
+        <div />
+      </SocketProvider>
+    );
+
+    expect(io).not.toHaveBeenCalled();
+
+    window.setTimeout(() => {
+      authMock.currentUser = { getIdToken };
+    }, 10);
+
+    await waitFor(() =>
+      expect(io).toHaveBeenCalledWith(
+        'http://localhost:3002',
+        expect.objectContaining({
+          auth: { token: 'restored-token' },
         })
       )
     );

--- a/tests/unit/playerDataConvergenceTempDbApplySimulation.test.ts
+++ b/tests/unit/playerDataConvergenceTempDbApplySimulation.test.ts
@@ -136,6 +136,10 @@ function executor(): PlayerDataConvergenceTempDbExecutor & {
 } {
   const executedSql: string[] = [];
   const queries: string[] = [];
+  const query = vi.fn(async (sql: string, _params?: readonly unknown[]): Promise<unknown[]> => {
+    queries.push(sql);
+    return [{ count: 0 }];
+  });
 
   return {
     executedSql,
@@ -144,10 +148,7 @@ function executor(): PlayerDataConvergenceTempDbExecutor & {
       executedSql.push(sql);
       return 1;
     }),
-    async query<T>(sql: string, _params?: readonly unknown[]): Promise<T[]> {
-      queries.push(sql);
-      return [{ count: 0 }] as T[];
-    },
+    query: query as unknown as PlayerDataConvergenceTempDbExecutor['query'],
   };
 }
 

--- a/tests/unit/playerDataConvergenceTempDbApplySimulation.test.ts
+++ b/tests/unit/playerDataConvergenceTempDbApplySimulation.test.ts
@@ -144,10 +144,10 @@ function executor(): PlayerDataConvergenceTempDbExecutor & {
       executedSql.push(sql);
       return 1;
     }),
-    query: vi.fn(async <T,>(sql: string): Promise<T[]> => {
+    async query<T>(sql: string, _params?: readonly unknown[]): Promise<T[]> {
       queries.push(sql);
       return [{ count: 0 }] as T[];
-    }),
+    },
   };
 }
 

--- a/tests/unit/playerDataConvergenceTempDbRunner.test.ts
+++ b/tests/unit/playerDataConvergenceTempDbRunner.test.ts
@@ -112,6 +112,10 @@ function executor(): PlayerDataConvergenceTempDbExecutor & {
 } {
   const executedSql: string[] = [];
   const queries: string[] = [];
+  const query = vi.fn(async (sql: string, _params?: readonly unknown[]): Promise<unknown[]> => {
+    queries.push(sql);
+    return [{ count: 4 }];
+  });
 
   return {
     executedSql,
@@ -120,10 +124,7 @@ function executor(): PlayerDataConvergenceTempDbExecutor & {
       executedSql.push(sql);
       return 1;
     }),
-    async query<T>(sql: string, _params?: readonly unknown[]): Promise<T[]> {
-      queries.push(sql);
-      return [{ count: 4 }] as T[];
-    },
+    query: query as unknown as PlayerDataConvergenceTempDbExecutor['query'],
   };
 }
 

--- a/tests/unit/playerDataConvergenceTempDbRunner.test.ts
+++ b/tests/unit/playerDataConvergenceTempDbRunner.test.ts
@@ -120,10 +120,10 @@ function executor(): PlayerDataConvergenceTempDbExecutor & {
       executedSql.push(sql);
       return 1;
     }),
-    query: vi.fn(async <T,>(sql: string): Promise<T[]> => {
+    async query<T>(sql: string, _params?: readonly unknown[]): Promise<T[]> {
       queries.push(sql);
       return [{ count: 4 }] as T[];
-    }),
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- update the draft watchlist panel to match the current draft-room layout
- make watchlist add/remove mutations per-player and optimistic so rapid single clicks register consistently
- retry socket auth during draft reconnect and add regression coverage for watchlist/reconnect paths
- preserve generic temp DB executor test helper typing so the full test gate passes

## Verification
- npm test
- npm run typecheck:app
- npm run lint (passes with existing advisory warnings)
- git diff --check origin/main...HEAD
- browser smoke in local draft room: two separate players added to watchlist with one click each, persisted, then test rows cleaned up

## Notes
- Clean PR branch excludes older homepage/public asset and draft stats fallback commits present on codex/full-stack-dev-testing.

## Summary by Sourcery

Improve draft watchlist reliability and UX while making watchlist mutations per-player and resilient to rapid interactions and auth timing issues.

New Features:
- Add per-player optimistic watchlist updates in the draft context and UI, including pending state tracking to prevent duplicate or conflicting actions.
- Update the draft watchlist panel to align with the unified draft room layout and expose richer player and availability information.
- Introduce socket auth retry logic so the socket connection waits for Firebase auth restoration before initializing.

Bug Fixes:
- Ensure rapid consecutive watchlist additions are preserved even when API responses resolve out of order or from stale render state.
- Prevent watchlist buttons for other players from being disabled when a single player’s watchlist mutation is in flight.
- Fix socket initialization so it no longer fails when auth state is briefly unavailable during draft reconnects.

Enhancements:
- Normalize and consistently sort watchlist items on hydration and server response, keeping ordering stable across priority/rank variations.
- Streamline handling of watchlist add/remove actions via dedicated merge/remove/pending reducer actions instead of full list resets.
- Refine the draft watchlist component’s accessibility and empty states to better communicate availability, injuries, and filters.
- Tighten typing and shape of the temporary DB executor test helper to match the expected query signature.

Tests:
- Extend draft context tests to cover watchlist hydration, incremental additions, and rapid optimistic updates under delayed API responses.
- Add socket provider tests to validate auth retry behaviour before establishing a socket connection.
- Add PlayerGrid accessibility coverage to ensure watchlist controls remain available for unaffected players during pending mutations.