### PR TITLE
[codex] Refine league overview and waiver order

### DIFF
--- a/src/components/league/LeagueTabs.tsx
+++ b/src/components/league/LeagueTabs.tsx
@@ -62,6 +62,13 @@ type OverviewTradeSummary = {
   lastUpdated?: number;
 };
 
+type OverviewWaiverClaim = {
+  id: string;
+  playerId: string;
+  playerName: string;
+  bidAmount?: number;
+};
+
 const TAB_IDS: readonly TabType[] = [
   'overview',
   'teams',
@@ -100,6 +107,10 @@ export default function LeagueTabs({
   const [removingUserId, setRemovingUserId] = useState<string | null>(null);
   const [overviewTrades, setOverviewTrades] = useState<OverviewTradeSummary[]>([]);
   const [overviewTradesStatus, setOverviewTradesStatus] = useState<
+    'idle' | 'loading' | 'ready' | 'error'
+  >('idle');
+  const [overviewWaiverClaims, setOverviewWaiverClaims] = useState<OverviewWaiverClaim[]>([]);
+  const [overviewWaiversStatus, setOverviewWaiversStatus] = useState<
     'idle' | 'loading' | 'ready' | 'error'
   >('idle');
 
@@ -254,6 +265,73 @@ export default function LeagueTabs({
 
     return () => {
       cancelled = true;
+    };
+  }, [currentUserId, league.id]);
+
+  useEffect(() => {
+    if (!currentUserId) return;
+
+    const controller = new AbortController();
+
+    async function loadOverviewWaivers() {
+      setOverviewWaiversStatus('loading');
+
+      try {
+        const response = await fetch(
+          `/api/leagues/${encodeURIComponent(league.id)}/waivers?playersLimit=0&activityLimit=0`,
+          { signal: controller.signal }
+        );
+        const payload = (await response.json().catch(() => ({}))) as unknown;
+
+        if (!response.ok) {
+          throw new Error(`status ${response.status}`);
+        }
+
+        const claims = isRecord(payload) && Array.isArray(payload.claims) ? payload.claims : [];
+        const playersIndex = isRecord(payload) && isRecord(payload.playersIndex)
+          ? payload.playersIndex
+          : {};
+        const pendingClaims = claims
+          .map((claim): OverviewWaiverClaim | null => {
+            if (!isRecord(claim)) return null;
+            const id = typeof claim.id === 'string' ? claim.id : null;
+            const playerId = typeof claim.playerId === 'string' ? claim.playerId : null;
+            const status = typeof claim.status === 'string' ? claim.status : 'PENDING';
+
+            if (!id || !playerId || status !== 'PENDING') return null;
+
+            const player = playersIndex[playerId];
+            const playerName =
+              isRecord(player) && typeof player.name === 'string'
+                ? player.name
+                : `Player ${playerId}`;
+
+            return {
+              id,
+              playerId,
+              playerName,
+              bidAmount: typeof claim.bidAmount === 'number' ? claim.bidAmount : undefined,
+            };
+          })
+          .filter((claim): claim is OverviewWaiverClaim => claim !== null)
+          .slice(0, 3);
+
+        if (!controller.signal.aborted) {
+          setOverviewWaiverClaims(pendingClaims);
+          setOverviewWaiversStatus('ready');
+        }
+      } catch {
+        if (!controller.signal.aborted) {
+          setOverviewWaiverClaims([]);
+          setOverviewWaiversStatus('error');
+        }
+      }
+    }
+
+    void loadOverviewWaivers();
+
+    return () => {
+      controller.abort();
     };
   }, [currentUserId, league.id]);
 
@@ -529,7 +607,7 @@ export default function LeagueTabs({
                           Trades
                         </p>
                         <h2 className="mt-1 text-lg font-semibold text-slate-950">
-                          Offers needing review
+                          Trade offers
                         </h2>
                       </div>
                       <button
@@ -542,9 +620,7 @@ export default function LeagueTabs({
                     </div>
                     <div className="mt-4 space-y-3">
                       {overviewTradesStatus === 'loading' ? (
-                        <p className="text-sm text-slate-600">
-                          Checking pending offers...
-                        </p>
+                        <p className="text-sm text-slate-600">Checking offers...</p>
                       ) : overviewTrades.length > 0 ? (
                         overviewTrades.map((trade) => (
                           <div
@@ -576,7 +652,7 @@ export default function LeagueTabs({
                           Waivers
                         </p>
                         <h2 className="mt-1 text-lg font-semibold text-slate-950">
-                          Your claim position
+                          Waiver position
                         </h2>
                       </div>
                       <button
@@ -594,11 +670,31 @@ export default function LeagueTabs({
                       <p className="mt-1 text-sm capitalize text-slate-600">
                         {waiverPolicyLabel} waiver order
                       </p>
-                      <p className="mt-3 text-sm text-slate-600">
-                        {waiverPriorityIndex >= 0
-                          ? 'Use the waiver tab to submit claims and check the queue before processing.'
-                          : 'Waiver order has not been set for your team yet.'}
-                      </p>
+                      {overviewWaiversStatus === 'loading' ? (
+                        <p className="mt-3 text-sm text-slate-600">Checking waiver bids...</p>
+                      ) : overviewWaiverClaims.length > 0 ? (
+                        <div className="mt-4 space-y-2">
+                          {overviewWaiverClaims.map((claim) => (
+                            <div
+                              key={claim.id}
+                              className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2"
+                            >
+                              <p className="min-w-0 truncate text-sm font-semibold text-slate-950">
+                                {claim.playerName}
+                              </p>
+                              <p className="shrink-0 text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">
+                                {typeof claim.bidAmount === 'number'
+                                  ? `$${claim.bidAmount}`
+                                  : 'Claim'}
+                              </p>
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="mt-3 text-sm text-slate-600">
+                          {waiverPriorityIndex >= 0 ? 'No pending waiver bids.' : 'Not set.'}
+                        </p>
+                      )}
                     </div>
                   </div>
                 </section>

--- a/src/server/leagues/leagueDetail.ts
+++ b/src/server/leagues/leagueDetail.ts
@@ -63,7 +63,14 @@ async function loadLeagueDetail(leagueId: string): Promise<LeagueDetailResult> {
     });
 
     if (prismaLeague) {
-      const draftReadiness = await getLeagueDraftOperationalReadiness(prisma, { leagueId });
+      const [draftReadiness, waiverPriorityRows] = await Promise.all([
+        getLeagueDraftOperationalReadiness(prisma, { leagueId }),
+        prisma.waiverPriority.findMany({
+          where: { leagueId },
+          orderBy: { priority: 'asc' },
+          select: { memberId: true },
+        }),
+      ]);
       const members = prismaLeague.members.map((member) => ({
         id: member.id,
         leagueId: member.leagueId,
@@ -84,6 +91,7 @@ async function loadLeagueDetail(leagueId: string): Promise<LeagueDetailResult> {
       });
 
       const categories = normalizeLeagueCategories(prismaLeague.categoriesJson);
+      const waiverRule = prismaLeague.settings?.waiverRule?.toLowerCase() as League['waiverRule'];
 
       return {
         ok: true,
@@ -101,7 +109,7 @@ async function loadLeagueDetail(leagueId: string): Promise<LeagueDetailResult> {
           draftDate: prismaLeague.settings?.startAt?.toISOString(),
           draftType: prismaLeague.settings?.draftType?.toLowerCase() as League['draftType'],
           pickOrder: prismaLeague.settings?.pickOrder?.toLowerCase() as League['pickOrder'],
-          waiverRule: prismaLeague.settings?.waiverRule?.toLowerCase() as League['waiverRule'],
+          waiverRule,
           draftReadiness,
           createdAt: prismaLeague.createdAt.toISOString(),
           tradeSettings: {
@@ -109,9 +117,9 @@ async function loadLeagueDetail(leagueId: string): Promise<LeagueDetailResult> {
             tradeReview: 'none',
           },
           waiverWire: {
-            waiverOrder: [],
+            waiverOrder: waiverPriorityRows.map((row) => row.memberId),
             waiverPeriodHours: 24,
-            waiverResetPolicy: 'weekly',
+            waiverResetPolicy: waiverRule ?? 'weekly',
           },
         },
         members,

--- a/src/server/rosters/RosterProjectionService.ts
+++ b/src/server/rosters/RosterProjectionService.ts
@@ -2,7 +2,10 @@ import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
 import { WaiverAvailabilityProjectionService } from '@/server/waivers/WaiverAvailabilityProjectionService';
 
-type PrismaLike = Pick<typeof prisma, 'pick' | 'leagueRoster' | 'leagueRosterPlayer'>;
+type PrismaLike = Pick<
+  typeof prisma,
+  'pick' | 'leagueRoster' | 'leagueRosterPlayer' | 'waiverPriority'
+>;
 type WaiverAvailabilityProjectionLike = Pick<WaiverAvailabilityProjectionService, 'projectLeague'>;
 
 export interface RosterProjectionResult {
@@ -22,7 +25,7 @@ export class RosterProjectionService {
     const picks = await this.db.pick.findMany({
       where: { draftId: input.draftId },
       orderBy: { overall: 'asc' },
-      select: { id: true, draftId: true, playerId: true, memberId: true },
+      select: { id: true, draftId: true, playerId: true, memberId: true, overall: true },
     });
 
     const rosterShells = new Set<string>();
@@ -66,6 +69,34 @@ export class RosterProjectionService {
           pickId: pick.id,
           playerId: pick.playerId,
           acquiredBy: 'DRAFT',
+        },
+      });
+    }
+
+    const finalPickByMemberId = new Map<string, number>();
+    for (const pick of picks) {
+      finalPickByMemberId.set(pick.memberId, pick.overall);
+    }
+
+    const waiverPriorityEntries = [...finalPickByMemberId.entries()]
+      .map(([memberId, finalPick]) => ({ memberId, finalPick }))
+      .sort((a, b) => b.finalPick - a.finalPick);
+
+    for (const [index, entry] of waiverPriorityEntries.entries()) {
+      await this.db.waiverPriority.upsert({
+        where: {
+          leagueId_memberId: {
+            leagueId: input.leagueId,
+            memberId: entry.memberId,
+          },
+        },
+        update: {
+          priority: index + 1,
+        },
+        create: {
+          leagueId: input.leagueId,
+          memberId: entry.memberId,
+          priority: index + 1,
         },
       });
     }

--- a/src/server/waivers/WaiverProcessingService.ts
+++ b/src/server/waivers/WaiverProcessingService.ts
@@ -548,6 +548,11 @@ interface WaiverPriorityEntry extends PriorityEntry {
   memberId: string;
 }
 
+interface DraftWaiverPrioritySeedRow {
+  memberId: string;
+  finalPick: number | bigint;
+}
+
 type PrismaWaiverStoreTransaction = Omit<PrismaWaiverStoreDb, '$transaction'>;
 
 export class PrismaWaiverClaimStore implements ClaimStore {
@@ -948,11 +953,22 @@ export class PrismaWaiverClaimStore implements ClaimStore {
       }),
       this.loadPriorityRows(tx, leagueId),
     ]);
+    const draftPriorityMemberIds = await this.loadDraftPriorityMemberIds(tx, leagueId);
+    const memberIds = new Set(members.map((member) => member.id));
+    const orderedMembers =
+      draftPriorityMemberIds.length > 0
+        ? [
+            ...draftPriorityMemberIds
+              .filter((memberId) => memberIds.has(memberId))
+              .map((memberId) => ({ id: memberId })),
+            ...members.filter((member) => !draftPriorityMemberIds.includes(member.id)),
+          ]
+        : members;
     const existingMemberIds = new Set(existingRows.map((row) => row.memberId));
     const existingPriorities = existingRows.map((row) => row.priority);
     let nextPriority = existingPriorities.length > 0 ? Math.max(...existingPriorities) + 1 : 1;
 
-    for (const member of members) {
+    for (const member of orderedMembers) {
       if (existingMemberIds.has(member.id)) continue;
 
       await tx.$executeRaw`
@@ -1010,6 +1026,24 @@ export class PrismaWaiverClaimStore implements ClaimStore {
       updatedAt = ${new Date()}
       WHERE leagueId = ${claim.leagueId} AND memberId = ${claim.teamId}
     `;
+  }
+
+  private async loadDraftPriorityMemberIds(
+    db: Pick<PrismaWaiverStoreDb, '$queryRaw'>,
+    leagueId: string
+  ): Promise<string[]> {
+    const rows = (await db.$queryRaw`
+      SELECT p.memberId, MAX(p.overall) AS finalPick
+      FROM "Pick" p
+      INNER JOIN "Draft" d ON d.id = p.draftId
+      WHERE d.leagueId = ${leagueId}
+      GROUP BY p.memberId
+      ORDER BY finalPick DESC
+    `) as DraftWaiverPrioritySeedRow[];
+
+    return rows
+      .filter((row) => typeof row.memberId === 'string' && Number.isFinite(Number(row.finalPick)))
+      .map((row) => row.memberId);
   }
 
   private async loadPriorityRows(

--- a/tests/unit/LeagueTabs.overview.test.tsx
+++ b/tests/unit/LeagueTabs.overview.test.tsx
@@ -78,6 +78,30 @@ const members: LeagueMember[] = [
 
 describe('LeagueTabs overview snapshot', () => {
   it('shows teams, waiver priority, pending trades, and league context at a glance', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        claims: [
+          {
+            id: 'claim-1',
+            userId: 'user-2',
+            teamId: 'member-2',
+            playerId: 'player-1',
+            priority: 1,
+            status: 'PENDING',
+            createdAt: '2026-07-04T00:00:00.000Z',
+            bidAmount: 12,
+          },
+        ],
+        playersIndex: {
+          'player-1': {
+            id: 'player-1',
+            name: 'Caleb Serong',
+          },
+        },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
     authenticatedFetchMock.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -101,7 +125,7 @@ describe('LeagueTabs overview snapshot', () => {
     expect(screen.getByText('League overview')).toBeInTheDocument();
     expect(screen.getAllByText('Snapshot League').length).toBeGreaterThan(0);
     expect(screen.getByText('3/4 teams')).toBeInTheDocument();
-    expect(screen.getByText('Trade offers')).toBeInTheDocument();
+    expect(screen.getAllByText('Trade offers').length).toBeGreaterThan(0);
     expect(screen.getByText('5 categories')).toBeInTheDocument();
     expect(screen.getAllByText('Priority 2').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Teams').length).toBeGreaterThan(1);
@@ -123,19 +147,28 @@ describe('LeagueTabs overview snapshot', () => {
     expect(screen.getByText('ST')).toBeInTheDocument();
     expect(screen.getByText('Third Team')).toBeInTheDocument();
     expect(screen.getByText('TT')).toBeInTheDocument();
-    expect(screen.getByText('Offers needing review')).toBeInTheDocument();
+    expect(screen.queryByText('Offers needing review')).not.toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getByText('Midfield upgrade')).toBeInTheDocument();
     });
 
     expect(screen.getByText('Player A, Player B')).toBeInTheDocument();
-    expect(screen.getByText('Your claim position')).toBeInTheDocument();
+    expect(screen.getAllByText('Waiver position').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Your claim position')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Caleb Serong')).toBeInTheDocument();
+    });
+    expect(screen.getByText('$12')).toBeInTheDocument();
     expect(screen.queryByText('Next action')).not.toBeInTheDocument();
     expect(authenticatedFetchMock).toHaveBeenCalledWith(
       '/api/trades/list?leagueId=league-1&status=PENDING&pageSize=3',
       {},
       'user-2'
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/leagues/league-1/waivers?playersLimit=0&activityLimit=0',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
   });
 });

--- a/tests/unit/RosterProjectionService.test.ts
+++ b/tests/unit/RosterProjectionService.test.ts
@@ -22,6 +22,7 @@ describe('RosterProjectionService', () => {
             draftId: 'draft-1',
             playerId: 'player-1',
             memberId: 'member-1',
+            overall: 1,
           },
         ]),
       },
@@ -30,6 +31,9 @@ describe('RosterProjectionService', () => {
       },
       leagueRosterPlayer: {
         upsert: vi.fn().mockResolvedValue({ id: 'ownership-1' }),
+      },
+      waiverPriority: {
+        upsert: vi.fn().mockResolvedValue({ id: 'waiver-priority-1' }),
       },
     };
     const waiverAvailabilityProjectionService = {
@@ -42,7 +46,7 @@ describe('RosterProjectionService', () => {
     expect(db.pick.findMany).toHaveBeenCalledWith({
       where: { draftId: 'draft-1' },
       orderBy: { overall: 'asc' },
-      select: { id: true, draftId: true, playerId: true, memberId: true },
+      select: { id: true, draftId: true, playerId: true, memberId: true, overall: true },
     });
     expect(db.leagueRoster.upsert).toHaveBeenCalledWith({
       where: { leagueId_memberId: { leagueId: 'league-1', memberId: 'member-1' } },
@@ -75,6 +79,15 @@ describe('RosterProjectionService', () => {
     expect(waiverAvailabilityProjectionService.projectLeague).toHaveBeenCalledWith({
       leagueId: 'league-1',
     });
+    expect(db.waiverPriority.upsert).toHaveBeenCalledWith({
+      where: { leagueId_memberId: { leagueId: 'league-1', memberId: 'member-1' } },
+      update: { priority: 1 },
+      create: {
+        leagueId: 'league-1',
+        memberId: 'member-1',
+        priority: 1,
+      },
+    });
     expect(result).toEqual({ projected: 1 });
   });
 
@@ -87,6 +100,7 @@ describe('RosterProjectionService', () => {
             draftId: 'draft-1',
             playerId: 'player-1',
             memberId: 'member-1',
+            overall: 1,
           },
         ]),
       },
@@ -95,6 +109,9 @@ describe('RosterProjectionService', () => {
       },
       leagueRosterPlayer: {
         upsert: vi.fn().mockResolvedValue({ id: 'ownership-1' }),
+      },
+      waiverPriority: {
+        upsert: vi.fn().mockResolvedValue({ id: 'waiver-priority-1' }),
       },
     };
     const waiverAvailabilityProjectionService = {
@@ -113,6 +130,78 @@ describe('RosterProjectionService', () => {
       leagueId: 'league-1',
     });
     expect(result).toEqual({ projected: 1 });
+  });
+
+  it('seeds waiver priority from reverse final draft pick order', async () => {
+    const db = {
+      pick: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: 'pick-1',
+            draftId: 'draft-1',
+            playerId: 'player-1',
+            memberId: 'member-1',
+            overall: 1,
+          },
+          {
+            id: 'pick-2',
+            draftId: 'draft-1',
+            playerId: 'player-2',
+            memberId: 'member-2',
+            overall: 2,
+          },
+          {
+            id: 'pick-3',
+            draftId: 'draft-1',
+            playerId: 'player-3',
+            memberId: 'member-2',
+            overall: 3,
+          },
+          {
+            id: 'pick-4',
+            draftId: 'draft-1',
+            playerId: 'player-4',
+            memberId: 'member-1',
+            overall: 4,
+          },
+        ]),
+      },
+      leagueRoster: {
+        upsert: vi.fn().mockResolvedValue({ id: 'roster-1', playerIds: '[]' }),
+      },
+      leagueRosterPlayer: {
+        upsert: vi.fn().mockResolvedValue({ id: 'ownership-1' }),
+      },
+      waiverPriority: {
+        upsert: vi.fn().mockResolvedValue({ id: 'waiver-priority-1' }),
+      },
+    };
+    const waiverAvailabilityProjectionService = {
+      projectLeague: vi.fn().mockResolvedValue({ owned: 4, available: 0 }),
+    };
+
+    const service = new RosterProjectionService(db as never, waiverAvailabilityProjectionService);
+
+    await service.projectDraft({ leagueId: 'league-1', draftId: 'draft-1' });
+
+    expect(db.waiverPriority.upsert).toHaveBeenNthCalledWith(1, {
+      where: { leagueId_memberId: { leagueId: 'league-1', memberId: 'member-1' } },
+      update: { priority: 1 },
+      create: {
+        leagueId: 'league-1',
+        memberId: 'member-1',
+        priority: 1,
+      },
+    });
+    expect(db.waiverPriority.upsert).toHaveBeenNthCalledWith(2, {
+      where: { leagueId_memberId: { leagueId: 'league-1', memberId: 'member-2' } },
+      update: { priority: 2 },
+      create: {
+        leagueId: 'league-1',
+        memberId: 'member-2',
+        priority: 2,
+      },
+    });
   });
 
   it('projects rosters after completed draft command results', () => {

--- a/tests/unit/WaiverProcessingService.test.ts
+++ b/tests/unit/WaiverProcessingService.test.ts
@@ -421,6 +421,7 @@ describe('PrismaWaiverClaimStore', () => {
           { memberId: 'member-1', priority: 1, remainingFAAB: 100, pendingBidTotal: 7 },
         ])
         .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ memberId: 'member-1', finalPick: 1 }])
         .mockResolvedValueOnce([{ memberId: 'member-1', remainingFAAB: 100, pendingBidTotal: 0 }]),
       $executeRaw: vi.fn().mockResolvedValue(1),
       $transaction: vi.fn((work: (client: unknown) => Promise<unknown>) => work(db)),
@@ -468,6 +469,72 @@ describe('PrismaWaiverClaimStore', () => {
         claimId: 'action-1',
       })
     );
+  });
+
+  it('seeds missing canonical waiver priorities from reverse final draft pick order', async () => {
+    const joinedAt = new Date('2026-06-01T00:00:00.000Z');
+    const db = {
+      leagueMember: {
+        findFirst: vi.fn().mockResolvedValue({ id: 'member-2', userId: 'user-2' }),
+        findMany: vi.fn().mockResolvedValue([
+          { id: 'member-1', userId: 'user-1', draftSlot: 1, joinedAt },
+          { id: 'member-2', userId: 'user-2', draftSlot: 2, joinedAt },
+        ]),
+      },
+      teamAction: {
+        create: vi.fn().mockResolvedValue({ id: 'action-1' }),
+        update: vi.fn().mockResolvedValue({ id: 'action-1' }),
+      },
+      $queryRaw: vi
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          { memberId: 'member-2', finalPick: 4 },
+          { memberId: 'member-1', finalPick: 3 },
+        ])
+        .mockResolvedValue([
+          { memberId: 'member-2', priority: 1, remainingFAAB: null, pendingBidTotal: 0 },
+          { memberId: 'member-1', priority: 2, remainingFAAB: null, pendingBidTotal: 0 },
+        ]),
+      $executeRaw: vi.fn().mockResolvedValue(1),
+      $transaction: vi.fn((work: (client: unknown) => Promise<unknown>) => work(db)),
+    };
+    const { firestore, waiverDoc, activityDoc } = createCompatibilityProjectionMock();
+    const store = new PrismaWaiverClaimStore(db as never, firestore as never);
+
+    await store.submitClaim({
+      leagueId: 'league-1',
+      userId: 'user-2',
+      teamId: 'member-2',
+      playerId: 'free-player',
+      priority: 1,
+      waiverSettings: { system: 'PRIORITY' },
+    });
+
+    expect(db.$executeRaw).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.any(String),
+      'league-1',
+      'member-2',
+      1,
+      null,
+      expect.any(Date),
+      expect.any(Date)
+    );
+    expect(db.$executeRaw).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.any(String),
+      'league-1',
+      'member-1',
+      2,
+      null,
+      expect.any(Date),
+      expect.any(Date)
+    );
+    expect(waiverDoc.set).toHaveBeenCalledWith(expect.objectContaining({ teamId: 'member-2' }));
+    expect(activityDoc.set).toHaveBeenCalledWith(expect.objectContaining({ claimId: 'action-1' }));
   });
 
   it('updates canonical status and mirrors successful processing to Firestore', async () => {

--- a/tests/unit/leagueDetailRouteArchitecture.test.ts
+++ b/tests/unit/leagueDetailRouteArchitecture.test.ts
@@ -64,6 +64,8 @@ describe('league detail route architecture', () => {
     expect(loaderSource).toContain('!access.isMember');
     expect(loaderSource).not.toContain('verifyLeagueMembership');
     expect(loaderSource).toContain('prisma.league.findUnique');
+    expect(loaderSource).toContain('prisma.waiverPriority.findMany');
+    expect(loaderSource).toContain('waiverOrder: waiverPriorityRows.map((row) => row.memberId)');
     expect(loaderSource).toContain("adminDb.collection('leagues').doc(leagueId)");
     expect(loaderSource).toContain('REAL_DATA_NINE_CATEGORY_PRESET');
     expect(loaderSource).toContain('normalizeLeagueCategories(prismaLeague.categoriesJson)');


### PR DESCRIPTION
## Summary
- trims league overview trade/waiver copy and shows pending waiver bids
- seeds canonical waiver order from reverse final draft pick order
- exposes canonical waiver order in league detail and uses the same fallback during first waiver claim initialization

## Verification
- npm run test:unit -- tests/unit/LeagueTabs.overview.test.tsx
- npm run test:unit -- tests/unit/WaiverProcessingService.test.ts tests/unit/RosterProjectionService.test.ts tests/unit/leagueDetailRouteArchitecture.test.ts
- npx eslint src/components/league/LeagueTabs.tsx tests/unit/LeagueTabs.overview.test.tsx
- npx eslint src/server/waivers/WaiverProcessingService.ts src/server/rosters/RosterProjectionService.ts src/server/leagues/leagueDetail.ts tests/unit/WaiverProcessingService.test.ts tests/unit/RosterProjectionService.test.ts tests/unit/leagueDetailRouteArchitecture.test.ts
- npm run typecheck:tests
- npm run typecheck:app
- git diff --check

## Summary by Sourcery

Refine league overview waivers/trades and align waiver priority seeding and exposure with canonical draft-based order.

New Features:
- Show a snapshot of up to three pending waiver bids in the league overview tab.
- Expose canonical waiver order in league detail responses via waiverPriority rows.

Enhancements:
- Simplify trade and waiver overview copy and loading messages in the league overview tab.
- Seed canonical waiver priorities from reverse final draft pick order during roster projection and when initializing missing priorities in waiver processing.

Tests:
- Extend unit tests for roster projection, waiver processing, league detail loader, and league overview snapshots to cover waiver priority seeding and new overview behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * League overview now shows pending waiver claims, including player names, bid amounts when available, and up to three items.
  * League details now include a populated waiver order and waiver reset policy.

* **Bug Fixes**
  * Updated waiver and trade cards in the league overview with clearer wording and loading states.
  * Waiver priority now follows draft-based ordering, improving the accuracy of claim positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->