### PR TITLE
Simplify login and prevent auth transition flash

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -26,184 +26,21 @@ export default async function LoginPage({
 
   return (
     <main className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto grid min-h-screen w-full max-w-[1440px] px-4 py-4 sm:px-6 lg:grid-cols-[minmax(0,1fr)_32rem] lg:px-8 lg:py-8">
-        <section className="hidden min-w-0 flex-col overflow-hidden rounded-l-[2rem] border border-border bg-card p-8 shadow-sm lg:flex xl:p-10">
-          <div>
-            <Image
-              src="/brand/statly-primary-logo.png"
-              alt="Statly"
-              width={312}
-              height={118}
-              priority
-              className="h-auto w-56"
-            />
-            <h1 className="mt-10 max-w-2xl text-4xl font-semibold leading-tight tracking-normal text-foreground xl:text-5xl">
-              Your fantasy AFL command center.
-            </h1>
-            <p className="mt-4 max-w-2xl text-base leading-7 text-muted-foreground">
-              Draft smarter, compare every stat that matters, and move from league setup to live
-              decisions without changing tools.
-            </p>
-            <div className="mt-6 flex flex-wrap gap-4 text-sm font-medium text-muted-foreground">
-              {['Live draft rooms', 'Advanced analytics', 'Team management', 'Real-time updates'].map(
-                (item) => (
-                  <span key={item} className="inline-flex items-center gap-2">
-                    <span className="h-1.5 w-1.5 rounded-full bg-primary" aria-hidden="true" />
-                    {item}
-                  </span>
-                )
-              )}
-            </div>
-          </div>
-
-          <div className="mb-8 mt-10 grid gap-4 xl:grid-cols-[minmax(0,1fr)_17rem]">
-            <div className="rounded-2xl border border-border bg-background p-4 shadow-sm">
-              <div className="flex items-center justify-between gap-4 border-b border-border pb-3">
-                <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-                    Live draft
-                  </p>
-                  <p className="mt-1 text-lg font-semibold text-foreground">Round 1 / Pick 7</p>
-                </div>
-                <div className="rounded-full bg-primary px-3 py-1 text-xs font-semibold text-primary-foreground">
-                  1:48
-                </div>
-              </div>
-              <div className="mt-4 flex flex-wrap gap-2">
-                {['All', 'G', 'DEF', 'MID', 'FWD', 'RUC'].map((filter) => (
-                  <span
-                    key={filter}
-                    className="rounded-lg border border-border bg-card px-3 py-1.5 text-xs font-semibold text-foreground"
-                  >
-                    {filter}
-                  </span>
-                ))}
-              </div>
-              <div className="mt-4 overflow-hidden rounded-xl border border-border">
-                <div className="grid grid-cols-[2.5rem_minmax(0,1.4fr)_4rem_4rem_4rem] bg-muted px-3 py-2 text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                  <span>#</span>
-                  <span>Player</span>
-                  <span>Pos</span>
-                  <span>Avg</span>
-                  <span>Trend</span>
-                </div>
-                {[
-                  ['1', 'Nick Daicos', 'COL', 'MID', '118.6'],
-                  ['2', 'Marcus Bontempelli', 'WBD', 'MID', '112.4'],
-                  ['3', 'Zak Butters', 'PA', 'MID', '109.7'],
-                  ['4', 'Jye Caldwell', 'ESS', 'MID', '104.9'],
-                ].map(([rank, player, club, position, average]) => (
-                  <div
-                    key={rank}
-                    className="grid grid-cols-[2.5rem_minmax(0,1.4fr)_4rem_4rem_4rem] items-center border-t border-border px-3 py-3 text-sm"
-                  >
-                    <span className="text-muted-foreground">{rank}</span>
-                    <div className="min-w-0">
-                      <p className="truncate font-semibold text-foreground">{player}</p>
-                      <p className="truncate text-xs text-muted-foreground">{club}</p>
-                    </div>
-                    <span className="rounded-md bg-primary/10 px-2 py-1 text-xs font-semibold text-primary">
-                      {position}
-                    </span>
-                    <span className="font-semibold text-foreground">{average}</span>
-                    <span className="font-semibold text-primary" aria-label="trending up">
-                      {'\u2197'}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <div className="space-y-4">
-              <div className="rounded-2xl border border-border bg-background p-4 shadow-sm">
-                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-                  Draft order
-                </p>
-                <div className="mt-4 space-y-2">
-                  {[
-                    ['35', 'Footy Fanatics', 'Complete'],
-                    ['36', 'Goal Getters', 'Complete'],
-                    ['37', 'Robbo Rockers', 'On clock'],
-                    ['38', 'Mark Masters', 'Upcoming'],
-                  ].map(([pick, team, status]) => (
-                    <div
-                      key={`${pick}-${team}`}
-                      className="grid grid-cols-[2rem_minmax(0,1fr)_4.5rem] items-center gap-2 rounded-lg px-2 py-2 text-xs"
-                    >
-                      <span className="font-semibold text-muted-foreground">{pick}</span>
-                      <span className="truncate font-semibold text-foreground">{team}</span>
-                      <span className="truncate text-right text-muted-foreground">{status}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              <div className="rounded-2xl border border-border bg-background p-4 shadow-sm">
-                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-                  My roster
-                </p>
-                <div className="mt-4 space-y-2 text-xs">
-                  {[
-                    ['DEF', 'Jake Lloyd'],
-                    ['MID', 'Marcus Bontempelli'],
-                    ['MID', 'Zak Butters'],
-                    ['FWD', 'Empty'],
-                  ].map(([slot, player]) => (
-                    <div key={`${slot}-${player}`} className="flex justify-between gap-3">
-                      <span className="font-semibold text-muted-foreground">{slot}</span>
-                      <span className="truncate text-foreground">{player}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="mt-auto grid grid-cols-3 gap-3 border-t border-border pt-6">
-            {[
-              ['642', 'player pool'],
-              ['9', 'scoring categories'],
-              ['22', 'roster slots'],
-            ].map(([value, label]) => (
-              <div key={label}>
-                <p className="text-2xl font-semibold text-foreground">{value}</p>
-                <p className="mt-1 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                  {label}
-                </p>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section className="flex min-w-0 items-center justify-center rounded-[2rem] border border-border bg-card px-5 py-8 shadow-sm sm:px-8 lg:rounded-l-none lg:border-l-0">
-          <div className="w-full max-w-[26rem]">
-            <div className="mb-8 lg:hidden">
+      <div className="mx-auto flex min-h-screen w-full max-w-3xl items-center px-4 py-8 sm:px-6 lg:px-8">
+        <section className="w-full py-8 sm:py-10">
+          <div className="mx-auto w-full max-w-xl">
+            <div className="mb-10 text-center">
               <Image
-                src="/brand/statly-wordmark-logo.png"
+                src="/brand/statly-primary-logo.png"
                 alt="Statly"
-                width={182}
-                height={60}
+                width={312}
+                height={118}
                 priority
-                className="h-auto w-36"
+                className="mx-auto mb-8 h-auto w-64 max-w-full sm:w-80"
               />
-              <h1 className="mt-3 text-3xl font-semibold leading-tight tracking-normal text-foreground">
-                Fantasy AFL operations.
-              </h1>
-            </div>
-
-            <div className="mb-8">
-              <div className="mb-6 flex h-12 w-12 items-center justify-center rounded-2xl border border-border bg-background">
-                <Image
-                  src="/brand/statly-compact-logo.png"
-                  alt="Statly logo"
-                  width={36}
-                  height={24}
-                  priority
-                  className="h-7 w-10 object-contain"
-                />
-              </div>
-              <h2 className="text-3xl font-semibold tracking-normal text-foreground">
+              <h1 className="text-3xl font-semibold tracking-normal text-foreground">
                 Sign in to Statly
-              </h2>
+              </h1>
               <p className="mt-3 text-sm leading-6 text-muted-foreground">
                 Access your leagues, live draft rooms, watchlists, and commissioner tools.
               </p>
@@ -244,7 +81,7 @@ export default async function LoginPage({
               </div>
             </div>
 
-            <LegalLinks prefix="By signing in, you agree to our" className="mt-8" />
+            <LegalLinks prefix="By signing in, you agree to our" className="mt-8 text-center" />
           </div>
         </section>
       </div>

--- a/src/app/dashboard/DashboardClient.test.tsx
+++ b/src/app/dashboard/DashboardClient.test.tsx
@@ -20,7 +20,12 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('@/components/navigation', () => ({
-  AppLayout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AppLayout: ({ children }: { children: ReactNode }) => (
+    <div>
+      <div>Legacy navigation</div>
+      {children}
+    </div>
+  ),
 }));
 
 vi.mock('@/components/DashboardLoading', () => ({
@@ -45,6 +50,16 @@ describe('DashboardClient auth restore behavior', () => {
       expect(mocks.replace).toHaveBeenCalledWith('/login?next=%2Fdashboard');
     });
     expect(screen.getByText('Restoring dashboard session')).toBeInTheDocument();
+    expect(screen.queryByText('Legacy navigation')).not.toBeInTheDocument();
+  });
+
+  it('keeps the legacy navigation out of the auth-resolution state', () => {
+    mocks.useAuth.mockReturnValue({ user: null, loading: true });
+
+    render(<DashboardClient />);
+
+    expect(screen.getByText('Restoring dashboard session')).toBeInTheDocument();
+    expect(screen.queryByText('Legacy navigation')).not.toBeInTheDocument();
   });
 
   it('renders the dashboard once Firebase auth is available', () => {
@@ -56,5 +71,6 @@ describe('DashboardClient auth restore behavior', () => {
     render(<DashboardClient />);
 
     expect(screen.getByText('Dashboard for tester@statly.dev')).toBeInTheDocument();
+    expect(screen.getByText('Legacy navigation')).toBeInTheDocument();
   });
 });

--- a/src/app/dashboard/DashboardClient.tsx
+++ b/src/app/dashboard/DashboardClient.tsx
@@ -18,11 +18,7 @@ export default function DashboardClient() {
   }, [loading, router, user]);
 
   if (loading || !user) {
-    return (
-      <AppLayout>
-        <DashboardLoading />
-      </AppLayout>
-    );
+    return <DashboardLoading />;
   }
 
   return (

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { useAuth } from '@/AuthContext';
 import { useRouter } from 'next/navigation';
@@ -62,6 +62,7 @@ const AuthForm = ({
   } = useAuth();
   const router = useRouter();
   const { notification, showNotification } = useNotification();
+  const hasStartedRedirect = useRef(false);
 
   // Safe redirect helper to avoid open redirects
   const toSafeRedirect = (url?: string) =>
@@ -145,6 +146,17 @@ const AuthForm = ({
     return { label: 'Strong', color: 'text-success' };
   };
 
+  const redirectAfterAuthentication = () => {
+    const destination = toSafeRedirect(nextUrl);
+    if (destination) {
+      hasStartedRedirect.current = true;
+      router.replace(destination);
+      return;
+    }
+
+    onSuccess?.();
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
@@ -175,16 +187,7 @@ const AuthForm = ({
         await login(email, password);
         showNotification('success', 'Welcome back! You are now signed in.');
       }
-      if (nextUrl) {
-        const dest = toSafeRedirect(nextUrl);
-        if (dest) {
-          router.replace(dest);
-        } else {
-          onSuccess?.();
-        }
-      } else {
-        onSuccess?.();
-      }
+      redirectAfterAuthentication();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Authentication error occurred';
       setError(message);
@@ -200,16 +203,7 @@ const AuthForm = ({
     try {
       await loginWithGoogle();
       showNotification('success', 'Successfully signed in with Google!');
-      if (nextUrl) {
-        const dest = toSafeRedirect(nextUrl);
-        if (dest) {
-          router.replace(dest);
-        } else {
-          onSuccess?.();
-        }
-      } else {
-        onSuccess?.();
-      }
+      redirectAfterAuthentication();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Google sign-in failed';
       setError(message);
@@ -225,16 +219,7 @@ const AuthForm = ({
     try {
       await loginWithFacebook();
       showNotification('success', 'Successfully signed in with Facebook!');
-      if (nextUrl) {
-        const dest = toSafeRedirect(nextUrl);
-        if (dest) {
-          router.replace(dest);
-        } else {
-          onSuccess?.();
-        }
-      } else {
-        onSuccess?.();
-      }
+      redirectAfterAuthentication();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Facebook sign-in failed';
       setError(message);
@@ -250,16 +235,7 @@ const AuthForm = ({
     try {
       await loginWithApple();
       showNotification('success', 'Successfully signed in with Apple!');
-      if (nextUrl) {
-        const dest = toSafeRedirect(nextUrl);
-        if (dest) {
-          router.replace(dest);
-        } else {
-          onSuccess?.();
-        }
-      } else {
-        onSuccess?.();
-      }
+      redirectAfterAuthentication();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Apple sign-in failed';
       setError(message);
@@ -271,8 +247,9 @@ const AuthForm = ({
 
   // Optional: redirect immediately if already authenticated
   useEffect(() => {
-    if (autoRedirectIfAuthenticated && user) {
+    if (autoRedirectIfAuthenticated && user && !hasStartedRedirect.current) {
       const destination = toSafeRedirect(nextUrl) || '/dashboard';
+      hasStartedRedirect.current = true;
       router.replace(destination);
     }
   }, [autoRedirectIfAuthenticated, nextUrl, router, user]);
@@ -312,6 +289,10 @@ const AuthForm = ({
         </div>
       </div>
     );
+  }
+
+  if (user && autoRedirectIfAuthenticated) {
+    return null;
   }
 
   if (user) {

--- a/tests/unit/authFormInitialValidation.test.tsx
+++ b/tests/unit/authFormInitialValidation.test.tsx
@@ -1,8 +1,14 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { User } from 'firebase/auth';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AuthForm from '@/components/AuthForm';
 import { useAuth } from '@/AuthContext';
+
+const mocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+}));
 
 vi.mock('@/AuthContext', () => ({
   useAuth: vi.fn(),
@@ -11,7 +17,7 @@ vi.mock('@/AuthContext', () => ({
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: vi.fn(),
-    replace: vi.fn(),
+    replace: mocks.replace,
   }),
 }));
 
@@ -36,6 +42,7 @@ const mockAuthContext = {
 
 describe('AuthForm initial validation state', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(useAuth).mockReturnValue(mockAuthContext);
   });
 
@@ -45,5 +52,50 @@ describe('AuthForm initial validation state', () => {
     expect(screen.queryByText('Email is required')).not.toBeInTheDocument();
     expect(screen.queryByText('Password is required')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Sign In' })).toBeEnabled();
+  });
+
+  it('does not redirect a second time when auth state updates after a successful login', async () => {
+    const user = userEvent.setup();
+    const mockLogin = vi.fn().mockResolvedValue(undefined);
+    let authState = {
+      ...mockAuthContext,
+      login: mockLogin,
+      user: null as User | null,
+    };
+
+    vi.mocked(useAuth).mockImplementation(() => authState as ReturnType<typeof useAuth>);
+    const { rerender } = render(
+      <AuthForm initialMode="login" nextUrl="/dashboard" autoRedirectIfAuthenticated />
+    );
+
+    await user.type(screen.getByLabelText('Email Address'), 'test@example.com');
+    await user.type(screen.getByLabelText('Password'), 'password123');
+    await user.click(screen.getByRole('button', { name: 'Sign In' }));
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/dashboard');
+    });
+
+    authState = { ...authState, user: { uid: 'test-user-id' } as User };
+    rerender(<AuthForm initialMode="login" nextUrl="/dashboard" autoRedirectIfAuthenticated />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText('Welcome back!')).not.toBeInTheDocument();
+  });
+
+  it('does not render the authenticated profile card while redirecting an existing session', async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      ...mockAuthContext,
+      user: { uid: 'test-user-id' } as User,
+    } as ReturnType<typeof useAuth>);
+
+    render(<AuthForm initialMode="login" nextUrl="/dashboard" autoRedirectIfAuthenticated />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/dashboard');
+    });
+    expect(screen.queryByText('Welcome back!')).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/loginPageLayout.test.ts
+++ b/tests/unit/loginPageLayout.test.ts
@@ -10,16 +10,20 @@ function readRepoFile(path: string): string {
 }
 
 describe('login page layout', () => {
-  it('uses the product-auth shell instead of the legacy split-gradient marketing panel', () => {
+  it('uses a focused auth shell without the promotional preview', () => {
     const loginPage = readRepoFile('src/app/(auth)/login/page.tsx');
 
-    expect(loginPage).toContain('Your fantasy AFL command center.');
     expect(loginPage).toContain('Sign in to Statly');
-    expect(loginPage).toContain('Live draft');
-    expect(loginPage).toContain('Draft order');
-    expect(loginPage).toContain('My roster');
+    expect(loginPage).toContain('/brand/statly-primary-logo.png');
+    expect(loginPage).toContain('sm:w-80');
     expect(loginPage).toContain('<AuthForm');
 
+    expect(loginPage).not.toContain('Your fantasy AFL command center.');
+    expect(loginPage).not.toContain('Live draft');
+    expect(loginPage).not.toContain('Draft order');
+    expect(loginPage).not.toContain('My roster');
+    expect(loginPage).not.toContain('/brand/statly-wordmark-logo.png');
+    expect(loginPage).not.toContain('/brand/statly-compact-logo.png');
     expect(loginPage).not.toContain('Welcome to Statly');
     expect(loginPage).not.toContain('Welcome Back');
     expect(loginPage).not.toContain('bg-gradient-to-br from-blue-600 to-purple-700');


### PR DESCRIPTION
## Summary
- simplify the login page to a focused sign-in surface using the primary Statly wordmark
- prevent legacy authenticated and navigation shells from flashing during login redirects

## Root cause
The login form briefly rendered its legacy authenticated profile card after auth state updated and before navigation completed. The dashboard auth fallback could also mount legacy navigation.

## Validation
- eslint and app/test type checks passed
- focused unit tests passed
- login-to-dashboard Playwright smoke passed

## Known environment failures
- full E2E has unrelated draft-full-soak and league-roster-smoke failures
- local integration setup uses a `DATABASE_URL_TEST` incompatible with the SQLite Prisma schema

## Summary by Sourcery

Simplify the login experience and tighten authenticated redirect behavior to avoid legacy UI flashes during auth transitions.

Bug Fixes:
- Prevent double redirects when auth state updates after a successful login.
- Avoid rendering the authenticated profile card while an existing session is auto-redirecting from the login page.
- Keep legacy dashboard navigation out of the loading/auth-resolution state so it does not flash during session restore.

Enhancements:
- Streamline the login page into a focused, single-column sign-in layout using the primary Statly wordmark and centered legal links.

Tests:
- Extend AuthForm unit tests to cover redirect behavior and absence of authenticated UI during auto-redirect.
- Update dashboard client auth-restore tests to assert navigation is only shown after auth resolution.
- Adjust login page layout test expectations to match the simplified, focused auth shell without promotional content.