### PR TITLE
[codex] Show completed draft summaries in league draft tab

### DIFF
--- a/src/components/league/DraftManager.tsx
+++ b/src/components/league/DraftManager.tsx
@@ -70,6 +70,27 @@ interface ExistingDraft {
   createdAt: string;
 }
 
+interface CompletedDraftSummary {
+  id: string;
+  leagueId: string;
+  completedAt: string | null;
+  totalPicks: number;
+  picksMade: number;
+  teamCount: number;
+  totalRounds: number;
+  autoPickCount: number;
+  manualPickCount: number;
+  completionPct: number;
+  firstPick: {
+    player: { name: string; position: string; club: string };
+    member: { teamName: string };
+  } | null;
+  lastPick: {
+    player: { name: string; position: string; club: string };
+    member: { teamName: string };
+  } | null;
+}
+
 interface DraftResponseShape {
   id: string;
   status?: string | null;
@@ -202,7 +223,9 @@ function getOrderedDraftMembers(input: {
   draftOrderRandomized: boolean;
 }): LeagueMember[] {
   const orderedMembers =
-    input.draftOrderMembers.length === input.members.length ? input.draftOrderMembers : input.members;
+    input.draftOrderMembers.length === input.members.length
+      ? input.draftOrderMembers
+      : input.members;
 
   if (input.draftSettings.pickOrder === 'random' && !input.draftOrderRandomized) {
     return shuffleMembers(orderedMembers);
@@ -228,7 +251,9 @@ function buildDraftParticipants(input: {
     return participants;
   }
 
-  const alreadyIncluded = participants.some((participant) => participant.userId === input.currentUserId);
+  const alreadyIncluded = participants.some(
+    (participant) => participant.userId === input.currentUserId
+  );
   if (!alreadyIncluded) {
     const lastIndex = participants.length - 1;
     const replacement = {
@@ -305,6 +330,10 @@ export default function DraftManager({
   const [showDraftSettings, setShowDraftSettings] = useState(false);
   const [savingDraft, setSavingDraft] = useState(false);
   const [existingDraft, setExistingDraft] = useState<ExistingDraft | null>(null);
+  const [completedDraftSummary, setCompletedDraftSummary] = useState<CompletedDraftSummary | null>(
+    null
+  );
+  const [loadingCompletedDraftSummary, setLoadingCompletedDraftSummary] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [draftOrderMemberIds, setDraftOrderMemberIds] = useState<string[]>(() =>
     members.map((member) => member.id)
@@ -394,6 +423,44 @@ export default function DraftManager({
   }, [refreshDraftState]);
 
   useEffect(() => {
+    if (existingDraft?.status !== 'COMPLETED') {
+      setCompletedDraftSummary(null);
+      setLoadingCompletedDraftSummary(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchCompletedDraftSummary = async () => {
+      try {
+        setLoadingCompletedDraftSummary(true);
+        const response = await fetchApi(`drafts/history/${existingDraft.id}`);
+
+        if (!cancelled) {
+          setCompletedDraftSummary(
+            response.success ? (response.data as CompletedDraftSummary) : null
+          );
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error('Error fetching completed draft summary:', error);
+          setCompletedDraftSummary(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingCompletedDraftSummary(false);
+        }
+      }
+    };
+
+    void fetchCompletedDraftSummary();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [existingDraft?.id, existingDraft?.status]);
+
+  useEffect(() => {
     setDraftOrderMemberIds((current) => {
       const activeIds = new Set(members.map((member) => member.id));
       const retained = current.filter((memberId) => activeIds.has(memberId));
@@ -471,45 +538,45 @@ export default function DraftManager({
     }));
   };
 
-	  const createDraft = async () => {
-	    if (!canCreateDraft) return;
+  const createDraft = async () => {
+    if (!canCreateDraft) return;
 
-	    setSavingDraft(true);
-	    setError(null);
+    setSavingDraft(true);
+    setError(null);
 
-	    try {
-	      const validationError = validateDraftScheduledTime(draftSettings.scheduledTime);
-	      if (validationError) {
-	        setError(validationError);
-	        return;
-	      }
+    try {
+      const validationError = validateDraftScheduledTime(draftSettings.scheduledTime);
+      if (validationError) {
+        setError(validationError);
+        return;
+      }
 
-	      const orderedMembers = getOrderedDraftMembers({
-	        members,
-	        draftOrderMembers,
-	        draftSettings,
-	        draftOrderRandomized,
-	      });
-	      const participants = buildDraftParticipants({ orderedMembers, league, currentUserId });
-	      const draftPayload = buildDraftCreatePayload({
-	        league,
-	        members,
-	        draftSettings,
-	        participants,
-	        currentUserId,
-	      });
+      const orderedMembers = getOrderedDraftMembers({
+        members,
+        draftOrderMembers,
+        draftSettings,
+        draftOrderRandomized,
+      });
+      const participants = buildDraftParticipants({ orderedMembers, league, currentUserId });
+      const draftPayload = buildDraftCreatePayload({
+        league,
+        members,
+        draftSettings,
+        participants,
+        currentUserId,
+      });
 
-	      const response = await fetchApi('drafts', {
-	        method: 'POST',
-	        body: JSON.stringify(draftPayload),
-	      });
+      const response = await fetchApi('drafts', {
+        method: 'POST',
+        body: JSON.stringify(draftPayload),
+      });
 
-	      if (response.success) {
-	        const createdDraft = response.data as DraftResponseShape;
+      if (response.success) {
+        const createdDraft = response.data as DraftResponseShape;
 
-	        if (!isDraftLinkedToLeague(league, createdDraft)) {
-	          throw new Error('Draft was created without the expected league link');
-	        }
+        if (!isDraftLinkedToLeague(league, createdDraft)) {
+          throw new Error('Draft was created without the expected league link');
+        }
 
         setExistingDraft(toExistingDraft(createdDraft));
         await refreshDraftState();
@@ -552,6 +619,15 @@ export default function DraftManager({
     }
   };
 
+  const viewDraftSummary = () => {
+    if (!existingDraft) return;
+
+    const summaryLeagueId = completedDraftSummary?.leagueId ?? league.id;
+    router.push(
+      `/drafts/history/${existingDraft.id}?leagueId=${encodeURIComponent(summaryLeagueId)}`
+    );
+  };
+
   const getStatusBadge = (status: string) => {
     const statusColors = {
       SCHEDULED: 'bg-primary/10 text-primary',
@@ -571,8 +647,13 @@ export default function DraftManager({
     );
   };
 
-  const formatDateTime = (dateTime: string) => {
-    return new Date(dateTime).toLocaleString('en-AU', {
+  const formatDateTime = (dateTime: string | null) => {
+    if (!dateTime) return 'Not recorded';
+
+    const date = new Date(dateTime);
+    if (Number.isNaN(date.getTime())) return 'Not recorded';
+
+    return date.toLocaleString('en-AU', {
       timeZone: draftSettings.timeZone,
       dateStyle: 'medium',
       timeStyle: 'short',
@@ -606,6 +687,7 @@ export default function DraftManager({
   const rosterSize = getRosterSizeFromPositionLimits(draftSettings.positionLimits);
   const benchSize = getBenchSizeFromPositionLimits(draftSettings.positionLimits);
   const totalDraftPicks = members.length * rosterSize;
+  const isCompletedDraft = existingDraft?.status === 'COMPLETED';
   const readinessItems = [
     {
       label: 'League members',
@@ -676,27 +758,84 @@ export default function DraftManager({
           animate={{ opacity: 1, y: 0 }}
           className="m-6 rounded-lg border border-border bg-muted/50 p-4"
         >
-          <div className="flex items-center justify-between">
-            <div>
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="min-w-0">
               <div className="mb-2 flex items-center space-x-3">
                 <CheckCircleIcon className="h-5 w-5 text-primary" />
-                <h3 className="font-semibold text-foreground">Draft Created</h3>
+                <h3 className="font-semibold text-foreground">
+                  {isCompletedDraft ? 'Draft Completed' : 'Draft Created'}
+                </h3>
                 {getStatusBadge(existingDraft.status)}
               </div>
               <p className="mb-1 text-sm text-muted-foreground">
                 Draft ID: <span className="font-mono text-xs">{existingDraft.id}</span>
               </p>
               <p className="text-sm text-muted-foreground">
-                Scheduled: {formatDateTime(existingDraft.startAt)}
+                {isCompletedDraft
+                  ? `Completed: ${formatDateTime(completedDraftSummary?.completedAt ?? existingDraft.startAt)}`
+                  : `Scheduled: ${formatDateTime(existingDraft.startAt)}`}
               </p>
+              {isCompletedDraft && (
+                <div className="mt-4 grid gap-3 sm:grid-cols-4">
+                  <div className="rounded-md border border-border bg-background p-3">
+                    <p className="text-xs font-medium text-muted-foreground">Picks</p>
+                    <p className="mt-1 text-lg font-semibold text-foreground">
+                      {completedDraftSummary
+                        ? `${completedDraftSummary.picksMade}/${completedDraftSummary.totalPicks}`
+                        : loadingCompletedDraftSummary
+                          ? 'Loading'
+                          : 'Not recorded'}
+                    </p>
+                  </div>
+                  <div className="rounded-md border border-border bg-background p-3">
+                    <p className="text-xs font-medium text-muted-foreground">Teams</p>
+                    <p className="mt-1 text-lg font-semibold text-foreground">
+                      {completedDraftSummary?.teamCount ?? members.length}
+                    </p>
+                  </div>
+                  <div className="rounded-md border border-border bg-background p-3">
+                    <p className="text-xs font-medium text-muted-foreground">Rounds</p>
+                    <p className="mt-1 text-lg font-semibold text-foreground">
+                      {completedDraftSummary?.totalRounds ?? rosterSize}
+                    </p>
+                  </div>
+                  <div className="rounded-md border border-border bg-background p-3">
+                    <p className="text-xs font-medium text-muted-foreground">Complete</p>
+                    <p className="mt-1 text-lg font-semibold text-foreground">
+                      {completedDraftSummary
+                        ? `${completedDraftSummary.completionPct}%`
+                        : loadingCompletedDraftSummary
+                          ? 'Loading'
+                          : '100%'}
+                    </p>
+                  </div>
+                </div>
+              )}
+              {isCompletedDraft && completedDraftSummary?.firstPick && (
+                <p className="mt-3 text-sm text-muted-foreground">
+                  First pick: {completedDraftSummary.firstPick.player.name},{' '}
+                  {completedDraftSummary.firstPick.player.position},{' '}
+                  {completedDraftSummary.firstPick.player.club}
+                </p>
+              )}
             </div>
-            <button
-              onClick={joinDraftRoom}
-              className="flex items-center space-x-2 rounded-lg bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              <PlayIcon className="h-4 w-4" />
-              <span>Join Draft Room</span>
-            </button>
+            {isCompletedDraft ? (
+              <button
+                onClick={viewDraftSummary}
+                className="flex items-center justify-center space-x-2 rounded-lg bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <CheckCircleIcon className="h-4 w-4" />
+                <span>View Draft Summary</span>
+              </button>
+            ) : (
+              <button
+                onClick={joinDraftRoom}
+                className="flex items-center justify-center space-x-2 rounded-lg bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <PlayIcon className="h-4 w-4" />
+                <span>Join Draft Room</span>
+              </button>
+            )}
           </div>
         </motion.div>
       )}

--- a/tests/unit/DraftManager.calendarUx.test.tsx
+++ b/tests/unit/DraftManager.calendarUx.test.tsx
@@ -90,4 +90,63 @@ describe('DraftManager calendar UX', () => {
     expect(screen.getByText(/Draft starts/i)).toBeInTheDocument();
     expect(container.querySelector('input[type="datetime-local"]')).not.toBeInTheDocument();
   });
+
+  it('shows a completed draft summary instead of a join-room action', async () => {
+    apiMocks.fetchApi
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          draft: {
+            id: 'cmqz8kv270002uxud8xurmb0m',
+            status: 'COMPLETED',
+            startAt: '2026-06-29T13:20:00.000Z',
+            createdAt: '2026-06-29T13:20:00.000Z',
+            leagueId: league.id,
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          id: 'cmqz8kv270002uxud8xurmb0m',
+          leagueId: league.id,
+          completedAt: '2026-06-29T14:45:00.000Z',
+          totalPicks: 216,
+          picksMade: 216,
+          teamCount: 12,
+          totalRounds: 18,
+          autoPickCount: 12,
+          manualPickCount: 204,
+          completionPct: 100,
+          firstPick: {
+            player: { name: 'Nick Daicos', position: 'MID', club: 'COLL' },
+            member: { teamName: 'Owner Team' },
+          },
+          lastPick: null,
+        },
+      });
+
+    render(
+      <DraftManager league={league} members={buildMembers()} currentUserId={league.ownerId} />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Draft Completed')).toBeInTheDocument();
+    expect(apiMocks.fetchApi).toHaveBeenCalledWith('drafts/history/cmqz8kv270002uxud8xurmb0m');
+    expect(screen.queryByRole('button', { name: 'Join Draft Room' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'View Draft Summary' })).toBeInTheDocument();
+    expect(screen.getByText('216/216')).toBeInTheDocument();
+    expect(screen.getByText('100%')).toBeInTheDocument();
+    expect(screen.getByText(/First pick: Nick Daicos, MID, COLL/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'View Draft Summary' }));
+
+    expect(routerMocks.push).toHaveBeenCalledWith(
+      '/drafts/history/cmqz8kv270002uxud8xurmb0m?leagueId=league-1'
+    );
+  });
 });

--- a/tests/unit/draftManagerDesignArchitecture.test.ts
+++ b/tests/unit/draftManagerDesignArchitecture.test.ts
@@ -40,6 +40,8 @@ describe('draft manager design architecture', () => {
     expect(draftManagerSource).toContain('Prepare the league draft room');
     expect(draftManagerSource).toContain('Prepare draft settings');
     expect(draftManagerSource).toContain('Join Draft Room');
+    expect(draftManagerSource).toContain('View Draft Summary');
+    expect(draftManagerSource).toContain("existingDraft?.status === 'COMPLETED'");
     expect(draftManagerSource).toContain('Draft Start Time');
     expect(draftManagerSource).toContain('Format and Clock');
     expect(draftManagerSource).toContain('Draft Order');

--- a/tests/unit/teamActionsRouteArchitecture.test.ts
+++ b/tests/unit/teamActionsRouteArchitecture.test.ts
@@ -59,6 +59,18 @@ vi.mock('../../src/lib/logger', () => ({
   },
 }));
 
+vi.mock('@/server/waivers/WaiverAvailabilityProjectionService', () => ({
+  WaiverAvailabilityProjectionService: vi.fn(() => ({
+    projectLeague: vi.fn().mockResolvedValue({ owned: 0, available: 0 }),
+  })),
+}));
+
+vi.mock('../../src/server/waivers/WaiverAvailabilityProjectionService', () => ({
+  WaiverAvailabilityProjectionService: vi.fn(() => ({
+    projectLeague: vi.fn().mockResolvedValue({ owned: 0, available: 0 }),
+  })),
+}));
+
 describe('team actions route architecture', () => {
   beforeEach(() => {
     vi.resetModules();


### PR DESCRIPTION
## Summary
- Show completed draft summaries in the league Draft tab instead of sending completed drafts back to the live draft room.
- Fetch the existing draft history read model for completed-draft metrics and route `View Draft Summary` to `/drafts/history/{id}?leagueId={leagueId}`.
- Add focused regression coverage so completed drafts hide `Join Draft Room` and keep the history-summary action.

## Root Cause
The league Draft tab treated every existing draft as a live-room draft, so a completed draft still rendered `Join Draft Room` and routed users to `/drafts/{id}`.

## Verification
- `npm run typecheck:tests`
- `npm run test:unit -- tests/unit/DraftManager.calendarUx.test.tsx tests/unit/draftManagerDesignArchitecture.test.ts`
- `npx eslint src/components/league/DraftManager.tsx tests/unit/DraftManager.calendarUx.test.tsx tests/unit/draftManagerDesignArchitecture.test.ts`
- `npx prettier --check src/components/league/DraftManager.tsx tests/unit/DraftManager.calendarUx.test.tsx tests/unit/draftManagerDesignArchitecture.test.ts`
- Browser QA on `http://localhost:3000/leagues/cmni37suz001gux0nlx0506es?tab=draft` at desktop and mobile-size viewport

## Deployment Notes
Next.js app/API deployment required. No Prisma migration, Socket.IO deployment, Firebase rules, worker deployment, or env change required.

## Dirty Files Excluded
- `prisma/dev.db` remains a local dirty file and is not part of this PR.

## Summary by Sourcery

Show completed league drafts as summarized history entries in the Draft tab instead of returning users to the live draft room.

New Features:
- Display key metrics and first-pick details for completed drafts within the league Draft tab.
- Provide a View Draft Summary action that navigates to the draft history page for completed drafts.

Enhancements:
- Handle completed draft metadata via a dedicated summary read model fetched when a draft reaches COMPLETED status.
- Improve date/time formatting to safely handle missing or invalid completion timestamps.

Tests:
- Add unit coverage to ensure completed drafts show summary metrics, hide the Join Draft Room button, and route correctly to the history view.
- Extend design-architecture tests to assert the presence of completed-draft handling and the View Draft Summary action in the DraftManager component.