### PR TITLE
Centralize league ownership transactions

### DIFF
--- a/Scripts/check-league-ownership-invariants.ts
+++ b/Scripts/check-league-ownership-invariants.ts
@@ -1,0 +1,137 @@
+import { prisma } from '@/lib/prisma';
+
+interface DuplicateMembershipRow {
+  leagueId: string;
+  userId: string;
+  memberCount: bigint;
+}
+
+interface OrphanOwnerRow {
+  leagueId: string;
+  ownerId: string;
+}
+
+interface CrossLeagueOwnershipRow {
+  rosterPlayerId: string;
+  rosterLeagueId: string;
+  memberLeagueId: string;
+}
+
+interface RosterProjectionRow {
+  leagueId: string;
+  memberId: string;
+  playerIds: string;
+}
+
+interface TableRow {
+  name: string;
+}
+
+function parsePlayerIds(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? [...new Set(parsed.map(String))].sort() : [];
+  } catch {
+    return [];
+  }
+}
+
+function samePlayerIds(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((playerId, index) => playerId === right[index]);
+}
+
+async function main(): Promise<void> {
+  const requiredTables = ['League', 'LeagueMember', 'LeagueRoster', 'LeagueRosterPlayer'];
+  const tables = await prisma.$queryRaw<TableRow[]>`
+    SELECT name
+    FROM sqlite_master
+    WHERE type = 'table' AND name IN ('League', 'LeagueMember', 'LeagueRoster', 'LeagueRosterPlayer')
+  `;
+  const existingTables = new Set(tables.map((table) => table.name));
+  const missingTables = requiredTables.filter((table) => !existingTables.has(table));
+  if (missingTables.length > 0) {
+    throw new Error(
+      `Database is missing ${missingTables.join(', ')}. Apply existing Prisma migrations before running this preflight.`
+    );
+  }
+
+  const [duplicateMemberships, orphanOwners, crossLeagueOwnerships, rosters, ownerships] =
+    await Promise.all([
+      prisma.$queryRaw<DuplicateMembershipRow[]>`
+        SELECT "leagueId", "userId", COUNT(*) AS "memberCount"
+        FROM "LeagueMember"
+        GROUP BY "leagueId", "userId"
+        HAVING COUNT(*) > 1
+      `,
+      prisma.$queryRaw<OrphanOwnerRow[]>`
+        SELECT league."id" AS "leagueId", league."ownerId" AS "ownerId"
+        FROM "League" AS league
+        LEFT JOIN "LeagueMember" AS member
+          ON member."leagueId" = league."id" AND member."userId" = league."ownerId"
+        WHERE member."id" IS NULL
+      `,
+      prisma.$queryRaw<CrossLeagueOwnershipRow[]>`
+        SELECT
+          rosterPlayer."id" AS "rosterPlayerId",
+          rosterPlayer."leagueId" AS "rosterLeagueId",
+          member."leagueId" AS "memberLeagueId"
+        FROM "LeagueRosterPlayer" AS rosterPlayer
+        INNER JOIN "LeagueMember" AS member ON member."id" = rosterPlayer."memberId"
+        WHERE rosterPlayer."leagueId" <> member."leagueId"
+      `,
+      prisma.leagueRoster.findMany({
+        select: { leagueId: true, memberId: true, playerIds: true },
+      }) as Promise<RosterProjectionRow[]>,
+      prisma.leagueRosterPlayer.findMany({
+        select: { leagueId: true, memberId: true, playerId: true },
+      }),
+    ]);
+
+  const ownershipByRoster = new Map<string, string[]>();
+  for (const ownership of ownerships) {
+    const key = `${ownership.leagueId}:${ownership.memberId}`;
+    ownershipByRoster.set(key, [...(ownershipByRoster.get(key) ?? []), ownership.playerId]);
+  }
+
+  const rosterProjectionDrift = rosters.filter((roster) => {
+    const canonical = [
+      ...(ownershipByRoster.get(`${roster.leagueId}:${roster.memberId}`) ?? []),
+    ].sort();
+    return !samePlayerIds(parsePlayerIds(roster.playerIds), canonical);
+  });
+
+  const violations = [
+    ...duplicateMemberships.map(
+      (row) =>
+        `duplicate membership league=${row.leagueId} user=${row.userId} count=${row.memberCount}`
+    ),
+    ...orphanOwners.map(
+      (row) => `owner without membership league=${row.leagueId} user=${row.ownerId}`
+    ),
+    ...crossLeagueOwnerships.map(
+      (row) =>
+        `cross-league ownership rosterPlayer=${row.rosterPlayerId} rosterLeague=${row.rosterLeagueId} memberLeague=${row.memberLeagueId}`
+    ),
+    ...rosterProjectionDrift.map(
+      (row) => `roster projection drift league=${row.leagueId} member=${row.memberId}`
+    ),
+  ];
+
+  if (violations.length > 0) {
+    console.error('League ownership migration preflight failed:');
+    for (const violation of violations) console.error(`- ${violation}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('League ownership migration preflight passed.');
+}
+
+main()
+  .catch((error) => {
+    console.error('League ownership migration preflight could not complete:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/functions/src/draftWorker.ts
+++ b/functions/src/draftWorker.ts
@@ -49,23 +49,13 @@ export const onTradeUpdate = functions
 
     if (!tradeData) return;
 
-    functions.logger.info(`Processing league-specific trade update in league ${leagueId}`);
-
-    try {
-      switch (tradeData.status) {
-        case 'PROPOSED':
-          await handleLeagueTradeProposal(leagueId, tradeId);
-          break;
-        case 'ACCEPTED':
-          await processAcceptedLeagueTrade(leagueId, tradeId, tradeData);
-          break;
-        case 'REJECTED':
-          await notifyLeagueTradeRejection(leagueId);
-          break;
+    // SQL owns trade validation and roster transfer. Firestore mirrors that state for realtime reads.
+    functions.logger.info(
+      `Ignoring legacy Firestore trade mutation for ${tradeId} in league ${leagueId}`,
+      {
+        status: tradeData.status,
       }
-    } catch (error) {
-      functions.logger.error(`League-scoped trade processing failed for ${tradeId}:`, error);
-    }
+    );
   });
 
 /**
@@ -216,85 +206,6 @@ async function isPlayerAvailable(leagueId: string, playerId: string): Promise<bo
   return data?.leagueAvailability?.[leagueId] !== false;
 }
 
-// League-specific trade processing functions
-
-async function handleLeagueTradeProposal(leagueId: string, tradeId: string): Promise<void> {
-  // Validate trade within league context
-  const isValid = await validateTradeForLeague(leagueId);
-
-  if (!isValid) {
-    await db.collection('leagues').doc(leagueId).collection('trades').doc(tradeId).update({
-      status: 'REJECTED',
-      rejectionReason: 'Invalid trade configuration for this league',
-      updatedAt: Timestamp.now(),
-    });
-    return;
-  }
-
-  // Set expiration (72 hours default)
-  const tradeExpiresAt = Timestamp.fromMillis(Date.now() + 72 * 60 * 60 * 1000);
-
-  await db.collection('leagues').doc(leagueId).collection('trades').doc(tradeId).update({
-    expiresAt: tradeExpiresAt,
-    updatedAt: Timestamp.now(),
-  });
-
-  // Notify trade partner within league
-  await notifyLeagueTradePartner(leagueId);
-}
-
-async function processAcceptedLeagueTrade(
-  leagueId: string,
-  tradeId: string,
-  tradeData: any
-): Promise<void> {
-  const batch = db.batch();
-
-  // Update rosters within league scope
-  const fromRosterRef = db
-    .collection('leagues')
-    .doc(leagueId)
-    .collection('rosters')
-    .doc(tradeData.fromTeamId);
-
-  const toRosterRef = db
-    .collection('leagues')
-    .doc(leagueId)
-    .collection('rosters')
-    .doc(tradeData.toTeamId);
-
-  // Remove players from sending team
-  batch.update(fromRosterRef, {
-    playerIds: FieldValue.arrayRemove(...tradeData.fromPlayerIds),
-    updatedAt: Timestamp.now(),
-  });
-
-  // Remove players from receiving team who are being sent away
-  batch.update(toRosterRef, {
-    playerIds: FieldValue.arrayRemove(...tradeData.toPlayerIds),
-    updatedAt: Timestamp.now(),
-  });
-
-  // Add players to receiving team
-  batch.update(toRosterRef, {
-    playerIds: FieldValue.arrayUnion(...tradeData.fromPlayerIds),
-    updatedAt: Timestamp.now(),
-  });
-
-  // Mark trade as processed within league
-  const tradeRef = db.collection('leagues').doc(leagueId).collection('trades').doc(tradeId);
-
-  batch.update(tradeRef, {
-    status: 'PROCESSED',
-    processedAt: Timestamp.now(),
-    updatedAt: Timestamp.now(),
-  });
-
-  await batch.commit();
-
-  functions.logger.info(`League trade ${tradeId} processed successfully in league ${leagueId}`);
-}
-
 // Waiver processing functions
 
 async function getLeaguesWithPendingWaivers(): Promise<string[]> {
@@ -405,18 +316,6 @@ async function processWaiverClaim(leagueId: string, waiver: any, batch: any): Pr
   return true;
 }
 
-// League-specific notification functions
-
-async function notifyLeagueTradePartner(leagueId: string): Promise<void> {
-  // Implement league-scoped trade proposal notification
-  functions.logger.info(`Notifying trade partner in league ${leagueId}`);
-}
-
-async function notifyLeagueTradeRejection(leagueId: string): Promise<void> {
-  // Implement league-scoped trade rejection notification
-  functions.logger.info(`Notifying trade rejection in league ${leagueId}`);
-}
-
 // Team-specific notification functions
 
 async function notifyTeamRosterChanges(
@@ -480,7 +379,9 @@ async function syncRosterOwnershipForLeague(
 
   await Promise.all([
     ...addedPlayers.map((playerId) => updatePlayerAvailabilityForLeague(leagueId, playerId, false)),
-    ...removedPlayers.map((playerId) => updatePlayerAvailabilityForLeague(leagueId, playerId, true)),
+    ...removedPlayers.map((playerId) =>
+      updatePlayerAvailabilityForLeague(leagueId, playerId, true)
+    ),
   ]);
 }
 
@@ -494,15 +395,6 @@ function getRosterPlayerIds(data: DocumentData): string[] {
 
 function stringOrUndefined(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
-}
-
-// League-specific validation functions
-
-async function validateTradeForLeague(leagueId: string): Promise<boolean> {
-  // Implement league-specific trade validation logic
-  // Check league roster limits, position requirements, etc.
-  functions.logger.info(`Validating trade for league ${leagueId}`);
-  return true;
 }
 
 // League-specific player availability functions

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "player-data:temp-db-apply-simulation": "tsx Scripts/player-data-convergence-temp-db-apply-simulation.ts",
     "player-data:runner": "tsx Scripts/player-data-convergence-runner.ts",
     "db:check": "tsx Scripts/check-database.ts",
+    "db:check-league-ownership": "tsx Scripts/check-league-ownership-invariants.ts",
     "firestore:smoke": "tsx Scripts/firestore-smoke.ts",
     "test:unit": "vitest run --config vitest.config.unit.ts",
     "test:int": "vitest run --config vitest.config.int.ts",

--- a/prisma/migrations/20260710150000_canonical_league_ownership_transactions/migration.sql
+++ b/prisma/migrations/20260710150000_canonical_league_ownership_transactions/migration.sql
@@ -1,0 +1,55 @@
+CREATE UNIQUE INDEX "LeagueMember_leagueId_userId_key" ON "LeagueMember"("leagueId", "userId");
+
+CREATE TABLE "LeagueWaiverHold" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "leagueId" TEXT NOT NULL,
+    "playerId" TEXT NOT NULL,
+    "releasedByMemberId" TEXT NOT NULL,
+    "availableAt" DATETIME NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "LeagueWaiverHold_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "LeagueWaiverHold_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "Player"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "LeagueWaiverHold_releasedByMemberId_fkey" FOREIGN KEY ("releasedByMemberId") REFERENCES "LeagueMember"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "LeagueWaiverHold_leagueId_playerId_key" ON "LeagueWaiverHold"("leagueId", "playerId");
+CREATE INDEX "LeagueWaiverHold_leagueId_availableAt_idx" ON "LeagueWaiverHold"("leagueId", "availableAt");
+CREATE INDEX "LeagueWaiverHold_releasedByMemberId_idx" ON "LeagueWaiverHold"("releasedByMemberId");
+
+CREATE TABLE "LeagueTrade" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "leagueId" TEXT NOT NULL,
+    "proposerMemberId" TEXT NOT NULL,
+    "recipientMemberId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "message" TEXT,
+    "expiresAt" DATETIME NOT NULL,
+    "processedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "LeagueTrade_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "LeagueTrade_proposerMemberId_fkey" FOREIGN KEY ("proposerMemberId") REFERENCES "LeagueMember"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "LeagueTrade_recipientMemberId_fkey" FOREIGN KEY ("recipientMemberId") REFERENCES "LeagueMember"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "LeagueTrade_leagueId_status_idx" ON "LeagueTrade"("leagueId", "status");
+CREATE INDEX "LeagueTrade_proposerMemberId_status_idx" ON "LeagueTrade"("proposerMemberId", "status");
+CREATE INDEX "LeagueTrade_recipientMemberId_status_idx" ON "LeagueTrade"("recipientMemberId", "status");
+
+CREATE TABLE "LeagueTradePlayer" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "tradeId" TEXT NOT NULL,
+    "playerId" TEXT NOT NULL,
+    "fromMemberId" TEXT NOT NULL,
+    "toMemberId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "LeagueTradePlayer_tradeId_fkey" FOREIGN KEY ("tradeId") REFERENCES "LeagueTrade"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "LeagueTradePlayer_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "Player"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "LeagueTradePlayer_fromMemberId_fkey" FOREIGN KEY ("fromMemberId") REFERENCES "LeagueMember"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "LeagueTradePlayer_toMemberId_fkey" FOREIGN KEY ("toMemberId") REFERENCES "LeagueMember"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "LeagueTradePlayer_tradeId_playerId_key" ON "LeagueTradePlayer"("tradeId", "playerId");
+CREATE INDEX "LeagueTradePlayer_fromMemberId_idx" ON "LeagueTradePlayer"("fromMemberId");
+CREATE INDEX "LeagueTradePlayer_toMemberId_idx" ON "LeagueTradePlayer"("toMemberId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,8 @@ model League {
   lineups        LeagueLineup[]
   matchupScores  LeagueMatchupScore[]
   standings      LeagueStanding[]
+  waiverHolds    LeagueWaiverHold[]
+  trades         LeagueTrade[]
   createdAt      DateTime             @default(now())
 
   @@index([ownerId])
@@ -82,15 +84,20 @@ model LeagueMember {
   lineups                  LeagueLineup[]
   matchupScores            LeagueMatchupScore[]
   standings                LeagueStanding[]
+  releasedWaiverHolds      LeagueWaiverHold[]
+  proposedTrades           LeagueTrade[]        @relation("TradeProposer")
+  receivedTrades           LeagueTrade[]        @relation("TradeRecipient")
+  sentTradePlayers         LeagueTradePlayer[]  @relation("TradePlayerFrom")
+  receivedTradePlayers     LeagueTradePlayer[]  @relation("TradePlayerTo")
 
   // Lobby relations
   watchlists      DraftWatchlist[]
   preDraftQueues  PreDraftQueue[]
   lobbyActivities LobbyActivity[]
 
+  @@unique([leagueId, userId])
   @@index([leagueId])
   @@index([userId])
-  @@index([leagueId, userId])
   @@index([draftSlot])
 }
 
@@ -319,6 +326,8 @@ model Player {
   picks         Pick[]
   rosterPlayers LeagueRosterPlayer[]
   lineupPlayers LeagueLineupPlayer[]
+  waiverHolds   LeagueWaiverHold[]
+  tradePlayers  LeagueTradePlayer[]
 
   // Lobby relations
   watchlists     DraftWatchlist[]
@@ -401,6 +410,74 @@ model LeagueRosterPlayer {
   @@unique([leagueId, memberId, playerId])
   @@index([leagueId, memberId])
   @@index([leagueId, acquiredBy])
+}
+
+// An active record means the player cannot be added as a free agent until availableAt.
+// Ownership itself remains represented only by LeagueRosterPlayer.
+model LeagueWaiverHold {
+  id                 String   @id @default(cuid())
+  leagueId           String
+  playerId           String
+  releasedByMemberId String
+  availableAt        DateTime
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  league     League       @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  player     Player       @relation(fields: [playerId], references: [id], onDelete: Cascade)
+  releasedBy LeagueMember @relation(fields: [releasedByMemberId], references: [id], onDelete: Cascade)
+
+  @@unique([leagueId, playerId])
+  @@index([leagueId, availableAt])
+  @@index([releasedByMemberId])
+}
+
+enum LeagueTradeStatus {
+  PENDING
+  PROCESSED
+  REJECTED
+  CANCELLED
+  EXPIRED
+}
+
+model LeagueTrade {
+  id                String            @id @default(cuid())
+  leagueId          String
+  proposerMemberId  String
+  recipientMemberId String
+  status            LeagueTradeStatus @default(PENDING)
+  message           String?
+  expiresAt         DateTime
+  processedAt       DateTime?
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+
+  league    League              @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  proposer  LeagueMember        @relation("TradeProposer", fields: [proposerMemberId], references: [id], onDelete: Cascade)
+  recipient LeagueMember        @relation("TradeRecipient", fields: [recipientMemberId], references: [id], onDelete: Cascade)
+  players   LeagueTradePlayer[]
+
+  @@index([leagueId, status])
+  @@index([proposerMemberId, status])
+  @@index([recipientMemberId, status])
+}
+
+model LeagueTradePlayer {
+  id           String   @id @default(cuid())
+  tradeId      String
+  playerId     String
+  fromMemberId String
+  toMemberId   String
+  createdAt    DateTime @default(now())
+
+  trade      LeagueTrade  @relation(fields: [tradeId], references: [id], onDelete: Cascade)
+  player     Player       @relation(fields: [playerId], references: [id], onDelete: Cascade)
+  fromMember LeagueMember @relation("TradePlayerFrom", fields: [fromMemberId], references: [id], onDelete: Cascade)
+  toMember   LeagueMember @relation("TradePlayerTo", fields: [toMemberId], references: [id], onDelete: Cascade)
+
+  @@unique([tradeId, playerId])
+  @@index([fromMemberId])
+  @@index([toMemberId])
 }
 
 model LeagueMatchup {

--- a/src/app/api/leagues/[id]/actions/[userId]/route.ts
+++ b/src/app/api/leagues/[id]/actions/[userId]/route.ts
@@ -7,6 +7,7 @@ import { prisma } from '@/lib/prisma';
 import { ensureRosterTables } from '@/lib/ensureLobbyColumns';
 import { getAuthenticatedUserId } from '@/lib/serverAuth';
 import { verifyLeagueMembership } from '@/lib/leagueMembership';
+import { LeagueOwnershipService } from '@/server/rosters/LeagueOwnershipService';
 import { WaiverAvailabilityProjectionService } from '@/server/waivers/WaiverAvailabilityProjectionService';
 
 // GET /api/leagues/[id]/actions/[userId] - Get user's team actions
@@ -337,25 +338,15 @@ async function processDropPlayerAction(actionId: string): Promise<void> {
     const leagueId = String(action.leagueId);
     const memberId = String(action.memberId);
 
-    await prisma.$transaction(async (tx) => {
-      const roster = await tx.leagueRoster.findUnique({
-        where: { leagueId_memberId: { leagueId, memberId } },
-        select: { playerIds: true },
-      });
-
-      const playerIds = parsePlayerIds(roster?.playerIds);
-      const nextPlayerIds = playerIds.filter((id) => id !== playerId);
-
-      await tx.leagueRosterPlayer.deleteMany({
-        where: { leagueId, memberId, playerId },
-      });
-
-      if (roster) {
-        await tx.leagueRoster.update({
-          where: { leagueId_memberId: { leagueId, memberId } },
-          data: { playerIds: JSON.stringify(nextPlayerIds) },
-        });
-      }
+    const parsedProcessingAt = new Date(String(action.processingAt));
+    const availableAt = Number.isNaN(parsedProcessingAt.getTime())
+      ? new Date(Date.now() + 24 * 60 * 60 * 1000)
+      : parsedProcessingAt;
+    await new LeagueOwnershipService().dropToWaivers({
+      leagueId,
+      memberId,
+      playerId,
+      availableAt,
     });
 
     await new WaiverAvailabilityProjectionService().projectLeague({ leagueId });
@@ -382,15 +373,6 @@ async function processDropPlayerAction(actionId: string): Promise<void> {
       SET status = 'REJECTED', processedAt = datetime('now')
       WHERE id = ${actionId}
     `;
-  }
-}
-
-function parsePlayerIds(raw: unknown): string[] {
-  try {
-    const parsed = JSON.parse(String(raw || '[]'));
-    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : [];
-  } catch {
-    return [];
   }
 }
 

--- a/src/app/api/leagues/[id]/roster/add/route.ts
+++ b/src/app/api/leagues/[id]/roster/add/route.ts
@@ -9,19 +9,11 @@ import { tags } from '@/lib/cacheTags';
 import { logger } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedUserId } from '@/lib/serverAuth';
+import {
+  LeagueOwnershipService,
+  OwnershipMutationError,
+} from '@/server/rosters/LeagueOwnershipService';
 import { WaiverAvailabilityProjectionService } from '@/server/waivers/WaiverAvailabilityProjectionService';
-
-function parsePlayerIds(value: unknown): string[] {
-  if (Array.isArray(value)) return value.map(String);
-  if (typeof value !== 'string') return [];
-
-  try {
-    const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? parsed.map(String) : [];
-  } catch {
-    return [];
-  }
-}
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -33,54 +25,16 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     const playerId = typeof body.playerId === 'string' ? body.playerId.trim() : '';
     if (!leagueId || !playerId) return errorResponse('League ID and player ID are required', 400);
 
-    const [member, player, existingOwnership, activeWaiverHold] = await prisma.$transaction([
-      prisma.leagueMember.findFirst({ where: { leagueId, userId }, select: { id: true } }),
-      prisma.player.findUnique({ where: { id: playerId }, select: { id: true } }),
-      prisma.leagueRosterPlayer.findFirst({
-        where: { leagueId, playerId },
-        select: { memberId: true },
-      }),
-      prisma.teamAction.findFirst({
-        where: {
-          leagueId,
-          actionType: 'DROP_PLAYER',
-          status: 'PENDING',
-          processingAt: { gt: new Date() },
-          details: { contains: `"playerId":"${playerId}"` },
-        },
-        select: { id: true },
-      }),
-    ]);
-
+    const member = await prisma.leagueMember.findUnique({
+      where: { leagueId_userId: { leagueId, userId } },
+      select: { id: true },
+    });
     if (!member) return errorResponse('User is not a member of this league', 404);
-    if (!player) return errorResponse('Player not found', 404);
-    if (existingOwnership) return errorResponse('Player already owned in this league', 409);
-    if (activeWaiverHold) return errorResponse('Player is on waivers', 409);
 
-    const result = await prisma.$transaction(async (tx) => {
-      const roster = await tx.leagueRoster.upsert({
-        where: { leagueId_memberId: { leagueId, memberId: member.id } },
-        create: { leagueId, memberId: member.id, playerIds: JSON.stringify([playerId]) },
-        update: {},
-      });
-
-      const nextPlayerIds = Array.from(new Set([...parsePlayerIds(roster.playerIds), playerId]));
-
-      await tx.leagueRoster.update({
-        where: { leagueId_memberId: { leagueId, memberId: member.id } },
-        data: { playerIds: JSON.stringify(nextPlayerIds) },
-      });
-
-      await tx.leagueRosterPlayer.create({
-        data: {
-          leagueId,
-          memberId: member.id,
-          playerId,
-          acquiredBy: 'FREE_AGENT',
-        },
-      });
-
-      return { rosterId: roster.id, playerIds: nextPlayerIds };
+    const result = await new LeagueOwnershipService().addFreeAgent({
+      leagueId,
+      memberId: member.id,
+      playerId,
     });
 
     await Promise.allSettled([
@@ -89,13 +43,17 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       revalidateTag(tags.waivers(leagueId)),
     ]);
 
-    return successResponse({
-      leagueId,
-      playerId,
-      rosterId: result.rosterId,
-      playerIds: result.playerIds,
-    });
+    return successResponse({ leagueId, playerId, playerIds: result.playerIds });
   } catch (error) {
+    if (error instanceof OwnershipMutationError) {
+      const status =
+        error.code === 'LEAGUE_NOT_FOUND' ||
+        error.code === 'TEAM_NOT_FOUND' ||
+        error.code === 'PLAYER_NOT_FOUND'
+          ? 404
+          : 409;
+      return errorResponse(error.message, status);
+    }
     logger.error('Failed to add player to roster', {
       error: error instanceof Error ? error.message : String(error),
     });

--- a/src/app/api/leagues/[id]/trades/[tradeId]/accept/route.ts
+++ b/src/app/api/leagues/[id]/trades/[tradeId]/accept/route.ts
@@ -1,0 +1,70 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
+
+import { adminDb } from '@/lib/firebaseAdmin';
+import { logLeagueActivity } from '@/lib/activity';
+import { tags } from '@/lib/cacheTags';
+import { logger } from '@/lib/logger';
+import { getAuthenticatedUserId } from '@/lib/serverAuth';
+import { TradeMutationError, LeagueTradeService } from '@/server/trades/LeagueTradeService';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; tradeId: string }> }
+) {
+  try {
+    const { id: leagueId, tradeId } = await params;
+    const userId = await getAuthenticatedUserId(req);
+    if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const trade = await new LeagueTradeService().acceptProposal({
+      leagueId,
+      tradeId,
+      recipientUserId: userId,
+    });
+
+    await Promise.allSettled([
+      adminDb.collection('leagues').doc(leagueId).collection('trades').doc(trade.id).set(
+        {
+          canonicalTradeId: trade.id,
+          status: 'PROCESSED',
+          processedAt: trade.processedAt,
+          updatedAt: new Date(),
+        },
+        { merge: true }
+      ),
+      logLeagueActivity(leagueId, 'trade-processed', {
+        tradeId: trade.id,
+        fromTeamId: trade.proposerMemberId,
+        toTeamId: trade.recipientMemberId,
+      }),
+      revalidateTag(tags.trades(leagueId)),
+      revalidateTag(tags.league(leagueId)),
+      revalidateTag(tags.waivers(leagueId)),
+    ]);
+
+    return NextResponse.json({
+      id: trade.id,
+      status: trade.status,
+      processedAt: trade.processedAt,
+    });
+  } catch (error) {
+    if (error instanceof TradeMutationError) {
+      const status =
+        error.code === 'TRADE_NOT_FOUND'
+          ? 404
+          : error.code === 'FORBIDDEN'
+            ? 403
+            : error.code === 'INVALID_TRADE'
+              ? 400
+              : 409;
+      return NextResponse.json({ error: error.message }, { status });
+    }
+    logger.apiError('POST', '/api/leagues/[id]/trades/[tradeId]/accept', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/leagues/[id]/trades/route.ts
+++ b/src/app/api/leagues/[id]/trades/route.ts
@@ -2,23 +2,22 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { revalidateTag } from 'next/cache';
 import { z } from 'zod';
+
 import { adminDb } from '@/lib/firebaseAdmin';
-import { getAuthenticatedUserId } from '@/lib/serverAuth';
-import { verifyLeagueMembership } from '@/lib/leagueMembership';
 import { logLeagueActivity } from '@/lib/activity';
 import { tags } from '@/lib/cacheTags';
 import { logger } from '@/lib/logger';
+import { getAuthenticatedUserId } from '@/lib/serverAuth';
+import { LeagueTradeService, TradeMutationError } from '@/server/trades/LeagueTradeService';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 const tradeSchema = z.object({
-  fromTeamId: z.string().trim().min(1),
-  toTeamId: z.string().trim().min(1),
-  fromUserId: z.string().trim().min(1),
-  toUserId: z.string().trim().min(1),
-  playersOffered: z.array(z.string()).default([]),
-  playersRequested: z.array(z.string()).default([]),
+  recipientMemberId: z.string().trim().min(1).optional(),
+  toTeamId: z.string().trim().min(1).optional(),
+  playersOffered: z.array(z.string().trim().min(1)).default([]),
+  playersRequested: z.array(z.string().trim().min(1)).default([]),
   picksOffered: z.array(z.unknown()).default([]),
   picksRequested: z.array(z.unknown()).default([]),
   message: z.string().trim().max(1000).optional(),
@@ -28,14 +27,10 @@ const tradeSchema = z.object({
 export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id: leagueId } = await params;
-    if (!leagueId) {
-      return NextResponse.json({ error: 'Missing leagueId' }, { status: 400 });
-    }
+    if (!leagueId) return NextResponse.json({ error: 'Missing leagueId' }, { status: 400 });
 
     const userId = await getAuthenticatedUserId(req);
-    if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const parsed = tradeSchema.safeParse(await req.json().catch(() => ({})));
     if (!parsed.success) {
@@ -45,77 +40,99 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       );
     }
 
-    const trade = parsed.data;
-    if (trade.fromUserId !== userId) {
-      return NextResponse.json({ error: 'Trade proposer mismatch' }, { status: 403 });
-    }
-
-    const [proposerMembership, recipientMembership] = await Promise.all([
-      verifyLeagueMembership(leagueId, trade.fromUserId),
-      verifyLeagueMembership(leagueId, trade.toUserId),
-    ]);
-
-    if (!proposerMembership.isMember || !recipientMembership.isMember) {
+    const input = parsed.data;
+    if (input.picksOffered.length > 0 || input.picksRequested.length > 0) {
       return NextResponse.json(
-        { error: 'Trade participants must be league members' },
-        { status: 403 }
+        { error: 'Draft-pick assets are not supported by the canonical trade system yet' },
+        { status: 400 }
       );
     }
-
-    const expiresAt = toTradeExpiry(trade.expiresAt);
-    const tradeRef = adminDb.collection('leagues').doc(leagueId).collection('trades').doc();
-    const tradeDoc = {
-      leagueId,
-      fromTeamId: trade.fromTeamId,
-      toTeamId: trade.toTeamId,
-      fromUserId: trade.fromUserId,
-      toUserId: trade.toUserId,
-      playersOffered: trade.playersOffered,
-      playersRequested: trade.playersRequested,
-      picksOffered: trade.picksOffered,
-      picksRequested: trade.picksRequested,
-      status: 'PENDING',
-      ...(trade.message ? { message: trade.message } : {}),
-      expiresAt,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-
-    await tradeRef.set(tradeDoc);
-
-    await logLeagueActivity(leagueId, 'trade-proposed', {
-      tradeId: tradeRef.id,
-      fromUserId: trade.fromUserId,
-      toUserId: trade.toUserId,
-      fromTeamId: trade.fromTeamId,
-      toTeamId: trade.toTeamId,
-      playersOffered: trade.playersOffered,
-      playersRequested: trade.playersRequested,
-    });
-
-    try {
-      await Promise.allSettled([
-        revalidateTag(tags.trades(leagueId)),
-        revalidateTag(tags.league(leagueId)),
-      ]);
-    } catch (error) {
-      logger.warn('Failed to revalidate tags after trade proposal', { leagueId, error });
+    const recipientMemberId = input.recipientMemberId ?? input.toTeamId;
+    if (!recipientMemberId) {
+      return NextResponse.json({ error: 'A receiving team is required' }, { status: 400 });
     }
 
-    return NextResponse.json({ id: tradeRef.id }, { status: 201 });
+    const trade = await new LeagueTradeService().createProposal({
+      leagueId,
+      proposerUserId: userId,
+      recipientMemberId,
+      playersOffered: input.playersOffered,
+      playersRequested: input.playersRequested,
+      message: input.message,
+      expiresAt: toTradeExpiry(input.expiresAt),
+    });
+
+    await Promise.allSettled([
+      projectTradeToFirestore(trade),
+      logLeagueActivity(leagueId, 'trade-proposed', {
+        tradeId: trade.id,
+        fromUserId: trade.proposer.userId,
+        toUserId: trade.recipient.userId,
+        fromTeamId: trade.proposerMemberId,
+        toTeamId: trade.recipientMemberId,
+        playersOffered: input.playersOffered,
+        playersRequested: input.playersRequested,
+      }),
+      revalidateTag(tags.trades(leagueId)),
+      revalidateTag(tags.league(leagueId)),
+    ]);
+
+    return NextResponse.json({ id: trade.id }, { status: 201 });
   } catch (error) {
+    if (error instanceof TradeMutationError) {
+      const status = error.code === 'TEAM_NOT_FOUND' ? 404 : error.code === 'FORBIDDEN' ? 403 : 409;
+      return NextResponse.json({ error: error.message }, { status });
+    }
     logger.apiError('POST', '/api/leagues/[id]/trades', error);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
 }
 
+export async function projectTradeToFirestore(trade: {
+  id: string;
+  leagueId: string;
+  proposerMemberId: string;
+  recipientMemberId: string;
+  expiresAt: Date;
+  message: string | null;
+  players: Array<{ playerId: string; fromMemberId: string }>;
+  proposer: { userId: string };
+  recipient: { userId: string };
+}): Promise<void> {
+  const playersOffered = trade.players
+    .filter((player) => player.fromMemberId === trade.proposerMemberId)
+    .map((player) => player.playerId);
+  const playersRequested = trade.players
+    .filter((player) => player.fromMemberId === trade.recipientMemberId)
+    .map((player) => player.playerId);
+
+  await adminDb
+    .collection('leagues')
+    .doc(trade.leagueId)
+    .collection('trades')
+    .doc(trade.id)
+    .set(
+      {
+        canonicalTradeId: trade.id,
+        leagueId: trade.leagueId,
+        fromTeamId: trade.proposerMemberId,
+        toTeamId: trade.recipientMemberId,
+        fromUserId: trade.proposer.userId,
+        toUserId: trade.recipient.userId,
+        playersOffered,
+        playersRequested,
+        status: 'PENDING',
+        ...(trade.message ? { message: trade.message } : {}),
+        expiresAt: trade.expiresAt,
+        updatedAt: new Date(),
+      },
+      { merge: true }
+    );
+}
+
 function toTradeExpiry(value: unknown): Date {
   if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
-  if (typeof value === 'number') {
-    const date = new Date(value);
-    if (!Number.isNaN(date.getTime())) return date;
-  }
-  if (typeof value === 'string') {
+  if (typeof value === 'number' || typeof value === 'string') {
     const date = new Date(value);
     if (!Number.isNaN(date.getTime())) return date;
   }

--- a/src/server/rosters/LeagueOwnershipService.ts
+++ b/src/server/rosters/LeagueOwnershipService.ts
@@ -1,0 +1,291 @@
+import { Prisma } from '@prisma/client';
+
+import { prisma } from '@/lib/prisma';
+
+export type OwnershipMutationErrorCode =
+  | 'LEAGUE_NOT_FOUND'
+  | 'TEAM_NOT_FOUND'
+  | 'PLAYER_NOT_FOUND'
+  | 'PLAYER_OWNED'
+  | 'PLAYER_ON_WAIVERS'
+  | 'PLAYER_NOT_OWNED'
+  | 'ROSTER_LIMIT_REACHED';
+
+export class OwnershipMutationError extends Error {
+  constructor(
+    readonly code: OwnershipMutationErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'OwnershipMutationError';
+  }
+}
+
+export interface RosterMutationResult {
+  playerIds: string[];
+}
+
+type RosterTransaction = Prisma.TransactionClient;
+
+function serializePlayerIds(playerIds: string[]): string {
+  return JSON.stringify(playerIds);
+}
+
+async function requireMember(
+  tx: RosterTransaction,
+  leagueId: string,
+  memberId: string
+): Promise<void> {
+  const member = await tx.leagueMember.findUnique({
+    where: { id: memberId },
+    select: { leagueId: true },
+  });
+
+  if (!member || member.leagueId !== leagueId) {
+    throw new OwnershipMutationError('TEAM_NOT_FOUND', 'Team not found in this league');
+  }
+}
+
+async function requireLeagueRosterSize(tx: RosterTransaction, leagueId: string): Promise<number> {
+  const league = await tx.league.findUnique({
+    where: { id: leagueId },
+    select: { settings: { select: { rosterSize: true } } },
+  });
+
+  if (!league) {
+    throw new OwnershipMutationError('LEAGUE_NOT_FOUND', 'League not found');
+  }
+
+  return league.settings.rosterSize;
+}
+
+async function syncRosterProjection(
+  tx: RosterTransaction,
+  leagueId: string,
+  memberId: string
+): Promise<string[]> {
+  const ownerships = await tx.leagueRosterPlayer.findMany({
+    where: { leagueId, memberId },
+    orderBy: [{ acquiredAt: 'asc' }, { createdAt: 'asc' }],
+    select: { playerId: true },
+  });
+  const playerIds = ownerships.map((ownership) => ownership.playerId);
+
+  await tx.leagueRoster.upsert({
+    where: { leagueId_memberId: { leagueId, memberId } },
+    create: { leagueId, memberId, playerIds: serializePlayerIds(playerIds) },
+    update: { playerIds: serializePlayerIds(playerIds) },
+  });
+
+  return playerIds;
+}
+
+async function ensureUnownedPlayer(
+  tx: RosterTransaction,
+  input: { leagueId: string; playerId: string; allowWaiverHold: boolean }
+): Promise<void> {
+  const [player, ownership, hold] = await Promise.all([
+    tx.player.findUnique({ where: { id: input.playerId }, select: { id: true } }),
+    tx.leagueRosterPlayer.findUnique({
+      where: { leagueId_playerId: { leagueId: input.leagueId, playerId: input.playerId } },
+      select: { memberId: true },
+    }),
+    tx.leagueWaiverHold.findUnique({
+      where: { leagueId_playerId: { leagueId: input.leagueId, playerId: input.playerId } },
+      select: { availableAt: true },
+    }),
+  ]);
+
+  if (!player) {
+    throw new OwnershipMutationError('PLAYER_NOT_FOUND', 'Player not found');
+  }
+  if (ownership) {
+    throw new OwnershipMutationError('PLAYER_OWNED', 'Player already owned in this league');
+  }
+  if (hold && hold.availableAt > new Date() && !input.allowWaiverHold) {
+    throw new OwnershipMutationError('PLAYER_ON_WAIVERS', 'Player is on waivers');
+  }
+}
+
+async function ensureCapacity(
+  tx: RosterTransaction,
+  input: { leagueId: string; memberId: string; incoming: number; outgoing: number }
+): Promise<void> {
+  const [rosterSize, currentCount] = await Promise.all([
+    requireLeagueRosterSize(tx, input.leagueId),
+    tx.leagueRosterPlayer.count({ where: { leagueId: input.leagueId, memberId: input.memberId } }),
+  ]);
+
+  if (currentCount - input.outgoing + input.incoming > rosterSize) {
+    throw new OwnershipMutationError('ROSTER_LIMIT_REACHED', 'Roster limit reached');
+  }
+}
+
+export class LeagueOwnershipService {
+  constructor(private readonly db: Pick<typeof prisma, '$transaction'> = prisma) {}
+
+  async addFreeAgent(input: {
+    leagueId: string;
+    memberId: string;
+    playerId: string;
+  }): Promise<RosterMutationResult> {
+    try {
+      return await this.db.$transaction(async (tx) => {
+        await requireMember(tx, input.leagueId, input.memberId);
+        await ensureUnownedPlayer(tx, {
+          leagueId: input.leagueId,
+          playerId: input.playerId,
+          allowWaiverHold: false,
+        });
+        await ensureCapacity(tx, { ...input, incoming: 1, outgoing: 0 });
+
+        await tx.leagueRosterPlayer.create({
+          data: {
+            leagueId: input.leagueId,
+            memberId: input.memberId,
+            playerId: input.playerId,
+            acquiredBy: 'FREE_AGENT',
+          },
+        });
+
+        return { playerIds: await syncRosterProjection(tx, input.leagueId, input.memberId) };
+      });
+    } catch (error) {
+      throw normalizeOwnershipError(error);
+    }
+  }
+
+  async dropToWaivers(input: {
+    leagueId: string;
+    memberId: string;
+    playerId: string;
+    availableAt: Date;
+  }): Promise<RosterMutationResult> {
+    return this.db.$transaction(async (tx) => {
+      await requireMember(tx, input.leagueId, input.memberId);
+      const ownership = await tx.leagueRosterPlayer.findUnique({
+        where: { leagueId_playerId: { leagueId: input.leagueId, playerId: input.playerId } },
+        select: { memberId: true },
+      });
+
+      if (!ownership || ownership.memberId !== input.memberId) {
+        throw new OwnershipMutationError('PLAYER_NOT_OWNED', 'Player is not in this roster');
+      }
+
+      await tx.leagueRosterPlayer.delete({
+        where: { leagueId_playerId: { leagueId: input.leagueId, playerId: input.playerId } },
+      });
+      await tx.leagueWaiverHold.upsert({
+        where: { leagueId_playerId: { leagueId: input.leagueId, playerId: input.playerId } },
+        create: {
+          leagueId: input.leagueId,
+          playerId: input.playerId,
+          releasedByMemberId: input.memberId,
+          availableAt: input.availableAt,
+        },
+        update: {
+          releasedByMemberId: input.memberId,
+          availableAt: input.availableAt,
+        },
+      });
+
+      return { playerIds: await syncRosterProjection(tx, input.leagueId, input.memberId) };
+    });
+  }
+
+  async claimWaiver(input: {
+    leagueId: string;
+    memberId: string;
+    playerId: string;
+    dropPlayerId?: string;
+    droppedPlayerAvailableAt: Date;
+  }): Promise<RosterMutationResult> {
+    try {
+      return await this.db.$transaction(async (tx) => {
+        await requireMember(tx, input.leagueId, input.memberId);
+        await ensureUnownedPlayer(tx, {
+          leagueId: input.leagueId,
+          playerId: input.playerId,
+          allowWaiverHold: true,
+        });
+
+        if (input.dropPlayerId) {
+          const dropOwnership = await tx.leagueRosterPlayer.findUnique({
+            where: {
+              leagueId_playerId: { leagueId: input.leagueId, playerId: input.dropPlayerId },
+            },
+            select: { memberId: true },
+          });
+          if (!dropOwnership || dropOwnership.memberId !== input.memberId) {
+            throw new OwnershipMutationError(
+              'PLAYER_NOT_OWNED',
+              'Drop player is not in this roster'
+            );
+          }
+        }
+
+        await ensureCapacity(tx, {
+          leagueId: input.leagueId,
+          memberId: input.memberId,
+          incoming: 1,
+          outgoing: input.dropPlayerId ? 1 : 0,
+        });
+
+        if (input.dropPlayerId) {
+          await tx.leagueRosterPlayer.delete({
+            where: {
+              leagueId_playerId: { leagueId: input.leagueId, playerId: input.dropPlayerId },
+            },
+          });
+          await tx.leagueWaiverHold.upsert({
+            where: {
+              leagueId_playerId: { leagueId: input.leagueId, playerId: input.dropPlayerId },
+            },
+            create: {
+              leagueId: input.leagueId,
+              playerId: input.dropPlayerId,
+              releasedByMemberId: input.memberId,
+              availableAt: input.droppedPlayerAvailableAt,
+            },
+            update: {
+              releasedByMemberId: input.memberId,
+              availableAt: input.droppedPlayerAvailableAt,
+            },
+          });
+        }
+
+        await tx.leagueRosterPlayer.create({
+          data: {
+            leagueId: input.leagueId,
+            memberId: input.memberId,
+            playerId: input.playerId,
+            acquiredBy: 'WAIVER',
+          },
+        });
+        await tx.leagueWaiverHold.deleteMany({
+          where: { leagueId: input.leagueId, playerId: input.playerId },
+        });
+
+        return { playerIds: await syncRosterProjection(tx, input.leagueId, input.memberId) };
+      });
+    } catch (error) {
+      throw normalizeOwnershipError(error);
+    }
+  }
+}
+
+export async function syncCanonicalRosterProjection(
+  tx: RosterTransaction,
+  leagueId: string,
+  memberId: string
+): Promise<string[]> {
+  return syncRosterProjection(tx, leagueId, memberId);
+}
+
+function normalizeOwnershipError(error: unknown): Error {
+  if (error instanceof OwnershipMutationError) return error;
+  if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+    return new OwnershipMutationError('PLAYER_OWNED', 'Player already owned in this league');
+  }
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/src/server/trades/LeagueTradeService.ts
+++ b/src/server/trades/LeagueTradeService.ts
@@ -1,0 +1,233 @@
+import { LeagueTradeStatus, Prisma } from '@prisma/client';
+
+import { prisma } from '@/lib/prisma';
+import { syncCanonicalRosterProjection } from '@/server/rosters/LeagueOwnershipService';
+
+export type TradeMutationErrorCode =
+  | 'TRADE_NOT_FOUND'
+  | 'TEAM_NOT_FOUND'
+  | 'FORBIDDEN'
+  | 'INVALID_TRADE'
+  | 'STALE_TRADE'
+  | 'ROSTER_LIMIT_REACHED';
+
+export class TradeMutationError extends Error {
+  constructor(
+    readonly code: TradeMutationErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'TradeMutationError';
+  }
+}
+
+interface TradePlayerMove {
+  playerId: string;
+  fromMemberId: string;
+  toMemberId: string;
+}
+
+function uniquePlayerIds(playerIds: string[]): string[] {
+  return [...new Set(playerIds.map((playerId) => playerId.trim()).filter(Boolean))];
+}
+
+function rejectDuplicateAssets(offeredPlayerIds: string[], requestedPlayerIds: string[]): void {
+  const assetIds = [...offeredPlayerIds, ...requestedPlayerIds];
+  if (assetIds.length === 0) {
+    throw new TradeMutationError('INVALID_TRADE', 'A trade must include at least one player');
+  }
+  if (new Set(assetIds).size !== assetIds.length) {
+    throw new TradeMutationError('INVALID_TRADE', 'A player can only appear once in a trade');
+  }
+}
+
+export class LeagueTradeService {
+  constructor(private readonly db: Pick<typeof prisma, '$transaction'> = prisma) {}
+
+  async createProposal(input: {
+    leagueId: string;
+    proposerUserId: string;
+    recipientMemberId: string;
+    playersOffered: string[];
+    playersRequested: string[];
+    message?: string;
+    expiresAt: Date;
+  }) {
+    const playersOffered = uniquePlayerIds(input.playersOffered);
+    const playersRequested = uniquePlayerIds(input.playersRequested);
+    rejectDuplicateAssets(playersOffered, playersRequested);
+
+    return this.db.$transaction(async (tx) => {
+      const [proposer, recipient, league] = await Promise.all([
+        tx.leagueMember.findUnique({
+          where: { leagueId_userId: { leagueId: input.leagueId, userId: input.proposerUserId } },
+          select: { id: true },
+        }),
+        tx.leagueMember.findUnique({
+          where: { id: input.recipientMemberId },
+          select: { id: true, leagueId: true },
+        }),
+        tx.league.findUnique({ where: { id: input.leagueId }, select: { id: true } }),
+      ]);
+
+      if (!league) throw new TradeMutationError('TEAM_NOT_FOUND', 'League not found');
+      if (!proposer || !recipient || recipient.leagueId !== input.leagueId) {
+        throw new TradeMutationError('TEAM_NOT_FOUND', 'Trade team not found in this league');
+      }
+      if (proposer.id === recipient.id) {
+        throw new TradeMutationError('INVALID_TRADE', 'A team cannot trade with itself');
+      }
+      if (input.expiresAt <= new Date()) {
+        throw new TradeMutationError('INVALID_TRADE', 'Trade expiry must be in the future');
+      }
+
+      const moves: TradePlayerMove[] = [
+        ...playersOffered.map((playerId) => ({
+          playerId,
+          fromMemberId: proposer.id,
+          toMemberId: recipient.id,
+        })),
+        ...playersRequested.map((playerId) => ({
+          playerId,
+          fromMemberId: recipient.id,
+          toMemberId: proposer.id,
+        })),
+      ];
+      await this.assertOwnership(tx, input.leagueId, moves);
+
+      return tx.leagueTrade.create({
+        data: {
+          leagueId: input.leagueId,
+          proposerMemberId: proposer.id,
+          recipientMemberId: recipient.id,
+          message: input.message?.trim() || null,
+          expiresAt: input.expiresAt,
+          players: {
+            create: moves,
+          },
+        },
+        include: {
+          players: true,
+          proposer: { select: { userId: true } },
+          recipient: { select: { userId: true } },
+        },
+      });
+    });
+  }
+
+  async acceptProposal(input: { leagueId: string; tradeId: string; recipientUserId: string }) {
+    return this.db.$transaction(async (tx) => {
+      const trade = await tx.leagueTrade.findUnique({
+        where: { id: input.tradeId },
+        include: { players: true, recipient: { select: { userId: true } } },
+      });
+
+      if (!trade || trade.leagueId !== input.leagueId) {
+        throw new TradeMutationError('TRADE_NOT_FOUND', 'Trade not found');
+      }
+      if (trade.recipient.userId !== input.recipientUserId) {
+        throw new TradeMutationError('FORBIDDEN', 'Only the receiving team can accept this trade');
+      }
+      if (trade.status !== LeagueTradeStatus.PENDING) {
+        throw new TradeMutationError('STALE_TRADE', 'Trade is no longer pending');
+      }
+      if (trade.expiresAt <= new Date()) {
+        await tx.leagueTrade.update({
+          where: { id: trade.id },
+          data: { status: LeagueTradeStatus.EXPIRED },
+        });
+        throw new TradeMutationError('STALE_TRADE', 'Trade has expired');
+      }
+
+      await this.assertOwnership(tx, input.leagueId, trade.players);
+      await this.assertTradeCapacity(tx, input.leagueId, trade.players);
+
+      for (const move of trade.players) {
+        const update = await tx.leagueRosterPlayer.updateMany({
+          where: {
+            leagueId: input.leagueId,
+            playerId: move.playerId,
+            memberId: move.fromMemberId,
+          },
+          data: {
+            memberId: move.toMemberId,
+            acquiredBy: 'TRADE',
+            acquiredAt: new Date(),
+          },
+        });
+        if (update.count !== 1) {
+          throw new TradeMutationError(
+            'STALE_TRADE',
+            'Player ownership changed before trade acceptance'
+          );
+        }
+      }
+
+      for (const memberId of new Set(
+        trade.players.flatMap((move) => [move.fromMemberId, move.toMemberId])
+      )) {
+        await syncCanonicalRosterProjection(tx, input.leagueId, memberId);
+      }
+
+      return tx.leagueTrade.update({
+        where: { id: trade.id },
+        data: { status: LeagueTradeStatus.PROCESSED, processedAt: new Date() },
+        include: { players: true },
+      });
+    });
+  }
+
+  private async assertOwnership(
+    tx: Prisma.TransactionClient,
+    leagueId: string,
+    moves: TradePlayerMove[]
+  ): Promise<void> {
+    const ownerships = await tx.leagueRosterPlayer.findMany({
+      where: { leagueId, playerId: { in: moves.map((move) => move.playerId) } },
+      select: { playerId: true, memberId: true },
+    });
+    const ownerByPlayer = new Map(
+      ownerships.map((ownership) => [ownership.playerId, ownership.memberId])
+    );
+
+    for (const move of moves) {
+      if (ownerByPlayer.get(move.playerId) !== move.fromMemberId) {
+        throw new TradeMutationError(
+          'STALE_TRADE',
+          'Trade contains a player no longer owned by the offering team'
+        );
+      }
+    }
+  }
+
+  private async assertTradeCapacity(
+    tx: Prisma.TransactionClient,
+    leagueId: string,
+    moves: TradePlayerMove[]
+  ): Promise<void> {
+    const league = await tx.league.findUnique({
+      where: { id: leagueId },
+      select: { settings: { select: { rosterSize: true } } },
+    });
+    if (!league) throw new TradeMutationError('TEAM_NOT_FOUND', 'League not found');
+
+    const memberIds = [...new Set(moves.flatMap((move) => [move.fromMemberId, move.toMemberId]))];
+    const currentCounts = await tx.leagueRosterPlayer.groupBy({
+      by: ['memberId'],
+      where: { leagueId, memberId: { in: memberIds } },
+      _count: { _all: true },
+    });
+    const countByMember = new Map(
+      currentCounts.map((count) => [count.memberId, count._count._all])
+    );
+
+    for (const memberId of memberIds) {
+      const outgoing = moves.filter((move) => move.fromMemberId === memberId).length;
+      const incoming = moves.filter((move) => move.toMemberId === memberId).length;
+      const current = countByMember.get(memberId) ?? 0;
+      if (current - outgoing + incoming > league.settings.rosterSize) {
+        throw new TradeMutationError('ROSTER_LIMIT_REACHED', 'Trade would exceed roster limit');
+      }
+    }
+  }
+}

--- a/src/server/waivers/WaiverAvailabilityProjectionService.ts
+++ b/src/server/waivers/WaiverAvailabilityProjectionService.ts
@@ -1,7 +1,7 @@
 import { adminDb } from '@/lib/firebaseAdmin';
 import { prisma } from '@/lib/prisma';
 
-type PrismaLike = Pick<typeof prisma, 'leagueRosterPlayer' | 'player' | 'teamAction'>;
+type PrismaLike = Pick<typeof prisma, 'leagueRosterPlayer' | 'leagueWaiverHold' | 'player'>;
 type FirestoreLike = typeof adminDb;
 const FIRESTORE_BATCH_WRITE_LIMIT = 450;
 
@@ -16,29 +16,23 @@ export class WaiverAvailabilityProjectionService {
     private readonly firestore: FirestoreLike = adminDb
   ) {}
 
-  async projectLeague(input: {
-    leagueId: string;
-  }): Promise<WaiverAvailabilityProjectionResult> {
+  async projectLeague(input: { leagueId: string }): Promise<WaiverAvailabilityProjectionResult> {
     const ownerships = await this.db.leagueRosterPlayer.findMany({
       where: { leagueId: input.leagueId },
       select: { playerId: true, memberId: true },
     });
-    const waiverHolds = await this.db.teamAction.findMany({
+    const waiverHolds = await this.db.leagueWaiverHold.findMany({
       where: {
         leagueId: input.leagueId,
-        actionType: 'DROP_PLAYER',
-        status: 'PENDING',
-        processingAt: { gt: new Date() },
+        availableAt: { gt: new Date() },
       },
-      select: { details: true, processingAt: true },
+      select: { playerId: true, availableAt: true },
     });
     const allPlayers = await this.db.player.findMany({ select: { id: true } });
     const owned = new Map(ownerships.map((ownership) => [ownership.playerId, ownership.memberId]));
     const held = new Map<string, Date | null>();
     for (const hold of waiverHolds) {
-      const details = parseActionDetails(hold.details);
-      const playerId = typeof details.playerId === 'string' ? details.playerId : null;
-      if (playerId) held.set(playerId, hold.processingAt ?? null);
+      held.set(hold.playerId, hold.availableAt);
     }
     const leagueRef = this.firestore.collection('leagues').doc(input.leagueId);
     let batch = this.firestore.batch();
@@ -121,16 +115,5 @@ export class WaiverAvailabilityProjectionService {
       available: allPlayers.filter((player) => !owned.has(player.id) && !held.has(player.id))
         .length,
     };
-  }
-}
-
-function parseActionDetails(raw: unknown): Record<string, unknown> {
-  if (raw && typeof raw === 'object') return raw as Record<string, unknown>;
-
-  try {
-    const parsed = JSON.parse(String(raw ?? '{}'));
-    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
-  } catch {
-    return {};
   }
 }

--- a/src/server/waivers/WaiverProcessingService.ts
+++ b/src/server/waivers/WaiverProcessingService.ts
@@ -5,6 +5,10 @@ import { FieldValue } from 'firebase-admin/firestore';
 import { adminDb } from '@/lib/firebaseAdmin';
 import { logger } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
+import {
+  LeagueOwnershipService,
+  OwnershipMutationError,
+} from '@/server/rosters/LeagueOwnershipService';
 import { WaiverAvailabilityProjectionService } from '@/server/waivers/WaiverAvailabilityProjectionService';
 
 export interface WaiverSettings {
@@ -405,61 +409,24 @@ export class WaiverProcessingService {
     claim: WaiverClaim,
     waiverSettings: WaiverSettings
   ): Promise<{ status: 'SUCCESSFUL' } | { status: 'FAILED'; reason: string }> {
-    return this.db.$transaction(
-      async (
-        tx: PrismaTransactionClient
-      ): Promise<{ status: 'SUCCESSFUL' } | { status: 'FAILED'; reason: string }> => {
-        const plan = await this.buildCanonicalRosterPlan(tx, leagueId, claim);
-        if (plan.status === 'FAILED') {
-          return plan;
-        }
-        if (claim.dropPlayerId) {
-          await tx.leagueRosterPlayer.deleteMany({
-            where: { leagueId, memberId: plan.memberId, playerId: claim.dropPlayerId },
-          });
-          await tx.teamAction.create({
-            data: {
-              leagueId,
-              memberId: plan.memberId,
-              actionType: 'DROP_PLAYER',
-              status: 'PENDING',
-              details: JSON.stringify({
-                playerId: claim.dropPlayerId,
-                source: 'drop-to-waivers',
-                waiverClaimId: claim.id,
-              }),
-              processingAt: calculateProcessingAt(waiverSettings),
-            },
-            select: { id: true },
-          });
-        }
+    const plan = await this.validateCanonicalRosterChange(leagueId, claim);
+    if (plan.status === 'FAILED') return plan;
 
-        await tx.leagueRoster.upsert({
-          where: { leagueId_memberId: { leagueId, memberId: plan.memberId } },
-          update: { playerIds: plan.nextPlayerIds },
-          create: { leagueId, memberId: plan.memberId, playerIds: plan.nextPlayerIds },
-        });
-        await tx.leagueRosterPlayer.upsert({
-          where: { leagueId_playerId: { leagueId, playerId: claim.playerId } },
-          update: {
-            memberId: plan.memberId,
-            draftId: null,
-            pickId: null,
-            acquiredBy: 'WAIVER',
-            acquiredAt: new Date(),
-          },
-          create: {
-            leagueId,
-            memberId: plan.memberId,
-            playerId: claim.playerId,
-            acquiredBy: 'WAIVER',
-            acquiredAt: new Date(),
-          },
-        });
-
-        return { status: 'SUCCESSFUL' };
+    try {
+      await new LeagueOwnershipService(this.db).claimWaiver({
+        leagueId,
+        memberId: plan.memberId,
+        playerId: claim.playerId,
+        dropPlayerId: claim.dropPlayerId,
+        droppedPlayerAvailableAt: calculateProcessingAt(waiverSettings),
+      });
+      return { status: 'SUCCESSFUL' };
+    } catch (error) {
+      if (error instanceof OwnershipMutationError) {
+        return { status: 'FAILED', reason: error.message };
       }
-    );
+      throw error;
+    }
   }
 
   private async validateCanonicalRosterChange(
@@ -488,7 +455,8 @@ export class WaiverProcessingService {
     const member = await tx.leagueMember.findFirst({
       where: {
         leagueId,
-        OR: [{ id: claim.teamId }, { userId: claim.userId }],
+        id: claim.teamId,
+        userId: claim.userId,
       },
       select: { id: true },
     });
@@ -1212,19 +1180,19 @@ export class FirestoreWaiverClaimStore implements ClaimStore {
       let query: FirebaseFirestore.Query = pendingCol.orderBy('__name__').limit(pageSize);
       if (cursor) query = query.startAfter(cursor);
 
-	      const snap = await query.get();
-	      if (snap.empty) break;
+      const snap = await query.get();
+      if (snap.empty) break;
 
-	      for (const document of snap.docs) {
-	        pending.push(toFirestoreWaiverClaim(document, leagueId));
-	      }
+      for (const document of snap.docs) {
+        pending.push(toFirestoreWaiverClaim(document, leagueId));
+      }
 
-	      if (snap.size < pageSize) break;
-	      cursor = snap.docs[snap.docs.length - 1] ?? null;
-	    }
+      if (snap.size < pageSize) break;
+      cursor = snap.docs[snap.docs.length - 1] ?? null;
+    }
 
-	    return applyWaiverPriorities(pending, await loadWaiverPriorityByUserId(leagueId));
-	  }
+    return applyWaiverPriorities(pending, await loadWaiverPriorityByUserId(leagueId));
+  }
 
   async markSuccessful(input: {
     leagueId: string;

--- a/tests/unit/LeagueOwnershipService.test.ts
+++ b/tests/unit/LeagueOwnershipService.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/prisma', () => ({ prisma: {} }));
+
+import {
+  LeagueOwnershipService,
+  OwnershipMutationError,
+} from '@/server/rosters/LeagueOwnershipService';
+
+describe('LeagueOwnershipService', () => {
+  it('does not create free-agent ownership while an active waiver hold exists', async () => {
+    const tx = {
+      leagueMember: { findUnique: vi.fn().mockResolvedValue({ leagueId: 'league-1' }) },
+      player: { findUnique: vi.fn().mockResolvedValue({ id: 'player-1' }) },
+      leagueRosterPlayer: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        create: vi.fn(),
+      },
+      leagueWaiverHold: {
+        findUnique: vi.fn().mockResolvedValue({ availableAt: new Date(Date.now() + 60_000) }),
+      },
+    };
+    const service = new LeagueOwnershipService({
+      $transaction: vi.fn((work) => work(tx)),
+    } as never);
+
+    await expect(
+      service.addFreeAgent({ leagueId: 'league-1', memberId: 'member-1', playerId: 'player-1' })
+    ).rejects.toMatchObject<Partial<OwnershipMutationError>>({ code: 'PLAYER_ON_WAIVERS' });
+    expect(tx.leagueRosterPlayer.create).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/WaiverProcessingService.test.ts
+++ b/tests/unit/WaiverProcessingService.test.ts
@@ -51,6 +51,10 @@ function createDbMock() {
         id: 'member-1',
         userId: 'user-1',
       }),
+      findUnique: vi.fn().mockResolvedValue({ leagueId: 'league-1' }),
+    },
+    player: {
+      findUnique: vi.fn().mockResolvedValue({ id: 'free-player' }),
     },
     leagueRoster: {
       findUnique: vi.fn().mockResolvedValue({
@@ -62,6 +66,17 @@ function createDbMock() {
     leagueRosterPlayer: {
       count: vi.fn().mockResolvedValue(2),
       deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+      delete: vi.fn().mockResolvedValue({ id: 'old-player' }),
+      create: vi.fn().mockResolvedValue({ id: 'roster-player-1' }),
+      findUnique: vi.fn(
+        async ({ where }: { where: { leagueId_playerId: { playerId: string } } }) => {
+          if (where.leagueId_playerId.playerId === 'old-player') return { memberId: 'member-1' };
+          return null;
+        }
+      ),
+      findMany: vi
+        .fn()
+        .mockResolvedValue([{ playerId: 'keep-player' }, { playerId: 'free-player' }]),
       findFirst: vi.fn(async ({ where }: { where: { playerId?: string; memberId?: string } }) => {
         if (where.playerId === 'free-player') return null;
         if (where.playerId === 'old-player' && where.memberId === 'member-1') {
@@ -70,6 +85,11 @@ function createDbMock() {
         return null;
       }),
       upsert: vi.fn().mockResolvedValue({ id: 'roster-player-1' }),
+    },
+    leagueWaiverHold: {
+      findUnique: vi.fn().mockResolvedValue(null),
+      upsert: vi.fn().mockResolvedValue({ id: 'hold-1' }),
+      deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
     },
     teamAction: {
       create: vi.fn().mockResolvedValue({ id: 'drop-hold-1' }),
@@ -133,33 +153,22 @@ describe('WaiverProcessingService', () => {
     });
 
     expect(result.results).toEqual([{ id: 'claim-1', status: 'SUCCESSFUL' }]);
-    expect(tx.leagueRosterPlayer.deleteMany).toHaveBeenCalledWith({
-      where: { leagueId: 'league-1', memberId: 'member-1', playerId: 'old-player' },
+    expect(tx.leagueRosterPlayer.delete).toHaveBeenCalledWith({
+      where: { leagueId_playerId: { leagueId: 'league-1', playerId: 'old-player' } },
     });
-    expect(tx.teamAction.create).toHaveBeenCalledWith({
+    expect(tx.leagueRosterPlayer.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
-        leagueId: 'league-1',
-        memberId: 'member-1',
-        actionType: 'DROP_PLAYER',
-        status: 'PENDING',
-        details: expect.stringContaining('"playerId":"old-player"'),
-        processingAt: expect.any(Date),
-      }),
-      select: { id: true },
-    });
-    expect(tx.leagueRosterPlayer.upsert).toHaveBeenCalledWith({
-      where: { leagueId_playerId: { leagueId: 'league-1', playerId: 'free-player' } },
-      update: expect.objectContaining({
-        memberId: 'member-1',
-        acquiredBy: 'WAIVER',
-      }),
-      create: expect.objectContaining({
         leagueId: 'league-1',
         memberId: 'member-1',
         playerId: 'free-player',
         acquiredBy: 'WAIVER',
       }),
     });
+    expect(tx.leagueWaiverHold.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { leagueId_playerId: { leagueId: 'league-1', playerId: 'old-player' } },
+      })
+    );
     expect(tx.leagueRoster.upsert).toHaveBeenCalledWith({
       where: { leagueId_memberId: { leagueId: 'league-1', memberId: 'member-1' } },
       update: { playerIds: JSON.stringify(['keep-player', 'free-player']) },

--- a/tests/unit/leagueRosterAddAvailability.test.ts
+++ b/tests/unit/leagueRosterAddAvailability.test.ts
@@ -1,116 +1,45 @@
 import type { NextRequest } from 'next/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const authMocks = vi.hoisted(() => ({
-  getAuthenticatedUserId: vi.fn(),
-}));
+const authMocks = vi.hoisted(() => ({ getAuthenticatedUserId: vi.fn() }));
+const prismaMocks = vi.hoisted(() => ({ leagueMember: { findUnique: vi.fn() } }));
+const ownershipMocks = vi.hoisted(() => ({ addFreeAgent: vi.fn() }));
 
-const prismaMocks = vi.hoisted(() => ({
-  $transaction: vi.fn(),
-  leagueMember: {
-    findFirst: vi.fn(),
-  },
-  player: {
-    findUnique: vi.fn(),
-  },
-  leagueRoster: {
-    upsert: vi.fn(),
-    update: vi.fn(),
-  },
-  leagueRosterPlayer: {
-    findFirst: vi.fn(),
-    create: vi.fn(),
-  },
-  teamAction: {
-    findFirst: vi.fn(),
-  },
-}));
-
-vi.mock('@/lib/serverAuth', () => ({
-  getAuthenticatedUserId: authMocks.getAuthenticatedUserId,
-}));
-
+vi.mock('@/lib/serverAuth', () => ({ getAuthenticatedUserId: authMocks.getAuthenticatedUserId }));
 vi.mock('../../src/lib/serverAuth', () => ({
   getAuthenticatedUserId: authMocks.getAuthenticatedUserId,
 }));
-
-vi.mock('@/lib/prisma', () => ({
-  prisma: prismaMocks,
-}));
-
-vi.mock('../../src/lib/prisma', () => ({
-  prisma: prismaMocks,
-}));
-
-vi.mock('next/cache', () => ({
-  revalidateTag: vi.fn(),
-}));
-
+vi.mock('@/lib/prisma', () => ({ prisma: prismaMocks }));
+vi.mock('../../src/lib/prisma', () => ({ prisma: prismaMocks }));
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }));
 vi.mock('@/lib/cacheTags', () => ({
-  tags: {
-    league: (leagueId: string) => `league:${leagueId}`,
-    waivers: (leagueId: string) => `waivers:${leagueId}`,
-  },
+  tags: { league: (id: string) => id, waivers: (id: string) => id },
 }));
-
-vi.mock('../../src/lib/cacheTags', () => ({
-  tags: {
-    league: (leagueId: string) => `league:${leagueId}`,
-    waivers: (leagueId: string) => `waivers:${leagueId}`,
-  },
-}));
-
-vi.mock('@/lib/logger', () => ({
-  logger: {
-    error: vi.fn(),
-  },
-}));
-
-vi.mock('../../src/lib/logger', () => ({
-  logger: {
-    error: vi.fn(),
-  },
-}));
-
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }));
 vi.mock('@/server/waivers/WaiverAvailabilityProjectionService', () => ({
-  WaiverAvailabilityProjectionService: vi.fn(() => ({
-    projectLeague: vi.fn().mockResolvedValue({ owned: 0, available: 1 }),
-  })),
+  WaiverAvailabilityProjectionService: vi.fn(() => ({ projectLeague: vi.fn() })),
 }));
-
-vi.mock('../../src/server/waivers/WaiverAvailabilityProjectionService', () => ({
-  WaiverAvailabilityProjectionService: vi.fn(() => ({
-    projectLeague: vi.fn().mockResolvedValue({ owned: 0, available: 1 }),
-  })),
-}));
+vi.mock('@/server/rosters/LeagueOwnershipService', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/server/rosters/LeagueOwnershipService')>();
+  return {
+    ...actual,
+    LeagueOwnershipService: vi.fn(() => ({ addFreeAgent: ownershipMocks.addFreeAgent })),
+  };
+});
 
 describe('league roster free-agent add eligibility', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-
     authMocks.getAuthenticatedUserId.mockResolvedValue('user-1');
-    prismaMocks.leagueMember.findFirst.mockResolvedValue({ id: 'member-1' });
-    prismaMocks.player.findUnique.mockResolvedValue({ id: 'held-player' });
-    prismaMocks.leagueRosterPlayer.findFirst.mockResolvedValue(null);
-    prismaMocks.teamAction.findFirst.mockResolvedValue({
-      id: 'drop-hold-1',
-      processingAt: new Date(Date.now() + 60 * 60 * 1000),
-    });
-    prismaMocks.leagueRoster.upsert.mockResolvedValue({
-      id: 'roster-1',
-      playerIds: JSON.stringify([]),
-    });
-    prismaMocks.leagueRoster.update.mockResolvedValue({ id: 'roster-1' });
-    prismaMocks.leagueRosterPlayer.create.mockResolvedValue({ id: 'roster-player-1' });
-    prismaMocks.$transaction.mockImplementation((work: unknown) => {
-      if (Array.isArray(work)) return Promise.all(work);
-      if (typeof work === 'function') return work(prismaMocks);
-      return Promise.resolve(null);
-    });
+    prismaMocks.leagueMember.findUnique.mockResolvedValue({ id: 'member-1' });
   });
 
-  it('rejects direct free-agent adds while a dropped player is still on waivers', async () => {
+  it('returns a stable conflict while a player is on waivers', async () => {
+    const { OwnershipMutationError } = await import('@/server/rosters/LeagueOwnershipService');
+    ownershipMocks.addFreeAgent.mockRejectedValue(
+      new OwnershipMutationError('PLAYER_ON_WAIVERS', 'Player is on waivers')
+    );
     const { POST } = await import('../../src/app/api/leagues/[id]/roster/add/route');
 
     const response = await POST(
@@ -119,21 +48,16 @@ describe('league roster free-agent add eligibility', () => {
         params: Promise.resolve({ id: 'league-1' }),
       }
     );
-    const body = await response.json();
 
     expect(response.status).toBe(409);
-    expect(body.error).toEqual({ message: 'Player is on waivers' });
-    expect(prismaMocks.teamAction.findFirst).toHaveBeenCalledWith({
-      where: {
-        leagueId: 'league-1',
-        actionType: 'DROP_PLAYER',
-        status: 'PENDING',
-        processingAt: { gt: expect.any(Date) },
-        details: { contains: '"playerId":"held-player"' },
-      },
-      select: { id: true },
+    expect(await response.json()).toEqual(
+      expect.objectContaining({ error: { message: 'Player is on waivers' } })
+    );
+    expect(ownershipMocks.addFreeAgent).toHaveBeenCalledWith({
+      leagueId: 'league-1',
+      memberId: 'member-1',
+      playerId: 'held-player',
     });
-    expect(prismaMocks.leagueRosterPlayer.create).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/tradeRouteArchitecture.test.ts
+++ b/tests/unit/tradeRouteArchitecture.test.ts
@@ -1,19 +1,99 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-describe('league trade route Firestore architecture', () => {
-  it('provides a league-scoped server mutation boundary for trade proposals', () => {
-    const routePath = join(process.cwd(), 'src/app/api/leagues/[id]/trades/route.ts');
+vi.mock('@/lib/prisma', () => ({ prisma: {} }));
 
-    expect(existsSync(routePath)).toBe(true);
+import { LeagueTradeService, TradeMutationError } from '@/server/trades/LeagueTradeService';
 
-    const source = readFileSync(routePath, 'utf8');
-    expect(source).toContain('export async function POST');
-    expect(source).toContain('getAuthenticatedUserId');
-    expect(source).toContain('verifyLeagueMembership');
-    expect(source).toContain("collection('trades')");
-    expect(source).toContain('revalidateTag(tags.trades(leagueId))');
-    expect(source).toContain('revalidateTag(tags.league(leagueId))');
+describe('LeagueTradeService', () => {
+  it('rejects an empty proposal before it enters a transaction', async () => {
+    const db = { $transaction: vi.fn() };
+    const service = new LeagueTradeService(db as never);
+
+    await expect(
+      service.createProposal({
+        leagueId: 'league-1',
+        proposerUserId: 'user-1',
+        recipientMemberId: 'member-2',
+        playersOffered: [],
+        playersRequested: [],
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+    ).rejects.toMatchObject<Partial<TradeMutationError>>({ code: 'INVALID_TRADE' });
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('refuses acceptance by anyone other than the receiving manager', async () => {
+    const tx = {
+      leagueTrade: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: 'trade-1',
+          leagueId: 'league-1',
+          status: 'PENDING',
+          expiresAt: new Date(Date.now() + 60_000),
+          recipient: { userId: 'user-2' },
+          players: [],
+        }),
+      },
+    };
+    const service = new LeagueTradeService({ $transaction: vi.fn((work) => work(tx)) } as never);
+
+    await expect(
+      service.acceptProposal({
+        leagueId: 'league-1',
+        tradeId: 'trade-1',
+        recipientUserId: 'user-1',
+      })
+    ).rejects.toMatchObject<Partial<TradeMutationError>>({ code: 'FORBIDDEN' });
+  });
+
+  it('transfers every asset and refreshes both canonical roster projections atomically', async () => {
+    const moves = [
+      { playerId: 'player-1', fromMemberId: 'member-1', toMemberId: 'member-2' },
+      { playerId: 'player-2', fromMemberId: 'member-2', toMemberId: 'member-1' },
+    ];
+    const tx = {
+      leagueTrade: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: 'trade-1',
+          leagueId: 'league-1',
+          status: 'PENDING',
+          expiresAt: new Date(Date.now() + 60_000),
+          recipient: { userId: 'user-2' },
+          players: moves,
+        }),
+        update: vi.fn().mockResolvedValue({ id: 'trade-1', status: 'PROCESSED', players: moves }),
+      },
+      league: { findUnique: vi.fn().mockResolvedValue({ settings: { rosterSize: 2 } }) },
+      leagueRosterPlayer: {
+        findMany: vi.fn(async ({ where }) => {
+          if (where.playerId?.in) {
+            return [
+              { playerId: 'player-1', memberId: 'member-1' },
+              { playerId: 'player-2', memberId: 'member-2' },
+            ];
+          }
+          return [{ playerId: 'player-1' }];
+        }),
+        groupBy: vi.fn().mockResolvedValue([
+          { memberId: 'member-1', _count: { _all: 1 } },
+          { memberId: 'member-2', _count: { _all: 1 } },
+        ]),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      leagueRoster: { upsert: vi.fn() },
+    };
+    const service = new LeagueTradeService({ $transaction: vi.fn((work) => work(tx)) } as never);
+
+    await service.acceptProposal({
+      leagueId: 'league-1',
+      tradeId: 'trade-1',
+      recipientUserId: 'user-2',
+    });
+
+    expect(tx.leagueRosterPlayer.updateMany).toHaveBeenCalledTimes(2);
+    expect(tx.leagueRoster.upsert).toHaveBeenCalledTimes(2);
+    expect(tx.leagueTrade.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'PROCESSED' }) })
+    );
   });
 });

--- a/tests/unit/waiverAvailabilityProjection.test.ts
+++ b/tests/unit/waiverAvailabilityProjection.test.ts
@@ -48,7 +48,7 @@ describe('WaiverAvailabilityProjectionService', () => {
       leagueRosterPlayer: {
         findMany: vi.fn().mockResolvedValue([{ playerId: 'owned-1', memberId: 'member-1' }]),
       },
-      teamAction: {
+      leagueWaiverHold: {
         findMany: vi.fn().mockResolvedValue([]),
       },
       player: {
@@ -63,14 +63,12 @@ describe('WaiverAvailabilityProjectionService', () => {
       where: { leagueId: 'league-1' },
       select: { playerId: true, memberId: true },
     });
-    expect(db.teamAction.findMany).toHaveBeenCalledWith({
+    expect(db.leagueWaiverHold.findMany).toHaveBeenCalledWith({
       where: {
         leagueId: 'league-1',
-        actionType: 'DROP_PLAYER',
-        status: 'PENDING',
-        processingAt: { gt: expect.any(Date) },
+        availableAt: { gt: expect.any(Date) },
       },
-      select: { details: true, processingAt: true },
+      select: { playerId: true, availableAt: true },
     });
     expect(db.player.findMany).toHaveBeenCalledWith({ select: { id: true } });
 
@@ -118,11 +116,11 @@ describe('WaiverAvailabilityProjectionService', () => {
       leagueRosterPlayer: {
         findMany: vi.fn().mockResolvedValue([]),
       },
-      teamAction: {
+      leagueWaiverHold: {
         findMany: vi.fn().mockResolvedValue([
           {
-            details: JSON.stringify({ playerId: 'dropped-1', source: 'drop-to-waivers' }),
-            processingAt,
+            playerId: 'dropped-1',
+            availableAt: processingAt,
           },
         ]),
       },
@@ -160,7 +158,7 @@ describe('WaiverAvailabilityProjectionService', () => {
       leagueRosterPlayer: {
         findMany: vi.fn().mockResolvedValue([]),
       },
-      teamAction: {
+      leagueWaiverHold: {
         findMany: vi.fn().mockResolvedValue([]),
       },
       player: {


### PR DESCRIPTION
## Summary
- make LeagueRosterPlayer the transactional ownership source for free agents, waivers, and trades
- add typed waiver holds and relational trade records
- retire Firestore trade roster mutation; Firestore now mirrors canonical trade state
- add a migration preflight for membership and ownership drift

## Validation
- npm run typecheck
- npm run lint:ci
- npx tsc -p functions/tsconfig.json --noEmit
- focused unit suite: 22 tests passing
- migrated a disposable copy of the repository database and ran the preflight successfully

## Rollout
Run npm run db:check-league-ownership after existing migrations are current, then apply the Prisma migration.

## Summary by Sourcery

Centralize league roster ownership and trades around canonical SQL-backed services, with Firestore acting as a realtime projection layer and add a migration preflight for league ownership invariants.

New Features:
- Introduce LeagueOwnershipService to manage free-agent adds, waiver claims, and drops as canonical league roster transactions.
- Introduce LeagueTradeService and new trade API routes for proposing and accepting league trades backed by relational trade records.
- Add a league ownership invariants preflight script and associated npm command to validate database state before migrations.

Bug Fixes:
- Ensure free-agent add and waiver claim flows consistently reject players that are already owned or currently on waivers with stable conflict responses.
- Prevent empty or invalid trades and enforce that only the receiving manager can accept a pending trade.
- Ensure trade acceptance fails gracefully when player ownership or roster capacity has changed since the proposal.

Enhancements:
- Refactor waiver processing to delegate roster mutations to the canonical LeagueOwnershipService while retaining validation logic.
- Update waiver availability projection to rely on typed LeagueWaiverHold records instead of generic team actions.
- Align roster add and team action drop endpoints with canonical ownership services and standardized error handling.
- Project canonical trade state into Firestore for realtime reads instead of mutating rosters directly from Firestore triggers.

Build:
- Add db:check-league-ownership npm script for running the league ownership invariants preflight before applying migrations.

Deployment:
- Add a Prisma migration defining LeagueWaiverHold, LeagueTrade, and LeagueTradePlayer tables and related indexes for canonical league transactions.

Tests:
- Add unit coverage for LeagueOwnershipService and LeagueTradeService behavior, including waiver holds, roster limits, and trade validation.
- Update existing unit tests for roster free-agent adds and waiver availability projection to reflect the new canonical ownership model and waiver hold schema.

Chores:
- Remove legacy Firestore-based league trade processing logic from the draft worker in favor of SQL-owned trade state.