### PR TITLE
feat(social): implement persistent league social features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "@clickhouse/client": "^1.12.1",
+        "@giphy/js-analytics": "5.0.0",
+        "@giphy/js-fetch-api": "5.8.0",
+        "@giphy/react-components": "10.1.2",
         "@headlessui/react": "^2.2.7",
         "@hello-pangea/dnd": "^18.0.1",
         "@heroicons/react": "^2.2.0",
@@ -48,6 +51,7 @@
         "react-window": "^1.8.11",
         "server-only": "0.0.1",
         "socket.io": "^4.8.1",
+        "styled-components": "6.1.19",
         "swr": "^2.3.6",
         "tailwind-merge": "^3.3.1",
         "tailwind-scrollbar": "^4.0.2",
@@ -630,6 +634,27 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
+      "license": "MIT"
     },
     "node_modules/@epic-web/invariant": {
       "version": "1.0.0",
@@ -1918,6 +1943,84 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@giphy/colors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@giphy/colors/-/colors-1.0.1.tgz",
+      "integrity": "sha512-CMUY2UR8Ujl/wTRVjwu9spss6Cf2qkQNATKfoWCTWQp7CXdSfPWUDepp0c0/F0n7lYphLFvD9qzOC4NSdBt7nw==",
+      "license": "MIT"
+    },
+    "node_modules/@giphy/js-analytics": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@giphy/js-analytics/-/js-analytics-5.0.0.tgz",
+      "integrity": "sha512-jBZG6OqyMWB6meLi8Sz3iLplXYnhkbj+DJhS4ChmRX8Y6UA7i5dbbsUN/So1s7tTjhZOvu0rxA6rWJE73S1FvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@giphy/js-types": "*",
+        "@giphy/js-util": "*",
+        "append-query": "^2.1.0",
+        "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/@giphy/js-fetch-api": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@giphy/js-fetch-api/-/js-fetch-api-5.8.0.tgz",
+      "integrity": "sha512-DWdNauYaBSLPeAe/O+uzXtPIoUvmSnYV8Q49p+cPjEQ7Ncj1mDg1fuSKyl0OmPxCm6fzGJ4kuJjsWzyWn9ubbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@giphy/js-types": "*",
+        "@giphy/js-util": "*"
+      }
+    },
+    "node_modules/@giphy/js-types": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@giphy/js-types/-/js-types-5.1.0.tgz",
+      "integrity": "sha512-BZYCDtYNRR7cUWkbDLB4wmm3qmWMsVCQdUiBNOfmZ3yAazCgygKJoDI/5Rq4CK5MBaOc5LVdF8viC2WtoBdaPA==",
+      "license": "MIT"
+    },
+    "node_modules/@giphy/js-util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@giphy/js-util/-/js-util-5.2.0.tgz",
+      "integrity": "sha512-Qt7pGh2cqiNmXLeWAgb459wK8+BuMLtIxTfg4ZksnPHPsLthiHT9hhzs2QhqUh7Pp/HOq+Cbv2etGDfnq+xiKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@giphy/js-types": "*",
+        "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/@giphy/js-util/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@giphy/react-components": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@giphy/react-components/-/react-components-10.1.2.tgz",
+      "integrity": "sha512-DVyIgf5az0uzHwnkS8tUaqO4qNx8DoxJupnRLhOl8M5CcvV9ykeZBLDxLj+jyDTySPYaIIJtrlR+8SeV2dHZwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@giphy/colors": "*",
+        "@giphy/js-analytics": "*",
+        "@giphy/js-fetch-api": "*",
+        "@giphy/js-types": "*",
+        "@giphy/js-util": "*",
+        "intersection-observer": "^0.12.2",
+        "react-use": "17.6.0",
+        "throttle-debounce": "^3.0.1"
+      },
+      "peerDependencies": {
+        "react": "18 - 19",
+        "styled-components": ">= 5"
+      }
     },
     "node_modules/@google-cloud/paginator": {
       "version": "5.0.2",
@@ -5497,6 +5600,12 @@
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "license": "MIT"
     },
+    "node_modules/@types/js-cookie": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -5704,6 +5813,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/stylis": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
+      "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
       "license": "MIT"
     },
     "node_modules/@types/tedious": {
@@ -6624,6 +6739,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@xobotyi/scrollbar-width": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==",
+      "license": "MIT"
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -6824,6 +6945,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/append-query": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/append-query/-/append-query-2.1.1.tgz",
+      "integrity": "sha512-adm0E8o1o7ay+HbkWvGIpNNeciLB/rxJ0heThHuzSSVq5zcdQ5/ZubFnUoY0imFmk6gZVghSpwoubLVtwi9EHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2"
       }
     },
     "node_modules/arg": {
@@ -7531,6 +7661,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001733",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001733.tgz",
@@ -7986,6 +8125,15 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "license": "MIT",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -8060,6 +8208,24 @@
         "tiny-invariant": "^1.0.6"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-in-js-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
+      "license": "MIT",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.3"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -8074,6 +8240,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/css-what": {
@@ -8126,7 +8316,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/daisyui": {
@@ -8799,6 +8988,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-abstract": {
@@ -9713,6 +9911,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -9748,6 +9951,12 @@
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
+    },
+    "node_modules/fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==",
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -11121,6 +11330,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -11204,6 +11419,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/inline-style-prefixer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
+      "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-in-js-utils": "^3.1.0"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -11218,6 +11442,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/intersection-observer": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.12.2.tgz",
+      "integrity": "sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==",
+      "deprecated": "The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.",
+      "license": "Apache-2.0"
     },
     "node_modules/ioredis": {
       "version": "5.7.0",
@@ -11890,6 +12121,12 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -12650,6 +12887,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0"
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -12899,6 +13142,26 @@
         "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
         "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/nano-css": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.6.2.tgz",
+      "integrity": "sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==",
+      "license": "Unlicense",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "css-tree": "^1.1.2",
+        "csstype": "^3.1.2",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^7.0.1",
+        "rtl-css-js": "^1.16.1",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.3.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/nanoid": {
@@ -13934,7 +14197,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/postgres-array": {
@@ -14355,6 +14617,41 @@
         }
       }
     },
+    "node_modules/react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
+      "peerDependencies": {
+        "react": "*",
+        "tslib": "*"
+      }
+    },
+    "node_modules/react-use": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.6.0.tgz",
+      "integrity": "sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==",
+      "license": "Unlicense",
+      "dependencies": {
+        "@types/js-cookie": "^2.2.6",
+        "@xobotyi/scrollbar-width": "^1.9.5",
+        "copy-to-clipboard": "^3.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-shallow-equal": "^1.0.0",
+        "js-cookie": "^2.2.1",
+        "nano-css": "^5.6.2",
+        "react-universal-interface": "^0.6.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.1.0",
+        "set-harmonic-interval": "^1.0.1",
+        "throttle-debounce": "^3.0.1",
+        "ts-easing": "^0.2.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/react-window": {
       "version": "1.8.11",
       "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
@@ -14536,6 +14833,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -14693,6 +14996,15 @@
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rtl-css-js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -14884,6 +15196,18 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -14983,6 +15307,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/set-harmonic-interval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=6.9"
+      }
+    },
     "node_modules/set-proto": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
@@ -15003,6 +15336,12 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.3",
@@ -15440,12 +15779,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "license": "MIT"
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "license": "MIT",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.11",
@@ -15844,6 +16228,74 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/styled-components": {
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz",
+      "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.2.2",
+        "@emotion/unitless": "0.8.1",
+        "@types/stylis": "4.2.5",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.1.3",
+        "postcss": "8.4.49",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.2",
+        "tslib": "2.6.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      }
+    },
+    "node_modules/styled-components/node_modules/postcss": {
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/styled-components/node_modules/stylis": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
+      "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
+      "license": "MIT"
+    },
+    "node_modules/styled-components/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -15866,6 +16318,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -16197,6 +16655,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -16324,6 +16791,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -16390,6 +16863,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-easing": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==",
+      "license": "Unlicense"
     },
     "node_modules/ts-node": {
       "version": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
   },
   "dependencies": {
     "@clickhouse/client": "^1.12.1",
+    "@giphy/js-analytics": "5.0.0",
+    "@giphy/js-fetch-api": "5.8.0",
+    "@giphy/react-components": "10.1.2",
     "@headlessui/react": "^2.2.7",
     "@hello-pangea/dnd": "^18.0.1",
     "@heroicons/react": "^2.2.0",
@@ -126,6 +129,7 @@
     "react-window": "^1.8.11",
     "server-only": "0.0.1",
     "socket.io": "^4.8.1",
+    "styled-components": "6.1.19",
     "swr": "^2.3.6",
     "tailwind-merge": "^3.3.1",
     "tailwind-scrollbar": "^4.0.2",

--- a/prisma/migrations/20260719090000_add_league_social_domain/migration.sql
+++ b/prisma/migrations/20260719090000_add_league_social_domain/migration.sql
@@ -1,0 +1,341 @@
+-- Establish a durable league-season boundary and retain membership history.
+ALTER TABLE "LeagueMember" ADD COLUMN "isActive" BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE "LeagueMember" ADD COLUMN "status" TEXT NOT NULL DEFAULT 'ACTIVE';
+ALTER TABLE "LeagueMember" ADD COLUMN "leftAt" DATETIME;
+ALTER TABLE "LeagueMember" ADD COLUMN "socialStandardsAcceptedAt" DATETIME;
+
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "LeagueSeason" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "leagueId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "year" INTEGER,
+    "startsAt" DATETIME,
+    "endsAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "LeagueSeason_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "new_League" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "inviteCode" TEXT NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "settingsId" TEXT NOT NULL,
+    "activeSeasonId" TEXT,
+    "categoriesJson" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "League_settingsId_fkey" FOREIGN KEY ("settingsId") REFERENCES "LeagueSettings" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "League_activeSeasonId_fkey" FOREIGN KEY ("activeSeasonId") REFERENCES "LeagueSeason" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+INSERT INTO "new_League" (
+    "id",
+    "name",
+    "inviteCode",
+    "ownerId",
+    "settingsId",
+    "activeSeasonId",
+    "categoriesJson",
+    "createdAt"
+)
+SELECT
+    "id",
+    "name",
+    "inviteCode",
+    "ownerId",
+    "settingsId",
+    NULL,
+    "categoriesJson",
+    "createdAt"
+FROM "League";
+
+DROP TABLE "League";
+ALTER TABLE "new_League" RENAME TO "League";
+
+CREATE UNIQUE INDEX "League_inviteCode_key" ON "League"("inviteCode");
+CREATE UNIQUE INDEX "League_settingsId_key" ON "League"("settingsId");
+CREATE UNIQUE INDEX "League_activeSeasonId_key" ON "League"("activeSeasonId");
+CREATE INDEX "League_ownerId_idx" ON "League"("ownerId");
+CREATE INDEX "League_createdAt_idx" ON "League"("createdAt");
+CREATE INDEX "League_inviteCode_idx" ON "League"("inviteCode");
+
+INSERT INTO "LeagueSeason" (
+    "id",
+    "leagueId",
+    "label",
+    "year",
+    "startsAt",
+    "endsAt",
+    "createdAt",
+    "updatedAt"
+)
+SELECT
+    'initial:' || "id",
+    "id",
+    'Initial season',
+    CAST(strftime('%Y', "createdAt") AS INTEGER),
+    NULL,
+    NULL,
+    "createdAt",
+    CURRENT_TIMESTAMP
+FROM "League";
+
+UPDATE "League"
+SET "activeSeasonId" = 'initial:' || "id";
+
+CREATE UNIQUE INDEX "LeagueSeason_leagueId_year_key" ON "LeagueSeason"("leagueId", "year");
+CREATE INDEX "LeagueSeason_leagueId_createdAt_idx" ON "LeagueSeason"("leagueId", "createdAt");
+CREATE INDEX "LeagueMember_leagueId_isActive_idx" ON "LeagueMember"("leagueId", "isActive");
+
+CREATE TABLE "SocialMessage" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "leagueId" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "authorUserId" TEXT,
+    "authorMemberId" TEXT,
+    "type" TEXT NOT NULL DEFAULT 'MEMBER',
+    "content" TEXT NOT NULL,
+    "relatedEntityType" TEXT,
+    "relatedEntityId" TEXT,
+    "moderationStatus" TEXT NOT NULL DEFAULT 'ACTIVE',
+    "editedAt" DATETIME,
+    "deletedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "SocialMessage_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialMessage_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "LeagueSeason" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialMessage_authorMemberId_fkey" FOREIGN KEY ("authorMemberId") REFERENCES "LeagueMember" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "SocialBoardCategory" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "leagueId" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "archivedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "SocialBoardCategory_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialBoardCategory_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "LeagueSeason" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "SocialPost" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "leagueId" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "categoryId" TEXT NOT NULL,
+    "authorUserId" TEXT NOT NULL,
+    "authorMemberId" TEXT,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "isAnnouncement" BOOLEAN NOT NULL DEFAULT false,
+    "isPinned" BOOLEAN NOT NULL DEFAULT false,
+    "pinnedAt" DATETIME,
+    "isLocked" BOOLEAN NOT NULL DEFAULT false,
+    "lockedAt" DATETIME,
+    "moderationStatus" TEXT NOT NULL DEFAULT 'ACTIVE',
+    "replyCount" INTEGER NOT NULL DEFAULT 0,
+    "latestActivityAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "editedAt" DATETIME,
+    "deletedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "SocialPost_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialPost_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "LeagueSeason" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialPost_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "SocialBoardCategory" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "SocialPost_authorMemberId_fkey" FOREIGN KEY ("authorMemberId") REFERENCES "LeagueMember" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "SocialReply" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "leagueId" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "authorUserId" TEXT NOT NULL,
+    "authorMemberId" TEXT,
+    "body" TEXT NOT NULL,
+    "moderationStatus" TEXT NOT NULL DEFAULT 'ACTIVE',
+    "editedAt" DATETIME,
+    "deletedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "SocialReply_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialReply_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "LeagueSeason" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialReply_postId_fkey" FOREIGN KEY ("postId") REFERENCES "SocialPost" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialReply_authorMemberId_fkey" FOREIGN KEY ("authorMemberId") REFERENCES "LeagueMember" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "SocialReadState" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "leagueId" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "memberId" TEXT NOT NULL,
+    "channel" TEXT NOT NULL,
+    "lastReadAt" DATETIME,
+    "lastReadSequence" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "SocialReadState_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialReadState_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "LeagueSeason" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialReadState_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES "LeagueMember" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "SocialModerationRecord" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "leagueId" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "actorUserId" TEXT NOT NULL,
+    "actorMemberId" TEXT,
+    "targetUserId" TEXT,
+    "targetMemberId" TEXT,
+    "contentType" TEXT NOT NULL,
+    "contentId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "reason" TEXT,
+    "retainedContentJson" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "SocialModerationRecord_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialModerationRecord_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "LeagueSeason" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialModerationRecord_actorMemberId_fkey" FOREIGN KEY ("actorMemberId") REFERENCES "LeagueMember" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "SocialModerationRecord_targetMemberId_fkey" FOREIGN KEY ("targetMemberId") REFERENCES "LeagueMember" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "SocialReport" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "leagueId" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "reporterUserId" TEXT NOT NULL,
+    "reporterMemberId" TEXT,
+    "authorUserId" TEXT,
+    "authorMemberId" TEXT,
+    "contentType" TEXT NOT NULL,
+    "contentId" TEXT NOT NULL,
+    "reason" TEXT NOT NULL,
+    "details" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'OPEN',
+    "resolvedByUserId" TEXT,
+    "resolvedAt" DATETIME,
+    "resolutionNotes" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "SocialReport_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialReport_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "LeagueSeason" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialReport_reporterMemberId_fkey" FOREIGN KEY ("reporterMemberId") REFERENCES "LeagueMember" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "SocialReport_authorMemberId_fkey" FOREIGN KEY ("authorMemberId") REFERENCES "LeagueMember" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "SocialMute" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "leagueId" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "mutedUserId" TEXT NOT NULL,
+    "mutedMemberId" TEXT,
+    "createdByUserId" TEXT NOT NULL,
+    "createdByMemberId" TEXT,
+    "reason" TEXT,
+    "startsAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" DATETIME,
+    "revokedAt" DATETIME,
+    "revokedByUserId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "SocialMute_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialMute_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "LeagueSeason" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialMute_mutedMemberId_fkey" FOREIGN KEY ("mutedMemberId") REFERENCES "LeagueMember" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "SocialMute_createdByMemberId_fkey" FOREIGN KEY ("createdByMemberId") REFERENCES "LeagueMember" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "SocialCommand" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "leagueId" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "actorUserId" TEXT NOT NULL,
+    "actorMemberId" TEXT NOT NULL,
+    "idempotencyKey" TEXT NOT NULL,
+    "commandType" TEXT NOT NULL,
+    "requestHash" TEXT NOT NULL,
+    "resultType" TEXT,
+    "resultId" TEXT,
+    "responseJson" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" DATETIME,
+    CONSTRAINT "SocialCommand_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialCommand_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "LeagueSeason" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialCommand_actorMemberId_fkey" FOREIGN KEY ("actorMemberId") REFERENCES "LeagueMember" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "SocialOutboxEvent" (
+    "sequence" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "id" TEXT NOT NULL,
+    "leagueId" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "channel" TEXT NOT NULL,
+    "actorUserId" TEXT,
+    "eventType" TEXT NOT NULL,
+    "aggregateType" TEXT NOT NULL,
+    "aggregateId" TEXT NOT NULL,
+    "payloadJson" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "availableAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lockedAt" DATETIME,
+    "lockedBy" TEXT,
+    "publishedAt" DATETIME,
+    "lastError" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "SocialOutboxEvent_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialOutboxEvent_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "LeagueSeason" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "SocialMessage_leagueId_seasonId_createdAt_id_idx" ON "SocialMessage"("leagueId", "seasonId", "createdAt", "id");
+CREATE INDEX "SocialMessage_authorUserId_createdAt_idx" ON "SocialMessage"("authorUserId", "createdAt");
+CREATE INDEX "SocialMessage_relatedEntityType_relatedEntityId_idx" ON "SocialMessage"("relatedEntityType", "relatedEntityId");
+
+CREATE UNIQUE INDEX "SocialBoardCategory_seasonId_slug_key" ON "SocialBoardCategory"("seasonId", "slug");
+CREATE INDEX "SocialBoardCategory_leagueId_seasonId_sortOrder_idx" ON "SocialBoardCategory"("leagueId", "seasonId", "sortOrder");
+
+CREATE INDEX "SocialPost_leagueId_seasonId_isPinned_latestActivityAt_idx" ON "SocialPost"("leagueId", "seasonId", "isPinned", "latestActivityAt");
+CREATE INDEX "SocialPost_categoryId_latestActivityAt_idx" ON "SocialPost"("categoryId", "latestActivityAt");
+CREATE INDEX "SocialPost_authorUserId_createdAt_idx" ON "SocialPost"("authorUserId", "createdAt");
+
+CREATE INDEX "SocialReply_postId_createdAt_id_idx" ON "SocialReply"("postId", "createdAt", "id");
+CREATE INDEX "SocialReply_leagueId_seasonId_createdAt_idx" ON "SocialReply"("leagueId", "seasonId", "createdAt");
+CREATE INDEX "SocialReply_authorUserId_createdAt_idx" ON "SocialReply"("authorUserId", "createdAt");
+
+CREATE UNIQUE INDEX "SocialReadState_seasonId_userId_channel_key" ON "SocialReadState"("seasonId", "userId", "channel");
+CREATE INDEX "SocialReadState_leagueId_userId_idx" ON "SocialReadState"("leagueId", "userId");
+CREATE INDEX "SocialReadState_memberId_idx" ON "SocialReadState"("memberId");
+
+CREATE INDEX "SocialModerationRecord_leagueId_seasonId_createdAt_idx" ON "SocialModerationRecord"("leagueId", "seasonId", "createdAt");
+CREATE INDEX "SocialModerationRecord_contentType_contentId_createdAt_idx" ON "SocialModerationRecord"("contentType", "contentId", "createdAt");
+CREATE INDEX "SocialModerationRecord_targetUserId_createdAt_idx" ON "SocialModerationRecord"("targetUserId", "createdAt");
+
+CREATE INDEX "SocialReport_leagueId_seasonId_status_createdAt_idx" ON "SocialReport"("leagueId", "seasonId", "status", "createdAt");
+CREATE INDEX "SocialReport_contentType_contentId_idx" ON "SocialReport"("contentType", "contentId");
+CREATE INDEX "SocialReport_reporterUserId_createdAt_idx" ON "SocialReport"("reporterUserId", "createdAt");
+
+CREATE INDEX "SocialMute_leagueId_seasonId_mutedUserId_revokedAt_expiresAt_idx" ON "SocialMute"("leagueId", "seasonId", "mutedUserId", "revokedAt", "expiresAt");
+CREATE INDEX "SocialMute_mutedMemberId_createdAt_idx" ON "SocialMute"("mutedMemberId", "createdAt");
+
+CREATE UNIQUE INDEX "SocialCommand_leagueId_actorUserId_idempotencyKey_key" ON "SocialCommand"("leagueId", "actorUserId", "idempotencyKey");
+CREATE INDEX "SocialCommand_seasonId_createdAt_idx" ON "SocialCommand"("seasonId", "createdAt");
+CREATE INDEX "SocialCommand_expiresAt_idx" ON "SocialCommand"("expiresAt");
+
+CREATE UNIQUE INDEX "SocialOutboxEvent_id_key" ON "SocialOutboxEvent"("id");
+CREATE INDEX "SocialOutboxEvent_status_availableAt_createdAt_idx" ON "SocialOutboxEvent"("status", "availableAt", "createdAt");
+CREATE INDEX "SocialOutboxEvent_leagueId_seasonId_createdAt_idx" ON "SocialOutboxEvent"("leagueId", "seasonId", "createdAt");
+CREATE INDEX "SocialOutboxEvent_leagueId_seasonId_channel_sequence_idx" ON "SocialOutboxEvent"("leagueId", "seasonId", "channel", "sequence");
+CREATE INDEX "SocialOutboxEvent_actorUserId_sequence_idx" ON "SocialOutboxEvent"("actorUserId", "sequence");
+CREATE INDEX "SocialOutboxEvent_aggregateType_aggregateId_idx" ON "SocialOutboxEvent"("aggregateType", "aggregateId");
+CREATE INDEX "SocialOutboxEvent_lockedAt_createdAt_idx" ON "SocialOutboxEvent"("lockedAt", "createdAt");
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/migrations/20260719120000_separate_league_social_activity/migration.sql
+++ b/prisma/migrations/20260719120000_separate_league_social_activity/migration.sql
@@ -1,0 +1,109 @@
+-- Add optional structured context to member chat messages.
+ALTER TABLE "SocialMessage" ADD COLUMN "contextJson" TEXT;
+
+-- System activity is its own unread/realtime channel. Existing system messages remain
+-- the durable content records while their delivery events move out of chat.
+UPDATE "SocialOutboxEvent"
+SET
+    "channel" = 'ACTIVITY',
+    "eventType" = 'social:activity',
+    "aggregateType" = 'activity'
+WHERE
+    "aggregateType" = 'message'
+    AND "aggregateId" IN (
+        SELECT "id"
+        FROM "SocialMessage"
+        WHERE "type" = 'SYSTEM'
+    );
+
+-- Preserve what members had already viewed. The global outbox sequence remains valid
+-- as a monotonic cursor even when the referenced sequence belongs to another channel.
+INSERT OR IGNORE INTO "SocialReadState" (
+    "id",
+    "leagueId",
+    "seasonId",
+    "userId",
+    "memberId",
+    "channel",
+    "lastReadAt",
+    "lastReadSequence",
+    "createdAt",
+    "updatedAt"
+)
+SELECT
+    'activity:' || "id",
+    "leagueId",
+    "seasonId",
+    "userId",
+    "memberId",
+    'ACTIVITY',
+    "lastReadAt",
+    "lastReadSequence",
+    "createdAt",
+    CURRENT_TIMESTAMP
+FROM "SocialReadState"
+WHERE "channel" = 'CHAT';
+
+-- System idempotency commands must not be owned by an arbitrary league member.
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "new_SocialCommand" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "leagueId" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "actorUserId" TEXT NOT NULL,
+    "actorMemberId" TEXT,
+    "idempotencyKey" TEXT NOT NULL,
+    "commandType" TEXT NOT NULL,
+    "requestHash" TEXT NOT NULL,
+    "resultType" TEXT,
+    "resultId" TEXT,
+    "responseJson" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" DATETIME,
+    CONSTRAINT "SocialCommand_leagueId_fkey" FOREIGN KEY ("leagueId") REFERENCES "League" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialCommand_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "LeagueSeason" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SocialCommand_actorMemberId_fkey" FOREIGN KEY ("actorMemberId") REFERENCES "LeagueMember" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+INSERT INTO "new_SocialCommand" (
+    "id",
+    "leagueId",
+    "seasonId",
+    "actorUserId",
+    "actorMemberId",
+    "idempotencyKey",
+    "commandType",
+    "requestHash",
+    "resultType",
+    "resultId",
+    "responseJson",
+    "createdAt",
+    "expiresAt"
+)
+SELECT
+    "id",
+    "leagueId",
+    "seasonId",
+    "actorUserId",
+    "actorMemberId",
+    "idempotencyKey",
+    "commandType",
+    "requestHash",
+    "resultType",
+    "resultId",
+    "responseJson",
+    "createdAt",
+    "expiresAt"
+FROM "SocialCommand";
+
+DROP TABLE "SocialCommand";
+ALTER TABLE "new_SocialCommand" RENAME TO "SocialCommand";
+
+CREATE UNIQUE INDEX "SocialCommand_leagueId_actorUserId_idempotencyKey_key" ON "SocialCommand"("leagueId", "actorUserId", "idempotencyKey");
+CREATE INDEX "SocialCommand_seasonId_createdAt_idx" ON "SocialCommand"("seasonId", "createdAt");
+CREATE INDEX "SocialCommand_expiresAt_idx" ON "SocialCommand"("expiresAt");
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/migrations/20260720100000_add_giphy_to_social_messages/migration.sql
+++ b/prisma/migrations/20260720100000_add_giphy_to_social_messages/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "SocialMessage" ADD COLUMN "giphyId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -702,6 +702,7 @@ enum SocialModerationStatus {
 enum SocialChannel {
   CHAT
   BOARD
+  ACTIVITY
 }
 
 enum SocialOutboxStatus {
@@ -719,6 +720,7 @@ model SocialMessage {
   authorMemberId    String?
   type              SocialMessageType      @default(MEMBER)
   content           String
+  contextJson       String?
   relatedEntityType String?
   relatedEntityId   String?
   moderationStatus  SocialModerationStatus @default(ACTIVE)
@@ -906,22 +908,22 @@ model SocialMute {
 }
 
 model SocialCommand {
-  id             String       @id @default(cuid())
+  id             String        @id @default(cuid())
   leagueId       String
   seasonId       String
   actorUserId    String
-  actorMemberId  String
+  actorMemberId  String?
   idempotencyKey String
   commandType    String
   requestHash    String
   resultType     String?
   resultId       String?
   responseJson   String?
-  createdAt      DateTime     @default(now())
+  createdAt      DateTime      @default(now())
   expiresAt      DateTime?
-  league         League       @relation(fields: [leagueId], references: [id], onDelete: Cascade)
-  season         LeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
-  actorMember    LeagueMember @relation(fields: [actorMemberId], references: [id], onDelete: Cascade)
+  league         League        @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  season         LeagueSeason  @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  actorMember    LeagueMember? @relation(fields: [actorMemberId], references: [id], onDelete: SetNull)
 
   @@unique([leagueId, actorUserId, idempotencyKey])
   @@index([seasonId, createdAt])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,24 +35,37 @@ model Session {
 }
 
 model League {
-  id                String                   @id @default(cuid())
-  name              String
-  inviteCode        String                   @unique
-  ownerId           String
-  settingsId        String                   @unique
-  categoriesJson    String?
-  members           LeagueMember[]
-  settings          LeagueSettings           @relation(fields: [settingsId], references: [id])
-  drafts            Draft[]
-  draftEvents       DraftEvent[]
-  rosterPlayers     LeagueRosterPlayer[]
-  matchups          LeagueMatchup[]
-  lineups           LeagueLineup[]
-  matchupScores     LeagueMatchupScore[]
-  standings         LeagueStanding[]
-  competitionRounds LeagueCompetitionRound[]
-  competitionAudits LeagueCompetitionAudit[]
-  createdAt         DateTime                 @default(now())
+  id                      String                   @id @default(cuid())
+  name                    String
+  inviteCode              String                   @unique
+  ownerId                 String
+  settingsId              String                   @unique
+  activeSeasonId          String?                  @unique
+  categoriesJson          String?
+  members                 LeagueMember[]
+  settings                LeagueSettings           @relation(fields: [settingsId], references: [id])
+  seasons                 LeagueSeason[]           @relation("LeagueSeasons")
+  activeSeason            LeagueSeason?            @relation("ActiveLeagueSeason", fields: [activeSeasonId], references: [id], onDelete: SetNull)
+  drafts                  Draft[]
+  draftEvents             DraftEvent[]
+  rosterPlayers           LeagueRosterPlayer[]
+  matchups                LeagueMatchup[]
+  lineups                 LeagueLineup[]
+  matchupScores           LeagueMatchupScore[]
+  standings               LeagueStanding[]
+  competitionRounds       LeagueCompetitionRound[]
+  competitionAudits       LeagueCompetitionAudit[]
+  socialMessages          SocialMessage[]
+  socialBoardCategories   SocialBoardCategory[]
+  socialPosts             SocialPost[]
+  socialReplies           SocialReply[]
+  socialReadStates        SocialReadState[]
+  socialModerationRecords SocialModerationRecord[]
+  socialReports           SocialReport[]
+  socialMutes             SocialMute[]
+  socialCommands          SocialCommand[]
+  socialOutboxEvents      SocialOutboxEvent[]
+  createdAt               DateTime                 @default(now())
 
   @@index([ownerId])
   @@index([createdAt])
@@ -60,32 +73,47 @@ model League {
 }
 
 model LeagueMember {
-  id                       String                   @id @default(cuid())
-  leagueId                 String
-  userId                   String
-  role                     LeagueRole
-  teamName                 String
-  teamLogoUrl              String?
-  teamLogoPositionX        Int?
-  teamLogoPositionY        Int?
-  teamLogoZoom             Float?
-  notificationSettingsJson String?
-  draftSlot                Int?
-  joinedAt                 DateTime                 @default(now())
-  league                   League                   @relation(fields: [leagueId], references: [id])
-  user                     User                     @relation(fields: [userId], references: [id])
-  picks                    Pick[]
-  orders                   DraftOrder[]
-  rosterPlayers            LeagueRosterPlayer[]
-  homeMatchups             LeagueMatchup[]          @relation("HomeMemberMatchups")
-  awayMatchups             LeagueMatchup[]          @relation("AwayMemberMatchups")
-  byeMatchups              LeagueMatchup[]          @relation("ByeMemberMatchups")
-  winnerMatchups           LeagueMatchup[]          @relation("WinnerMemberMatchups")
-  lineups                  LeagueLineup[]
-  matchupScores            LeagueMatchupScore[]
-  standings                LeagueStanding[]
-  competitionAuditEvents   LeagueCompetitionAudit[] @relation("CompetitionAuditActor")
-  isCoCommissioner         Boolean                  @default(false)
+  id                        String                   @id @default(cuid())
+  leagueId                  String
+  userId                    String
+  role                      LeagueRole
+  teamName                  String
+  teamLogoUrl               String?
+  teamLogoPositionX         Int?
+  teamLogoPositionY         Int?
+  teamLogoZoom              Float?
+  notificationSettingsJson  String?
+  socialStandardsAcceptedAt DateTime?
+  isActive                  Boolean                  @default(true)
+  status                    String                   @default("ACTIVE")
+  leftAt                    DateTime?
+  draftSlot                 Int?
+  joinedAt                  DateTime                 @default(now())
+  league                    League                   @relation(fields: [leagueId], references: [id])
+  user                      User                     @relation(fields: [userId], references: [id])
+  picks                     Pick[]
+  orders                    DraftOrder[]
+  rosterPlayers             LeagueRosterPlayer[]
+  homeMatchups              LeagueMatchup[]          @relation("HomeMemberMatchups")
+  awayMatchups              LeagueMatchup[]          @relation("AwayMemberMatchups")
+  byeMatchups               LeagueMatchup[]          @relation("ByeMemberMatchups")
+  winnerMatchups            LeagueMatchup[]          @relation("WinnerMemberMatchups")
+  lineups                   LeagueLineup[]
+  matchupScores             LeagueMatchupScore[]
+  standings                 LeagueStanding[]
+  competitionAuditEvents    LeagueCompetitionAudit[] @relation("CompetitionAuditActor")
+  socialMessages            SocialMessage[]          @relation("SocialMessageAuthor")
+  socialPosts               SocialPost[]             @relation("SocialPostAuthor")
+  socialReplies             SocialReply[]            @relation("SocialReplyAuthor")
+  socialReadStates          SocialReadState[]
+  socialModerationActions   SocialModerationRecord[] @relation("SocialModerationActor")
+  socialModerationTargets   SocialModerationRecord[] @relation("SocialModerationTarget")
+  socialReportsFiled        SocialReport[]           @relation("SocialReportReporter")
+  socialReportsAgainst      SocialReport[]           @relation("SocialReportAuthor")
+  socialMutesReceived       SocialMute[]             @relation("SocialMuteTarget")
+  socialMutesCreated        SocialMute[]             @relation("SocialMuteActor")
+  socialCommands            SocialCommand[]
+  isCoCommissioner          Boolean                  @default(false)
 
   // Lobby relations
   watchlists      DraftWatchlist[]
@@ -95,7 +123,34 @@ model LeagueMember {
   @@index([leagueId])
   @@index([userId])
   @@index([leagueId, userId])
+  @@index([leagueId, isActive])
   @@index([draftSlot])
+}
+
+model LeagueSeason {
+  id                      String                   @id @default(cuid())
+  leagueId                String
+  label                   String
+  year                    Int?
+  startsAt                DateTime?
+  endsAt                  DateTime?
+  createdAt               DateTime                 @default(now())
+  updatedAt               DateTime                 @updatedAt
+  league                  League                   @relation("LeagueSeasons", fields: [leagueId], references: [id], onDelete: Cascade)
+  activeForLeague         League?                  @relation("ActiveLeagueSeason")
+  socialMessages          SocialMessage[]
+  socialBoardCategories   SocialBoardCategory[]
+  socialPosts             SocialPost[]
+  socialReplies           SocialReply[]
+  socialReadStates        SocialReadState[]
+  socialModerationRecords SocialModerationRecord[]
+  socialReports           SocialReport[]
+  socialMutes             SocialMute[]
+  socialCommands          SocialCommand[]
+  socialOutboxEvents      SocialOutboxEvent[]
+
+  @@unique([leagueId, year])
+  @@index([leagueId, createdAt])
 }
 
 enum LeagueRole {
@@ -631,6 +686,276 @@ model LeagueStanding {
   @@unique([leagueId, memberId])
   @@index([leagueId])
   @@index([memberId])
+}
+
+enum SocialMessageType {
+  MEMBER
+  SYSTEM
+}
+
+enum SocialModerationStatus {
+  ACTIVE
+  UNDER_REVIEW
+  REMOVED
+}
+
+enum SocialChannel {
+  CHAT
+  BOARD
+}
+
+enum SocialOutboxStatus {
+  PENDING
+  PROCESSING
+  PUBLISHED
+  FAILED
+}
+
+model SocialMessage {
+  id                String                 @id @default(cuid())
+  leagueId          String
+  seasonId          String
+  authorUserId      String?
+  authorMemberId    String?
+  type              SocialMessageType      @default(MEMBER)
+  content           String
+  relatedEntityType String?
+  relatedEntityId   String?
+  moderationStatus  SocialModerationStatus @default(ACTIVE)
+  editedAt          DateTime?
+  deletedAt         DateTime?
+  createdAt         DateTime               @default(now())
+  updatedAt         DateTime               @updatedAt
+  league            League                 @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  season            LeagueSeason           @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  authorMember      LeagueMember?          @relation("SocialMessageAuthor", fields: [authorMemberId], references: [id], onDelete: SetNull)
+
+  @@index([leagueId, seasonId, createdAt, id])
+  @@index([authorUserId, createdAt])
+  @@index([relatedEntityType, relatedEntityId])
+}
+
+model SocialBoardCategory {
+  id          String       @id @default(cuid())
+  leagueId    String
+  seasonId    String
+  slug        String
+  name        String
+  description String?
+  sortOrder   Int          @default(0)
+  archivedAt  DateTime?
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+  league      League       @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  season      LeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  posts       SocialPost[]
+
+  @@unique([seasonId, slug])
+  @@index([leagueId, seasonId, sortOrder])
+}
+
+model SocialPost {
+  id               String                 @id @default(cuid())
+  leagueId         String
+  seasonId         String
+  categoryId       String
+  authorUserId     String
+  authorMemberId   String?
+  title            String
+  body             String
+  isAnnouncement   Boolean                @default(false)
+  isPinned         Boolean                @default(false)
+  pinnedAt         DateTime?
+  isLocked         Boolean                @default(false)
+  lockedAt         DateTime?
+  moderationStatus SocialModerationStatus @default(ACTIVE)
+  replyCount       Int                    @default(0)
+  latestActivityAt DateTime               @default(now())
+  editedAt         DateTime?
+  deletedAt        DateTime?
+  createdAt        DateTime               @default(now())
+  updatedAt        DateTime               @updatedAt
+  league           League                 @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  season           LeagueSeason           @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  category         SocialBoardCategory    @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  authorMember     LeagueMember?          @relation("SocialPostAuthor", fields: [authorMemberId], references: [id], onDelete: SetNull)
+  replies          SocialReply[]
+
+  @@index([leagueId, seasonId, isPinned, latestActivityAt])
+  @@index([categoryId, latestActivityAt])
+  @@index([authorUserId, createdAt])
+}
+
+model SocialReply {
+  id               String                 @id @default(cuid())
+  leagueId         String
+  seasonId         String
+  postId           String
+  authorUserId     String
+  authorMemberId   String?
+  body             String
+  moderationStatus SocialModerationStatus @default(ACTIVE)
+  editedAt         DateTime?
+  deletedAt        DateTime?
+  createdAt        DateTime               @default(now())
+  updatedAt        DateTime               @updatedAt
+  league           League                 @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  season           LeagueSeason           @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  post             SocialPost             @relation(fields: [postId], references: [id], onDelete: Cascade)
+  authorMember     LeagueMember?          @relation("SocialReplyAuthor", fields: [authorMemberId], references: [id], onDelete: SetNull)
+
+  @@index([postId, createdAt, id])
+  @@index([leagueId, seasonId, createdAt])
+  @@index([authorUserId, createdAt])
+}
+
+model SocialReadState {
+  id               String        @id @default(cuid())
+  leagueId         String
+  seasonId         String
+  userId           String
+  memberId         String
+  channel          SocialChannel
+  lastReadAt       DateTime?
+  lastReadSequence Int           @default(0)
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @updatedAt
+  league           League        @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  season           LeagueSeason  @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  member           LeagueMember  @relation(fields: [memberId], references: [id], onDelete: Cascade)
+
+  @@unique([seasonId, userId, channel])
+  @@index([leagueId, userId])
+  @@index([memberId])
+}
+
+model SocialModerationRecord {
+  id                  String        @id @default(cuid())
+  leagueId            String
+  seasonId            String
+  actorUserId         String
+  actorMemberId       String?
+  targetUserId        String?
+  targetMemberId      String?
+  contentType         String
+  contentId           String
+  action              String
+  reason              String?
+  retainedContentJson String?
+  createdAt           DateTime      @default(now())
+  league              League        @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  season              LeagueSeason  @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  actorMember         LeagueMember? @relation("SocialModerationActor", fields: [actorMemberId], references: [id], onDelete: SetNull)
+  targetMember        LeagueMember? @relation("SocialModerationTarget", fields: [targetMemberId], references: [id], onDelete: SetNull)
+
+  @@index([leagueId, seasonId, createdAt])
+  @@index([contentType, contentId, createdAt])
+  @@index([targetUserId, createdAt])
+}
+
+model SocialReport {
+  id               String        @id @default(cuid())
+  leagueId         String
+  seasonId         String
+  reporterUserId   String
+  reporterMemberId String?
+  authorUserId     String?
+  authorMemberId   String?
+  contentType      String
+  contentId        String
+  reason           String
+  details          String?
+  status           String        @default("OPEN")
+  resolvedByUserId String?
+  resolvedAt       DateTime?
+  resolutionNotes  String?
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @updatedAt
+  league           League        @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  season           LeagueSeason  @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  reporterMember   LeagueMember? @relation("SocialReportReporter", fields: [reporterMemberId], references: [id], onDelete: SetNull)
+  authorMember     LeagueMember? @relation("SocialReportAuthor", fields: [authorMemberId], references: [id], onDelete: SetNull)
+
+  @@index([leagueId, seasonId, status, createdAt])
+  @@index([contentType, contentId])
+  @@index([reporterUserId, createdAt])
+}
+
+model SocialMute {
+  id                String        @id @default(cuid())
+  leagueId          String
+  seasonId          String
+  mutedUserId       String
+  mutedMemberId     String?
+  createdByUserId   String
+  createdByMemberId String?
+  reason            String?
+  startsAt          DateTime      @default(now())
+  expiresAt         DateTime?
+  revokedAt         DateTime?
+  revokedByUserId   String?
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+  league            League        @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  season            LeagueSeason  @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  mutedMember       LeagueMember? @relation("SocialMuteTarget", fields: [mutedMemberId], references: [id], onDelete: SetNull)
+  createdByMember   LeagueMember? @relation("SocialMuteActor", fields: [createdByMemberId], references: [id], onDelete: SetNull)
+
+  @@index([leagueId, seasonId, mutedUserId, revokedAt, expiresAt])
+  @@index([mutedMemberId, createdAt])
+}
+
+model SocialCommand {
+  id             String       @id @default(cuid())
+  leagueId       String
+  seasonId       String
+  actorUserId    String
+  actorMemberId  String
+  idempotencyKey String
+  commandType    String
+  requestHash    String
+  resultType     String?
+  resultId       String?
+  responseJson   String?
+  createdAt      DateTime     @default(now())
+  expiresAt      DateTime?
+  league         League       @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  season         LeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  actorMember    LeagueMember @relation(fields: [actorMemberId], references: [id], onDelete: Cascade)
+
+  @@unique([leagueId, actorUserId, idempotencyKey])
+  @@index([seasonId, createdAt])
+  @@index([expiresAt])
+}
+
+model SocialOutboxEvent {
+  sequence      Int                @id @default(autoincrement())
+  id            String             @unique @default(cuid())
+  leagueId      String
+  seasonId      String
+  channel       SocialChannel
+  actorUserId   String?
+  eventType     String
+  aggregateType String
+  aggregateId   String
+  payloadJson   String
+  status        SocialOutboxStatus @default(PENDING)
+  attempts      Int                @default(0)
+  availableAt   DateTime           @default(now())
+  lockedAt      DateTime?
+  lockedBy      String?
+  publishedAt   DateTime?
+  lastError     String?
+  createdAt     DateTime           @default(now())
+  league        League             @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  season        LeagueSeason       @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+
+  @@index([status, availableAt, createdAt])
+  @@index([leagueId, seasonId, createdAt])
+  @@index([leagueId, seasonId, channel, sequence])
+  @@index([actorUserId, sequence])
+  @@index([aggregateType, aggregateId])
+  @@index([lockedAt, createdAt])
 }
 
 // Team Actions (trades, waivers, etc.)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -721,6 +721,7 @@ model SocialMessage {
   type              SocialMessageType      @default(MEMBER)
   content           String
   contextJson       String?
+  giphyId           String?
   relatedEntityType String?
   relatedEntityId   String?
   moderationStatus  SocialModerationStatus @default(ACTIVE)

--- a/src/app/(app)/drafts/[id]/page.tsx
+++ b/src/app/(app)/drafts/[id]/page.tsx
@@ -10,7 +10,6 @@ import { DraftProvider } from '@/contexts/DraftContext';
 import UnifiedDraftRoom from '@/components/draft/UnifiedDraftRoom';
 import DraftErrorBoundary from '@/components/ui/ErrorBoundary';
 import { AppLayout } from '@/components/navigation';
-import { SocketProvider } from '@/providers/SocketProvider';
 
 function DraftAccessState({
   title,
@@ -73,11 +72,9 @@ export default function DraftPage() {
 
   return (
     <DraftErrorBoundary>
-      <SocketProvider uid={user.uid}>
-        <DraftProvider draftId={draftId} userId={user.uid}>
-          <UnifiedDraftRoom draftId={draftId} userId={user.uid} />
-        </DraftProvider>
-      </SocketProvider>
+      <DraftProvider draftId={draftId} userId={user.uid}>
+        <UnifiedDraftRoom draftId={draftId} userId={user.uid} />
+      </DraftProvider>
     </DraftErrorBoundary>
   );
 }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { AuthProvider } from '@/AuthContext';
+import LeagueSocialAppProvider from '@/components/league/social/LeagueSocialAppProvider';
 import PerformanceMonitor from '@/components/PerformanceMonitor';
 import { PageErrorBoundary } from '@/components/ui/ErrorBoundary';
 
@@ -9,7 +10,7 @@ export default function AppRouteLayout({ children }: { readonly children: ReactN
     <PageErrorBoundary name="AppRouteLayout">
       <PerformanceMonitor />
       <AuthProvider>
-        {children}
+        <LeagueSocialAppProvider>{children}</LeagueSocialAppProvider>
       </AuthProvider>
     </PageErrorBoundary>
   );

--- a/src/app/(app)/leagues/[id]/social/SocialPageClient.tsx
+++ b/src/app/(app)/leagues/[id]/social/SocialPageClient.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link';
 
 import { AppLayout } from '@/components/navigation';
 import { LeagueSocialShell, type LeagueSocialView } from '@/components/league/social';
-import { SocketProvider } from '@/providers/SocketProvider';
 
 export default function SocialPageClient({
   leagueId,
@@ -31,15 +30,13 @@ export default function SocialPageClient({
             <ArrowLeft className="size-4" aria-hidden="true" />
             Back to {leagueName}
           </Link>
-          <SocketProvider uid={userId}>
-            <LeagueSocialShell
-              leagueId={leagueId}
-              currentUserId={userId}
-              initialView={initialView}
-              initialPostId={initialPostId}
-              title={`${leagueName} social`}
-            />
-          </SocketProvider>
+          <LeagueSocialShell
+            leagueId={leagueId}
+            currentUserId={userId}
+            initialView={initialView}
+            initialPostId={initialPostId}
+            title={`${leagueName} social`}
+          />
         </div>
       </main>
     </AppLayout>

--- a/src/app/(app)/leagues/[id]/social/SocialPageClient.tsx
+++ b/src/app/(app)/leagues/[id]/social/SocialPageClient.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+
+import { AppLayout } from '@/components/navigation';
+import { LeagueSocialShell, type LeagueSocialView } from '@/components/league/social';
+import { SocketProvider } from '@/providers/SocketProvider';
+
+export default function SocialPageClient({
+  leagueId,
+  leagueName,
+  userId,
+  initialView,
+  initialPostId,
+}: {
+  leagueId: string;
+  leagueName: string;
+  userId: string;
+  initialView: LeagueSocialView;
+  initialPostId?: string;
+}): React.JSX.Element {
+  return (
+    <AppLayout>
+      <main className="min-h-screen bg-background px-4 py-6 text-foreground sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl">
+          <Link
+            href={`/leagues/${encodeURIComponent(leagueId)}`}
+            className="mb-4 inline-flex min-h-10 items-center gap-2 rounded-lg px-2 text-sm font-semibold text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <ArrowLeft className="size-4" aria-hidden="true" />
+            Back to {leagueName}
+          </Link>
+          <SocketProvider uid={userId}>
+            <LeagueSocialShell
+              leagueId={leagueId}
+              currentUserId={userId}
+              initialView={initialView}
+              initialPostId={initialPostId}
+              title={`${leagueName} social`}
+            />
+          </SocketProvider>
+        </div>
+      </main>
+    </AppLayout>
+  );
+}

--- a/src/app/(app)/leagues/[id]/social/page.tsx
+++ b/src/app/(app)/leagues/[id]/social/page.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
+
+import { AppLayout } from '@/components/navigation';
+import { getAuthenticatedUserIdFromServerContext } from '@/lib/serverAuth';
+import { loadAuthorizedLeagueDetail } from '@/server/leagues/leagueDetail';
+
+import SocialPageClient from './SocialPageClient';
+
+export const dynamic = 'force-dynamic';
+
+export default async function LeagueSocialPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ view?: string; post?: string }>;
+}) {
+  const [{ id }, query, userId] = await Promise.all([
+    params,
+    searchParams,
+    getAuthenticatedUserIdFromServerContext(),
+  ]);
+  if (!userId) redirect(`/login?next=${encodeURIComponent(`/leagues/${id}/social`)}`);
+
+  const result = await loadAuthorizedLeagueDetail(id, userId);
+  if (!result.ok) {
+    if (result.status === 404) notFound();
+    return (
+      <AppLayout>
+        <main className="min-h-screen bg-background px-4 py-10 text-foreground">
+          <section className="mx-auto max-w-lg rounded-2xl border border-border bg-card p-6 text-center">
+            <h1 className="text-xl font-semibold">League social is unavailable</h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              You must be a current league member to view chat or message-board content.
+            </p>
+            <Link
+              href="/leagues"
+              className="mt-5 inline-flex min-h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              View your leagues
+            </Link>
+          </section>
+        </main>
+      </AppLayout>
+    );
+  }
+  if (!result.league) notFound();
+
+  return (
+    <SocialPageClient
+      leagueId={id}
+      leagueName={result.league.name}
+      userId={userId}
+      initialView={query.view === 'board' ? 'board' : 'chat'}
+      initialPostId={query.post}
+    />
+  );
+}

--- a/src/app/(app)/leagues/[id]/social/page.tsx
+++ b/src/app/(app)/leagues/[id]/social/page.tsx
@@ -52,7 +52,9 @@ export default async function LeagueSocialPage({
       leagueId={id}
       leagueName={result.league.name}
       userId={userId}
-      initialView={query.view === 'board' ? 'board' : 'chat'}
+      initialView={
+        query.view === 'board' || query.view === 'activity' ? query.view : 'chat'
+      }
       initialPostId={query.post}
     />
   );

--- a/src/app/(app)/leagues/[id]/social/posts/[postId]/page.tsx
+++ b/src/app/(app)/leagues/[id]/social/posts/[postId]/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from 'next/navigation';
+
+export default async function LeagueSocialPostPage({
+  params,
+}: {
+  params: Promise<{ id: string; postId: string }>;
+}) {
+  const { id, postId } = await params;
+  redirect(
+    `/leagues/${encodeURIComponent(id)}/social?view=board&post=${encodeURIComponent(postId)}`
+  );
+}

--- a/src/app/(app)/leagues/[id]/trades/page.tsx
+++ b/src/app/(app)/leagues/[id]/trades/page.tsx
@@ -1,4 +1,5 @@
 import { AppLayout } from '@/components/navigation';
+import { LeagueSocialDiscussButton } from '@/components/league/LeagueSocialDiscussButton';
 import { LeagueTradeProposalForm } from '@/components/league/LeagueTradeProposalForm';
 import { tags } from '@/lib/cacheTags';
 import { cookies, headers } from 'next/headers';
@@ -121,6 +122,9 @@ export default async function LeagueTradesPage({
                   <th scope="col" className="p-3 border">
                     Updated
                   </th>
+                  <th scope="col" className="p-3 border">
+                    Discuss
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -143,6 +147,21 @@ export default async function LeagueTradesPage({
                     </td>
                     <td className="p-3 border whitespace-nowrap">
                       {formatTimestamp(t.summary.lastUpdated)}
+                    </td>
+                    <td className="p-3 border">
+                      <LeagueSocialDiscussButton
+                        leagueId={id}
+                        context={{
+                          type: 'trade',
+                          id: t.tradeId,
+                          title: t.summary.tradeName || `Trade ${t.tradeId.slice(0, 8)}`,
+                          subtitle: t.summary.playerNames.join(', ').slice(0, 300) || undefined,
+                          metadata: {
+                            status: t.summary.status,
+                            teams: String(t.summary.teamCount),
+                          },
+                        }}
+                      />
                     </td>
                   </tr>
                 ))}

--- a/src/app/(app)/players/PlayersPageClient.tsx
+++ b/src/app/(app)/players/PlayersPageClient.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { ArrowDownAZ, ArrowUpAZ, Search, SlidersHorizontal, Users } from 'lucide-react';
 
+import { LeagueSocialDiscussButton } from '@/components/league/LeagueSocialDiscussButton';
 import type { Player } from '@/types/players';
 
 interface PlayersPageClientProps {
@@ -273,12 +274,27 @@ export default function PlayersPageClient({ players }: PlayersPageClientProps) {
                           getPlayerValue(player, sortKey),
                         )}`}
                   </div>
-                  <Link
-                    href={`/players/${player.id}`}
-                    className="rounded-full bg-[color:var(--league-primary)] px-3 py-2 text-xs font-semibold text-white transition hover:bg-[color:var(--league-primary-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--league-primary)] focus-visible:ring-offset-2"
-                  >
-                    View profile
-                  </Link>
+                  <div className="flex items-center gap-2">
+                    <LeagueSocialDiscussButton
+                      context={{
+                        type: 'player',
+                        id: String(player.id),
+                        title: player.name,
+                        subtitle:
+                          [player.team, player.position].filter(Boolean).join(' · ') || undefined,
+                        metadata: {
+                          ...(player.team ? { club: player.team } : {}),
+                          ...(player.position ? { position: player.position } : {}),
+                        },
+                      }}
+                    />
+                    <Link
+                      href={`/players/${player.id}`}
+                      className="rounded-full bg-[color:var(--league-primary)] px-3 py-2 text-xs font-semibold text-white transition hover:bg-[color:var(--league-primary-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--league-primary)] focus-visible:ring-offset-2"
+                    >
+                      View profile
+                    </Link>
+                  </div>
                 </div>
               </article>
             ))}

--- a/src/app/api/leagues/[id]/members/me/route.ts
+++ b/src/app/api/leagues/[id]/members/me/route.ts
@@ -12,6 +12,10 @@ import {
   normalizeTeamSymbolZoom,
 } from '@/lib/teamSymbol';
 import type { LeagueMemberNotificationSettings } from '@/types/leagues';
+import {
+  DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES,
+  type SocialNotificationPreferences,
+} from '@/types/social';
 
 const DEFAULT_NOTIFICATION_SETTINGS: LeagueMemberNotificationSettings = {
   tradePush: true,
@@ -64,6 +68,7 @@ function parseNotificationSettings(value: unknown): LeagueMemberNotificationSett
   }
 
   const settings = value as Record<string, unknown>;
+  const social = parseSocialNotificationSettings(settings.social);
   return {
     tradePush:
       typeof settings.tradePush === 'boolean'
@@ -81,6 +86,45 @@ function parseNotificationSettings(value: unknown): LeagueMemberNotificationSett
       typeof settings.scoringAlerts === 'boolean'
         ? settings.scoringAlerts
         : DEFAULT_NOTIFICATION_SETTINGS.scoringAlerts,
+    social,
+  };
+}
+
+function parseSocialNotificationSettings(value: unknown): SocialNotificationPreferences {
+  const settings =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+
+  return {
+    chatInApp:
+      typeof settings.chatInApp === 'boolean'
+        ? settings.chatInApp
+        : DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES.chatInApp,
+    boardPosts:
+      typeof settings.boardPosts === 'boolean'
+        ? settings.boardPosts
+        : DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES.boardPosts,
+    ownPostReplies:
+      typeof settings.ownPostReplies === 'boolean'
+        ? settings.ownPostReplies
+        : DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES.ownPostReplies,
+    announcements:
+      typeof settings.announcements === 'boolean'
+        ? settings.announcements
+        : DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES.announcements,
+    tradeDiscussions:
+      typeof settings.tradeDiscussions === 'boolean'
+        ? settings.tradeDiscussions
+        : DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES.tradeDiscussions,
+    mentions:
+      typeof settings.mentions === 'boolean'
+        ? settings.mentions
+        : DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES.mentions,
+    systemActivityInApp:
+      typeof settings.systemActivityInApp === 'boolean'
+        ? settings.systemActivityInApp
+        : DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES.systemActivityInApp,
   };
 }
 
@@ -108,10 +152,7 @@ function getMembershipNotificationSettings(
   }
 }
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     if (!id) {
@@ -167,7 +208,24 @@ export async function PATCH(
       }
 
       if (hasBodyField(body, 'notificationSettings')) {
-        const notificationSettings = parseNotificationSettings(body.notificationSettings);
+        const rawSettings = body.notificationSettings as Record<string, unknown>;
+        const notificationSettings = parseNotificationSettings(rawSettings);
+        if (!hasBodyField(rawSettings, 'social')) {
+          const existingSettings =
+            membership.source === 'prisma' && membership.memberDocId
+              ? parseStoredNotificationSettings(
+                  (
+                    await prisma.leagueMember.findUnique({
+                      where: { id: membership.memberDocId },
+                      select: { notificationSettingsJson: true },
+                    })
+                  )?.notificationSettingsJson
+                )
+              : getMembershipNotificationSettings(membership.data?.notificationSettings);
+          if (existingSettings?.social) {
+            notificationSettings.social = existingSettings.social;
+          }
+        }
         prismaData.notificationSettingsJson = JSON.stringify(notificationSettings);
         firestorePatch.notificationSettings = notificationSettings;
       }

--- a/src/app/api/leagues/[id]/social/activity/route.ts
+++ b/src/app/api/leagues/[id]/social/activity/route.ts
@@ -1,0 +1,15 @@
+import type { NextRequest } from 'next/server';
+
+import { listSocialActivity } from '@/server/leagues/social/socialQueries';
+import { parseSocialPageSize } from '@/server/leagues/social/socialValidation';
+
+import { withLeagueSocialRoute } from '../socialRoute';
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withLeagueSocialRoute(request, params, ({ leagueId, userId }) =>
+    listSocialActivity(leagueId, userId, {
+      cursor: request.nextUrl.searchParams.get('cursor'),
+      limit: parseSocialPageSize(request.nextUrl.searchParams.get('limit')),
+    })
+  );
+}

--- a/src/app/api/leagues/[id]/social/messages/[messageId]/route.ts
+++ b/src/app/api/leagues/[id]/social/messages/[messageId]/route.ts
@@ -1,0 +1,23 @@
+import type { NextRequest } from 'next/server';
+
+import { deleteSocialMessage, editSocialMessage } from '@/server/leagues/social/socialCommands';
+
+import { readSocialJson, withLeagueSocialRoute } from '../../socialRoute';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; messageId: string }> }
+) {
+  return withLeagueSocialRoute(request, params, async ({ leagueId, userId, params: values }) =>
+    editSocialMessage(leagueId, userId, values.messageId, await readSocialJson(request))
+  );
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; messageId: string }> }
+) {
+  return withLeagueSocialRoute(request, params, ({ leagueId, userId, params: values }) =>
+    deleteSocialMessage(leagueId, userId, values.messageId)
+  );
+}

--- a/src/app/api/leagues/[id]/social/messages/route.ts
+++ b/src/app/api/leagues/[id]/social/messages/route.ts
@@ -1,0 +1,35 @@
+import type { NextRequest } from 'next/server';
+
+import { createSocialMessage } from '@/server/leagues/social/socialCommands';
+import { listSocialMessages } from '@/server/leagues/social/socialQueries';
+import { enforceSocialRateLimit } from '@/server/leagues/social/socialRateLimit';
+import { parseSocialPageSize } from '@/server/leagues/social/socialValidation';
+
+import { readSocialJson, withLeagueSocialRoute } from '../socialRoute';
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withLeagueSocialRoute(request, params, ({ leagueId, userId }) =>
+    listSocialMessages(leagueId, userId, {
+      cursor: request.nextUrl.searchParams.get('cursor'),
+      limit: parseSocialPageSize(request.nextUrl.searchParams.get('limit')),
+    })
+  );
+}
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withLeagueSocialRoute(
+    request,
+    params,
+    async ({ leagueId, userId }) => {
+      await enforceSocialRateLimit({
+        leagueId,
+        userId,
+        action: 'message',
+        maxRequests: 20,
+        windowSeconds: 60,
+      });
+      return createSocialMessage(leagueId, userId, await readSocialJson(request));
+    },
+    201
+  );
+}

--- a/src/app/api/leagues/[id]/social/moderation/route.ts
+++ b/src/app/api/leagues/[id]/social/moderation/route.ts
@@ -1,0 +1,19 @@
+import type { NextRequest } from 'next/server';
+
+import { moderateSocialContent } from '@/server/leagues/social/socialCommands';
+import { enforceSocialRateLimit } from '@/server/leagues/social/socialRateLimit';
+
+import { readSocialJson, withLeagueSocialRoute } from '../socialRoute';
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withLeagueSocialRoute(request, params, async ({ leagueId, userId }) => {
+    await enforceSocialRateLimit({
+      leagueId,
+      userId,
+      action: 'moderation',
+      maxRequests: 30,
+      windowSeconds: 60,
+    });
+    return moderateSocialContent(leagueId, userId, await readSocialJson(request));
+  });
+}

--- a/src/app/api/leagues/[id]/social/posts/[postId]/replies/route.ts
+++ b/src/app/api/leagues/[id]/social/posts/[postId]/replies/route.ts
@@ -1,0 +1,41 @@
+import type { NextRequest } from 'next/server';
+
+import { createSocialReply } from '@/server/leagues/social/socialCommands';
+import { getSocialPostThread } from '@/server/leagues/social/socialQueries';
+import { enforceSocialRateLimit } from '@/server/leagues/social/socialRateLimit';
+import { parseSocialPageSize } from '@/server/leagues/social/socialValidation';
+
+import { readSocialJson, withLeagueSocialRoute } from '../../../socialRoute';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; postId: string }> }
+) {
+  return withLeagueSocialRoute(request, params, ({ leagueId, userId, params: values }) =>
+    getSocialPostThread(leagueId, userId, values.postId, {
+      cursor: request.nextUrl.searchParams.get('cursor'),
+      limit: parseSocialPageSize(request.nextUrl.searchParams.get('limit')),
+    })
+  );
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; postId: string }> }
+) {
+  return withLeagueSocialRoute(
+    request,
+    params,
+    async ({ leagueId, userId, params: values }) => {
+      await enforceSocialRateLimit({
+        leagueId,
+        userId,
+        action: 'reply',
+        maxRequests: 12,
+        windowSeconds: 60,
+      });
+      return createSocialReply(leagueId, userId, values.postId, await readSocialJson(request));
+    },
+    201
+  );
+}

--- a/src/app/api/leagues/[id]/social/posts/[postId]/route.ts
+++ b/src/app/api/leagues/[id]/social/posts/[postId]/route.ts
@@ -1,0 +1,37 @@
+import type { NextRequest } from 'next/server';
+
+import { deleteSocialPost, editSocialPost } from '@/server/leagues/social/socialCommands';
+import { getSocialPostThread } from '@/server/leagues/social/socialQueries';
+import { parseSocialPageSize } from '@/server/leagues/social/socialValidation';
+
+import { readSocialJson, withLeagueSocialRoute } from '../../socialRoute';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; postId: string }> }
+) {
+  return withLeagueSocialRoute(request, params, ({ leagueId, userId, params: values }) =>
+    getSocialPostThread(leagueId, userId, values.postId, {
+      cursor: request.nextUrl.searchParams.get('cursor'),
+      limit: parseSocialPageSize(request.nextUrl.searchParams.get('limit')),
+    })
+  );
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; postId: string }> }
+) {
+  return withLeagueSocialRoute(request, params, async ({ leagueId, userId, params: values }) =>
+    editSocialPost(leagueId, userId, values.postId, await readSocialJson(request))
+  );
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; postId: string }> }
+) {
+  return withLeagueSocialRoute(request, params, ({ leagueId, userId, params: values }) =>
+    deleteSocialPost(leagueId, userId, values.postId)
+  );
+}

--- a/src/app/api/leagues/[id]/social/posts/route.ts
+++ b/src/app/api/leagues/[id]/social/posts/route.ts
@@ -1,0 +1,39 @@
+import type { NextRequest } from 'next/server';
+
+import { createSocialPost } from '@/server/leagues/social/socialCommands';
+import { listSocialPosts } from '@/server/leagues/social/socialQueries';
+import { enforceSocialRateLimit } from '@/server/leagues/social/socialRateLimit';
+import { parseSocialPageSize } from '@/server/leagues/social/socialValidation';
+
+import { readSocialJson, withLeagueSocialRoute } from '../socialRoute';
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const sort =
+    request.nextUrl.searchParams.get('sort') === 'createdAt' ? 'createdAt' : 'latestActivity';
+  return withLeagueSocialRoute(request, params, ({ leagueId, userId }) =>
+    listSocialPosts(leagueId, userId, {
+      cursor: request.nextUrl.searchParams.get('cursor'),
+      limit: parseSocialPageSize(request.nextUrl.searchParams.get('limit')),
+      categoryId: request.nextUrl.searchParams.get('categoryId'),
+      sort,
+    })
+  );
+}
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withLeagueSocialRoute(
+    request,
+    params,
+    async ({ leagueId, userId }) => {
+      await enforceSocialRateLimit({
+        leagueId,
+        userId,
+        action: 'post',
+        maxRequests: 8,
+        windowSeconds: 60,
+      });
+      return createSocialPost(leagueId, userId, await readSocialJson(request));
+    },
+    201
+  );
+}

--- a/src/app/api/leagues/[id]/social/preferences/route.ts
+++ b/src/app/api/leagues/[id]/social/preferences/route.ts
@@ -1,0 +1,11 @@
+import type { NextRequest } from 'next/server';
+
+import { updateSocialPreferences } from '@/server/leagues/social/socialCommands';
+
+import { readSocialJson, withLeagueSocialRoute } from '../socialRoute';
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withLeagueSocialRoute(request, params, async ({ leagueId, userId }) =>
+    updateSocialPreferences(leagueId, userId, await readSocialJson(request))
+  );
+}

--- a/src/app/api/leagues/[id]/social/read-state/route.ts
+++ b/src/app/api/leagues/[id]/social/read-state/route.ts
@@ -1,0 +1,11 @@
+import type { NextRequest } from 'next/server';
+
+import { markSocialChannelRead } from '@/server/leagues/social/socialCommands';
+
+import { readSocialJson, withLeagueSocialRoute } from '../socialRoute';
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withLeagueSocialRoute(request, params, async ({ leagueId, userId }) =>
+    markSocialChannelRead(leagueId, userId, await readSocialJson(request))
+  );
+}

--- a/src/app/api/leagues/[id]/social/replies/[replyId]/route.ts
+++ b/src/app/api/leagues/[id]/social/replies/[replyId]/route.ts
@@ -1,0 +1,23 @@
+import type { NextRequest } from 'next/server';
+
+import { deleteSocialReply, editSocialReply } from '@/server/leagues/social/socialCommands';
+
+import { readSocialJson, withLeagueSocialRoute } from '../../socialRoute';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; replyId: string }> }
+) {
+  return withLeagueSocialRoute(request, params, async ({ leagueId, userId, params: values }) =>
+    editSocialReply(leagueId, userId, values.replyId, await readSocialJson(request))
+  );
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; replyId: string }> }
+) {
+  return withLeagueSocialRoute(request, params, ({ leagueId, userId, params: values }) =>
+    deleteSocialReply(leagueId, userId, values.replyId)
+  );
+}

--- a/src/app/api/leagues/[id]/social/reports/route.ts
+++ b/src/app/api/leagues/[id]/social/reports/route.ts
@@ -1,0 +1,24 @@
+import type { NextRequest } from 'next/server';
+
+import { reportSocialContent } from '@/server/leagues/social/socialCommands';
+import { enforceSocialRateLimit } from '@/server/leagues/social/socialRateLimit';
+
+import { readSocialJson, withLeagueSocialRoute } from '../socialRoute';
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withLeagueSocialRoute(
+    request,
+    params,
+    async ({ leagueId, userId }) => {
+      await enforceSocialRateLimit({
+        leagueId,
+        userId,
+        action: 'report',
+        maxRequests: 5,
+        windowSeconds: 300,
+      });
+      return reportSocialContent(leagueId, userId, await readSocialJson(request));
+    },
+    201
+  );
+}

--- a/src/app/api/leagues/[id]/social/socialRoute.ts
+++ b/src/app/api/leagues/[id]/social/socialRoute.ts
@@ -1,0 +1,64 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { logger } from '@/lib/logger';
+import { getAuthenticatedUserId } from '@/lib/serverAuth';
+import { SocialError, toSocialErrorResponse } from '@/server/leagues/social/socialErrors';
+
+export interface LeagueSocialRouteContext {
+  leagueId: string;
+  userId: string;
+  params: Record<string, string>;
+}
+
+export async function withLeagueSocialRoute<T>(
+  request: NextRequest,
+  paramsPromise: Promise<Record<string, string>>,
+  handler: (context: LeagueSocialRouteContext) => Promise<T>,
+  status = 200
+): Promise<NextResponse> {
+  let context: LeagueSocialRouteContext | null = null;
+  try {
+    const params = await paramsPromise;
+    const leagueId = params.id;
+    if (!leagueId) throw new SocialError('VALIDATION', 'League ID is required');
+
+    const userId = await getAuthenticatedUserId(request);
+    if (!userId) throw new SocialError('UNAUTHORIZED', 'Sign in to use league social features');
+    context = { leagueId, userId, params };
+
+    const data = await handler(context);
+    return NextResponse.json(
+      { success: true, data },
+      {
+        status,
+        headers: {
+          'Cache-Control': 'private, no-store',
+        },
+      }
+    );
+  } catch (error) {
+    const response = toSocialErrorResponse(error);
+    if (!(error instanceof SocialError) || error.code === 'INTERNAL') {
+      logger.error('League social route failed', {
+        leagueId: context?.leagueId,
+        userId: context?.userId,
+        path: request.nextUrl.pathname,
+        method: request.method,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return NextResponse.json(response.body, {
+      status: response.status,
+      headers: { 'Cache-Control': 'private, no-store' },
+    });
+  }
+}
+
+export async function readSocialJson(request: NextRequest): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    throw new SocialError('VALIDATION', 'Request body must be valid JSON');
+  }
+}

--- a/src/app/api/leagues/[id]/social/standards/route.ts
+++ b/src/app/api/leagues/[id]/social/standards/route.ts
@@ -1,0 +1,11 @@
+import type { NextRequest } from 'next/server';
+
+import { acceptSocialStandards } from '@/server/leagues/social/socialCommands';
+
+import { withLeagueSocialRoute } from '../socialRoute';
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withLeagueSocialRoute(request, params, ({ leagueId, userId }) =>
+    acceptSocialStandards(leagueId, userId)
+  );
+}

--- a/src/app/api/leagues/[id]/social/summary/route.ts
+++ b/src/app/api/leagues/[id]/social/summary/route.ts
@@ -1,0 +1,11 @@
+import type { NextRequest } from 'next/server';
+
+import { getLeagueSocialSummary } from '@/server/leagues/social/socialQueries';
+
+import { withLeagueSocialRoute } from '../socialRoute';
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withLeagueSocialRoute(request, params, ({ leagueId, userId }) =>
+    getLeagueSocialSummary(leagueId, userId)
+  );
+}

--- a/src/components/PlayerDetail.tsx
+++ b/src/components/PlayerDetail.tsx
@@ -11,6 +11,7 @@ import PlayerSummaryCard from './PlayerSummaryCard';
 import MatchLogTable from './MatchLogTable';
 import PlayerChart from './PlayerChart';
 import { PlayerLeagueAvailabilityPanel } from './PlayerLeagueAvailabilityPanel';
+import { LeagueSocialDiscussButton } from './league/LeagueSocialDiscussButton';
 import { LoadingSpinner } from './ui';
 
 type PlayerDetailProps = {
@@ -415,6 +416,18 @@ export const PlayerDetail = ({ player }: PlayerDetailProps) => {
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2 text-xs font-semibold text-muted-foreground">
+            <LeagueSocialDiscussButton
+              context={{
+                type: 'player',
+                id: String(player.id),
+                title: player.name,
+                subtitle: [player.team, player.position].filter(Boolean).join(' · ') || undefined,
+                metadata: {
+                  ...(player.team ? { club: player.team } : {}),
+                  ...(player.position ? { position: player.position } : {}),
+                },
+              }}
+            />
             <span className="rounded-full border border-border bg-muted px-3 py-1">
               {aggregateStatsAvailable ? 'Season profile' : 'Limited data'}
             </span>

--- a/src/components/draft/UnifiedDraftRoom.tsx
+++ b/src/components/draft/UnifiedDraftRoom.tsx
@@ -3,10 +3,12 @@
 import { useMemo, useCallback, useState, useDeferredValue, useRef, useEffect } from 'react';
 
 import Link from 'next/link';
+import { MessagesSquare } from 'lucide-react';
 
 import DraftWatchlist from '@/components/DraftWatchlist';
 import LivePickHeader from '@/components/LivePickHeader';
 import PickFeed from '@/components/PickFeed';
+import { SocialDrawer } from '@/components/league/social';
 import { useConfirmation } from '@/components/ui';
 import DraftErrorBoundary from '@/components/ui/ErrorBoundary';
 import { useDraft } from '@/contexts/DraftContext';
@@ -204,6 +206,7 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
   const [positionFilter, setPositionFilter] = useState<string>('ALL');
   const [sortBy, setSortBy] = useState<PlayerSortKey>('statlyZ');
   const [isPickFeedOpen, setIsPickFeedOpen] = useState(false);
+  const [isSocialOpen, setIsSocialOpen] = useState(false);
 
   // Desktop FAB ref + modal focus mgmt refs
   const openFeedBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -643,6 +646,16 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
                 </div>
 
                 <div className="flex flex-wrap gap-3">
+                  {activeDraft.leagueId ? (
+                    <button
+                      type="button"
+                      onClick={() => setIsSocialOpen(true)}
+                      className="inline-flex items-center gap-2 rounded-full border border-[color:var(--draft-broadcast-border)] bg-[color:var(--draft-broadcast-panel-strong)] px-4 py-2 text-sm font-semibold text-[color:var(--draft-broadcast-text)] transition-colors hover:bg-[color:var(--draft-broadcast-border)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      <MessagesSquare className="size-4" aria-hidden="true" />
+                      League chat
+                    </button>
+                  ) : null}
                   <Link
                     href="/drafts"
                     className="inline-flex items-center rounded-full bg-[color:var(--draft-broadcast-red)] px-4 py-2 text-sm font-semibold text-white shadow-[0_0_24px_var(--draft-broadcast-red-glow)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -790,6 +803,14 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
           </div>
         )}
       </div>
+      {activeDraft.leagueId ? (
+        <SocialDrawer
+          open={isSocialOpen}
+          onClose={() => setIsSocialOpen(false)}
+          leagueId={activeDraft.leagueId}
+          currentUserId={userId}
+        />
+      ) : null}
       {ConfirmationModal}
     </DraftErrorBoundary>
   );

--- a/src/components/draft/UnifiedDraftRoom.tsx
+++ b/src/components/draft/UnifiedDraftRoom.tsx
@@ -8,7 +8,7 @@ import { MessagesSquare } from 'lucide-react';
 import DraftWatchlist from '@/components/DraftWatchlist';
 import LivePickHeader from '@/components/LivePickHeader';
 import PickFeed from '@/components/PickFeed';
-import { SocialDrawer } from '@/components/league/social';
+import { useLeagueSocialWidget } from '@/components/league/social';
 import { useConfirmation } from '@/components/ui';
 import DraftErrorBoundary from '@/components/ui/ErrorBoundary';
 import { useDraft } from '@/contexts/DraftContext';
@@ -200,13 +200,13 @@ function buildRosterSlots({
 export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomProps) {
   const draft = useDraft();
   const { confirm, ConfirmationModal } = useConfirmation();
+  const { open: openLeagueSocial, setLeagueContext } = useLeagueSocialWidget();
 
   const [searchQuery, setSearchQuery] = useState('');
   const deferredQuery = useDeferredValue(searchQuery);
   const [positionFilter, setPositionFilter] = useState<string>('ALL');
   const [sortBy, setSortBy] = useState<PlayerSortKey>('statlyZ');
   const [isPickFeedOpen, setIsPickFeedOpen] = useState(false);
-  const [isSocialOpen, setIsSocialOpen] = useState(false);
 
   // Desktop FAB ref + modal focus mgmt refs
   const openFeedBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -374,6 +374,12 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
       });
     }
   }, [isPickFeedOpen]);
+
+  useEffect(() => {
+    const leagueId = draft.draft?.leagueId;
+    setLeagueContext(leagueId ?? null, draft.draft?.name);
+    return () => setLeagueContext(null);
+  }, [draft.draft?.leagueId, draft.draft?.name, setLeagueContext]);
 
   // Loading
   if (draft.isLoading) {
@@ -649,7 +655,7 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
                   {activeDraft.leagueId ? (
                     <button
                       type="button"
-                      onClick={() => setIsSocialOpen(true)}
+                      onClick={() => openLeagueSocial({ view: 'chat' })}
                       className="inline-flex items-center gap-2 rounded-full border border-[color:var(--draft-broadcast-border)] bg-[color:var(--draft-broadcast-panel-strong)] px-4 py-2 text-sm font-semibold text-[color:var(--draft-broadcast-text)] transition-colors hover:bg-[color:var(--draft-broadcast-border)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
                       <MessagesSquare className="size-4" aria-hidden="true" />
@@ -803,14 +809,6 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
           </div>
         )}
       </div>
-      {activeDraft.leagueId ? (
-        <SocialDrawer
-          open={isSocialOpen}
-          onClose={() => setIsSocialOpen(false)}
-          leagueId={activeDraft.leagueId}
-          currentUserId={userId}
-        />
-      ) : null}
       {ConfirmationModal}
     </DraftErrorBoundary>
   );

--- a/src/components/league/LeagueChat.tsx
+++ b/src/components/league/LeagueChat.tsx
@@ -1,90 +1,20 @@
-import React, { useState, useEffect } from 'react';
-import { collection, query, orderBy, limit, onSnapshot, type Timestamp } from 'firebase/firestore';
-import { db } from '@/lib/firebaseClient';
+'use client';
 
-interface LeagueChatProps {
+import { LeagueSocialShell } from './social';
+
+export default function LeagueChat({
+  leagueId,
+  currentUserId,
+}: {
   leagueId: string;
   currentUserId?: string;
-}
-
-interface LeagueMessage {
-  id: string;
-  userId: string;
-  text: string;
-  createdAt?: Date;
-}
-
-function toMessageDate(value: Timestamp | Date | null | undefined): Date | undefined {
-  if (!value) return undefined;
-  return value instanceof Date ? value : value.toDate();
-}
-
-export default function LeagueChat({ leagueId, currentUserId: _currentUserId }: LeagueChatProps) {
-  const [messages, setMessages] = useState<LeagueMessage[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (!leagueId || !db) {
-      setLoading(false);
-      setMessages([]);
-      return;
-    }
-
-    setLoading(true);
-    const q = query(
-      collection(db, 'leagues', leagueId, 'messages'),
-      orderBy('createdAt', 'desc'),
-      limit(200)
-    );
-
-    const unsubscribe = onSnapshot(
-      q,
-      (snapshot) => {
-        const nextMessages = snapshot.docs
-          .map((doc) => {
-            const data = doc.data() as Record<string, unknown>;
-            return {
-              id: doc.id,
-              userId: typeof data.userId === 'string' ? data.userId : '',
-              text: typeof data.text === 'string' ? data.text : '',
-              createdAt: toMessageDate(data.createdAt as Timestamp | Date | null | undefined),
-            };
-          })
-          .reverse();
-        setMessages(nextMessages);
-        setLoading(false);
-      },
-      (error) => {
-        console.error(`Error fetching league chat messages (${leagueId}):`, error);
-        setLoading(false);
-      }
-    );
-
-    return () => unsubscribe();
-  }, [leagueId]);
-
-  if (loading) {
-    return <div>Loading chat...</div>;
-  }
-
+}): React.JSX.Element {
   return (
-    <div className="league-chat rounded-lg border border-border bg-background p-4">
-      <h3 className="font-medium text-foreground">League Chat</h3>
-      {messages.length === 0 ? (
-        <p className="mt-2 text-sm text-muted-foreground">No messages yet.</p>
-      ) : (
-        <ol className="mt-3 space-y-3">
-          {messages.map((message) => (
-            <li key={message.id} className="rounded-md bg-muted p-3">
-              <p className="text-sm text-foreground">{message.text}</p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                {message.userId || 'Unknown user'}
-                {message.createdAt && ` • ${message.createdAt.toLocaleString()}`}
-              </p>
-            </li>
-          ))}
-        </ol>
-      )}
-    </div>
+    <LeagueSocialShell
+      leagueId={leagueId}
+      currentUserId={currentUserId}
+      initialView="chat"
+      title="League chat"
+    />
   );
 }

--- a/src/components/league/LeagueSocialDiscussButton.tsx
+++ b/src/components/league/LeagueSocialDiscussButton.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { MessageCircle } from 'lucide-react';
+
+import { useLeagueSocialWidget } from '@/components/league/social/LeagueSocialWidgetProvider';
+import type { SocialDiscussionContext } from '@/types/social';
+
+interface LeagueSocialDiscussButtonProps {
+  context: SocialDiscussionContext;
+  leagueId?: string;
+  className?: string;
+  label?: string;
+}
+
+export function LeagueSocialDiscussButton({
+  context,
+  leagueId,
+  className = '',
+  label = 'Discuss',
+}: LeagueSocialDiscussButtonProps): React.JSX.Element {
+  const social = useLeagueSocialWidget();
+  const targetLeagueId = leagueId ?? social.leagueId;
+  const unavailable = !targetLeagueId;
+
+  return (
+    <button
+      type="button"
+      disabled={unavailable}
+      onClick={() => {
+        if (!targetLeagueId) return;
+        social.open({
+          leagueId: targetLeagueId,
+          view: 'chat',
+          context,
+        });
+      }}
+      title={unavailable ? 'Select a league before starting a discussion' : undefined}
+      aria-label={`${label}: ${context.title}`}
+      className={`inline-flex min-h-9 items-center justify-center gap-2 rounded-full border border-border bg-background px-3 text-xs font-semibold text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+    >
+      <MessageCircle className="size-4" aria-hidden="true" />
+      {label}
+    </button>
+  );
+}

--- a/src/components/league/LeagueTabs.tsx
+++ b/src/components/league/LeagueTabs.tsx
@@ -61,6 +61,7 @@ type TabType =
   | 'trades'
   | 'waivers'
   | 'draft'
+  | 'social'
   | 'team-settings'
   | 'league-settings';
 
@@ -85,6 +86,8 @@ type OverviewWaiverClaim = {
   playerName: string;
   bidAmount?: number;
 };
+
+type TeamNotificationToggleKey = 'tradePush' | 'waiverPush' | 'draftReminder' | 'scoringAlerts';
 
 const TAB_IDS: readonly TabType[] = [
   'overview',
@@ -136,6 +139,7 @@ export default function LeagueTabs({
   const [overviewWaiversStatus, setOverviewWaiversStatus] = useState<
     'idle' | 'loading' | 'ready' | 'error'
   >('idle');
+  const [socialUnread, setSocialUnread] = useState({ chat: 0, board: 0 });
 
   const currentMember = members.find((member) => member.userId === currentUserId);
   const selectedPlayerId = searchParams?.get('playerId') ?? null;
@@ -161,6 +165,31 @@ export default function LeagueTabs({
     (category) => FANTASY_CATEGORIES[category]?.label ?? category
   );
 
+  useEffect(() => {
+    if (!currentUserId) return;
+    let cancelled = false;
+    void authenticatedFetch(`/api/leagues/${league.id}/social/summary`, {}, currentUserId)
+      .then(async (response) => {
+        if (!response.ok) return null;
+        return (await response.json()) as {
+          data?: { unread?: { chat?: number; board?: number } };
+        };
+      })
+      .then((body) => {
+        if (cancelled || !body?.data?.unread) return;
+        setSocialUnread({
+          chat: body.data.unread.chat ?? 0,
+          board: body.data.unread.board ?? 0,
+        });
+      })
+      .catch(() => {
+        // Social has its own retry state; league navigation remains available.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentUserId, league.id]);
+
   // Handle URL tab parameter
   useEffect(() => {
     const tabParam = getLeagueTabFromSearch(
@@ -178,6 +207,10 @@ export default function LeagueTabs({
   }, [activeTab, canAccessCompetitionRules, searchParams]);
 
   const handleTabChange = (tabId: TabType) => {
+    if (tabId === 'social') {
+      router.push(`/leagues/${league.id}/social`);
+      return;
+    }
     setActiveTab(tabId);
     const newUrl = `${pathname}?tab=${tabId}`;
     router.push(newUrl, { scroll: false });
@@ -193,6 +226,11 @@ export default function LeagueTabs({
     { id: 'trades', name: 'Trades' },
     { id: 'waivers', name: 'Waivers' },
     { id: 'draft', name: 'Draft' },
+    {
+      id: 'social',
+      name: 'Social',
+      badge: socialUnread.chat + socialUnread.board || undefined,
+    },
     { id: 'team-settings', name: 'Team Settings' },
   ];
   const tabs: Tab[] = canAccessCompetitionRules
@@ -1422,10 +1460,7 @@ function TeamSettingsPanel({
     currentMember?.teamName,
   ]);
 
-  const updateNotificationSetting = (
-    key: keyof LeagueMemberNotificationSettings,
-    value: boolean
-  ) => {
+  const updateNotificationSetting = (key: TeamNotificationToggleKey, value: boolean) => {
     setNotificationSettings((current) => ({ ...current, [key]: value }));
   };
 
@@ -1619,25 +1654,22 @@ function TeamSettingsPanel({
                 />
               </label>
               <div className="grid gap-3 sm:grid-cols-2">
-                {[
-                  ['tradePush', 'Trade offers'],
-                  ['waiverPush', 'Waiver updates'],
-                  ['draftReminder', 'Draft reminders'],
-                  ['scoringAlerts', 'Scoring alerts'],
-                ].map(([key, label]) => (
+                {(
+                  [
+                    ['tradePush', 'Trade offers'],
+                    ['waiverPush', 'Waiver updates'],
+                    ['draftReminder', 'Draft reminders'],
+                    ['scoringAlerts', 'Scoring alerts'],
+                  ] satisfies Array<[TeamNotificationToggleKey, string]>
+                ).map(([key, label]) => (
                   <label
                     key={key}
                     className="flex min-h-10 items-center gap-3 rounded-md border border-[color:var(--league-border)] bg-[color:var(--league-page)] px-3 text-sm font-medium text-[color:var(--league-text)]"
                   >
                     <input
                       type="checkbox"
-                      checked={notificationSettings[key as keyof LeagueMemberNotificationSettings]}
-                      onChange={(event) =>
-                        updateNotificationSetting(
-                          key as keyof LeagueMemberNotificationSettings,
-                          event.target.checked
-                        )
-                      }
+                      checked={notificationSettings[key]}
+                      onChange={(event) => updateNotificationSetting(key, event.target.checked)}
                       className="size-4 rounded border-[color:var(--league-border)] text-[color:var(--league-primary)] focus:ring-[color:var(--league-primary)]"
                     />
                     {label}

--- a/src/components/league/LeagueTabs.tsx
+++ b/src/components/league/LeagueTabs.tsx
@@ -139,7 +139,7 @@ export default function LeagueTabs({
   const [overviewWaiversStatus, setOverviewWaiversStatus] = useState<
     'idle' | 'loading' | 'ready' | 'error'
   >('idle');
-  const [socialUnread, setSocialUnread] = useState({ chat: 0, board: 0 });
+  const [socialUnread, setSocialUnread] = useState({ chat: 0, board: 0, activity: 0 });
 
   const currentMember = members.find((member) => member.userId === currentUserId);
   const selectedPlayerId = searchParams?.get('playerId') ?? null;
@@ -172,7 +172,7 @@ export default function LeagueTabs({
       .then(async (response) => {
         if (!response.ok) return null;
         return (await response.json()) as {
-          data?: { unread?: { chat?: number; board?: number } };
+          data?: { unread?: { chat?: number; board?: number; activity?: number } };
         };
       })
       .then((body) => {
@@ -180,6 +180,7 @@ export default function LeagueTabs({
         setSocialUnread({
           chat: body.data.unread.chat ?? 0,
           board: body.data.unread.board ?? 0,
+          activity: body.data.unread.activity ?? 0,
         });
       })
       .catch(() => {
@@ -229,7 +230,7 @@ export default function LeagueTabs({
     {
       id: 'social',
       name: 'Social',
-      badge: socialUnread.chat + socialUnread.board || undefined,
+      badge: socialUnread.chat + socialUnread.board + socialUnread.activity || undefined,
     },
     { id: 'team-settings', name: 'Team Settings' },
   ];

--- a/src/components/league/social/ActivityPanel.test.tsx
+++ b/src/components/league/social/ActivityPanel.test.tsx
@@ -69,4 +69,35 @@ describe('ActivityPanel', () => {
     await user.click(screen.getByRole('button', { name: 'Discuss' }));
     expect(onDiscuss).toHaveBeenCalledWith(activity);
   });
+
+  it('uses restrained semantic accents with an icon and visible event label', () => {
+    const events: SocialMessage[] = [
+      activity,
+      { ...activity, id: 'activity-2', content: 'Taylor was added to the roster.' },
+      { ...activity, id: 'activity-3', content: 'Morgan was dropped from the roster.' },
+      { ...activity, id: 'activity-4', content: 'A trade completed between two teams.' },
+      { ...activity, id: 'activity-5', content: 'Waiver claim submitted and pending.' },
+      { ...activity, id: 'activity-6', content: 'Transaction failed and was reversed.' },
+      { ...activity, id: 'activity-7', content: 'Commissioner changed league settings.' },
+    ];
+
+    renderPanel({ activity: events });
+
+    const expectations = [
+      ['Draft selection', 'draft', 'border-l-social-action'],
+      ['Player added', 'addition', 'border-l-social-success'],
+      ['Player removed', 'removal', 'border-l-social-border-strong'],
+      ['Trade completed', 'trade', 'border-l-social-brand-strong'],
+      ['Waiver pending', 'waiver', 'border-l-social-warning'],
+      ['Transaction issue', 'error', 'border-l-social-error'],
+      ['Commissioner change', 'commissioner', 'border-l-social-action'],
+    ] as const;
+
+    for (const [label, kind, accent] of expectations) {
+      const labelElement = screen.getByText(label);
+      expect(labelElement.parentElement?.querySelector('svg')).toBeInTheDocument();
+      expect(labelElement.closest('article')).toHaveAttribute('data-activity-kind', kind);
+      expect(labelElement.closest('article')).toHaveClass(accent, 'bg-social-surface');
+    }
+  });
 });

--- a/src/components/league/social/ActivityPanel.test.tsx
+++ b/src/components/league/social/ActivityPanel.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SocialMessage } from '@/types/social';
+
+import ActivityPanel from './ActivityPanel';
+
+const activity: SocialMessage = {
+  id: 'activity-1',
+  leagueId: 'league-1',
+  seasonId: 'season-1',
+  type: 'system',
+  content: 'Alex drafted Jordan Example.',
+  author: null,
+  relatedEntityId: 'pick-1',
+  createdAt: '2026-07-19T10:01:00.000Z',
+  moderationStatus: 'active',
+  isOwn: false,
+};
+
+function renderPanel(overrides: Partial<React.ComponentProps<typeof ActivityPanel>> = {}) {
+  const props: React.ComponentProps<typeof ActivityPanel> = {
+    activity: [],
+    hasEarlierActivity: false,
+    loading: false,
+    loadingEarlier: false,
+    onRetry: vi.fn(),
+    onLoadEarlier: vi.fn(),
+    ...overrides,
+  };
+  return render(<ActivityPanel {...props} />);
+}
+
+describe('ActivityPanel', () => {
+  it('renders an empty state and earlier-activity pagination', async () => {
+    const user = userEvent.setup();
+    const onLoadEarlier = vi.fn();
+    const { rerender } = renderPanel();
+    expect(screen.getByText('No league activity yet')).toBeInTheDocument();
+
+    rerender(
+      <ActivityPanel
+        activity={[activity]}
+        hasEarlierActivity
+        loading={false}
+        loadingEarlier={false}
+        onRetry={vi.fn()}
+        onLoadEarlier={onLoadEarlier}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Load earlier activity' }));
+    expect(onLoadEarlier).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers contextual discussion without making activity part of chat', async () => {
+    const user = userEvent.setup();
+    const onDiscuss = vi.fn();
+    renderPanel({ activity: [activity], onDiscuss });
+
+    expect(screen.getByText('Alex drafted Jordan Example.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Discuss' }));
+    expect(onDiscuss).toHaveBeenCalledWith(activity);
+  });
+});

--- a/src/components/league/social/ActivityPanel.test.tsx
+++ b/src/components/league/social/ActivityPanel.test.tsx
@@ -33,6 +33,13 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof ActivityPane
 }
 
 describe('ActivityPanel', () => {
+  it('uses a flat feed presentation in compact mode', () => {
+    renderPanel({ compact: true });
+
+    const region = screen.getByRole('region', { name: 'League activity' });
+    expect(region).not.toHaveClass('rounded-2xl', 'border');
+  });
+
   it('renders an empty state and earlier-activity pagination', async () => {
     const user = userEvent.setup();
     const onLoadEarlier = vi.fn();

--- a/src/components/league/social/ActivityPanel.tsx
+++ b/src/components/league/social/ActivityPanel.tsx
@@ -1,6 +1,17 @@
 'use client';
 
-import { MessageCircle } from 'lucide-react';
+import {
+  AlertTriangle,
+  CircleMinus,
+  CirclePlus,
+  Clock3,
+  ListChecks,
+  MessageCircle,
+  RefreshCw,
+  Repeat2,
+  ShieldCheck,
+  type LucideIcon,
+} from 'lucide-react';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import type { SocialMessage } from '@/types/social';
@@ -22,6 +33,103 @@ interface ActivityPanelProps {
 }
 
 const BOTTOM_THRESHOLD_PX = 72;
+
+type ActivityKind =
+  | 'draft'
+  | 'addition'
+  | 'removal'
+  | 'trade'
+  | 'waiver'
+  | 'error'
+  | 'commissioner'
+  | 'general';
+
+interface ActivityPresentation {
+  kind: ActivityKind;
+  label: string;
+  icon: LucideIcon;
+  accentClass: string;
+  labelClass: string;
+}
+
+export function getActivityPresentation(content: string): ActivityPresentation {
+  const normalized = content.toLocaleLowerCase();
+
+  if (/\b(failed|reversed|voided|cancelled|canceled|rejected)\b/.test(normalized)) {
+    return {
+      kind: 'error',
+      label: 'Transaction issue',
+      icon: AlertTriangle,
+      accentClass: 'border-l-social-error',
+      labelClass: 'text-social-error',
+    };
+  }
+  if (
+    /\bwaiver(s)?\b.*\b(pending|submitted|processing)\b/.test(normalized) ||
+    /\b(pending|submitted|processing)\b.*\bwaiver(s)?\b/.test(normalized)
+  ) {
+    return {
+      kind: 'waiver',
+      label: 'Waiver pending',
+      icon: Clock3,
+      accentClass: 'border-l-social-warning',
+      labelClass: 'text-social-warning-text',
+    };
+  }
+  if (/\btrade(d|s)?\b/.test(normalized)) {
+    return {
+      kind: 'trade',
+      label: 'Trade completed',
+      icon: Repeat2,
+      accentClass: 'border-l-social-brand-strong',
+      labelClass: 'text-social-brand-strong',
+    };
+  }
+  if (/\bcommissioner\b/.test(normalized)) {
+    return {
+      kind: 'commissioner',
+      label: 'Commissioner change',
+      icon: ShieldCheck,
+      accentClass: 'border-l-social-action',
+      labelClass: 'text-social-action-pressed',
+    };
+  }
+  if (/\b(added|signed|claimed|acquired)\b/.test(normalized)) {
+    return {
+      kind: 'addition',
+      label: 'Player added',
+      icon: CirclePlus,
+      accentClass: 'border-l-social-success',
+      labelClass: 'text-social-success',
+    };
+  }
+  if (/\b(removed|dropped|delisted|waived)\b/.test(normalized)) {
+    return {
+      kind: 'removal',
+      label: 'Player removed',
+      icon: CircleMinus,
+      accentClass: 'border-l-social-border-strong',
+      labelClass: 'text-social-text-muted',
+    };
+  }
+  if (/\b(draft(ed)?|selection|selected|pick(ed)?)\b/.test(normalized)) {
+    return {
+      kind: 'draft',
+      label: 'Draft selection',
+      icon: ListChecks,
+      accentClass: 'border-l-social-action',
+      labelClass: 'text-social-action-pressed',
+    };
+  }
+
+  return {
+    kind: 'general',
+    label: 'League update',
+    icon: RefreshCw,
+    accentClass: 'border-l-social-border-strong',
+    labelClass: 'text-social-text-muted',
+  };
+}
 
 function isNearBottom(element: HTMLElement): boolean {
   return element.scrollHeight - element.scrollTop - element.clientHeight <= BOTTOM_THRESHOLD_PX;
@@ -106,15 +214,19 @@ export default function ActivityPanel({
       aria-labelledby="league-activity-heading"
       className={`flex min-h-0 flex-1 flex-col overflow-hidden ${
         compact
-          ? 'bg-background text-foreground'
-          : 'rounded-2xl border border-border bg-card text-card-foreground'
+          ? 'bg-social-canvas text-social-text'
+          : 'rounded-2xl border border-social-border bg-social-canvas text-social-text'
       }`}
     >
-      <header className={compact ? 'sr-only' : 'border-b border-border px-4 py-3'}>
-        <h2 id="league-activity-heading" className="text-base font-semibold text-foreground">
+      <header
+        className={
+          compact ? 'sr-only' : 'border-b border-social-border bg-social-surface px-4 py-3'
+        }
+      >
+        <h2 id="league-activity-heading" className="text-base font-semibold text-social-text">
           League activity
         </h2>
-        <p className="text-xs text-muted-foreground">
+        <p className="text-xs text-social-text-muted">
           Draft picks, transactions, results, and commissioner actions
         </p>
       </header>
@@ -138,7 +250,7 @@ export default function ActivityPanel({
                 type="button"
                 onClick={handleLoadEarlier}
                 disabled={loadingEarlier}
-                className="inline-flex min-h-9 items-center justify-center rounded-lg border border-border bg-background px-3 text-xs font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+                className="inline-flex min-h-9 items-center justify-center rounded-lg border border-social-border bg-social-surface px-3 text-xs font-semibold text-social-text transition-colors hover:border-social-border-strong hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
               >
                 {loadingEarlier ? 'Loading…' : 'Load earlier activity'}
               </button>
@@ -146,67 +258,74 @@ export default function ActivityPanel({
           ) : null}
 
           {loading && activity.length === 0 ? (
-            <p role="status" className="py-10 text-center text-sm text-muted-foreground">
+            <p role="status" className="py-10 text-center text-sm text-social-text-muted">
               Loading league activity…
             </p>
           ) : error && activity.length === 0 ? (
-            <div className="mx-auto max-w-sm rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-center">
-              <p role="alert" className="text-sm font-medium text-destructive">
+            <div className="mx-auto max-w-sm rounded-xl border border-social-error bg-social-error-soft p-4 text-center">
+              <p role="alert" className="text-sm font-medium text-social-error">
                 {error}
               </p>
               <button
                 type="button"
                 onClick={() => void onRetry()}
-                className="mt-3 inline-flex min-h-9 items-center justify-center rounded-lg border border-border bg-background px-3 text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="mt-3 inline-flex min-h-9 items-center justify-center rounded-lg border border-social-border bg-social-surface px-3 text-sm font-semibold text-social-text transition-colors hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
               >
                 Retry
               </button>
             </div>
           ) : activity.length === 0 ? (
             <div className="py-10 text-center">
-              <p className="text-sm font-semibold text-foreground">No league activity yet</p>
-              <p className="mt-1 text-sm text-muted-foreground">
+              <p className="text-sm font-semibold text-social-text">No league activity yet</p>
+              <p className="mt-1 text-sm text-social-text-muted">
                 League events will appear here as the season progresses.
               </p>
             </div>
           ) : (
-            <ol
-              className={compact ? 'divide-y divide-border' : 'space-y-3'}
-              aria-label="League activity"
-            >
-              {activity.map((item) => (
-                <li key={item.id}>
-                  <article
-                    className={
-                      compact
-                        ? 'px-1 py-3'
-                        : 'rounded-xl border border-primary/25 bg-primary/10 px-3 py-3'
-                    }
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <SafeSocialText value={item.content} />
-                        <time
-                          dateTime={item.createdAt}
-                          className="mt-1 block text-xs text-muted-foreground"
-                        >
-                          {new Date(item.createdAt).toLocaleString()}
-                        </time>
+            <ol className={compact ? 'space-y-2' : 'space-y-3'} aria-label="League activity">
+              {activity.map((item) => {
+                const presentation = getActivityPresentation(item.content);
+                const ActivityIcon = presentation.icon;
+
+                return (
+                  <li key={item.id}>
+                    <article
+                      data-activity-kind={presentation.kind}
+                      className={`border-l-4 border-social-border bg-social-surface ${presentation.accentClass} ${
+                        compact ? 'rounded-lg px-3 py-3' : 'rounded-xl border px-3 py-3'
+                      }`}
+                    >
+                      <div
+                        className={`mb-2 inline-flex items-center gap-1.5 text-xs font-semibold ${presentation.labelClass}`}
+                      >
+                        <ActivityIcon className="size-3.5" aria-hidden="true" />
+                        <span>{presentation.label}</span>
                       </div>
-                      {onDiscuss ? (
-                        <button
-                          type="button"
-                          onClick={() => onDiscuss(item)}
-                          className="inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-3 text-xs font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        >
-                          <MessageCircle className="size-3.5" aria-hidden="true" />
-                          Discuss
-                        </button>
-                      ) : null}
-                    </div>
-                  </article>
-                </li>
-              ))}
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <SafeSocialText value={item.content} />
+                          <time
+                            dateTime={item.createdAt}
+                            className="mt-1 block text-xs text-social-text-muted"
+                          >
+                            {new Date(item.createdAt).toLocaleString()}
+                          </time>
+                        </div>
+                        {onDiscuss ? (
+                          <button
+                            type="button"
+                            onClick={() => onDiscuss(item)}
+                            className="inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-lg border border-social-border bg-social-surface px-3 text-xs font-semibold text-social-text transition-colors hover:border-social-border-strong hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
+                          >
+                            <MessageCircle className="size-3.5" aria-hidden="true" />
+                            Discuss
+                          </button>
+                        ) : null}
+                      </div>
+                    </article>
+                  </li>
+                );
+              })}
             </ol>
           )}
         </div>
@@ -215,7 +334,7 @@ export default function ActivityPanel({
           <button
             type="button"
             onClick={jumpToLatest}
-            className="absolute bottom-3 left-1/2 z-10 -translate-x-1/2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            className="absolute bottom-3 left-1/2 z-10 -translate-x-1/2 rounded-full border border-social-action bg-social-action px-4 py-2 text-sm font-semibold text-social-action-foreground shadow-lg transition-colors hover:bg-social-action-hover active:bg-social-action-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus focus-visible:ring-offset-2 focus-visible:ring-offset-social-canvas"
           >
             {newActivityCount === 1
               ? '1 new activity item'

--- a/src/components/league/social/ActivityPanel.tsx
+++ b/src/components/league/social/ActivityPanel.tsx
@@ -104,9 +104,13 @@ export default function ActivityPanel({
   return (
     <section
       aria-labelledby="league-activity-heading"
-      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border bg-card text-card-foreground"
+      className={`flex min-h-0 flex-1 flex-col overflow-hidden ${
+        compact
+          ? 'bg-background text-foreground'
+          : 'rounded-2xl border border-border bg-card text-card-foreground'
+      }`}
     >
-      <header className="border-b border-border px-4 py-3">
+      <header className={compact ? 'sr-only' : 'border-b border-border px-4 py-3'}>
         <h2 id="league-activity-heading" className="text-base font-semibold text-foreground">
           League activity
         </h2>
@@ -118,7 +122,7 @@ export default function ActivityPanel({
       <div className="relative min-h-0 flex-1">
         <div
           ref={scrollRef}
-          className={`h-full overflow-y-auto px-4 py-3 ${compact ? 'min-h-0' : 'min-h-64'}`}
+          className={`h-full overflow-y-auto ${compact ? 'min-h-0 px-3 py-2' : 'min-h-64 px-4 py-3'}`}
           aria-busy={loading || loadingEarlier}
           onScroll={(event) => {
             const latestIsVisible = isNearBottom(event.currentTarget);
@@ -166,10 +170,19 @@ export default function ActivityPanel({
               </p>
             </div>
           ) : (
-            <ol className="space-y-3" aria-label="League activity">
+            <ol
+              className={compact ? 'divide-y divide-border' : 'space-y-3'}
+              aria-label="League activity"
+            >
               {activity.map((item) => (
                 <li key={item.id}>
-                  <article className="rounded-xl border border-primary/25 bg-primary/10 px-3 py-3">
+                  <article
+                    className={
+                      compact
+                        ? 'px-1 py-3'
+                        : 'rounded-xl border border-primary/25 bg-primary/10 px-3 py-3'
+                    }
+                  >
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0">
                         <SafeSocialText value={item.content} />

--- a/src/components/league/social/ActivityPanel.tsx
+++ b/src/components/league/social/ActivityPanel.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { MessageCircle } from 'lucide-react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+import type { SocialMessage } from '@/types/social';
+
+import SafeSocialText from './SafeSocialText';
+
+interface ActivityPanelProps {
+  activity: SocialMessage[];
+  hasEarlierActivity: boolean;
+  loading: boolean;
+  loadingEarlier: boolean;
+  error?: string | null;
+  visible?: boolean;
+  compact?: boolean;
+  onRetry: () => Promise<void> | void;
+  onLoadEarlier: () => Promise<void> | void;
+  onLatestVisibleChange?: (visible: boolean) => void;
+  onDiscuss?: (activity: SocialMessage) => void;
+}
+
+const BOTTOM_THRESHOLD_PX = 72;
+
+function isNearBottom(element: HTMLElement): boolean {
+  return element.scrollHeight - element.scrollTop - element.clientHeight <= BOTTOM_THRESHOLD_PX;
+}
+
+export default function ActivityPanel({
+  activity,
+  hasEarlierActivity,
+  loading,
+  loadingEarlier,
+  error,
+  visible = true,
+  compact = false,
+  onRetry,
+  onLoadEarlier,
+  onLatestVisibleChange,
+  onDiscuss,
+}: ActivityPanelProps): React.JSX.Element {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const previousLastIdRef = useRef<string | null>(null);
+  const previousScrollHeightRef = useRef<number | null>(null);
+  const hasInitializedRef = useRef(false);
+  const [newActivityCount, setNewActivityCount] = useState(0);
+  const latestActivity = activity.at(-1);
+
+  useLayoutEffect(() => {
+    const element = scrollRef.current;
+    if (!visible || !element) {
+      onLatestVisibleChange?.(false);
+      return;
+    }
+    onLatestVisibleChange?.(isNearBottom(element));
+  }, [onLatestVisibleChange, visible]);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!visible || !element || !latestActivity) return;
+
+    if (!hasInitializedRef.current) {
+      element.scrollTop = element.scrollHeight;
+      hasInitializedRef.current = true;
+      previousLastIdRef.current = latestActivity.id;
+      onLatestVisibleChange?.(true);
+      return;
+    }
+
+    if (previousLastIdRef.current === latestActivity.id) return;
+    const shouldFollow = isNearBottom(element);
+    previousLastIdRef.current = latestActivity.id;
+    if (shouldFollow) {
+      element.scrollTop = element.scrollHeight;
+      setNewActivityCount(0);
+      onLatestVisibleChange?.(true);
+    } else {
+      setNewActivityCount((count) => count + 1);
+    }
+  }, [latestActivity, onLatestVisibleChange, visible]);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element || previousScrollHeightRef.current === null || loadingEarlier) return;
+    element.scrollTop += element.scrollHeight - previousScrollHeightRef.current;
+    previousScrollHeightRef.current = null;
+  }, [activity.length, loadingEarlier]);
+
+  function handleLoadEarlier(): void {
+    if (scrollRef.current) {
+      previousScrollHeightRef.current = scrollRef.current.scrollHeight;
+    }
+    void onLoadEarlier();
+  }
+
+  function jumpToLatest(): void {
+    const element = scrollRef.current;
+    if (element) element.scrollTop = element.scrollHeight;
+    setNewActivityCount(0);
+    onLatestVisibleChange?.(true);
+  }
+
+  return (
+    <section
+      aria-labelledby="league-activity-heading"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border bg-card text-card-foreground"
+    >
+      <header className="border-b border-border px-4 py-3">
+        <h2 id="league-activity-heading" className="text-base font-semibold text-foreground">
+          League activity
+        </h2>
+        <p className="text-xs text-muted-foreground">
+          Draft picks, transactions, results, and commissioner actions
+        </p>
+      </header>
+
+      <div className="relative min-h-0 flex-1">
+        <div
+          ref={scrollRef}
+          className={`h-full overflow-y-auto px-4 py-3 ${compact ? 'min-h-0' : 'min-h-64'}`}
+          aria-busy={loading || loadingEarlier}
+          onScroll={(event) => {
+            const latestIsVisible = isNearBottom(event.currentTarget);
+            onLatestVisibleChange?.(latestIsVisible);
+            if (latestIsVisible) {
+              setNewActivityCount(0);
+            }
+          }}
+        >
+          {hasEarlierActivity ? (
+            <div className="mb-4 flex justify-center">
+              <button
+                type="button"
+                onClick={handleLoadEarlier}
+                disabled={loadingEarlier}
+                className="inline-flex min-h-9 items-center justify-center rounded-lg border border-border bg-background px-3 text-xs font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+              >
+                {loadingEarlier ? 'Loading…' : 'Load earlier activity'}
+              </button>
+            </div>
+          ) : null}
+
+          {loading && activity.length === 0 ? (
+            <p role="status" className="py-10 text-center text-sm text-muted-foreground">
+              Loading league activity…
+            </p>
+          ) : error && activity.length === 0 ? (
+            <div className="mx-auto max-w-sm rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-center">
+              <p role="alert" className="text-sm font-medium text-destructive">
+                {error}
+              </p>
+              <button
+                type="button"
+                onClick={() => void onRetry()}
+                className="mt-3 inline-flex min-h-9 items-center justify-center rounded-lg border border-border bg-background px-3 text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                Retry
+              </button>
+            </div>
+          ) : activity.length === 0 ? (
+            <div className="py-10 text-center">
+              <p className="text-sm font-semibold text-foreground">No league activity yet</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                League events will appear here as the season progresses.
+              </p>
+            </div>
+          ) : (
+            <ol className="space-y-3" aria-label="League activity">
+              {activity.map((item) => (
+                <li key={item.id}>
+                  <article className="rounded-xl border border-primary/25 bg-primary/10 px-3 py-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <SafeSocialText value={item.content} />
+                        <time
+                          dateTime={item.createdAt}
+                          className="mt-1 block text-xs text-muted-foreground"
+                        >
+                          {new Date(item.createdAt).toLocaleString()}
+                        </time>
+                      </div>
+                      {onDiscuss ? (
+                        <button
+                          type="button"
+                          onClick={() => onDiscuss(item)}
+                          className="inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-3 text-xs font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        >
+                          <MessageCircle className="size-3.5" aria-hidden="true" />
+                          Discuss
+                        </button>
+                      ) : null}
+                    </div>
+                  </article>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+
+        {newActivityCount > 0 ? (
+          <button
+            type="button"
+            onClick={jumpToLatest}
+            className="absolute bottom-3 left-1/2 z-10 -translate-x-1/2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            {newActivityCount === 1
+              ? '1 new activity item'
+              : `${newActivityCount} new activity items`}
+          </button>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/league/social/GiphyMessageMedia.test.tsx
+++ b/src/components/league/social/GiphyMessageMedia.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  gif: vi.fn().mockResolvedValue({
+    data: { id: 'xT9IgG50Fb7Mi0prBC', title: 'Celebration' },
+  }),
+}));
+
+vi.mock('@giphy/react-components', () => ({
+  Gif: ({ width }: { width: number }) => <img src="/gif.gif" alt="" data-width={width} />,
+}));
+
+vi.mock('./giphyClient', () => ({
+  getGiphyClient: () => ({ gif: mocks.gif }),
+}));
+
+import GiphyMessageMedia from './GiphyMessageMedia';
+
+describe('GiphyMessageMedia', () => {
+  beforeAll(() => {
+    HTMLDialogElement.prototype.showModal = function showModal() {
+      this.setAttribute('open', '');
+    };
+    HTMLDialogElement.prototype.close = function close() {
+      this.removeAttribute('open');
+      this.dispatchEvent(new Event('close'));
+    };
+  });
+
+  it('constrains a GIF in the timeline and opens an accessible expanded preview', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <GiphyMessageMedia gif={{ provider: 'giphy', id: 'xT9IgG50Fb7Mi0prBC' }} />
+    );
+
+    const expand = await screen.findByRole('button', { name: 'Expand GIF' });
+    expect(container.querySelector('.max-h-60')).toBeInTheDocument();
+
+    await user.click(expand);
+    expect(screen.getByRole('dialog', { name: 'GIF preview' })).toHaveAttribute('open');
+
+    await user.click(screen.getByRole('button', { name: 'Close GIF preview' }));
+    await waitFor(() => expect(expand).toHaveFocus());
+    expect(screen.queryByRole('dialog', { name: 'GIF preview' })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/league/social/GiphyMessageMedia.test.tsx
+++ b/src/components/league/social/GiphyMessageMedia.test.tsx
@@ -37,9 +37,17 @@ describe('GiphyMessageMedia', () => {
 
     const expand = await screen.findByRole('button', { name: 'Expand GIF' });
     expect(container.querySelector('.max-h-60')).toBeInTheDocument();
+    expect(expand).toHaveClass(
+      'bg-social-surface',
+      'hover:bg-social-brand-soft',
+      'active:bg-social-surface-subtle'
+    );
 
     await user.click(expand);
-    expect(screen.getByRole('dialog', { name: 'GIF preview' })).toHaveAttribute('open');
+    expect(screen.getByRole('dialog', { name: 'GIF preview' })).toHaveClass(
+      'bg-social-surface',
+      'border-social-border'
+    );
 
     await user.click(screen.getByRole('button', { name: 'Close GIF preview' }));
     await waitFor(() => expect(expand).toHaveFocus());

--- a/src/components/league/social/GiphyMessageMedia.tsx
+++ b/src/components/league/social/GiphyMessageMedia.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { Gif } from '@giphy/react-components';
+import { useEffect, useRef, useState } from 'react';
+
+import type { SocialGif } from '@/types/social';
+
+import { getGiphyClient, type GiphyGif } from './giphyClient';
+
+interface GiphyMessageMediaProps {
+  gif: SocialGif;
+}
+
+export default function GiphyMessageMedia({ gif }: GiphyMessageMediaProps): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [resolvedGif, setResolvedGif] = useState<GiphyGif | null>(null);
+  const [width, setWidth] = useState(320);
+  const [failed, setFailed] = useState(false);
+  const giphyUrl = `https://giphy.com/gifs/${encodeURIComponent(gif.id)}`;
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    const updateWidth = () => {
+      setWidth(
+        Math.min(360, Math.max(200, Math.floor(element.getBoundingClientRect().width || 320)))
+      );
+    };
+    updateWidth();
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const client = getGiphyClient();
+    if (!client) {
+      setFailed(true);
+      return;
+    }
+
+    let cancelled = false;
+    setResolvedGif(null);
+    setFailed(false);
+    void client
+      .gif(gif.id)
+      .then(({ data }) => {
+        if (!cancelled) setResolvedGif(data);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [gif.id]);
+
+  return (
+    <div ref={containerRef} className="mt-2 max-w-[22.5rem]">
+      {resolvedGif ? (
+        <Gif gif={resolvedGif} width={width} percentWidth="100%" borderRadius={10} />
+      ) : failed ? (
+        <a
+          href={giphyUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex min-h-10 items-center rounded-lg border border-border bg-muted px-3 text-sm font-semibold text-foreground underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          View GIF on GIPHY
+        </a>
+      ) : (
+        <div
+          role="status"
+          className="flex aspect-video items-center justify-center rounded-xl bg-muted text-sm text-muted-foreground"
+        >
+          Loading GIF…
+        </div>
+      )}
+      {resolvedGif ? (
+        <a
+          href="https://giphy.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-1 block text-right text-[10px] font-bold tracking-wide text-muted-foreground underline-offset-4 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Powered by GIPHY
+        </a>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/league/social/GiphyMessageMedia.tsx
+++ b/src/components/league/social/GiphyMessageMedia.tsx
@@ -77,7 +77,7 @@ export default function GiphyMessageMedia({ gif }: GiphyMessageMediaProps): Reac
     <div ref={containerRef} className="mt-2 max-w-[22.5rem]">
       {resolvedGif ? (
         <>
-          <div className="relative max-h-60 overflow-hidden rounded-xl bg-muted">
+          <div className="relative max-h-60 overflow-hidden rounded-xl bg-social-surface-subtle">
             <div className="max-h-60 overflow-hidden [&_img]:max-h-60 [&_img]:w-full [&_img]:object-cover">
               <Gif gif={resolvedGif} width={width} percentWidth="100%" borderRadius={10} noLink />
             </div>
@@ -85,7 +85,7 @@ export default function GiphyMessageMedia({ gif }: GiphyMessageMediaProps): Reac
               ref={expandButtonRef}
               type="button"
               onClick={() => setExpanded(true)}
-              className="absolute bottom-2 right-2 inline-flex min-h-9 items-center gap-1.5 rounded-full bg-background/90 px-3 text-xs font-semibold text-foreground shadow-sm backdrop-blur transition hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="absolute bottom-2 right-2 inline-flex min-h-9 items-center gap-1.5 rounded-full border border-social-border bg-social-surface px-3 text-xs font-semibold text-social-text shadow-sm transition-colors hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
               aria-label="Expand GIF"
             >
               <Expand className="size-3.5" aria-hidden="true" />
@@ -100,23 +100,23 @@ export default function GiphyMessageMedia({ gif }: GiphyMessageMediaProps): Reac
               setExpanded(false);
               expandButtonRef.current?.focus();
             }}
-            className="m-auto max-h-[90dvh] w-[min(44rem,calc(100vw-2rem))] max-w-none rounded-2xl border border-border bg-background p-0 text-foreground shadow-2xl backdrop:bg-background/80 backdrop:backdrop-blur-sm"
+            className="m-auto max-h-[90dvh] w-[min(44rem,calc(100vw-2rem))] max-w-none rounded-2xl border border-social-border bg-social-surface p-0 text-social-text shadow-2xl backdrop:bg-social-brand-strong/80 backdrop:backdrop-blur-sm"
           >
-            <div className="flex min-h-14 items-center justify-between gap-3 border-b border-border px-4">
+            <div className="flex min-h-14 items-center justify-between gap-3 border-b border-social-border px-4">
               <h2 id={`giphy-preview-${gif.id}`} className="text-sm font-semibold">
                 GIF preview
               </h2>
               <button
                 type="button"
                 onClick={() => setExpanded(false)}
-                className="inline-flex size-10 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="inline-flex size-10 items-center justify-center rounded-full text-social-text-muted transition-colors hover:bg-social-brand-soft hover:text-social-text active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
                 aria-label="Close GIF preview"
               >
                 <X className="size-4" aria-hidden="true" />
               </button>
             </div>
             <div className="max-h-[calc(90dvh-3.5rem)] overflow-auto p-4">
-              <div className="mx-auto max-w-2xl overflow-hidden rounded-xl bg-muted">
+              <div className="mx-auto max-w-2xl overflow-hidden rounded-xl bg-social-surface-subtle">
                 <Gif
                   gif={resolvedGif}
                   width={Math.min(640, Math.max(width, 480))}
@@ -129,7 +129,7 @@ export default function GiphyMessageMedia({ gif }: GiphyMessageMediaProps): Reac
                 href="https://giphy.com/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="mt-2 block text-right text-xs font-bold tracking-wide text-muted-foreground underline-offset-4 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="mt-2 block text-right text-xs font-bold tracking-wide text-social-text-muted underline-offset-4 hover:text-social-text hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
               >
                 Powered by GIPHY
               </a>
@@ -141,14 +141,14 @@ export default function GiphyMessageMedia({ gif }: GiphyMessageMediaProps): Reac
           href={giphyUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex min-h-10 items-center rounded-lg border border-border bg-muted px-3 text-sm font-semibold text-foreground underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="inline-flex min-h-10 items-center rounded-lg border border-social-border bg-social-surface-subtle px-3 text-sm font-semibold text-social-text underline-offset-4 transition-colors hover:bg-social-brand-soft hover:underline active:bg-social-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
         >
           View GIF on GIPHY
         </a>
       ) : (
         <div
           role="status"
-          className="flex aspect-video items-center justify-center rounded-xl bg-muted text-sm text-muted-foreground"
+          className="flex aspect-video items-center justify-center rounded-xl bg-social-surface-subtle text-sm text-social-text-muted"
         >
           Loading GIF…
         </div>
@@ -158,7 +158,7 @@ export default function GiphyMessageMedia({ gif }: GiphyMessageMediaProps): Reac
           href="https://giphy.com/"
           target="_blank"
           rel="noopener noreferrer"
-          className="mt-1 block text-right text-[10px] font-bold tracking-wide text-muted-foreground underline-offset-4 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="mt-1 block text-right text-[10px] font-bold tracking-wide text-social-text-muted underline-offset-4 hover:text-social-text hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
         >
           Powered by GIPHY
         </a>

--- a/src/components/league/social/GiphyMessageMedia.tsx
+++ b/src/components/league/social/GiphyMessageMedia.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Gif } from '@giphy/react-components';
+import { Expand, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import type { SocialGif } from '@/types/social';
@@ -13,9 +14,12 @@ interface GiphyMessageMediaProps {
 
 export default function GiphyMessageMedia({ gif }: GiphyMessageMediaProps): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const expandButtonRef = useRef<HTMLButtonElement>(null);
   const [resolvedGif, setResolvedGif] = useState<GiphyGif | null>(null);
   const [width, setWidth] = useState(320);
   const [failed, setFailed] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   const giphyUrl = `https://giphy.com/gifs/${encodeURIComponent(gif.id)}`;
 
   useEffect(() => {
@@ -59,10 +63,79 @@ export default function GiphyMessageMedia({ gif }: GiphyMessageMediaProps): Reac
     };
   }, [gif.id]);
 
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (expanded && !dialog.open) {
+      dialog.showModal();
+    } else if (!expanded && dialog.open) {
+      dialog.close();
+    }
+  }, [expanded]);
+
   return (
     <div ref={containerRef} className="mt-2 max-w-[22.5rem]">
       {resolvedGif ? (
-        <Gif gif={resolvedGif} width={width} percentWidth="100%" borderRadius={10} />
+        <>
+          <div className="relative max-h-60 overflow-hidden rounded-xl bg-muted">
+            <div className="max-h-60 overflow-hidden [&_img]:max-h-60 [&_img]:w-full [&_img]:object-cover">
+              <Gif gif={resolvedGif} width={width} percentWidth="100%" borderRadius={10} noLink />
+            </div>
+            <button
+              ref={expandButtonRef}
+              type="button"
+              onClick={() => setExpanded(true)}
+              className="absolute bottom-2 right-2 inline-flex min-h-9 items-center gap-1.5 rounded-full bg-background/90 px-3 text-xs font-semibold text-foreground shadow-sm backdrop-blur transition hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label="Expand GIF"
+            >
+              <Expand className="size-3.5" aria-hidden="true" />
+              Expand
+            </button>
+          </div>
+          <dialog
+            ref={dialogRef}
+            aria-labelledby={`giphy-preview-${gif.id}`}
+            onCancel={() => setExpanded(false)}
+            onClose={() => {
+              setExpanded(false);
+              expandButtonRef.current?.focus();
+            }}
+            className="m-auto max-h-[90dvh] w-[min(44rem,calc(100vw-2rem))] max-w-none rounded-2xl border border-border bg-background p-0 text-foreground shadow-2xl backdrop:bg-background/80 backdrop:backdrop-blur-sm"
+          >
+            <div className="flex min-h-14 items-center justify-between gap-3 border-b border-border px-4">
+              <h2 id={`giphy-preview-${gif.id}`} className="text-sm font-semibold">
+                GIF preview
+              </h2>
+              <button
+                type="button"
+                onClick={() => setExpanded(false)}
+                className="inline-flex size-10 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label="Close GIF preview"
+              >
+                <X className="size-4" aria-hidden="true" />
+              </button>
+            </div>
+            <div className="max-h-[calc(90dvh-3.5rem)] overflow-auto p-4">
+              <div className="mx-auto max-w-2xl overflow-hidden rounded-xl bg-muted">
+                <Gif
+                  gif={resolvedGif}
+                  width={Math.min(640, Math.max(width, 480))}
+                  percentWidth="100%"
+                  borderRadius={10}
+                  noLink
+                />
+              </div>
+              <a
+                href="https://giphy.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 block text-right text-xs font-bold tracking-wide text-muted-foreground underline-offset-4 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                Powered by GIPHY
+              </a>
+            </div>
+          </dialog>
+        </>
       ) : failed ? (
         <a
           href={giphyUrl}

--- a/src/components/league/social/GiphyPicker.test.tsx
+++ b/src/components/league/social/GiphyPicker.test.tsx
@@ -78,10 +78,13 @@ describe('GiphyPicker', () => {
 
     await user.click(await screen.findByRole('button', { name: 'Choose celebration' }));
     await waitFor(() =>
-      expect(onSelect).toHaveBeenCalledWith({
-        provider: 'giphy',
-        id: 'xT9IgG50Fb7Mi0prBC',
-      })
+      expect(onSelect).toHaveBeenCalledWith(
+        {
+          provider: 'giphy',
+          id: 'xT9IgG50Fb7Mi0prBC',
+        },
+        expect.stringMatching(/^chat-gif:/)
+      )
     );
     expect(mocks.pingback).toHaveBeenCalledWith({
       analyticsResponsePayload: 'analytics-payload',
@@ -99,9 +102,31 @@ describe('GiphyPicker', () => {
   it('uses an icon-sized trigger in a compact composer', () => {
     render(<GiphyPicker apiKey="test-web-key" compact onSelect={vi.fn()} />);
 
-    expect(screen.getByRole('button', { name: 'Add a GIF' })).toHaveClass(
-      'size-10',
-      'rounded-full'
+    expect(screen.getByRole('button', { name: 'Add a GIF' })).toHaveClass('size-11', 'rounded-lg');
+  });
+
+  it('reuses the same idempotency key when a failed GIF selection is retried', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Temporary failure'))
+      .mockResolvedValueOnce(undefined);
+    render(<GiphyPicker apiKey="test-web-key" onSelect={onSelect} />);
+
+    await user.click(screen.getByRole('button', { name: 'Add a GIF' }));
+    const choice = await screen.findByRole('button', { name: 'Choose celebration' });
+    await user.click(choice);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Unable to send that GIF. Please try again.'
     );
+
+    await user.click(choice);
+    await waitFor(() => expect(onSelect).toHaveBeenCalledTimes(2));
+
+    const firstAttemptKey = onSelect.mock.calls[0]?.[1];
+    const retryAttemptKey = onSelect.mock.calls[1]?.[1];
+    expect(firstAttemptKey).toMatch(/^chat-gif:/);
+    expect(retryAttemptKey).toBe(firstAttemptKey);
   });
 });

--- a/src/components/league/social/GiphyPicker.test.tsx
+++ b/src/components/league/social/GiphyPicker.test.tsx
@@ -95,4 +95,13 @@ describe('GiphyPicker', () => {
     const { container } = render(<GiphyPicker apiKey="" onSelect={vi.fn()} />);
     expect(container).toBeEmptyDOMElement();
   });
+
+  it('uses an icon-sized trigger in a compact composer', () => {
+    render(<GiphyPicker apiKey="test-web-key" compact onSelect={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Add a GIF' })).toHaveClass(
+      'size-10',
+      'rounded-full'
+    );
+  });
 });

--- a/src/components/league/social/GiphyPicker.test.tsx
+++ b/src/components/league/social/GiphyPicker.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { MouseEvent } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  gif: {
+    id: 'xT9IgG50Fb7Mi0prBC',
+    analytics_response_payload: 'analytics-payload',
+  },
+  search: vi.fn(),
+  trending: vi.fn(),
+  gifById: vi.fn(),
+  pingback: vi.fn(),
+}));
+
+vi.mock('@giphy/js-fetch-api', () => ({
+  GiphyFetch: class MockGiphyFetch {
+    search = mocks.search;
+    trending = mocks.trending;
+    gif = mocks.gifById;
+  },
+}));
+
+vi.mock('@giphy/js-analytics', () => ({
+  pingback: mocks.pingback,
+}));
+
+vi.mock('@giphy/react-components', () => ({
+  Grid: ({
+    fetchGifs,
+    onGifClick,
+  }: {
+    fetchGifs: (offset: number) => Promise<unknown>;
+    onGifClick: (gif: typeof mocks.gif, event: MouseEvent<HTMLButtonElement>) => void;
+  }) => (
+    <div>
+      <button type="button" onClick={() => void fetchGifs(0)}>
+        Fetch GIFs
+      </button>
+      <button type="button" onClick={(event) => onGifClick(mocks.gif, event)}>
+        Choose celebration
+      </button>
+    </div>
+  ),
+}));
+
+import GiphyPicker from './GiphyPicker';
+
+describe('GiphyPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.search.mockResolvedValue({ data: [mocks.gif] });
+    mocks.trending.mockResolvedValue({ data: [mocks.gif] });
+  });
+
+  it('searches G-rated GIFs, sends a selection, and registers sent analytics', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn().mockResolvedValue(undefined);
+    render(<GiphyPicker apiKey="test-web-key" onSelect={onSelect} />);
+
+    const trigger = screen.getByRole('button', { name: 'Add a GIF' });
+    await user.click(trigger);
+    expect(screen.getByRole('dialog', { name: 'Choose a GIF' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Powered by GIPHY' })).toBeInTheDocument();
+
+    await user.type(screen.getByRole('searchbox', { name: 'Search GIPHY' }), 'celebration');
+    await user.click(screen.getByRole('button', { name: 'Search GIFs' }));
+
+    await waitFor(() =>
+      expect(mocks.search).toHaveBeenCalledWith('celebration', {
+        offset: 0,
+        limit: 20,
+        rating: 'g',
+        type: 'gifs',
+      })
+    );
+
+    await user.click(await screen.findByRole('button', { name: 'Choose celebration' }));
+    await waitFor(() =>
+      expect(onSelect).toHaveBeenCalledWith({
+        provider: 'giphy',
+        id: 'xT9IgG50Fb7Mi0prBC',
+      })
+    );
+    expect(mocks.pingback).toHaveBeenCalledWith({
+      analyticsResponsePayload: 'analytics-payload',
+      actionType: 'SENT',
+    });
+    await waitFor(() => expect(trigger).toHaveFocus());
+    expect(screen.queryByRole('dialog', { name: 'Choose a GIF' })).not.toBeInTheDocument();
+  });
+
+  it('stays hidden when the chat-specific Web SDK key is not configured', () => {
+    const { container } = render(<GiphyPicker apiKey="" onSelect={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/league/social/GiphyPicker.test.tsx
+++ b/src/components/league/social/GiphyPicker.test.tsx
@@ -102,7 +102,12 @@ describe('GiphyPicker', () => {
   it('uses an icon-sized trigger in a compact composer', () => {
     render(<GiphyPicker apiKey="test-web-key" compact onSelect={vi.fn()} />);
 
-    expect(screen.getByRole('button', { name: 'Add a GIF' })).toHaveClass('size-11', 'rounded-lg');
+    expect(screen.getByRole('button', { name: 'Add a GIF' })).toHaveClass(
+      'size-11',
+      'rounded-lg',
+      'text-social-text-muted',
+      'hover:bg-social-brand-soft'
+    );
   });
 
   it('reuses the same idempotency key when a failed GIF selection is retried', async () => {

--- a/src/components/league/social/GiphyPicker.test.tsx
+++ b/src/components/league/social/GiphyPicker.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { MouseEvent } from 'react';
+import type { FormEvent, MouseEvent } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -92,6 +92,40 @@ describe('GiphyPicker', () => {
     });
     await waitFor(() => expect(trigger).toHaveFocus());
     expect(screen.queryByRole('dialog', { name: 'Choose a GIF' })).not.toBeInTheDocument();
+  });
+
+  it('searches by button or Enter without submitting a host message form', async () => {
+    const user = userEvent.setup();
+    const onHostSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => event.preventDefault());
+    const { container } = render(
+      <form aria-label="Message composer" onSubmit={onHostSubmit}>
+        <textarea aria-label="Message draft" defaultValue="Keep this draft unsent" />
+        <GiphyPicker apiKey="test-web-key" onSelect={vi.fn().mockResolvedValue(undefined)} />
+        <button type="submit">Send message</button>
+      </form>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add a GIF' }));
+    const search = screen.getByRole('searchbox', { name: 'Search GIPHY' });
+    const searchRegion = screen.getByRole('search');
+
+    expect(searchRegion.tagName).toBe('DIV');
+    expect(container.querySelector('form form')).not.toBeInTheDocument();
+
+    await user.type(search, 'celebration');
+    await user.click(screen.getByRole('button', { name: 'Search GIFs' }));
+    await waitFor(() =>
+      expect(mocks.search).toHaveBeenCalledWith('celebration', expect.anything())
+    );
+    expect(onHostSubmit).not.toHaveBeenCalled();
+
+    await user.clear(search);
+    await user.type(search, 'victory{Enter}');
+    await waitFor(() => expect(mocks.search).toHaveBeenCalledWith('victory', expect.anything()));
+    expect(onHostSubmit).not.toHaveBeenCalled();
+    expect(screen.getByRole('textbox', { name: 'Message draft' })).toHaveValue(
+      'Keep this draft unsent'
+    );
   });
 
   it('stays hidden when the chat-specific Web SDK key is not configured', () => {

--- a/src/components/league/social/GiphyPicker.tsx
+++ b/src/components/league/social/GiphyPicker.tsx
@@ -2,7 +2,15 @@
 
 import { Grid } from '@giphy/react-components';
 import { ImagePlus, Search, X } from 'lucide-react';
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
 
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import type { SocialGif } from '@/types/social';
@@ -139,10 +147,16 @@ export default function GiphyPicker({
 
   if (!client || !fetchGifs) return null;
 
-  function handleSearch(event: FormEvent<HTMLFormElement>): void {
-    event.preventDefault();
+  function handleSearch(): void {
     setError(null);
     setSearchTerm(searchDraft.trim().slice(0, 50));
+  }
+
+  function handleSearchKeyDown(event: ReactKeyboardEvent<HTMLInputElement>): void {
+    if (event.key !== 'Enter' || event.nativeEvent.isComposing) return;
+    event.preventDefault();
+    event.stopPropagation();
+    handleSearch();
   }
 
   return (
@@ -168,7 +182,7 @@ export default function GiphyPicker({
           aria-busy={selectionPending}
           className="bottom-full top-auto mb-2 mt-0 w-[min(24rem,calc(100vw-2rem))] border-social-border bg-social-surface p-3 text-social-text"
         >
-          <form className="flex items-center gap-2" onSubmit={handleSearch} role="search">
+          <div className="flex items-center gap-2" role="search">
             <label htmlFor={searchId} className="sr-only">
               Search GIPHY
             </label>
@@ -178,13 +192,15 @@ export default function GiphyPicker({
               type="search"
               value={searchDraft}
               onChange={(event) => setSearchDraft(event.target.value)}
+              onKeyDown={handleSearchKeyDown}
               maxLength={50}
               placeholder="Search GIPHY"
               className="min-h-10 min-w-0 flex-1 rounded-lg border border-social-border bg-social-surface px-3 text-sm text-social-text outline-none placeholder:text-social-text-muted focus-visible:border-social-action focus-visible:ring-2 focus-visible:ring-social-focus"
             />
             <button
-              type="submit"
+              type="button"
               aria-label="Search GIFs"
+              onClick={handleSearch}
               className="inline-flex size-10 shrink-0 items-center justify-center rounded-lg border border-social-action bg-social-action text-social-action-foreground transition-colors hover:border-social-action-hover hover:bg-social-action-hover active:border-social-action-pressed active:bg-social-action-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus focus-visible:ring-offset-2 focus-visible:ring-offset-social-surface"
             >
               <Search className="size-4" aria-hidden="true" />
@@ -204,7 +220,7 @@ export default function GiphyPicker({
                 <X className="size-4" aria-hidden="true" />
               </button>
             ) : null}
-          </form>
+          </div>
 
           <p className="mt-2 text-xs font-medium text-social-text-muted">
             {searchTerm ? `Results for “${searchTerm}”` : 'Trending GIFs'}

--- a/src/components/league/social/GiphyPicker.tsx
+++ b/src/components/league/social/GiphyPicker.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { Grid } from '@giphy/react-components';
+import { ImagePlus, Search, X } from 'lucide-react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
+
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import type { SocialGif } from '@/types/social';
+
+import { GIPHY_WEB_SDK_KEY, getGiphyClient, type GiphyGif, registerGiphySent } from './giphyClient';
+
+interface GiphyPickerProps {
+  disabled?: boolean;
+  onSelect: (gif: SocialGif) => Promise<void>;
+  apiKey?: string;
+}
+
+const PICKER_RESULT_LIMIT = 20;
+
+export default function GiphyPicker({
+  disabled = false,
+  onSelect,
+  apiKey = GIPHY_WEB_SDK_KEY,
+}: GiphyPickerProps): React.JSX.Element | null {
+  const client = useMemo(() => getGiphyClient(apiKey), [apiKey]);
+  const searchId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [searchDraft, setSearchDraft] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [gridWidth, setGridWidth] = useState(320);
+  const [initialGifs, setInitialGifs] = useState<GiphyGif[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectionPending, setSelectionPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const element = gridRef.current;
+    if (!open || !element) return;
+
+    const updateWidth = () => {
+      setGridWidth(Math.max(240, Math.floor(element.getBoundingClientRect().width || 320)));
+    };
+    updateWidth();
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [open]);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    window.requestAnimationFrame(() => {
+      if (nextOpen) {
+        searchRef.current?.focus();
+      } else {
+        rootRef.current?.querySelector<HTMLButtonElement>('[data-giphy-trigger]')?.focus();
+      }
+    });
+  }, []);
+
+  const fetchGifs = useMemo(() => {
+    if (!client) return null;
+    return (offset: number) =>
+      searchTerm
+        ? client.search(searchTerm, {
+            offset,
+            limit: PICKER_RESULT_LIMIT,
+            rating: 'g',
+            type: 'gifs',
+          })
+        : client.trending({
+            offset,
+            limit: PICKER_RESULT_LIMIT,
+            rating: 'g',
+            type: 'gifs',
+          });
+  }, [client, searchTerm]);
+
+  useEffect(() => {
+    if (!open || !fetchGifs) return;
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void fetchGifs(0)
+      .then(({ data }) => {
+        if (!cancelled) setInitialGifs(data);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setInitialGifs([]);
+          setError('GIPHY is unavailable right now.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchGifs, open]);
+
+  const selectGif = useCallback(
+    async (gif: GiphyGif) => {
+      if (selectionPending) return;
+      setSelectionPending(true);
+      setError(null);
+      try {
+        await onSelect({ provider: 'giphy', id: String(gif.id) });
+        registerGiphySent(gif);
+        handleOpenChange(false);
+      } catch {
+        setError('Unable to send that GIF. Please try again.');
+      } finally {
+        setSelectionPending(false);
+      }
+    },
+    [handleOpenChange, onSelect, selectionPending]
+  );
+
+  if (!client || !fetchGifs) return null;
+
+  function handleSearch(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    setError(null);
+    setSearchTerm(searchDraft.trim().slice(0, 50));
+  }
+
+  return (
+    <div ref={rootRef} className="relative mb-2">
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <PopoverTrigger
+          data-giphy-trigger
+          disabled={disabled}
+          aria-label="Add a GIF"
+          className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-semibold text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <ImagePlus className="size-4" aria-hidden="true" />
+          GIF
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          aria-label="Choose a GIF"
+          aria-busy={selectionPending}
+          className="bottom-full top-auto mb-2 mt-0 w-[min(24rem,calc(100vw-2rem))] p-3"
+        >
+          <form className="flex items-center gap-2" onSubmit={handleSearch} role="search">
+            <label htmlFor={searchId} className="sr-only">
+              Search GIPHY
+            </label>
+            <input
+              ref={searchRef}
+              id={searchId}
+              type="search"
+              value={searchDraft}
+              onChange={(event) => setSearchDraft(event.target.value)}
+              maxLength={50}
+              placeholder="Search GIPHY"
+              className="min-h-10 min-w-0 flex-1 rounded-lg border border-border bg-background px-3 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <button
+              type="submit"
+              aria-label="Search GIFs"
+              className="inline-flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <Search className="size-4" aria-hidden="true" />
+            </button>
+            {searchTerm ? (
+              <button
+                type="button"
+                aria-label="Clear GIF search"
+                onClick={() => {
+                  setSearchDraft('');
+                  setSearchTerm('');
+                  setError(null);
+                  searchRef.current?.focus();
+                }}
+                className="inline-flex size-10 shrink-0 items-center justify-center rounded-lg border border-border text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <X className="size-4" aria-hidden="true" />
+              </button>
+            ) : null}
+          </form>
+
+          <p className="mt-2 text-xs font-medium text-muted-foreground">
+            {searchTerm ? `Results for “${searchTerm}”` : 'Trending GIFs'}
+          </p>
+
+          <div
+            ref={gridRef}
+            className="mt-2 max-h-80 min-h-48 overflow-y-auto rounded-lg bg-muted/30"
+          >
+            {loading ? (
+              <p role="status" className="py-16 text-center text-sm text-muted-foreground">
+                Loading GIFs…
+              </p>
+            ) : initialGifs.length === 0 ? (
+              <p className="py-16 text-center text-sm text-muted-foreground">No GIFs found</p>
+            ) : (
+              <Grid
+                key={searchTerm || 'trending'}
+                width={gridWidth}
+                columns={gridWidth < 300 ? 2 : 3}
+                gutter={6}
+                fetchGifs={fetchGifs}
+                initialGifs={initialGifs}
+                noLink
+                tabIndex={selectionPending ? -1 : 0}
+                noResultsMessage="No GIFs found"
+                onGifsFetchError={() => setError('GIPHY is unavailable right now.')}
+                onGifClick={(gif, event) => {
+                  event.preventDefault();
+                  void selectGif(gif);
+                }}
+                onGifKeyPress={(gif, event) => {
+                  const key = (event.nativeEvent as KeyboardEvent).key;
+                  if (key !== 'Enter' && key !== ' ') return;
+                  event.preventDefault();
+                  void selectGif(gif);
+                }}
+              />
+            )}
+          </div>
+
+          {error ? (
+            <p role="alert" className="mt-2 text-sm font-medium text-destructive">
+              {error}
+            </p>
+          ) : null}
+
+          <a
+            href="https://giphy.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-3 block text-right text-xs font-bold tracking-wide text-foreground underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Powered by GIPHY
+          </a>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/league/social/GiphyPicker.tsx
+++ b/src/components/league/social/GiphyPicker.tsx
@@ -155,8 +155,8 @@ export default function GiphyPicker({
           aria-label="Add a GIF"
           className={
             compact
-              ? 'inline-flex size-11 items-center justify-center rounded-lg text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40'
-              : 'inline-flex min-h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-semibold text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50'
+              ? 'inline-flex size-11 items-center justify-center rounded-lg text-social-text-muted transition-colors hover:bg-social-brand-soft hover:text-social-text active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:bg-social-disabled-bg disabled:text-social-disabled-text'
+              : 'inline-flex min-h-10 items-center gap-2 rounded-lg border border-social-border bg-social-surface px-3 text-sm font-semibold text-social-text transition-colors hover:border-social-action hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:bg-social-disabled-bg disabled:text-social-disabled-text'
           }
         >
           <ImagePlus className="size-4" aria-hidden="true" />
@@ -166,7 +166,7 @@ export default function GiphyPicker({
           align="start"
           aria-label="Choose a GIF"
           aria-busy={selectionPending}
-          className="bottom-full top-auto mb-2 mt-0 w-[min(24rem,calc(100vw-2rem))] p-3"
+          className="bottom-full top-auto mb-2 mt-0 w-[min(24rem,calc(100vw-2rem))] border-social-border bg-social-surface p-3 text-social-text"
         >
           <form className="flex items-center gap-2" onSubmit={handleSearch} role="search">
             <label htmlFor={searchId} className="sr-only">
@@ -180,12 +180,12 @@ export default function GiphyPicker({
               onChange={(event) => setSearchDraft(event.target.value)}
               maxLength={50}
               placeholder="Search GIPHY"
-              className="min-h-10 min-w-0 flex-1 rounded-lg border border-border bg-background px-3 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+              className="min-h-10 min-w-0 flex-1 rounded-lg border border-social-border bg-social-surface px-3 text-sm text-social-text outline-none placeholder:text-social-text-muted focus-visible:border-social-action focus-visible:ring-2 focus-visible:ring-social-focus"
             />
             <button
               type="submit"
               aria-label="Search GIFs"
-              className="inline-flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="inline-flex size-10 shrink-0 items-center justify-center rounded-lg border border-social-action bg-social-action text-social-action-foreground transition-colors hover:border-social-action-hover hover:bg-social-action-hover active:border-social-action-pressed active:bg-social-action-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus focus-visible:ring-offset-2 focus-visible:ring-offset-social-surface"
             >
               <Search className="size-4" aria-hidden="true" />
             </button>
@@ -199,27 +199,27 @@ export default function GiphyPicker({
                   setError(null);
                   searchRef.current?.focus();
                 }}
-                className="inline-flex size-10 shrink-0 items-center justify-center rounded-lg border border-border text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="inline-flex size-10 shrink-0 items-center justify-center rounded-lg border border-social-border text-social-text-muted transition-colors hover:border-social-border-strong hover:bg-social-brand-soft hover:text-social-text active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
               >
                 <X className="size-4" aria-hidden="true" />
               </button>
             ) : null}
           </form>
 
-          <p className="mt-2 text-xs font-medium text-muted-foreground">
+          <p className="mt-2 text-xs font-medium text-social-text-muted">
             {searchTerm ? `Results for “${searchTerm}”` : 'Trending GIFs'}
           </p>
 
           <div
             ref={gridRef}
-            className="mt-2 max-h-80 min-h-48 overflow-y-auto rounded-lg bg-muted/30"
+            className="mt-2 max-h-80 min-h-48 overflow-y-auto rounded-lg bg-social-surface-subtle"
           >
             {loading ? (
-              <p role="status" className="py-16 text-center text-sm text-muted-foreground">
+              <p role="status" className="py-16 text-center text-sm text-social-text-muted">
                 Loading GIFs…
               </p>
             ) : initialGifs.length === 0 ? (
-              <p className="py-16 text-center text-sm text-muted-foreground">No GIFs found</p>
+              <p className="py-16 text-center text-sm text-social-text-muted">No GIFs found</p>
             ) : (
               <Grid
                 key={searchTerm || 'trending'}
@@ -247,7 +247,7 @@ export default function GiphyPicker({
           </div>
 
           {error ? (
-            <p role="alert" className="mt-2 text-sm font-medium text-destructive">
+            <p role="alert" className="mt-2 text-sm font-medium text-social-error">
               {error}
             </p>
           ) : null}
@@ -256,7 +256,7 @@ export default function GiphyPicker({
             href="https://giphy.com/"
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-3 block text-right text-xs font-bold tracking-wide text-foreground underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="mt-3 block rounded-sm text-right text-xs font-bold tracking-wide text-social-text underline-offset-4 hover:text-social-action hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
           >
             Powered by GIPHY
           </a>

--- a/src/components/league/social/GiphyPicker.tsx
+++ b/src/components/league/social/GiphyPicker.tsx
@@ -13,6 +13,7 @@ interface GiphyPickerProps {
   disabled?: boolean;
   onSelect: (gif: SocialGif) => Promise<void>;
   apiKey?: string;
+  compact?: boolean;
 }
 
 const PICKER_RESULT_LIMIT = 20;
@@ -21,6 +22,7 @@ export default function GiphyPicker({
   disabled = false,
   onSelect,
   apiKey = GIPHY_WEB_SDK_KEY,
+  compact = false,
 }: GiphyPickerProps): React.JSX.Element | null {
   const client = useMemo(() => getGiphyClient(apiKey), [apiKey]);
   const searchId = useId();
@@ -132,16 +134,21 @@ export default function GiphyPicker({
   }
 
   return (
-    <div ref={rootRef} className="relative mb-2">
+    <div ref={rootRef} className={compact ? 'relative' : 'relative mb-2'}>
       <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger
+          type="button"
           data-giphy-trigger
           disabled={disabled}
           aria-label="Add a GIF"
-          className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-semibold text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          className={
+            compact
+              ? 'inline-flex size-10 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40'
+              : 'inline-flex min-h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-semibold text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50'
+          }
         >
           <ImagePlus className="size-4" aria-hidden="true" />
-          GIF
+          {compact ? <span className="sr-only">GIF</span> : 'GIF'}
         </PopoverTrigger>
         <PopoverContent
           align="start"

--- a/src/components/league/social/GiphyPicker.tsx
+++ b/src/components/league/social/GiphyPicker.tsx
@@ -8,10 +8,11 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import type { SocialGif } from '@/types/social';
 
 import { GIPHY_WEB_SDK_KEY, getGiphyClient, type GiphyGif, registerGiphySent } from './giphyClient';
+import { createSocialComposerAttemptKey } from './socialComposerDraft';
 
 interface GiphyPickerProps {
   disabled?: boolean;
-  onSelect: (gif: SocialGif) => Promise<void>;
+  onSelect: (gif: SocialGif, idempotencyKey: string) => Promise<void>;
   apiKey?: string;
   compact?: boolean;
 }
@@ -29,6 +30,7 @@ export default function GiphyPicker({
   const rootRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
+  const selectionAttemptRef = useRef<{ gifId: string; idempotencyKey: string } | null>(null);
   const [open, setOpen] = useState(false);
   const [searchDraft, setSearchDraft] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
@@ -110,11 +112,21 @@ export default function GiphyPicker({
   const selectGif = useCallback(
     async (gif: GiphyGif) => {
       if (selectionPending) return;
+      const gifId = String(gif.id);
+      const attempt =
+        selectionAttemptRef.current?.gifId === gifId
+          ? selectionAttemptRef.current
+          : {
+              gifId,
+              idempotencyKey: createSocialComposerAttemptKey('chat-gif'),
+            };
+      selectionAttemptRef.current = attempt;
       setSelectionPending(true);
       setError(null);
       try {
-        await onSelect({ provider: 'giphy', id: String(gif.id) });
+        await onSelect({ provider: 'giphy', id: gifId }, attempt.idempotencyKey);
         registerGiphySent(gif);
+        selectionAttemptRef.current = null;
         handleOpenChange(false);
       } catch {
         setError('Unable to send that GIF. Please try again.');
@@ -143,7 +155,7 @@ export default function GiphyPicker({
           aria-label="Add a GIF"
           className={
             compact
-              ? 'inline-flex size-10 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40'
+              ? 'inline-flex size-11 items-center justify-center rounded-lg text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40'
               : 'inline-flex min-h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-semibold text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50'
           }
         >

--- a/src/components/league/social/LeagueChatPanel.test.tsx
+++ b/src/components/league/social/LeagueChatPanel.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SocialMessage } from '@/types/social';
+
+import LeagueChatPanel from './LeagueChatPanel';
+
+const memberMessage: SocialMessage = {
+  id: 'message-1',
+  leagueId: 'league-1',
+  seasonId: 'season-1',
+  type: 'member',
+  content: 'Review https://statly.dev/trade before voting.',
+  author: {
+    userId: 'user-1',
+    memberId: 'member-1',
+    displayName: 'Alex Smith',
+    teamName: 'Smith Squad',
+  },
+  createdAt: '2026-07-19T10:00:00.000Z',
+  moderationStatus: 'active',
+  isOwn: false,
+};
+
+const systemMessage: SocialMessage = {
+  ...memberMessage,
+  id: 'message-2',
+  type: 'system',
+  content: 'Player drafted',
+  author: null,
+  createdAt: '2026-07-19T10:01:00.000Z',
+};
+
+function renderPanel(messages: SocialMessage[] = []) {
+  return render(
+    <LeagueChatPanel
+      messages={messages}
+      hasEarlierMessages={false}
+      loading={false}
+      loadingEarlier={false}
+      sending={false}
+      canPublish
+      canManage={false}
+      onRetry={vi.fn()}
+      onLoadEarlier={vi.fn()}
+      onSend={vi.fn()}
+      onReport={vi.fn()}
+      onRemove={vi.fn()}
+    />
+  );
+}
+
+describe('LeagueChatPanel', () => {
+  it('renders the empty state and an accessible composer', () => {
+    renderPanel();
+    expect(screen.getByText('No messages yet')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Message league chat' })).toHaveAttribute(
+      'maxlength',
+      '1000'
+    );
+  });
+
+  it('renders safe external links and distinguishes system activity', () => {
+    renderPanel([memberMessage, systemMessage]);
+    expect(screen.getByRole('link', { name: 'https://statly.dev/trade' })).toHaveAttribute(
+      'rel',
+      'noopener noreferrer'
+    );
+    expect(screen.getByText('League activity')).toBeInTheDocument();
+    expect(screen.getByText('Alex Smith')).toBeInTheDocument();
+    expect(screen.getByText('Smith Squad')).toBeInTheDocument();
+  });
+});

--- a/src/components/league/social/LeagueChatPanel.test.tsx
+++ b/src/components/league/social/LeagueChatPanel.test.tsx
@@ -32,6 +32,13 @@ const systemMessage: SocialMessage = {
   createdAt: '2026-07-19T10:01:00.000Z',
 };
 
+const gifMessage: SocialMessage = {
+  ...memberMessage,
+  id: 'message-giphy',
+  content: '',
+  gif: { provider: 'giphy', id: 'xT9IgG50Fb7Mi0prBC' },
+};
+
 function renderPanel(messages: SocialMessage[] = []) {
   return render(
     <LeagueChatPanel
@@ -72,6 +79,28 @@ describe('LeagueChatPanel', () => {
     expect(screen.getByText('Smith Squad')).toBeInTheDocument();
   });
 
+  it('renders a durable GIPHY fallback when the Web SDK key is not configured', async () => {
+    renderPanel([gifMessage]);
+
+    expect(await screen.findByRole('link', { name: 'View GIF on GIPHY' })).toHaveAttribute(
+      'href',
+      'https://giphy.com/gifs/xT9IgG50Fb7Mi0prBC'
+    );
+  });
+
+  it('does not resolve or render GIF media after a message is removed', () => {
+    renderPanel([
+      {
+        ...gifMessage,
+        deletedAt: '2026-07-19T10:05:00.000Z',
+        moderationStatus: 'removed',
+      },
+    ]);
+
+    expect(screen.getByText('Message removed')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /GIF/i })).not.toBeInTheDocument();
+  });
+
   it('sends and clears structured discussion context only after a successful message', async () => {
     const onSend = vi.fn().mockResolvedValue(undefined);
     const onClearComposerContext = vi.fn();
@@ -104,10 +133,10 @@ describe('LeagueChatPanel', () => {
     await user.type(screen.getByRole('textbox', { name: 'Message league chat' }), 'Worth a look');
     await user.keyboard('{Enter}');
 
-    expect(onSend).toHaveBeenCalledWith(
-      'Worth a look',
-      expect.objectContaining({ type: 'player', id: 'player-1' })
-    );
+    expect(onSend).toHaveBeenCalledWith({
+      content: 'Worth a look',
+      context: expect.objectContaining({ type: 'player', id: 'player-1' }),
+    });
     expect(onClearComposerContext).toHaveBeenCalledTimes(1);
     expect(screen.getByText('Jordan Example')).toBeInTheDocument();
     expect(screen.getByText('Available')).toBeInTheDocument();

--- a/src/components/league/social/LeagueChatPanel.test.tsx
+++ b/src/components/league/social/LeagueChatPanel.test.tsx
@@ -151,9 +151,91 @@ describe('LeagueChatPanel', () => {
     expect(onSend).toHaveBeenCalledWith({
       content: 'Worth a look',
       context: expect.objectContaining({ type: 'player', id: 'player-1' }),
+      idempotencyKey: expect.stringMatching(/^chat:/),
     });
     expect(onClearComposerContext).toHaveBeenCalledTimes(1);
     expect(screen.getByText('Jordan Example')).toBeInTheDocument();
     expect(screen.getByText('Available')).toBeInTheDocument();
+  });
+
+  it('shows a read-only explanation without composer affordances before standards acceptance', () => {
+    render(
+      <LeagueChatPanel
+        messages={[]}
+        hasEarlierMessages={false}
+        loading={false}
+        loadingEarlier={false}
+        sending={false}
+        canPublish={false}
+        canManage={false}
+        onRetry={vi.fn()}
+        onLoadEarlier={vi.fn()}
+        onSend={vi.fn()}
+        onReport={vi.fn()}
+        onRemove={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Accept the community standards above before sending messages.'
+    );
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add a GIF' })).not.toBeInTheDocument();
+  });
+
+  it('shows a read-only mute explanation without a disabled composer', () => {
+    const mutedUntil = '2099-01-01T00:00:00.000Z';
+    render(
+      <LeagueChatPanel
+        messages={[]}
+        hasEarlierMessages={false}
+        loading={false}
+        loadingEarlier={false}
+        sending={false}
+        canPublish
+        canManage={false}
+        mutedUntil={mutedUntil}
+        onRetry={vi.fn()}
+        onLoadEarlier={vi.fn()}
+        onSend={vi.fn()}
+        onReport={vi.fn()}
+        onRemove={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'You can read chat, but cannot send until'
+    );
+    expect(screen.getByRole('time')).toHaveAttribute('datetime', mutedUntil);
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('lets a member dismiss a send error and returns focus to the composer', async () => {
+    const user = userEvent.setup();
+    const onDismissSubmitError = vi.fn();
+    render(
+      <LeagueChatPanel
+        messages={[]}
+        hasEarlierMessages={false}
+        loading={false}
+        loadingEarlier={false}
+        sending={false}
+        canPublish
+        canManage={false}
+        submitError="Connection interrupted"
+        onDismissSubmitError={onDismissSubmitError}
+        onRetry={vi.fn()}
+        onLoadEarlier={vi.fn()}
+        onSend={vi.fn()}
+        onReport={vi.fn()}
+        onRemove={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss send error' }));
+
+    expect(onDismissSubmitError).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Message league chat' })).toHaveFocus();
   });
 });

--- a/src/components/league/social/LeagueChatPanel.test.tsx
+++ b/src/components/league/social/LeagueChatPanel.test.tsx
@@ -79,6 +79,21 @@ describe('LeagueChatPanel', () => {
     expect(screen.getByText('Smith Squad')).toBeInTheDocument();
   });
 
+  it('groups consecutive messages from the same author into one identity block', () => {
+    renderPanel([
+      memberMessage,
+      {
+        ...memberMessage,
+        id: 'message-follow-up',
+        content: 'One more detail.',
+        createdAt: '2026-07-19T10:02:00.000Z',
+      },
+    ]);
+
+    expect(screen.getAllByText('Alex Smith')).toHaveLength(1);
+    expect(screen.getByText('One more detail.')).toBeInTheDocument();
+  });
+
   it('renders a durable GIPHY fallback when the Web SDK key is not configured', async () => {
     renderPanel([gifMessage]);
 

--- a/src/components/league/social/LeagueChatPanel.test.tsx
+++ b/src/components/league/social/LeagueChatPanel.test.tsx
@@ -94,6 +94,29 @@ describe('LeagueChatPanel', () => {
     expect(screen.getByText('One more detail.')).toBeInTheDocument();
   });
 
+  it('uses restrained semantic surfaces for mentions and the current member', () => {
+    renderPanel([
+      { ...memberMessage, content: '@Alex please review this.' },
+      {
+        ...memberMessage,
+        id: 'message-own',
+        content: 'I will take a look.',
+        createdAt: '2026-07-19T10:02:00.000Z',
+        isOwn: true,
+      },
+    ]);
+
+    const [mention, ownMessage] = screen.getAllByRole('article');
+    expect(mention).toHaveAccessibleName('Message containing a mention from Alex Smith');
+    expect(mention).toHaveClass(
+      'border-social-warning',
+      'bg-social-mention-bg',
+      'text-social-mention-text'
+    );
+    expect(screen.getByText('Mention')).toBeInTheDocument();
+    expect(ownMessage).toHaveClass('border-social-action', 'bg-social-brand-soft');
+  });
+
   it('renders a durable GIPHY fallback when the Web SDK key is not configured', async () => {
     renderPanel([gifMessage]);
 

--- a/src/components/league/social/LeagueChatPanel.test.tsx
+++ b/src/components/league/social/LeagueChatPanel.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { SocialMessage } from '@/types/social';
@@ -60,14 +61,55 @@ describe('LeagueChatPanel', () => {
     );
   });
 
-  it('renders safe external links and distinguishes system activity', () => {
+  it('renders safe external links and keeps system activity out of member chat', () => {
     renderPanel([memberMessage, systemMessage]);
     expect(screen.getByRole('link', { name: 'https://statly.dev/trade' })).toHaveAttribute(
       'rel',
       'noopener noreferrer'
     );
-    expect(screen.getByText('League activity')).toBeInTheDocument();
+    expect(screen.queryByText('Player drafted')).not.toBeInTheDocument();
     expect(screen.getByText('Alex Smith')).toBeInTheDocument();
     expect(screen.getByText('Smith Squad')).toBeInTheDocument();
+  });
+
+  it('sends and clears structured discussion context only after a successful message', async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    const onClearComposerContext = vi.fn();
+    render(
+      <LeagueChatPanel
+        messages={[]}
+        hasEarlierMessages={false}
+        loading={false}
+        loadingEarlier={false}
+        sending={false}
+        canPublish
+        canManage={false}
+        composerContext={{
+          type: 'player',
+          id: 'player-1',
+          title: 'Jordan Example',
+          subtitle: 'MID · Statly United',
+          metadata: { status: 'Available' },
+        }}
+        onClearComposerContext={onClearComposerContext}
+        onRetry={vi.fn()}
+        onLoadEarlier={vi.fn()}
+        onSend={onSend}
+        onReport={vi.fn()}
+        onRemove={vi.fn()}
+      />
+    );
+
+    const user = userEvent.setup();
+    await user.type(screen.getByRole('textbox', { name: 'Message league chat' }), 'Worth a look');
+    await user.keyboard('{Enter}');
+
+    expect(onSend).toHaveBeenCalledWith(
+      'Worth a look',
+      expect.objectContaining({ type: 'player', id: 'player-1' })
+    );
+    expect(onClearComposerContext).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Jordan Example')).toBeInTheDocument();
+    expect(screen.getByText('Available')).toBeInTheDocument();
   });
 });

--- a/src/components/league/social/LeagueChatPanel.tsx
+++ b/src/components/league/social/LeagueChatPanel.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { X } from 'lucide-react';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
-import type { SocialMessage, SocialReportReason } from '@/types/social';
+import type { SocialDiscussionContext, SocialMessage, SocialReportReason } from '@/types/social';
 
 import SafeSocialText from './SafeSocialText';
 import SocialAuthor from './SocialAuthor';
@@ -21,9 +22,14 @@ interface LeagueChatPanelProps {
   mutedUntil?: string | null;
   error?: string | null;
   submitError?: string | null;
+  visible?: boolean;
+  compact?: boolean;
+  composerContext?: SocialDiscussionContext | null;
+  onClearComposerContext?: () => void;
+  onLatestVisibleChange?: (visible: boolean) => void;
   onRetry: () => Promise<void> | void;
   onLoadEarlier: () => Promise<void> | void;
-  onSend: (content: string) => Promise<void>;
+  onSend: (content: string, context?: SocialDiscussionContext | null) => Promise<void>;
   onReport: (messageId: string, reason: SocialReportReason, details?: string) => Promise<void>;
   onRemove: (messageId: string, reason: string) => Promise<void>;
 }
@@ -51,6 +57,11 @@ export default function LeagueChatPanel({
   mutedUntil,
   error,
   submitError,
+  visible = true,
+  compact = false,
+  composerContext,
+  onClearComposerContext,
+  onLatestVisibleChange,
   onRetry,
   onLoadEarlier,
   onSend,
@@ -61,13 +72,19 @@ export default function LeagueChatPanel({
   const previousLastIdRef = useRef<string | null>(null);
   const previousScrollHeightRef = useRef<number | null>(null);
   const hasInitializedRef = useRef(false);
-  const [showSystemMessages, setShowSystemMessages] = useState(true);
   const [newMessageCount, setNewMessageCount] = useState(0);
-  const visibleMessages = showSystemMessages
-    ? messages
-    : messages.filter((message) => message.type !== 'system');
-  const latestMessage = messages.at(-1);
+  const visibleMessages = messages.filter((message) => message.type !== 'system');
+  const latestMessage = visibleMessages.at(-1);
   const muted = Boolean(mutedUntil && new Date(mutedUntil).getTime() > Date.now());
+
+  useLayoutEffect(() => {
+    const element = scrollRef.current;
+    if (!visible || !element) {
+      onLatestVisibleChange?.(false);
+      return;
+    }
+    onLatestVisibleChange?.(isNearBottom(element));
+  }, [onLatestVisibleChange, visible]);
 
   useLayoutEffect(() => {
     const element = scrollRef.current;
@@ -78,12 +95,13 @@ export default function LeagueChatPanel({
 
   useEffect(() => {
     const element = scrollRef.current;
-    if (!element || !latestMessage) return;
+    if (!visible || !element || !latestMessage) return;
 
     if (!hasInitializedRef.current) {
       element.scrollTop = element.scrollHeight;
       hasInitializedRef.current = true;
       previousLastIdRef.current = latestMessage.id;
+      onLatestVisibleChange?.(true);
       return;
     }
 
@@ -94,10 +112,11 @@ export default function LeagueChatPanel({
     if (shouldFollow) {
       element.scrollTop = element.scrollHeight;
       setNewMessageCount(0);
+      onLatestVisibleChange?.(true);
     } else {
       setNewMessageCount((count) => count + 1);
     }
-  }, [latestMessage]);
+  }, [latestMessage, onLatestVisibleChange, visible]);
 
   function handleLoadEarlier(): void {
     if (scrollRef.current) {
@@ -110,6 +129,7 @@ export default function LeagueChatPanel({
     const element = scrollRef.current;
     if (element) element.scrollTop = element.scrollHeight;
     setNewMessageCount(0);
+    onLatestVisibleChange?.(true);
   }
 
   return (
@@ -124,24 +144,19 @@ export default function LeagueChatPanel({
           </h2>
           <p className="text-xs text-muted-foreground">Private to current league members</p>
         </div>
-        <label className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 text-xs font-medium text-foreground">
-          <input
-            type="checkbox"
-            checked={showSystemMessages}
-            onChange={(event) => setShowSystemMessages(event.target.checked)}
-            className="size-4 rounded border-border text-primary focus:ring-ring"
-          />
-          Show league activity
-        </label>
       </header>
 
       <div className="relative min-h-0 flex-1">
         <div
           ref={scrollRef}
-          className="h-full min-h-64 overflow-y-auto px-4 py-3"
+          className={`h-full overflow-y-auto px-4 py-3 ${compact ? 'min-h-0' : 'min-h-64'}`}
           aria-busy={loading || loadingEarlier}
           onScroll={(event) => {
-            if (isNearBottom(event.currentTarget)) setNewMessageCount(0);
+            const latestIsVisible = isNearBottom(event.currentTarget);
+            onLatestVisibleChange?.(latestIsVisible);
+            if (latestIsVisible) {
+              setNewMessageCount(0);
+            }
           }}
         >
           {hasEarlierMessages ? (
@@ -196,65 +211,48 @@ export default function LeagueChatPanel({
                         <span className="h-px flex-1 bg-border" />
                       </div>
                     ) : null}
-                    {message.type === 'system' ? (
-                      <article className="rounded-xl border border-primary/25 bg-primary/10 px-3 py-2">
-                        <p className="text-xs font-semibold uppercase tracking-wide text-primary">
-                          League activity
-                        </p>
-                        <SafeSocialText value={message.content} className="mt-1" />
-                        <time
-                          dateTime={message.createdAt}
-                          className="mt-1 block text-xs text-muted-foreground"
-                        >
-                          {new Date(message.createdAt).toLocaleTimeString([], {
-                            hour: '2-digit',
-                            minute: '2-digit',
-                          })}
-                        </time>
-                      </article>
-                    ) : (
-                      <article
-                        className={`rounded-xl border p-3 ${
-                          message.isOwn
-                            ? 'border-primary/30 bg-primary/10'
-                            : 'border-border bg-background'
-                        }`}
-                      >
-                        <SocialAuthor
-                          author={message.author}
-                          timestamp={message.createdAt}
-                          editedAt={message.editedAt}
-                          compact
-                        />
-                        {message.moderationStatus === 'removed' || message.deletedAt ? (
-                          <p className="mt-2 text-sm italic text-muted-foreground">
-                            Message removed
-                          </p>
-                        ) : (
-                          <>
-                            <SafeSocialText value={message.content} className="mt-2" />
-                            {!message.isOwn ? (
-                              <div className="mt-2 flex justify-end">
-                                <SocialReportButton
-                                  label="message"
-                                  onReport={(reason, details) =>
-                                    onReport(message.id, reason, details)
-                                  }
-                                />
-                              </div>
-                            ) : null}
-                            {canManage ? (
-                              <div className="mt-2 flex justify-end">
-                                <SocialRemoveButton
-                                  label="message"
-                                  onRemove={(reason) => onRemove(message.id, reason)}
-                                />
-                              </div>
-                            ) : null}
-                          </>
-                        )}
-                      </article>
-                    )}
+                    <article
+                      className={`rounded-xl border p-3 ${
+                        message.isOwn
+                          ? 'border-primary/30 bg-primary/10'
+                          : 'border-border bg-background'
+                      }`}
+                    >
+                      <SocialAuthor
+                        author={message.author}
+                        timestamp={message.createdAt}
+                        editedAt={message.editedAt}
+                        compact
+                      />
+                      {message.moderationStatus === 'removed' || message.deletedAt ? (
+                        <p className="mt-2 text-sm italic text-muted-foreground">Message removed</p>
+                      ) : (
+                        <>
+                          {message.context ? (
+                            <DiscussionContextCard context={message.context} />
+                          ) : null}
+                          <SafeSocialText value={message.content} className="mt-2" />
+                          {!message.isOwn ? (
+                            <div className="mt-2 flex justify-end">
+                              <SocialReportButton
+                                label="message"
+                                onReport={(reason, details) =>
+                                  onReport(message.id, reason, details)
+                                }
+                              />
+                            </div>
+                          ) : null}
+                          {canManage ? (
+                            <div className="mt-2 flex justify-end">
+                              <SocialRemoveButton
+                                label="message"
+                                onRemove={(reason) => onRemove(message.id, reason)}
+                              />
+                            </div>
+                          ) : null}
+                        </>
+                      )}
+                    </article>
                   </li>
                 );
               })}
@@ -287,6 +285,13 @@ export default function LeagueChatPanel({
             .
           </p>
         ) : null}
+        {composerContext ? (
+          <DiscussionContextCard
+            context={composerContext}
+            onRemove={onClearComposerContext}
+            label="Discussing"
+          />
+        ) : null}
         <SocialComposer
           label="Message league chat"
           placeholder="Message your league…"
@@ -296,9 +301,53 @@ export default function LeagueChatPanel({
           disabled={!canPublish || muted}
           pending={sending}
           error={submitError}
-          onSubmit={onSend}
+          onSubmit={async (content) => {
+            await onSend(content, composerContext);
+            onClearComposerContext?.();
+          }}
         />
       </footer>
     </section>
+  );
+}
+
+function DiscussionContextCard({
+  context,
+  label = 'Context',
+  onRemove,
+}: {
+  context: SocialDiscussionContext;
+  label?: string;
+  onRemove?: () => void;
+}): React.JSX.Element {
+  const metadata = Object.values(context.metadata ?? {}).filter(Boolean);
+
+  return (
+    <div className="mt-2 rounded-xl border border-border bg-muted/40 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {label}
+          </p>
+          <p className="mt-1 truncate text-sm font-semibold text-foreground">{context.title}</p>
+          {context.subtitle ? (
+            <p className="mt-1 text-xs text-muted-foreground">{context.subtitle}</p>
+          ) : null}
+          {metadata.length > 0 ? (
+            <p className="mt-1 truncate text-xs text-muted-foreground">{metadata.join(' · ')}</p>
+          ) : null}
+        </div>
+        {onRemove ? (
+          <button
+            type="button"
+            onClick={onRemove}
+            className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Remove discussion context"
+          >
+            <X className="size-4" aria-hidden="true" />
+          </button>
+        ) : null}
+      </div>
+    </div>
   );
 }

--- a/src/components/league/social/LeagueChatPanel.tsx
+++ b/src/components/league/social/LeagueChatPanel.tsx
@@ -3,8 +3,15 @@
 import { X } from 'lucide-react';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
-import type { SocialDiscussionContext, SocialMessage, SocialReportReason } from '@/types/social';
+import type {
+  CreateSocialMessageInput,
+  SocialDiscussionContext,
+  SocialMessage,
+  SocialReportReason,
+} from '@/types/social';
 
+import GiphyMessageMedia from './GiphyMessageMedia';
+import GiphyPicker from './GiphyPicker';
 import SafeSocialText from './SafeSocialText';
 import SocialAuthor from './SocialAuthor';
 import SocialComposer from './SocialComposer';
@@ -29,7 +36,7 @@ interface LeagueChatPanelProps {
   onLatestVisibleChange?: (visible: boolean) => void;
   onRetry: () => Promise<void> | void;
   onLoadEarlier: () => Promise<void> | void;
-  onSend: (content: string, context?: SocialDiscussionContext | null) => Promise<void>;
+  onSend: (input: Omit<CreateSocialMessageInput, 'idempotencyKey'>) => Promise<void>;
   onReport: (messageId: string, reason: SocialReportReason, details?: string) => Promise<void>;
   onRemove: (messageId: string, reason: string) => Promise<void>;
 }
@@ -132,6 +139,16 @@ export default function LeagueChatPanel({
     onLatestVisibleChange?.(true);
   }
 
+  async function sendWithContext(
+    input: Omit<CreateSocialMessageInput, 'idempotencyKey' | 'context'>
+  ): Promise<void> {
+    await onSend({
+      ...input,
+      ...(composerContext ? { context: composerContext } : {}),
+    });
+    onClearComposerContext?.();
+  }
+
   return (
     <section
       aria-labelledby="league-chat-heading"
@@ -231,7 +248,10 @@ export default function LeagueChatPanel({
                           {message.context ? (
                             <DiscussionContextCard context={message.context} />
                           ) : null}
-                          <SafeSocialText value={message.content} className="mt-2" />
+                          {message.content ? (
+                            <SafeSocialText value={message.content} className="mt-2" />
+                          ) : null}
+                          {message.gif ? <GiphyMessageMedia gif={message.gif} /> : null}
                           {!message.isOwn ? (
                             <div className="mt-2 flex justify-end">
                               <SocialReportButton
@@ -292,6 +312,10 @@ export default function LeagueChatPanel({
             label="Discussing"
           />
         ) : null}
+        <GiphyPicker
+          disabled={!canPublish || muted || sending}
+          onSelect={(gif) => sendWithContext({ content: '', gif })}
+        />
         <SocialComposer
           label="Message league chat"
           placeholder="Message your league…"
@@ -301,10 +325,7 @@ export default function LeagueChatPanel({
           disabled={!canPublish || muted}
           pending={sending}
           error={submitError}
-          onSubmit={async (content) => {
-            await onSend(content, composerContext);
-            onClearComposerContext?.();
-          }}
+          onSubmit={(content) => sendWithContext({ content })}
         />
       </footer>
     </section>

--- a/src/components/league/social/LeagueChatPanel.tsx
+++ b/src/components/league/social/LeagueChatPanel.tsx
@@ -42,6 +42,7 @@ interface LeagueChatPanelProps {
 }
 
 const BOTTOM_THRESHOLD_PX = 72;
+const MESSAGE_GROUP_WINDOW_MS = 5 * 60 * 1000;
 
 function isNearBottom(element: HTMLElement): boolean {
   return element.scrollHeight - element.scrollTop - element.clientHeight <= BOTTOM_THRESHOLD_PX;
@@ -51,6 +52,26 @@ function messageDay(value: string): string {
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return 'Unknown date';
   return new Intl.DateTimeFormat('en-AU', { dateStyle: 'full' }).format(parsed);
+}
+
+function messageAuthorKey(message: SocialMessage): string {
+  return (
+    message.author?.userId ??
+    `${message.author?.displayName ?? 'former-member'}:${message.author?.teamName ?? ''}`
+  );
+}
+
+function isMessageContinuation(message: SocialMessage, previous?: SocialMessage): boolean {
+  if (!previous || messageDay(message.createdAt) !== messageDay(previous.createdAt)) return false;
+  if (messageAuthorKey(message) !== messageAuthorKey(previous)) return false;
+  const currentTime = new Date(message.createdAt).getTime();
+  const previousTime = new Date(previous.createdAt).getTime();
+  return (
+    Number.isFinite(currentTime) &&
+    Number.isFinite(previousTime) &&
+    currentTime >= previousTime &&
+    currentTime - previousTime <= MESSAGE_GROUP_WINDOW_MS
+  );
 }
 
 export default function LeagueChatPanel({
@@ -151,22 +172,13 @@ export default function LeagueChatPanel({
 
   return (
     <section
-      aria-labelledby="league-chat-heading"
-      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border bg-card text-card-foreground"
+      aria-label="League chat"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background text-foreground"
     >
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3">
-        <div>
-          <h2 id="league-chat-heading" className="text-base font-semibold text-foreground">
-            League chat
-          </h2>
-          <p className="text-xs text-muted-foreground">Private to current league members</p>
-        </div>
-      </header>
-
       <div className="relative min-h-0 flex-1">
         <div
           ref={scrollRef}
-          className={`h-full overflow-y-auto px-4 py-3 ${compact ? 'min-h-0' : 'min-h-64'}`}
+          className={`h-full overflow-y-auto px-3 py-2 ${compact ? 'min-h-0' : 'min-h-64'}`}
           aria-busy={loading || loadingEarlier}
           onScroll={(event) => {
             const latestIsVisible = isNearBottom(event.currentTarget);
@@ -214,60 +226,80 @@ export default function LeagueChatPanel({
               </p>
             </div>
           ) : (
-            <ol className="space-y-3" aria-label="League chat messages">
+            <ol className="space-y-1" aria-label="League chat messages">
               {visibleMessages.map((message, index) => {
                 const day = messageDay(message.createdAt);
                 const previousDay =
                   index > 0 ? messageDay(visibleMessages[index - 1].createdAt) : null;
+                const continuation = isMessageContinuation(message, visibleMessages[index - 1]);
                 return (
                   <li key={message.id}>
                     {day !== previousDay ? (
-                      <div className="my-4 flex items-center gap-3" aria-label={day}>
+                      <div className="my-3 flex items-center gap-3" aria-label={day}>
                         <span className="h-px flex-1 bg-border" />
                         <time className="text-xs font-medium text-muted-foreground">{day}</time>
                         <span className="h-px flex-1 bg-border" />
                       </div>
                     ) : null}
                     <article
-                      className={`rounded-xl border p-3 ${
-                        message.isOwn
-                          ? 'border-primary/30 bg-primary/10'
-                          : 'border-border bg-background'
-                      }`}
+                      aria-label={`Message from ${message.author?.displayName ?? 'former member'}`}
+                      className={`rounded-lg px-2 py-1.5 ${
+                        continuation ? 'pl-12' : ''
+                      } ${message.isOwn ? 'bg-muted/50' : 'bg-transparent'}`}
                     >
-                      <SocialAuthor
-                        author={message.author}
-                        timestamp={message.createdAt}
-                        editedAt={message.editedAt}
-                        compact
-                      />
+                      {!continuation ? (
+                        <SocialAuthor
+                          author={message.author}
+                          timestamp={message.createdAt}
+                          editedAt={message.editedAt}
+                          compact
+                          timestampStyle="time"
+                        />
+                      ) : (
+                        <time dateTime={message.createdAt} className="sr-only">
+                          {new Date(message.createdAt).toLocaleTimeString()}
+                        </time>
+                      )}
                       {message.moderationStatus === 'removed' || message.deletedAt ? (
-                        <p className="mt-2 text-sm italic text-muted-foreground">Message removed</p>
+                        <p
+                          className={`text-sm italic text-muted-foreground ${
+                            continuation ? '' : 'mt-1.5 pl-11'
+                          }`}
+                        >
+                          Message removed
+                        </p>
                       ) : (
                         <>
                           {message.context ? (
                             <DiscussionContextCard context={message.context} />
                           ) : null}
                           {message.content ? (
-                            <SafeSocialText value={message.content} className="mt-2" />
+                            <SafeSocialText
+                              value={message.content}
+                              className={continuation ? '' : 'mt-1.5 pl-11'}
+                            />
                           ) : null}
-                          {message.gif ? <GiphyMessageMedia gif={message.gif} /> : null}
-                          {!message.isOwn ? (
-                            <div className="mt-2 flex justify-end">
-                              <SocialReportButton
-                                label="message"
-                                onReport={(reason, details) =>
-                                  onReport(message.id, reason, details)
-                                }
-                              />
+                          {message.gif ? (
+                            <div className={continuation ? '' : 'pl-11'}>
+                              <GiphyMessageMedia gif={message.gif} />
                             </div>
                           ) : null}
-                          {canManage ? (
-                            <div className="mt-2 flex justify-end">
-                              <SocialRemoveButton
-                                label="message"
-                                onRemove={(reason) => onRemove(message.id, reason)}
-                              />
+                          {!message.isOwn || canManage ? (
+                            <div className="mt-1 flex justify-end gap-1">
+                              {!message.isOwn ? (
+                                <SocialReportButton
+                                  label="message"
+                                  onReport={(reason, details) =>
+                                    onReport(message.id, reason, details)
+                                  }
+                                />
+                              ) : null}
+                              {canManage ? (
+                                <SocialRemoveButton
+                                  label="message"
+                                  onRemove={(reason) => onRemove(message.id, reason)}
+                                />
+                              ) : null}
                             </div>
                           ) : null}
                         </>
@@ -291,7 +323,7 @@ export default function LeagueChatPanel({
         ) : null}
       </div>
 
-      <footer className="border-t border-border bg-background p-3">
+      <footer className="border-t border-border bg-background p-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
         {!canPublish && !muted ? (
           <p role="status" className="mb-2 text-sm text-muted-foreground">
             Accept the community standards above before sending messages.
@@ -312,10 +344,6 @@ export default function LeagueChatPanel({
             label="Discussing"
           />
         ) : null}
-        <GiphyPicker
-          disabled={!canPublish || muted || sending}
-          onSelect={(gif) => sendWithContext({ content: '', gif })}
-        />
         <SocialComposer
           label="Message league chat"
           placeholder="Message your league…"
@@ -325,6 +353,14 @@ export default function LeagueChatPanel({
           disabled={!canPublish || muted}
           pending={sending}
           error={submitError}
+          compact
+          leadingAction={
+            <GiphyPicker
+              compact
+              disabled={!canPublish || muted || sending}
+              onSelect={(gif) => sendWithContext({ content: '', gif })}
+            />
+          }
           onSubmit={(content) => sendWithContext({ content })}
         />
       </footer>

--- a/src/components/league/social/LeagueChatPanel.tsx
+++ b/src/components/league/social/LeagueChatPanel.tsx
@@ -15,6 +15,7 @@ import GiphyPicker from './GiphyPicker';
 import SafeSocialText from './SafeSocialText';
 import SocialAuthor from './SocialAuthor';
 import SocialComposer from './SocialComposer';
+import type { SocialComposerDraftScope } from './socialComposerDraft';
 import SocialReportButton from './SocialReportButton';
 import SocialRemoveButton from './SocialRemoveButton';
 
@@ -31,12 +32,15 @@ interface LeagueChatPanelProps {
   submitError?: string | null;
   visible?: boolean;
   compact?: boolean;
+  composerLabel?: string;
+  draftScope?: SocialComposerDraftScope;
   composerContext?: SocialDiscussionContext | null;
   onClearComposerContext?: () => void;
+  onDismissSubmitError?: () => void;
   onLatestVisibleChange?: (visible: boolean) => void;
   onRetry: () => Promise<void> | void;
   onLoadEarlier: () => Promise<void> | void;
-  onSend: (input: Omit<CreateSocialMessageInput, 'idempotencyKey'>) => Promise<void>;
+  onSend: (input: CreateSocialMessageInput) => Promise<void>;
   onReport: (messageId: string, reason: SocialReportReason, details?: string) => Promise<void>;
   onRemove: (messageId: string, reason: string) => Promise<void>;
 }
@@ -87,8 +91,11 @@ export default function LeagueChatPanel({
   submitError,
   visible = true,
   compact = false,
+  composerLabel = 'Message league chat',
+  draftScope,
   composerContext,
   onClearComposerContext,
+  onDismissSubmitError,
   onLatestVisibleChange,
   onRetry,
   onLoadEarlier,
@@ -160,9 +167,7 @@ export default function LeagueChatPanel({
     onLatestVisibleChange?.(true);
   }
 
-  async function sendWithContext(
-    input: Omit<CreateSocialMessageInput, 'idempotencyKey' | 'context'>
-  ): Promise<void> {
+  async function sendWithContext(input: Omit<CreateSocialMessageInput, 'context'>): Promise<void> {
     await onSend({
       ...input,
       ...(composerContext ? { context: composerContext } : {}),
@@ -325,11 +330,11 @@ export default function LeagueChatPanel({
 
       <footer className="border-t border-border bg-background p-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
         {!canPublish && !muted ? (
-          <p role="status" className="mb-2 text-sm text-muted-foreground">
+          <p role="status" className="py-2 text-center text-sm text-muted-foreground">
             Accept the community standards above before sending messages.
           </p>
         ) : muted ? (
-          <p role="status" className="mb-2 text-sm text-muted-foreground">
+          <p role="status" className="py-2 text-center text-sm text-muted-foreground">
             You can read chat, but cannot send until{' '}
             <time dateTime={mutedUntil ?? undefined}>
               {mutedUntil ? new Date(mutedUntil).toLocaleString() : 'the mute ends'}
@@ -337,32 +342,39 @@ export default function LeagueChatPanel({
             .
           </p>
         ) : null}
-        {composerContext ? (
-          <DiscussionContextCard
-            context={composerContext}
-            onRemove={onClearComposerContext}
-            label="Discussing"
-          />
-        ) : null}
-        <SocialComposer
-          label="Message league chat"
-          placeholder="Message your league…"
-          submitLabel="Send"
-          maxLength={1000}
-          submitOnEnter
-          disabled={!canPublish || muted}
-          pending={sending}
-          error={submitError}
-          compact
-          leadingAction={
-            <GiphyPicker
+        {canPublish && !muted ? (
+          <>
+            {composerContext ? (
+              <DiscussionContextCard
+                context={composerContext}
+                onRemove={onClearComposerContext}
+                label="Discussing"
+              />
+            ) : null}
+            <SocialComposer
+              label={composerLabel}
+              placeholder="Message your league…"
+              submitLabel="Send"
+              maxLength={1000}
+              submitOnEnter
+              pending={sending}
+              error={submitError}
+              onDismissError={onDismissSubmitError}
+              draftScope={draftScope}
               compact
-              disabled={!canPublish || muted || sending}
-              onSelect={(gif) => sendWithContext({ content: '', gif })}
+              leadingAction={
+                <GiphyPicker
+                  compact
+                  disabled={sending}
+                  onSelect={(gif, idempotencyKey) =>
+                    sendWithContext({ content: '', gif, idempotencyKey })
+                  }
+                />
+              }
+              onSubmit={(content, idempotencyKey) => sendWithContext({ content, idempotencyKey })}
             />
-          }
-          onSubmit={(content) => sendWithContext({ content })}
-        />
+          </>
+        ) : null}
       </footer>
     </section>
   );

--- a/src/components/league/social/LeagueChatPanel.tsx
+++ b/src/components/league/social/LeagueChatPanel.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+import type { SocialMessage, SocialReportReason } from '@/types/social';
+
+import SafeSocialText from './SafeSocialText';
+import SocialAuthor from './SocialAuthor';
+import SocialComposer from './SocialComposer';
+import SocialReportButton from './SocialReportButton';
+import SocialRemoveButton from './SocialRemoveButton';
+
+interface LeagueChatPanelProps {
+  messages: SocialMessage[];
+  hasEarlierMessages: boolean;
+  loading: boolean;
+  loadingEarlier: boolean;
+  sending: boolean;
+  canPublish: boolean;
+  canManage: boolean;
+  mutedUntil?: string | null;
+  error?: string | null;
+  submitError?: string | null;
+  onRetry: () => Promise<void> | void;
+  onLoadEarlier: () => Promise<void> | void;
+  onSend: (content: string) => Promise<void>;
+  onReport: (messageId: string, reason: SocialReportReason, details?: string) => Promise<void>;
+  onRemove: (messageId: string, reason: string) => Promise<void>;
+}
+
+const BOTTOM_THRESHOLD_PX = 72;
+
+function isNearBottom(element: HTMLElement): boolean {
+  return element.scrollHeight - element.scrollTop - element.clientHeight <= BOTTOM_THRESHOLD_PX;
+}
+
+function messageDay(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return 'Unknown date';
+  return new Intl.DateTimeFormat('en-AU', { dateStyle: 'full' }).format(parsed);
+}
+
+export default function LeagueChatPanel({
+  messages,
+  hasEarlierMessages,
+  loading,
+  loadingEarlier,
+  sending,
+  canPublish,
+  canManage,
+  mutedUntil,
+  error,
+  submitError,
+  onRetry,
+  onLoadEarlier,
+  onSend,
+  onReport,
+  onRemove,
+}: LeagueChatPanelProps): React.JSX.Element {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const previousLastIdRef = useRef<string | null>(null);
+  const previousScrollHeightRef = useRef<number | null>(null);
+  const hasInitializedRef = useRef(false);
+  const [showSystemMessages, setShowSystemMessages] = useState(true);
+  const [newMessageCount, setNewMessageCount] = useState(0);
+  const visibleMessages = showSystemMessages
+    ? messages
+    : messages.filter((message) => message.type !== 'system');
+  const latestMessage = messages.at(-1);
+  const muted = Boolean(mutedUntil && new Date(mutedUntil).getTime() > Date.now());
+
+  useLayoutEffect(() => {
+    const element = scrollRef.current;
+    if (!element || previousScrollHeightRef.current === null || loadingEarlier) return;
+    element.scrollTop += element.scrollHeight - previousScrollHeightRef.current;
+    previousScrollHeightRef.current = null;
+  }, [loadingEarlier, messages.length]);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element || !latestMessage) return;
+
+    if (!hasInitializedRef.current) {
+      element.scrollTop = element.scrollHeight;
+      hasInitializedRef.current = true;
+      previousLastIdRef.current = latestMessage.id;
+      return;
+    }
+
+    if (previousLastIdRef.current === latestMessage.id) return;
+    const shouldFollow = latestMessage.isOwn || isNearBottom(element);
+    previousLastIdRef.current = latestMessage.id;
+
+    if (shouldFollow) {
+      element.scrollTop = element.scrollHeight;
+      setNewMessageCount(0);
+    } else {
+      setNewMessageCount((count) => count + 1);
+    }
+  }, [latestMessage]);
+
+  function handleLoadEarlier(): void {
+    if (scrollRef.current) {
+      previousScrollHeightRef.current = scrollRef.current.scrollHeight;
+    }
+    void onLoadEarlier();
+  }
+
+  function jumpToLatest(): void {
+    const element = scrollRef.current;
+    if (element) element.scrollTop = element.scrollHeight;
+    setNewMessageCount(0);
+  }
+
+  return (
+    <section
+      aria-labelledby="league-chat-heading"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border bg-card text-card-foreground"
+    >
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3">
+        <div>
+          <h2 id="league-chat-heading" className="text-base font-semibold text-foreground">
+            League chat
+          </h2>
+          <p className="text-xs text-muted-foreground">Private to current league members</p>
+        </div>
+        <label className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-border bg-background px-3 text-xs font-medium text-foreground">
+          <input
+            type="checkbox"
+            checked={showSystemMessages}
+            onChange={(event) => setShowSystemMessages(event.target.checked)}
+            className="size-4 rounded border-border text-primary focus:ring-ring"
+          />
+          Show league activity
+        </label>
+      </header>
+
+      <div className="relative min-h-0 flex-1">
+        <div
+          ref={scrollRef}
+          className="h-full min-h-64 overflow-y-auto px-4 py-3"
+          aria-busy={loading || loadingEarlier}
+          onScroll={(event) => {
+            if (isNearBottom(event.currentTarget)) setNewMessageCount(0);
+          }}
+        >
+          {hasEarlierMessages ? (
+            <div className="mb-4 flex justify-center">
+              <button
+                type="button"
+                onClick={handleLoadEarlier}
+                disabled={loadingEarlier}
+                className="inline-flex min-h-9 items-center justify-center rounded-lg border border-border bg-background px-3 text-xs font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+              >
+                {loadingEarlier ? 'Loading…' : 'Load earlier messages'}
+              </button>
+            </div>
+          ) : null}
+
+          {loading && messages.length === 0 ? (
+            <p role="status" className="py-10 text-center text-sm text-muted-foreground">
+              Loading league chat…
+            </p>
+          ) : error && messages.length === 0 ? (
+            <div className="mx-auto max-w-sm rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-center">
+              <p role="alert" className="text-sm font-medium text-destructive">
+                {error}
+              </p>
+              <button
+                type="button"
+                onClick={() => void onRetry()}
+                className="mt-3 inline-flex min-h-9 items-center justify-center rounded-lg border border-border bg-background px-3 text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                Retry
+              </button>
+            </div>
+          ) : visibleMessages.length === 0 ? (
+            <div className="py-10 text-center">
+              <p className="text-sm font-semibold text-foreground">No messages yet</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Start the conversation with your league.
+              </p>
+            </div>
+          ) : (
+            <ol className="space-y-3" aria-label="League chat messages">
+              {visibleMessages.map((message, index) => {
+                const day = messageDay(message.createdAt);
+                const previousDay =
+                  index > 0 ? messageDay(visibleMessages[index - 1].createdAt) : null;
+                return (
+                  <li key={message.id}>
+                    {day !== previousDay ? (
+                      <div className="my-4 flex items-center gap-3" aria-label={day}>
+                        <span className="h-px flex-1 bg-border" />
+                        <time className="text-xs font-medium text-muted-foreground">{day}</time>
+                        <span className="h-px flex-1 bg-border" />
+                      </div>
+                    ) : null}
+                    {message.type === 'system' ? (
+                      <article className="rounded-xl border border-primary/25 bg-primary/10 px-3 py-2">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-primary">
+                          League activity
+                        </p>
+                        <SafeSocialText value={message.content} className="mt-1" />
+                        <time
+                          dateTime={message.createdAt}
+                          className="mt-1 block text-xs text-muted-foreground"
+                        >
+                          {new Date(message.createdAt).toLocaleTimeString([], {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                          })}
+                        </time>
+                      </article>
+                    ) : (
+                      <article
+                        className={`rounded-xl border p-3 ${
+                          message.isOwn
+                            ? 'border-primary/30 bg-primary/10'
+                            : 'border-border bg-background'
+                        }`}
+                      >
+                        <SocialAuthor
+                          author={message.author}
+                          timestamp={message.createdAt}
+                          editedAt={message.editedAt}
+                          compact
+                        />
+                        {message.moderationStatus === 'removed' || message.deletedAt ? (
+                          <p className="mt-2 text-sm italic text-muted-foreground">
+                            Message removed
+                          </p>
+                        ) : (
+                          <>
+                            <SafeSocialText value={message.content} className="mt-2" />
+                            {!message.isOwn ? (
+                              <div className="mt-2 flex justify-end">
+                                <SocialReportButton
+                                  label="message"
+                                  onReport={(reason, details) =>
+                                    onReport(message.id, reason, details)
+                                  }
+                                />
+                              </div>
+                            ) : null}
+                            {canManage ? (
+                              <div className="mt-2 flex justify-end">
+                                <SocialRemoveButton
+                                  label="message"
+                                  onRemove={(reason) => onRemove(message.id, reason)}
+                                />
+                              </div>
+                            ) : null}
+                          </>
+                        )}
+                      </article>
+                    )}
+                  </li>
+                );
+              })}
+            </ol>
+          )}
+        </div>
+
+        {newMessageCount > 0 ? (
+          <button
+            type="button"
+            onClick={jumpToLatest}
+            className="absolute bottom-3 left-1/2 z-10 -translate-x-1/2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            {newMessageCount === 1 ? '1 new message' : `${newMessageCount} new messages`}
+          </button>
+        ) : null}
+      </div>
+
+      <footer className="border-t border-border bg-background p-3">
+        {!canPublish && !muted ? (
+          <p role="status" className="mb-2 text-sm text-muted-foreground">
+            Accept the community standards above before sending messages.
+          </p>
+        ) : muted ? (
+          <p role="status" className="mb-2 text-sm text-muted-foreground">
+            You can read chat, but cannot send until{' '}
+            <time dateTime={mutedUntil ?? undefined}>
+              {mutedUntil ? new Date(mutedUntil).toLocaleString() : 'the mute ends'}
+            </time>
+            .
+          </p>
+        ) : null}
+        <SocialComposer
+          label="Message league chat"
+          placeholder="Message your league…"
+          submitLabel="Send"
+          maxLength={1000}
+          submitOnEnter
+          disabled={!canPublish || muted}
+          pending={sending}
+          error={submitError}
+          onSubmit={onSend}
+        />
+      </footer>
+    </section>
+  );
+}

--- a/src/components/league/social/LeagueChatPanel.tsx
+++ b/src/components/league/social/LeagueChatPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { X } from 'lucide-react';
+import { AtSign, X } from 'lucide-react';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import type {
@@ -76,6 +76,10 @@ function isMessageContinuation(message: SocialMessage, previous?: SocialMessage)
     currentTime >= previousTime &&
     currentTime - previousTime <= MESSAGE_GROUP_WINDOW_MS
   );
+}
+
+export function containsSocialMention(value: string): boolean {
+  return /(^|\s)@[a-z0-9][a-z0-9._-]*/i.test(value);
 }
 
 export default function LeagueChatPanel({
@@ -178,7 +182,7 @@ export default function LeagueChatPanel({
   return (
     <section
       aria-label="League chat"
-      className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background text-foreground"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden bg-social-canvas text-social-text"
     >
       <div className="relative min-h-0 flex-1">
         <div
@@ -199,7 +203,7 @@ export default function LeagueChatPanel({
                 type="button"
                 onClick={handleLoadEarlier}
                 disabled={loadingEarlier}
-                className="inline-flex min-h-9 items-center justify-center rounded-lg border border-border bg-background px-3 text-xs font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+                className="inline-flex min-h-9 items-center justify-center rounded-lg border border-social-border bg-social-surface px-3 text-xs font-semibold text-social-text transition-colors hover:border-social-border-strong hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
               >
                 {loadingEarlier ? 'Loading…' : 'Load earlier messages'}
               </button>
@@ -207,26 +211,26 @@ export default function LeagueChatPanel({
           ) : null}
 
           {loading && messages.length === 0 ? (
-            <p role="status" className="py-10 text-center text-sm text-muted-foreground">
+            <p role="status" className="py-10 text-center text-sm text-social-text-muted">
               Loading league chat…
             </p>
           ) : error && messages.length === 0 ? (
-            <div className="mx-auto max-w-sm rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-center">
-              <p role="alert" className="text-sm font-medium text-destructive">
+            <div className="mx-auto max-w-sm rounded-xl border border-social-error bg-social-error-soft p-4 text-center">
+              <p role="alert" className="text-sm font-medium text-social-error">
                 {error}
               </p>
               <button
                 type="button"
                 onClick={() => void onRetry()}
-                className="mt-3 inline-flex min-h-9 items-center justify-center rounded-lg border border-border bg-background px-3 text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="mt-3 inline-flex min-h-9 items-center justify-center rounded-lg border border-social-border bg-social-surface px-3 text-sm font-semibold text-social-text transition-colors hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
               >
                 Retry
               </button>
             </div>
           ) : visibleMessages.length === 0 ? (
             <div className="py-10 text-center">
-              <p className="text-sm font-semibold text-foreground">No messages yet</p>
-              <p className="mt-1 text-sm text-muted-foreground">
+              <p className="text-sm font-semibold text-social-text">No messages yet</p>
+              <p className="mt-1 text-sm text-social-text-muted">
                 Start the conversation with your league.
               </p>
             </div>
@@ -237,20 +241,25 @@ export default function LeagueChatPanel({
                 const previousDay =
                   index > 0 ? messageDay(visibleMessages[index - 1].createdAt) : null;
                 const continuation = isMessageContinuation(message, visibleMessages[index - 1]);
+                const containsMention = containsSocialMention(message.content);
                 return (
                   <li key={message.id}>
                     {day !== previousDay ? (
                       <div className="my-3 flex items-center gap-3" aria-label={day}>
-                        <span className="h-px flex-1 bg-border" />
-                        <time className="text-xs font-medium text-muted-foreground">{day}</time>
-                        <span className="h-px flex-1 bg-border" />
+                        <span className="h-px flex-1 bg-social-border" />
+                        <time className="text-xs font-medium text-social-text-muted">{day}</time>
+                        <span className="h-px flex-1 bg-social-border" />
                       </div>
                     ) : null}
                     <article
-                      aria-label={`Message from ${message.author?.displayName ?? 'former member'}`}
-                      className={`rounded-lg px-2 py-1.5 ${
-                        continuation ? 'pl-12' : ''
-                      } ${message.isOwn ? 'bg-muted/50' : 'bg-transparent'}`}
+                      aria-label={`${containsMention ? 'Message containing a mention' : 'Message'} from ${message.author?.displayName ?? 'former member'}`}
+                      className={`rounded-lg border px-2 py-1.5 ${continuation ? 'pl-12' : ''} ${
+                        containsMention
+                          ? 'border-social-warning bg-social-mention-bg text-social-mention-text'
+                          : message.isOwn
+                            ? 'border-social-action bg-social-brand-soft'
+                            : 'border-transparent bg-social-surface'
+                      }`}
                     >
                       {!continuation ? (
                         <SocialAuthor
@@ -267,7 +276,7 @@ export default function LeagueChatPanel({
                       )}
                       {message.moderationStatus === 'removed' || message.deletedAt ? (
                         <p
-                          className={`text-sm italic text-muted-foreground ${
+                          className={`text-sm italic text-social-text-muted ${
                             continuation ? '' : 'mt-1.5 pl-11'
                           }`}
                         >
@@ -275,6 +284,12 @@ export default function LeagueChatPanel({
                         </p>
                       ) : (
                         <>
+                          {containsMention ? (
+                            <span className="mt-1.5 inline-flex items-center gap-1 rounded-full border border-social-warning bg-social-warning-soft px-2 py-0.5 text-xs font-semibold text-social-mention-text">
+                              <AtSign className="size-3" aria-hidden="true" />
+                              Mention
+                            </span>
+                          ) : null}
                           {message.context ? (
                             <DiscussionContextCard context={message.context} />
                           ) : null}
@@ -321,20 +336,20 @@ export default function LeagueChatPanel({
           <button
             type="button"
             onClick={jumpToLatest}
-            className="absolute bottom-3 left-1/2 z-10 -translate-x-1/2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            className="absolute bottom-3 left-1/2 z-10 -translate-x-1/2 rounded-full border border-social-action bg-social-action px-4 py-2 text-sm font-semibold text-social-action-foreground shadow-lg transition-colors hover:border-social-action-hover hover:bg-social-action-hover active:border-social-action-pressed active:bg-social-action-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus focus-visible:ring-offset-2 focus-visible:ring-offset-social-canvas"
           >
             {newMessageCount === 1 ? '1 new message' : `${newMessageCount} new messages`}
           </button>
         ) : null}
       </div>
 
-      <footer className="border-t border-border bg-background p-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
+      <footer className="border-t border-social-border bg-social-surface p-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
         {!canPublish && !muted ? (
-          <p role="status" className="py-2 text-center text-sm text-muted-foreground">
+          <p role="status" className="py-2 text-center text-sm text-social-text-muted">
             Accept the community standards above before sending messages.
           </p>
         ) : muted ? (
-          <p role="status" className="py-2 text-center text-sm text-muted-foreground">
+          <p role="status" className="py-2 text-center text-sm text-social-text-muted">
             You can read chat, but cannot send until{' '}
             <time dateTime={mutedUntil ?? undefined}>
               {mutedUntil ? new Date(mutedUntil).toLocaleString() : 'the mute ends'}
@@ -392,25 +407,25 @@ function DiscussionContextCard({
   const metadata = Object.values(context.metadata ?? {}).filter(Boolean);
 
   return (
-    <div className="mt-2 rounded-xl border border-border bg-muted/40 p-3">
+    <div className="mt-2 rounded-xl border border-social-border bg-social-surface-subtle p-3">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          <p className="text-xs font-semibold uppercase tracking-wide text-social-text-muted">
             {label}
           </p>
-          <p className="mt-1 truncate text-sm font-semibold text-foreground">{context.title}</p>
+          <p className="mt-1 truncate text-sm font-semibold text-social-text">{context.title}</p>
           {context.subtitle ? (
-            <p className="mt-1 text-xs text-muted-foreground">{context.subtitle}</p>
+            <p className="mt-1 text-xs text-social-text-muted">{context.subtitle}</p>
           ) : null}
           {metadata.length > 0 ? (
-            <p className="mt-1 truncate text-xs text-muted-foreground">{metadata.join(' · ')}</p>
+            <p className="mt-1 truncate text-xs text-social-text-muted">{metadata.join(' · ')}</p>
           ) : null}
         </div>
         {onRemove ? (
           <button
             type="button"
             onClick={onRemove}
-            className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg text-social-text-muted transition-colors hover:bg-social-brand-soft hover:text-social-text active:bg-social-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
             aria-label="Remove discussion context"
           >
             <X className="size-4" aria-hidden="true" />

--- a/src/components/league/social/LeagueSocialAppProvider.test.tsx
+++ b/src/components/league/social/LeagueSocialAppProvider.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import LeagueSocialAppProvider from './LeagueSocialAppProvider';
+
+const mocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/AuthContext', () => ({
+  useAuth: mocks.useAuth,
+}));
+
+vi.mock('@/providers/SocketProvider', () => ({
+  SocketProvider: ({ uid, children }: { uid: string; children: React.ReactNode }) => (
+    <div data-testid="socket-provider" data-uid={uid}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('./LeagueSocialWidgetProvider', () => ({
+  LeagueSocialWidgetProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="widget-provider">{children}</div>
+  ),
+}));
+
+vi.mock('./LeagueSocialWidget', () => ({
+  default: ({ currentUserId }: { currentUserId: string }) => (
+    <div data-testid="social-widget" data-user-id={currentUserId} />
+  ),
+}));
+
+describe('LeagueSocialAppProvider', () => {
+  it('owns one socket around app routes and the persistent widget for an authenticated user', () => {
+    mocks.useAuth.mockReturnValue({ user: { uid: 'user-1' } });
+
+    render(
+      <LeagueSocialAppProvider>
+        <main>App route</main>
+      </LeagueSocialAppProvider>
+    );
+
+    expect(screen.getAllByTestId('socket-provider')).toHaveLength(1);
+    expect(screen.getByTestId('socket-provider')).toHaveAttribute('data-uid', 'user-1');
+    expect(screen.getByText('App route')).toBeInTheDocument();
+    expect(screen.getByTestId('social-widget')).toHaveAttribute('data-user-id', 'user-1');
+  });
+
+  it('keeps the widget API boundary without opening a socket before authentication', () => {
+    mocks.useAuth.mockReturnValue({ user: null });
+
+    render(
+      <LeagueSocialAppProvider>
+        <main>Restoring route</main>
+      </LeagueSocialAppProvider>
+    );
+
+    expect(screen.getByTestId('widget-provider')).toBeInTheDocument();
+    expect(screen.queryByTestId('socket-provider')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('social-widget')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/league/social/LeagueSocialAppProvider.tsx
+++ b/src/components/league/social/LeagueSocialAppProvider.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { useAuth } from '@/AuthContext';
+import { SocketProvider } from '@/providers/SocketProvider';
+
+import LeagueSocialWidget from './LeagueSocialWidget';
+import { LeagueSocialWidgetProvider } from './LeagueSocialWidgetProvider';
+
+export default function LeagueSocialAppProvider({
+  children,
+}: {
+  children: ReactNode;
+}): React.JSX.Element {
+  const { user } = useAuth();
+
+  return (
+    <LeagueSocialWidgetProvider>
+      {user ? (
+        <SocketProvider uid={user.uid}>
+          {children}
+          <LeagueSocialWidget currentUserId={user.uid} />
+        </SocketProvider>
+      ) : (
+        children
+      )}
+    </LeagueSocialWidgetProvider>
+  );
+}

--- a/src/components/league/social/LeagueSocialShell.test.tsx
+++ b/src/components/league/social/LeagueSocialShell.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import LeagueSocialShell from './LeagueSocialShell';
+
+const controller = {
+  summary: {
+    leagueId: 'league-1',
+    seasonId: 'season-1',
+    canManage: false,
+    canPublish: false,
+    standardsAccepted: true,
+    mutedUntil: null,
+    unread: { chat: 2, board: 3 },
+    latestSequence: { chat: 4, board: 7 },
+    categories: [],
+  },
+  messages: [],
+  posts: [],
+  threads: {},
+  messagesCursor: null,
+  postsCursor: null,
+  loading: false,
+  loadingEarlierMessages: false,
+  loadingMorePosts: false,
+  sendingMessage: false,
+  creatingPost: false,
+  error: null,
+  submitError: null,
+  retry: vi.fn(),
+  loadEarlierMessages: vi.fn(),
+  loadMorePosts: vi.fn(),
+  sendMessage: vi.fn(),
+  createPost: vi.fn(),
+  loadReplies: vi.fn(),
+  createReply: vi.fn(),
+  markRead: vi.fn().mockResolvedValue(undefined),
+  postSort: 'latestActivity' as const,
+  setPostSort: vi.fn(),
+};
+
+vi.mock('./useLeagueSocial', () => ({
+  useLeagueSocial: () => controller,
+}));
+
+describe('LeagueSocialShell', () => {
+  it('exposes chat and board as keyboard-navigable tabs with separate unread labels', async () => {
+    const user = userEvent.setup();
+    render(<LeagueSocialShell leagueId="league-1" currentUserId="user-1" />);
+
+    const chatTab = screen.getByRole('tab', { name: /chat 2 unread/i });
+    const boardTab = screen.getByRole('tab', { name: /message board 3 unread/i });
+    expect(chatTab).toHaveAttribute('aria-selected', 'true');
+
+    chatTab.focus();
+    await user.keyboard('{ArrowRight}');
+
+    await waitFor(() => expect(boardTab).toHaveFocus());
+    expect(boardTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('No discussions yet')).toBeInTheDocument();
+  });
+});

--- a/src/components/league/social/LeagueSocialShell.test.tsx
+++ b/src/components/league/social/LeagueSocialShell.test.tsx
@@ -204,8 +204,9 @@ describe('LeagueSocialShell', () => {
     expect(shell).not.toHaveClass('min-h-[36rem]');
     const chatTab = screen.getByRole('tab', { name: /chat 2 unread/i });
     const boardTab = screen.getByRole('tab', { name: /board 3 unread/i });
-    expect(chatTab).toHaveClass('border-primary');
+    expect(chatTab).toHaveClass('border-social-action', 'text-social-text');
     expect(boardTab).toHaveClass('border-transparent');
+    expect(boardTab).toHaveClass('text-social-text-muted');
     expect(screen.getByRole('button', { name: 'Social notification preferences' })).toHaveClass(
       'rounded-full'
     );

--- a/src/components/league/social/LeagueSocialShell.test.tsx
+++ b/src/components/league/social/LeagueSocialShell.test.tsx
@@ -2,6 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { SocialMessage, SocialPost } from '@/types/social';
+
 import LeagueSocialShell from './LeagueSocialShell';
 
 const controller = {
@@ -9,20 +11,23 @@ const controller = {
     leagueId: 'league-1',
     seasonId: 'season-1',
     canManage: false,
-    canPublish: false,
+    canPublish: true,
     standardsAccepted: true,
     mutedUntil: null,
-    unread: { chat: 2, board: 3 },
-    latestSequence: { chat: 4, board: 7 },
+    unread: { chat: 2, board: 3, activity: 4 },
+    latestSequence: { chat: 4, board: 7, activity: 9 },
     categories: [],
   },
   messages: [],
-  posts: [],
+  activity: [] as SocialMessage[],
+  posts: [] as SocialPost[],
   threads: {},
   messagesCursor: null,
+  activityCursor: null,
   postsCursor: null,
   loading: false,
   loadingEarlierMessages: false,
+  loadingEarlierActivity: false,
   loadingMorePosts: false,
   sendingMessage: false,
   creatingPost: false,
@@ -30,6 +35,7 @@ const controller = {
   submitError: null,
   retry: vi.fn(),
   loadEarlierMessages: vi.fn(),
+  loadEarlierActivity: vi.fn(),
   loadMorePosts: vi.fn(),
   sendMessage: vi.fn(),
   createPost: vi.fn(),
@@ -45,13 +51,17 @@ vi.mock('./useLeagueSocial', () => ({
 }));
 
 describe('LeagueSocialShell', () => {
-  it('exposes chat and board as keyboard-navigable tabs with separate unread labels', async () => {
+  it('keeps three panels mounted and exposes keyboard tabs with separate unread labels', async () => {
     const user = userEvent.setup();
     render(<LeagueSocialShell leagueId="league-1" currentUserId="user-1" />);
 
     const chatTab = screen.getByRole('tab', { name: /chat 2 unread/i });
     const boardTab = screen.getByRole('tab', { name: /message board 3 unread/i });
+    const activityTab = screen.getByRole('tab', { name: /activity 4 unread/i });
     expect(chatTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getAllByRole('tabpanel', { hidden: true })).toHaveLength(3);
+    const chatComposer = screen.getByRole('textbox', { name: 'Message league chat' });
+    await user.type(chatComposer, 'Preserve this draft');
 
     chatTab.focus();
     await user.keyboard('{ArrowRight}');
@@ -59,5 +69,143 @@ describe('LeagueSocialShell', () => {
     await waitFor(() => expect(boardTab).toHaveFocus());
     expect(boardTab).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByText('No discussions yet')).toBeInTheDocument();
+
+    await user.keyboard('{End}');
+    await waitFor(() => expect(activityTab).toHaveFocus());
+    expect(activityTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('No league activity yet')).toBeInTheDocument();
+
+    await user.keyboard('{Home}');
+    await waitFor(() => expect(chatTab).toHaveFocus());
+    expect(screen.getByRole('textbox', { name: 'Message league chat' })).toHaveValue(
+      'Preserve this draft'
+    );
+  });
+
+  it('supports the compact header contract without removing preferences', () => {
+    render(
+      <LeagueSocialShell
+        leagueId="league-1"
+        currentUserId="user-1"
+        title="Hidden title"
+        showHeader={false}
+      />
+    );
+
+    expect(screen.queryByRole('heading', { name: 'Hidden title' })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Social notification preferences' })
+    ).toBeInTheDocument();
+  });
+
+  it('marks only latest visible content read and waits while the shell is minimized', async () => {
+    const user = userEvent.setup();
+    controller.markRead.mockClear();
+    const { rerender } = render(
+      <LeagueSocialShell leagueId="league-1" currentUserId="user-1" visible={false} />
+    );
+
+    await user.click(screen.getByRole('tab', { name: /message board 3 unread/i }));
+    await waitFor(() => expect(screen.getByText('No discussions yet')).toBeInTheDocument());
+    expect(controller.markRead).not.toHaveBeenCalled();
+
+    rerender(<LeagueSocialShell leagueId="league-1" currentUserId="user-1" visible />);
+    await waitFor(() => expect(controller.markRead).toHaveBeenCalledWith('board'));
+    expect(controller.markRead).not.toHaveBeenCalledWith('chat');
+    expect(controller.markRead).not.toHaveBeenCalledWith('activity');
+  });
+
+  it('does not mark the whole board read while viewing one discussion thread', async () => {
+    const post: SocialPost = {
+      id: 'post-1',
+      leagueId: 'league-1',
+      seasonId: 'season-1',
+      category: { id: 'category-1', key: 'general', name: 'General', position: 1 },
+      author: {
+        userId: 'user-2',
+        displayName: 'Other Member',
+        teamName: 'Other Team',
+      },
+      title: 'One discussion',
+      body: 'This is not the whole board.',
+      isPinned: false,
+      isLocked: false,
+      isAnnouncement: false,
+      replyCount: 1,
+      latestActivityAt: '2026-07-19T10:00:00.000Z',
+      createdAt: '2026-07-19T09:00:00.000Z',
+      updatedAt: '2026-07-19T10:00:00.000Z',
+      moderationStatus: 'active',
+      isOwn: false,
+    };
+    controller.posts = [post];
+    controller.threads = {
+      'post-1': { items: [], nextCursor: null, loading: false, error: null },
+    };
+    controller.markRead.mockClear();
+
+    render(
+      <LeagueSocialShell
+        leagueId="league-1"
+        currentUserId="user-1"
+        initialView="board"
+        initialPostId="post-1"
+      />
+    );
+
+    expect(await screen.findByRole('heading', { name: 'One discussion' })).toBeInTheDocument();
+    await waitFor(() => expect(controller.loadReplies).toHaveBeenCalledWith('post-1'));
+    expect(controller.markRead).not.toHaveBeenCalledWith('board');
+
+    controller.posts = [];
+    controller.threads = {};
+  });
+
+  it('moves focus to Chat after starting a discussion from Activity', async () => {
+    const user = userEvent.setup();
+    const activity: SocialMessage = {
+      id: 'activity-1',
+      leagueId: 'league-1',
+      seasonId: 'season-1',
+      type: 'system',
+      content: 'Player drafted',
+      author: null,
+      createdAt: '2026-07-19T10:00:00.000Z',
+      moderationStatus: 'active',
+      isOwn: false,
+    };
+    const onDiscussActivity = vi.fn();
+    controller.activity = [activity];
+
+    render(
+      <LeagueSocialShell
+        leagueId="league-1"
+        currentUserId="user-1"
+        initialView="activity"
+        onDiscussActivity={onDiscussActivity}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Discuss' }));
+
+    expect(onDiscussActivity).toHaveBeenCalledWith(activity);
+    await waitFor(() => expect(screen.getByRole('tab', { name: /chat/i })).toHaveFocus());
+
+    controller.activity = [];
+  });
+
+  it('removes fixed minimum heights in compact mode', () => {
+    render(
+      <LeagueSocialShell leagueId="league-1" currentUserId="user-1" compact showHeader={false} />
+    );
+
+    const shell = screen.getByLabelText('League social');
+    expect(shell).toHaveClass('min-h-0');
+    expect(shell).not.toHaveClass('min-h-[36rem]');
+    const chatScroller = screen
+      .getByRole('textbox', { name: 'Message league chat' })
+      .closest('section')
+      ?.querySelector('.overflow-y-auto');
+    expect(chatScroller).toHaveClass('min-h-0');
+    expect(chatScroller).not.toHaveClass('min-h-64');
   });
 });

--- a/src/components/league/social/LeagueSocialShell.test.tsx
+++ b/src/components/league/social/LeagueSocialShell.test.tsx
@@ -56,7 +56,7 @@ describe('LeagueSocialShell', () => {
     render(<LeagueSocialShell leagueId="league-1" currentUserId="user-1" />);
 
     const chatTab = screen.getByRole('tab', { name: /chat 2 unread/i });
-    const boardTab = screen.getByRole('tab', { name: /message board 3 unread/i });
+    const boardTab = screen.getByRole('tab', { name: /board 3 unread/i });
     const activityTab = screen.getByRole('tab', { name: /activity 4 unread/i });
     expect(chatTab).toHaveAttribute('aria-selected', 'true');
     expect(screen.getAllByRole('tabpanel', { hidden: true })).toHaveLength(3);
@@ -105,7 +105,7 @@ describe('LeagueSocialShell', () => {
       <LeagueSocialShell leagueId="league-1" currentUserId="user-1" visible={false} />
     );
 
-    await user.click(screen.getByRole('tab', { name: /message board 3 unread/i }));
+    await user.click(screen.getByRole('tab', { name: /board 3 unread/i }));
     await waitFor(() => expect(screen.getByText('No discussions yet')).toBeInTheDocument());
     expect(controller.markRead).not.toHaveBeenCalled();
 
@@ -201,6 +201,15 @@ describe('LeagueSocialShell', () => {
     const shell = screen.getByLabelText('League social');
     expect(shell).toHaveClass('min-h-0');
     expect(shell).not.toHaveClass('min-h-[36rem]');
+    const chatTab = screen.getByRole('tab', { name: /chat 2 unread/i });
+    const boardTab = screen.getByRole('tab', { name: /board 3 unread/i });
+    expect(chatTab).toHaveClass('border-primary');
+    expect(boardTab).toHaveClass('border-transparent');
+    expect(screen.getByRole('button', { name: 'Social notification preferences' })).toHaveClass(
+      'rounded-full'
+    );
+    const chatPanel = screen.getByRole('tabpanel', { name: /chat/i });
+    expect(chatPanel).toHaveClass('p-0');
     const chatScroller = screen
       .getByRole('textbox', { name: 'Message league chat' })
       .closest('section')

--- a/src/components/league/social/LeagueSocialShell.test.tsx
+++ b/src/components/league/social/LeagueSocialShell.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { SocialMessage, SocialPost } from '@/types/social';
 
 import LeagueSocialShell from './LeagueSocialShell';
+import { getSocialComposerDraftKey } from './socialComposerDraft';
 
 const controller = {
   summary: {
@@ -216,5 +217,39 @@ describe('LeagueSocialShell', () => {
       ?.querySelector('.overflow-y-auto');
     expect(chatScroller).toHaveClass('min-h-0');
     expect(chatScroller).not.toHaveClass('min-h-64');
+  });
+
+  it('persists the shared composer under its Draft Room surface and accessible label', async () => {
+    const user = userEvent.setup();
+    const draftScope = {
+      userId: 'draft-user',
+      leagueId: 'draft-league',
+      leagueSeasonId: 'season-1',
+      surface: { type: 'draft-chat' as const, draftId: 'draft-42' },
+    };
+    const leagueScope = {
+      ...draftScope,
+      surface: { type: 'league-chat' as const },
+    };
+    render(
+      <LeagueSocialShell
+        leagueId="draft-league"
+        currentUserId="draft-user"
+        composerLabel="Message the members of Draft League"
+        composerSurface={draftScope.surface}
+      />
+    );
+
+    await user.type(
+      screen.getByRole('textbox', { name: 'Message the members of Draft League' }),
+      'Draft-room thought'
+    );
+
+    await waitFor(() =>
+      expect(localStorage.getItem(getSocialComposerDraftKey(draftScope))).toContain(
+        'Draft-room thought'
+      )
+    );
+    expect(localStorage.getItem(getSocialComposerDraftKey(leagueScope))).toBeNull();
   });
 });

--- a/src/components/league/social/LeagueSocialShell.tsx
+++ b/src/components/league/social/LeagueSocialShell.tsx
@@ -1,30 +1,43 @@
 'use client';
 
-import { MessageCircle, MessagesSquare, Settings } from 'lucide-react';
-import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react';
+import { Activity, MessageCircle, MessagesSquare, Settings } from 'lucide-react';
+import { useCallback, useEffect, useId, useRef, useState, type KeyboardEvent } from 'react';
 
-import type { SocialChannel, SocialPost } from '@/types/social';
+import type {
+  SocialChannel,
+  SocialDiscussionContext,
+  SocialMessage,
+  SocialPost,
+} from '@/types/social';
 
+import ActivityPanel from './ActivityPanel';
 import LeagueChatPanel from './LeagueChatPanel';
 import MessageBoardPanel from './MessageBoardPanel';
 import PostThread from './PostThread';
 import SocialPreferencesPanel from './SocialPreferencesPanel';
 import { useLeagueSocial } from './useLeagueSocial';
 
-export type LeagueSocialView = 'chat' | 'board';
+export type LeagueSocialView = SocialChannel;
 
-interface LeagueSocialShellProps {
+export interface LeagueSocialShellProps {
   leagueId: string;
   currentUserId?: string;
   initialView?: LeagueSocialView;
   initialPostId?: string;
   className?: string;
   title?: string;
+  showHeader?: boolean;
+  compact?: boolean;
+  visible?: boolean;
+  composerContext?: SocialDiscussionContext | null;
+  onClearComposerContext?: () => void;
+  onDiscussActivity?: (activity: SocialMessage) => void;
 }
 
 const tabs: Array<{ id: LeagueSocialView; label: string; icon: typeof MessageCircle }> = [
   { id: 'chat', label: 'Chat', icon: MessageCircle },
   { id: 'board', label: 'Message board', icon: MessagesSquare },
+  { id: 'activity', label: 'Activity', icon: Activity },
 ];
 
 export default function LeagueSocialShell({
@@ -34,12 +47,19 @@ export default function LeagueSocialShell({
   initialPostId,
   className = '',
   title = 'League social',
+  showHeader = true,
+  compact = false,
+  visible = true,
+  composerContext,
+  onClearComposerContext,
+  onDiscussActivity,
 }: LeagueSocialShellProps): React.JSX.Element {
   const controller = useLeagueSocial(leagueId, currentUserId);
   const tabSetId = useId();
   const tabRefs = useRef<Record<LeagueSocialView, HTMLButtonElement | null>>({
     chat: null,
     board: null,
+    activity: null,
   });
   const loadedInitialPostRef = useRef<string | null>(null);
   const [activeView, setActiveView] = useState<LeagueSocialView>(initialView);
@@ -47,6 +67,14 @@ export default function LeagueSocialShell({
   const [showPreferences, setShowPreferences] = useState(false);
   const [acceptingStandards, setAcceptingStandards] = useState(false);
   const [standardsError, setStandardsError] = useState<string | null>(null);
+  const [documentVisible, setDocumentVisible] = useState(
+    () => typeof document === 'undefined' || document.visibilityState === 'visible'
+  );
+  const [latestVisible, setLatestVisible] = useState<Record<SocialChannel, boolean>>({
+    chat: false,
+    board: false,
+    activity: false,
+  });
   const selectedPost = controller.posts.find((post) => post.id === selectedPostId) ?? null;
   const selectedThread = selectedPostId ? controller.threads[selectedPostId] : undefined;
 
@@ -63,18 +91,26 @@ export default function LeagueSocialShell({
   }, [controller.loadReplies, initialPostId]);
 
   useEffect(() => {
-    if (controller.loading) return;
-    void controller.markRead(activeView as SocialChannel);
-  }, [
-    activeView,
-    controller.loading,
-    controller.markRead,
-    controller.summary?.latestSequence[activeView],
-  ]);
+    const handleVisibilityChange = () => {
+      setDocumentVisible(document.visibilityState === 'visible');
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, []);
+
+  useEffect(() => {
+    if (!visible || !documentVisible || controller.loading || !latestVisible[activeView]) return;
+    void controller.markRead(activeView);
+  }, [activeView, controller, documentVisible, latestVisible, visible]);
+
+  const handleLatestVisibleChange = useCallback((channel: SocialChannel, isVisible: boolean) => {
+    setLatestVisible((current) =>
+      current[channel] === isVisible ? current : { ...current, [channel]: isVisible }
+    );
+  }, []);
 
   function selectView(view: LeagueSocialView): void {
     setActiveView(view);
-    if (view === 'chat') setSelectedPostId(null);
   }
 
   function handleTabKeyDown(event: KeyboardEvent<HTMLButtonElement>): void {
@@ -93,33 +129,42 @@ export default function LeagueSocialShell({
   }
 
   function handleSelectPost(post: SocialPost): void {
+    handleLatestVisibleChange('board', false);
     setSelectedPostId(post.id);
     void controller.loadReplies(post.id);
   }
 
+  const settingsButton = (
+    <button
+      type="button"
+      onClick={() => setShowPreferences((preferencesVisible) => !preferencesVisible)}
+      aria-expanded={showPreferences}
+      className="inline-flex size-10 shrink-0 items-center justify-center rounded-lg border border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <Settings className="size-4" aria-hidden="true" />
+      <span className="sr-only">Social notification preferences</span>
+    </button>
+  );
+
   return (
     <section
-      className={`flex min-h-[36rem] min-w-0 flex-col overflow-hidden rounded-2xl border border-border bg-background text-foreground shadow-sm ${className}`}
+      className={`flex min-w-0 flex-col overflow-hidden rounded-2xl border border-border bg-background text-foreground shadow-sm ${
+        compact ? 'min-h-0' : 'min-h-[36rem]'
+      } ${className}`}
       aria-label={title}
     >
       <div className="border-b border-border bg-card px-3 pt-3">
-        <div className="flex items-start justify-between gap-3 px-1 pb-3">
-          <div>
-            <h1 className="text-lg font-semibold tracking-tight text-foreground">{title}</h1>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Chat live or revisit persistent league discussions.
-            </p>
+        {showHeader ? (
+          <div className="flex items-start justify-between gap-3 px-1 pb-3">
+            <div>
+              <h1 className="text-lg font-semibold tracking-tight text-foreground">{title}</h1>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Chat live or revisit persistent league discussions.
+              </p>
+            </div>
+            {settingsButton}
           </div>
-          <button
-            type="button"
-            onClick={() => setShowPreferences((visible) => !visible)}
-            aria-expanded={showPreferences}
-            className="inline-flex size-10 shrink-0 items-center justify-center rounded-lg border border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <Settings className="size-4" aria-hidden="true" />
-            <span className="sr-only">Social notification preferences</span>
-          </button>
-        </div>
+        ) : null}
         {showPreferences && controller.summary ? (
           <SocialPreferencesPanel
             preferences={controller.summary.preferences}
@@ -163,78 +208,97 @@ export default function LeagueSocialShell({
             ) : null}
           </div>
         ) : null}
-        <div
-          role="tablist"
-          aria-label="League social views"
-          className="grid max-w-md grid-cols-2 gap-1 rounded-xl bg-muted p-1"
-        >
-          {tabs.map((tab) => {
-            const active = activeView === tab.id;
-            const unread = controller.summary?.unread[tab.id] ?? 0;
-            const Icon = tab.icon;
-            return (
-              <button
-                key={tab.id}
-                ref={(element) => {
-                  tabRefs.current[tab.id] = element;
-                }}
-                id={`${tabSetId}-${tab.id}-tab`}
-                type="button"
-                role="tab"
-                aria-selected={active}
-                aria-controls={`${tabSetId}-${tab.id}-panel`}
-                tabIndex={active ? 0 : -1}
-                onClick={() => selectView(tab.id)}
-                onKeyDown={handleTabKeyDown}
-                className={`inline-flex min-h-10 items-center justify-center gap-2 rounded-lg px-3 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
-                  active
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                <Icon className="size-4" aria-hidden="true" />
-                <span>{tab.label}</span>
-                {unread > 0 ? (
-                  <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 py-0.5 text-xs font-semibold text-destructive-foreground">
-                    <span className="sr-only">{unread} unread</span>
-                    <span aria-hidden="true">{unread > 99 ? '99+' : unread}</span>
-                  </span>
-                ) : null}
-              </button>
-            );
-          })}
+        <div className="flex items-center gap-2 pb-3">
+          <div
+            role="tablist"
+            aria-label="League social views"
+            className="grid min-w-0 max-w-xl flex-1 grid-cols-3 gap-1 rounded-xl bg-muted p-1"
+          >
+            {tabs.map((tab) => {
+              const active = activeView === tab.id;
+              const unread = controller.summary?.unread[tab.id] ?? 0;
+              const Icon = tab.icon;
+              return (
+                <button
+                  key={tab.id}
+                  ref={(element) => {
+                    tabRefs.current[tab.id] = element;
+                  }}
+                  id={`${tabSetId}-${tab.id}-tab`}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  aria-controls={`${tabSetId}-${tab.id}-panel`}
+                  tabIndex={active ? 0 : -1}
+                  onClick={() => selectView(tab.id)}
+                  onKeyDown={handleTabKeyDown}
+                  className={`inline-flex min-h-10 items-center justify-center gap-2 rounded-lg px-3 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                    active
+                      ? 'bg-background text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  <Icon className="size-4" aria-hidden="true" />
+                  <span>{tab.label}</span>
+                  {unread > 0 ? (
+                    <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 py-0.5 text-xs font-semibold text-destructive-foreground">
+                      <span className="sr-only">{unread} unread</span>
+                      <span aria-hidden="true">{unread > 99 ? '99+' : unread}</span>
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+          {!showHeader ? settingsButton : null}
         </div>
       </div>
 
       <div
-        id={`${tabSetId}-${activeView}-panel`}
+        id={`${tabSetId}-chat-panel`}
         role="tabpanel"
-        aria-labelledby={`${tabSetId}-${activeView}-tab`}
-        className="flex min-h-0 flex-1 p-3"
+        aria-labelledby={`${tabSetId}-chat-tab`}
+        hidden={activeView !== 'chat'}
+        aria-hidden={activeView !== 'chat'}
+        className={`${activeView === 'chat' ? 'flex' : 'hidden'} min-h-0 flex-1 p-3`}
       >
-        {activeView === 'chat' ? (
-          <LeagueChatPanel
-            messages={controller.messages}
-            hasEarlierMessages={Boolean(controller.messagesCursor)}
-            loading={controller.loading}
-            loadingEarlier={controller.loadingEarlierMessages}
-            sending={controller.sendingMessage}
-            canPublish={controller.summary?.canPublish ?? false}
-            canManage={controller.summary?.canManage ?? false}
-            mutedUntil={controller.summary?.mutedUntil}
-            error={controller.error}
-            submitError={controller.submitError}
-            onRetry={controller.retry}
-            onLoadEarlier={controller.loadEarlierMessages}
-            onSend={controller.sendMessage}
-            onReport={(messageId, reason, details) =>
-              controller.reportContent('message', messageId, reason, details)
-            }
-            onRemove={(messageId, reason) =>
-              controller.moderateContent('message', messageId, reason)
-            }
-          />
-        ) : selectedPost ? (
+        <LeagueChatPanel
+          messages={controller.messages}
+          hasEarlierMessages={Boolean(controller.messagesCursor)}
+          loading={controller.loading}
+          loadingEarlier={controller.loadingEarlierMessages}
+          sending={controller.sendingMessage}
+          canPublish={controller.summary?.canPublish ?? false}
+          canManage={controller.summary?.canManage ?? false}
+          mutedUntil={controller.summary?.mutedUntil}
+          error={controller.error}
+          submitError={controller.submitError}
+          visible={visible && activeView === 'chat'}
+          compact={compact}
+          composerContext={composerContext}
+          onClearComposerContext={onClearComposerContext}
+          onLatestVisibleChange={(isLatestVisible) =>
+            handleLatestVisibleChange('chat', isLatestVisible)
+          }
+          onRetry={controller.retry}
+          onLoadEarlier={controller.loadEarlierMessages}
+          onSend={controller.sendMessage}
+          onReport={(messageId, reason, details) =>
+            controller.reportContent('message', messageId, reason, details)
+          }
+          onRemove={(messageId, reason) => controller.moderateContent('message', messageId, reason)}
+        />
+      </div>
+
+      <div
+        id={`${tabSetId}-board-panel`}
+        role="tabpanel"
+        aria-labelledby={`${tabSetId}-board-tab`}
+        hidden={activeView !== 'board'}
+        aria-hidden={activeView !== 'board'}
+        className={`${activeView === 'board' ? 'flex' : 'hidden'} min-h-0 flex-1 p-3`}
+      >
+        {selectedPost ? (
           <PostThread
             post={selectedPost}
             replies={selectedThread?.items ?? []}
@@ -245,7 +309,11 @@ export default function LeagueSocialShell({
             canPublish={controller.summary?.canPublish ?? false}
             error={selectedThread?.error}
             submitError={controller.submitError}
-            onBack={() => setSelectedPostId(null)}
+            visible={visible && activeView === 'board'}
+            onBack={() => {
+              handleLatestVisibleChange('board', false);
+              setSelectedPostId(null);
+            }}
             onRetry={() => controller.loadReplies(selectedPost.id)}
             onLoadMore={() => controller.loadReplies(selectedPost.id, true)}
             onReply={(body) => controller.createReply(selectedPost.id, body)}
@@ -273,14 +341,51 @@ export default function LeagueSocialShell({
             mutedUntil={controller.summary?.mutedUntil}
             error={controller.error}
             submitError={controller.submitError}
+            visible={visible && activeView === 'board'}
             onRetry={controller.retry}
             onLoadMore={controller.loadMorePosts}
             onSelectPost={handleSelectPost}
             onCreatePost={controller.createPost}
             sort={controller.postSort}
             onSortChange={controller.setPostSort}
+            onLatestVisibleChange={(isLatestVisible) =>
+              handleLatestVisibleChange('board', isLatestVisible)
+            }
           />
         )}
+      </div>
+
+      <div
+        id={`${tabSetId}-activity-panel`}
+        role="tabpanel"
+        aria-labelledby={`${tabSetId}-activity-tab`}
+        hidden={activeView !== 'activity'}
+        aria-hidden={activeView !== 'activity'}
+        className={`${activeView === 'activity' ? 'flex' : 'hidden'} min-h-0 flex-1 p-3`}
+      >
+        <ActivityPanel
+          activity={controller.activity}
+          hasEarlierActivity={Boolean(controller.activityCursor)}
+          loading={controller.loading}
+          loadingEarlier={controller.loadingEarlierActivity}
+          error={controller.error}
+          visible={visible && activeView === 'activity'}
+          compact={compact}
+          onRetry={controller.retry}
+          onLoadEarlier={controller.loadEarlierActivity}
+          onLatestVisibleChange={(isLatestVisible) =>
+            handleLatestVisibleChange('activity', isLatestVisible)
+          }
+          onDiscuss={
+            onDiscussActivity
+              ? (activity) => {
+                  onDiscussActivity(activity);
+                  selectView('chat');
+                  window.requestAnimationFrame(() => tabRefs.current.chat?.focus());
+                }
+              : undefined
+          }
+        />
       </div>
     </section>
   );

--- a/src/components/league/social/LeagueSocialShell.tsx
+++ b/src/components/league/social/LeagueSocialShell.tsx
@@ -36,7 +36,7 @@ export interface LeagueSocialShellProps {
 
 const tabs: Array<{ id: LeagueSocialView; label: string; icon: typeof MessageCircle }> = [
   { id: 'chat', label: 'Chat', icon: MessageCircle },
-  { id: 'board', label: 'Message board', icon: MessagesSquare },
+  { id: 'board', label: 'Board', icon: MessagesSquare },
   { id: 'activity', label: 'Activity', icon: Activity },
 ];
 
@@ -139,7 +139,7 @@ export default function LeagueSocialShell({
       type="button"
       onClick={() => setShowPreferences((preferencesVisible) => !preferencesVisible)}
       aria-expanded={showPreferences}
-      className="inline-flex size-10 shrink-0 items-center justify-center rounded-lg border border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="inline-flex size-10 shrink-0 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <Settings className="size-4" aria-hidden="true" />
       <span className="sr-only">Social notification preferences</span>
@@ -153,7 +153,11 @@ export default function LeagueSocialShell({
       } ${className}`}
       aria-label={title}
     >
-      <div className="border-b border-border bg-card px-3 pt-3">
+      <div
+        className={
+          compact ? 'border-b border-border bg-card' : 'border-b border-border bg-card px-3 pt-3'
+        }
+      >
         {showHeader ? (
           <div className="flex items-start justify-between gap-3 px-1 pb-3">
             <div>
@@ -166,16 +170,22 @@ export default function LeagueSocialShell({
           </div>
         ) : null}
         {showPreferences && controller.summary ? (
-          <SocialPreferencesPanel
-            preferences={controller.summary.preferences}
-            onSave={async (preferences) => {
-              await controller.updatePreferences(preferences);
-            }}
-            onClose={() => setShowPreferences(false)}
-          />
+          <div className={compact ? 'px-3 pt-3' : undefined}>
+            <SocialPreferencesPanel
+              preferences={controller.summary.preferences}
+              onSave={async (preferences) => {
+                await controller.updatePreferences(preferences);
+              }}
+              onClose={() => setShowPreferences(false)}
+            />
+          </div>
         ) : null}
         {controller.summary && !controller.summary.standardsAccepted ? (
-          <div className="mb-3 rounded-xl border border-primary/30 bg-primary/10 p-3">
+          <div
+            className={`rounded-xl border border-primary/30 bg-primary/10 p-3 ${
+              compact ? 'm-3' : 'mb-3'
+            }`}
+          >
             <p className="text-sm font-semibold text-foreground">Community standards</p>
             <p className="mt-1 text-sm text-muted-foreground">
               Keep league discussion respectful, safe, and relevant. You can read league social
@@ -208,11 +218,15 @@ export default function LeagueSocialShell({
             ) : null}
           </div>
         ) : null}
-        <div className="flex items-center gap-2 pb-3">
+        <div className={compact ? 'flex h-12 items-center px-2' : 'flex items-center gap-2 pb-3'}>
           <div
             role="tablist"
             aria-label="League social views"
-            className="grid min-w-0 max-w-xl flex-1 grid-cols-3 gap-1 rounded-xl bg-muted p-1"
+            className={
+              compact
+                ? 'flex h-full min-w-0 flex-1 items-stretch'
+                : 'grid min-w-0 max-w-xl flex-1 grid-cols-3 gap-1 rounded-xl bg-muted p-1'
+            }
           >
             {tabs.map((tab) => {
               const active = activeView === tab.id;
@@ -232,10 +246,18 @@ export default function LeagueSocialShell({
                   tabIndex={active ? 0 : -1}
                   onClick={() => selectView(tab.id)}
                   onKeyDown={handleTabKeyDown}
-                  className={`inline-flex min-h-10 items-center justify-center gap-2 rounded-lg px-3 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
-                    active
-                      ? 'bg-background text-foreground shadow-sm'
-                      : 'text-muted-foreground hover:text-foreground'
+                  className={`relative inline-flex min-h-10 items-center justify-center gap-1.5 px-2 text-sm transition focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
+                    compact
+                      ? `flex-1 border-b-2 ${
+                          active
+                            ? 'border-primary font-semibold text-foreground'
+                            : 'border-transparent font-medium text-muted-foreground hover:text-foreground'
+                        }`
+                      : `rounded-lg font-semibold ${
+                          active
+                            ? 'bg-background text-foreground shadow-sm'
+                            : 'text-muted-foreground hover:text-foreground'
+                        }`
                   }`}
                 >
                   <Icon className="size-4" aria-hidden="true" />
@@ -260,7 +282,9 @@ export default function LeagueSocialShell({
         aria-labelledby={`${tabSetId}-chat-tab`}
         hidden={activeView !== 'chat'}
         aria-hidden={activeView !== 'chat'}
-        className={`${activeView === 'chat' ? 'flex' : 'hidden'} min-h-0 flex-1 p-3`}
+        className={`${activeView === 'chat' ? 'flex' : 'hidden'} min-h-0 flex-1 ${
+          compact ? 'p-0' : 'p-3'
+        }`}
       >
         <LeagueChatPanel
           messages={controller.messages}
@@ -296,7 +320,9 @@ export default function LeagueSocialShell({
         aria-labelledby={`${tabSetId}-board-tab`}
         hidden={activeView !== 'board'}
         aria-hidden={activeView !== 'board'}
-        className={`${activeView === 'board' ? 'flex' : 'hidden'} min-h-0 flex-1 p-3`}
+        className={`${activeView === 'board' ? 'flex' : 'hidden'} min-h-0 flex-1 ${
+          compact ? 'p-0' : 'p-3'
+        }`}
       >
         {selectedPost ? (
           <PostThread
@@ -310,6 +336,7 @@ export default function LeagueSocialShell({
             error={selectedThread?.error}
             submitError={controller.submitError}
             visible={visible && activeView === 'board'}
+            compact={compact}
             onBack={() => {
               handleLatestVisibleChange('board', false);
               setSelectedPostId(null);
@@ -342,6 +369,7 @@ export default function LeagueSocialShell({
             error={controller.error}
             submitError={controller.submitError}
             visible={visible && activeView === 'board'}
+            compact={compact}
             onRetry={controller.retry}
             onLoadMore={controller.loadMorePosts}
             onSelectPost={handleSelectPost}
@@ -361,7 +389,9 @@ export default function LeagueSocialShell({
         aria-labelledby={`${tabSetId}-activity-tab`}
         hidden={activeView !== 'activity'}
         aria-hidden={activeView !== 'activity'}
-        className={`${activeView === 'activity' ? 'flex' : 'hidden'} min-h-0 flex-1 p-3`}
+        className={`${activeView === 'activity' ? 'flex' : 'hidden'} min-h-0 flex-1 ${
+          compact ? 'p-0' : 'p-3'
+        }`}
       >
         <ActivityPanel
           activity={controller.activity}

--- a/src/components/league/social/LeagueSocialShell.tsx
+++ b/src/components/league/social/LeagueSocialShell.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import { MessageCircle, MessagesSquare, Settings } from 'lucide-react';
+import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react';
+
+import type { SocialChannel, SocialPost } from '@/types/social';
+
+import LeagueChatPanel from './LeagueChatPanel';
+import MessageBoardPanel from './MessageBoardPanel';
+import PostThread from './PostThread';
+import SocialPreferencesPanel from './SocialPreferencesPanel';
+import { useLeagueSocial } from './useLeagueSocial';
+
+export type LeagueSocialView = 'chat' | 'board';
+
+interface LeagueSocialShellProps {
+  leagueId: string;
+  currentUserId?: string;
+  initialView?: LeagueSocialView;
+  initialPostId?: string;
+  className?: string;
+  title?: string;
+}
+
+const tabs: Array<{ id: LeagueSocialView; label: string; icon: typeof MessageCircle }> = [
+  { id: 'chat', label: 'Chat', icon: MessageCircle },
+  { id: 'board', label: 'Message board', icon: MessagesSquare },
+];
+
+export default function LeagueSocialShell({
+  leagueId,
+  currentUserId,
+  initialView = 'chat',
+  initialPostId,
+  className = '',
+  title = 'League social',
+}: LeagueSocialShellProps): React.JSX.Element {
+  const controller = useLeagueSocial(leagueId, currentUserId);
+  const tabSetId = useId();
+  const tabRefs = useRef<Record<LeagueSocialView, HTMLButtonElement | null>>({
+    chat: null,
+    board: null,
+  });
+  const loadedInitialPostRef = useRef<string | null>(null);
+  const [activeView, setActiveView] = useState<LeagueSocialView>(initialView);
+  const [selectedPostId, setSelectedPostId] = useState<string | null>(initialPostId ?? null);
+  const [showPreferences, setShowPreferences] = useState(false);
+  const [acceptingStandards, setAcceptingStandards] = useState(false);
+  const [standardsError, setStandardsError] = useState<string | null>(null);
+  const selectedPost = controller.posts.find((post) => post.id === selectedPostId) ?? null;
+  const selectedThread = selectedPostId ? controller.threads[selectedPostId] : undefined;
+
+  useEffect(() => {
+    setActiveView(initialView);
+  }, [initialView]);
+
+  useEffect(() => {
+    if (!initialPostId || loadedInitialPostRef.current === initialPostId) return;
+    loadedInitialPostRef.current = initialPostId;
+    setActiveView('board');
+    setSelectedPostId(initialPostId);
+    void controller.loadReplies(initialPostId);
+  }, [controller.loadReplies, initialPostId]);
+
+  useEffect(() => {
+    if (controller.loading) return;
+    void controller.markRead(activeView as SocialChannel);
+  }, [
+    activeView,
+    controller.loading,
+    controller.markRead,
+    controller.summary?.latestSequence[activeView],
+  ]);
+
+  function selectView(view: LeagueSocialView): void {
+    setActiveView(view);
+    if (view === 'chat') setSelectedPostId(null);
+  }
+
+  function handleTabKeyDown(event: KeyboardEvent<HTMLButtonElement>): void {
+    const currentIndex = tabs.findIndex((tab) => tab.id === activeView);
+    let nextIndex = currentIndex;
+    if (event.key === 'ArrowRight') nextIndex = (currentIndex + 1) % tabs.length;
+    else if (event.key === 'ArrowLeft') nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+    else if (event.key === 'Home') nextIndex = 0;
+    else if (event.key === 'End') nextIndex = tabs.length - 1;
+    else return;
+
+    event.preventDefault();
+    const nextView = tabs[nextIndex].id;
+    selectView(nextView);
+    window.requestAnimationFrame(() => tabRefs.current[nextView]?.focus());
+  }
+
+  function handleSelectPost(post: SocialPost): void {
+    setSelectedPostId(post.id);
+    void controller.loadReplies(post.id);
+  }
+
+  return (
+    <section
+      className={`flex min-h-[36rem] min-w-0 flex-col overflow-hidden rounded-2xl border border-border bg-background text-foreground shadow-sm ${className}`}
+      aria-label={title}
+    >
+      <div className="border-b border-border bg-card px-3 pt-3">
+        <div className="flex items-start justify-between gap-3 px-1 pb-3">
+          <div>
+            <h1 className="text-lg font-semibold tracking-tight text-foreground">{title}</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Chat live or revisit persistent league discussions.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowPreferences((visible) => !visible)}
+            aria-expanded={showPreferences}
+            className="inline-flex size-10 shrink-0 items-center justify-center rounded-lg border border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <Settings className="size-4" aria-hidden="true" />
+            <span className="sr-only">Social notification preferences</span>
+          </button>
+        </div>
+        {showPreferences && controller.summary ? (
+          <SocialPreferencesPanel
+            preferences={controller.summary.preferences}
+            onSave={async (preferences) => {
+              await controller.updatePreferences(preferences);
+            }}
+            onClose={() => setShowPreferences(false)}
+          />
+        ) : null}
+        {controller.summary && !controller.summary.standardsAccepted ? (
+          <div className="mb-3 rounded-xl border border-primary/30 bg-primary/10 p-3">
+            <p className="text-sm font-semibold text-foreground">Community standards</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Keep league discussion respectful, safe, and relevant. You can read league social
+              content now, but must accept these standards before posting.
+            </p>
+            <button
+              type="button"
+              disabled={acceptingStandards}
+              onClick={async () => {
+                setAcceptingStandards(true);
+                setStandardsError(null);
+                try {
+                  await controller.acceptStandards();
+                } catch (error) {
+                  setStandardsError(
+                    error instanceof Error ? error.message : 'Could not record your acceptance.'
+                  );
+                } finally {
+                  setAcceptingStandards(false);
+                }
+              }}
+              className="mt-3 inline-flex min-h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {acceptingStandards ? 'Saving…' : 'I accept the community standards'}
+            </button>
+            {standardsError ? (
+              <p role="alert" className="mt-2 text-sm font-medium text-destructive">
+                {standardsError}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+        <div
+          role="tablist"
+          aria-label="League social views"
+          className="grid max-w-md grid-cols-2 gap-1 rounded-xl bg-muted p-1"
+        >
+          {tabs.map((tab) => {
+            const active = activeView === tab.id;
+            const unread = controller.summary?.unread[tab.id] ?? 0;
+            const Icon = tab.icon;
+            return (
+              <button
+                key={tab.id}
+                ref={(element) => {
+                  tabRefs.current[tab.id] = element;
+                }}
+                id={`${tabSetId}-${tab.id}-tab`}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                aria-controls={`${tabSetId}-${tab.id}-panel`}
+                tabIndex={active ? 0 : -1}
+                onClick={() => selectView(tab.id)}
+                onKeyDown={handleTabKeyDown}
+                className={`inline-flex min-h-10 items-center justify-center gap-2 rounded-lg px-3 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                  active
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                <Icon className="size-4" aria-hidden="true" />
+                <span>{tab.label}</span>
+                {unread > 0 ? (
+                  <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 py-0.5 text-xs font-semibold text-destructive-foreground">
+                    <span className="sr-only">{unread} unread</span>
+                    <span aria-hidden="true">{unread > 99 ? '99+' : unread}</span>
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div
+        id={`${tabSetId}-${activeView}-panel`}
+        role="tabpanel"
+        aria-labelledby={`${tabSetId}-${activeView}-tab`}
+        className="flex min-h-0 flex-1 p-3"
+      >
+        {activeView === 'chat' ? (
+          <LeagueChatPanel
+            messages={controller.messages}
+            hasEarlierMessages={Boolean(controller.messagesCursor)}
+            loading={controller.loading}
+            loadingEarlier={controller.loadingEarlierMessages}
+            sending={controller.sendingMessage}
+            canPublish={controller.summary?.canPublish ?? false}
+            canManage={controller.summary?.canManage ?? false}
+            mutedUntil={controller.summary?.mutedUntil}
+            error={controller.error}
+            submitError={controller.submitError}
+            onRetry={controller.retry}
+            onLoadEarlier={controller.loadEarlierMessages}
+            onSend={controller.sendMessage}
+            onReport={(messageId, reason, details) =>
+              controller.reportContent('message', messageId, reason, details)
+            }
+            onRemove={(messageId, reason) =>
+              controller.moderateContent('message', messageId, reason)
+            }
+          />
+        ) : selectedPost ? (
+          <PostThread
+            post={selectedPost}
+            replies={selectedThread?.items ?? []}
+            loading={selectedThread?.loading ?? true}
+            hasMore={Boolean(selectedThread?.nextCursor)}
+            mutedUntil={controller.summary?.mutedUntil}
+            canManage={controller.summary?.canManage ?? false}
+            canPublish={controller.summary?.canPublish ?? false}
+            error={selectedThread?.error}
+            submitError={controller.submitError}
+            onBack={() => setSelectedPostId(null)}
+            onRetry={() => controller.loadReplies(selectedPost.id)}
+            onLoadMore={() => controller.loadReplies(selectedPost.id, true)}
+            onReply={(body) => controller.createReply(selectedPost.id, body)}
+            onUpdatePost={async (input) => {
+              await controller.updatePost(selectedPost.id, input);
+            }}
+            onRemovePost={(reason) => controller.moderateContent('post', selectedPost.id, reason)}
+            onRemoveReply={(replyId, reason) =>
+              controller.moderateContent('reply', replyId, reason)
+            }
+            onReport={(contentType, contentId, reason, details) =>
+              controller.reportContent(contentType, contentId, reason, details)
+            }
+          />
+        ) : (
+          <MessageBoardPanel
+            posts={controller.posts}
+            categories={controller.summary?.categories ?? []}
+            loading={controller.loading}
+            loadingMore={controller.loadingMorePosts}
+            creating={controller.creatingPost}
+            hasMore={Boolean(controller.postsCursor)}
+            canPublish={controller.summary?.canPublish ?? false}
+            canManage={controller.summary?.canManage ?? false}
+            mutedUntil={controller.summary?.mutedUntil}
+            error={controller.error}
+            submitError={controller.submitError}
+            onRetry={controller.retry}
+            onLoadMore={controller.loadMorePosts}
+            onSelectPost={handleSelectPost}
+            onCreatePost={controller.createPost}
+            sort={controller.postSort}
+            onSortChange={controller.setPostSort}
+          />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/league/social/LeagueSocialShell.tsx
+++ b/src/components/league/social/LeagueSocialShell.tsx
@@ -144,7 +144,7 @@ export default function LeagueSocialShell({
       type="button"
       onClick={() => setShowPreferences((preferencesVisible) => !preferencesVisible)}
       aria-expanded={showPreferences}
-      className="inline-flex size-10 shrink-0 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="inline-flex size-10 shrink-0 items-center justify-center rounded-full text-social-text-muted transition-colors hover:bg-social-brand-soft hover:text-social-text active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
     >
       <Settings className="size-4" aria-hidden="true" />
       <span className="sr-only">Social notification preferences</span>
@@ -153,21 +153,23 @@ export default function LeagueSocialShell({
 
   return (
     <section
-      className={`flex min-w-0 flex-col overflow-hidden rounded-2xl border border-border bg-background text-foreground shadow-sm ${
+      className={`league-social flex min-w-0 flex-col overflow-hidden rounded-2xl border border-social-border bg-social-canvas text-social-text shadow-sm ${
         compact ? 'min-h-0' : 'min-h-[36rem]'
       } ${className}`}
       aria-label={title}
     >
       <div
         className={
-          compact ? 'border-b border-border bg-card' : 'border-b border-border bg-card px-3 pt-3'
+          compact
+            ? 'border-b border-social-border bg-social-surface'
+            : 'border-b border-social-border bg-social-surface px-3 pt-3'
         }
       >
         {showHeader ? (
           <div className="flex items-start justify-between gap-3 px-1 pb-3">
             <div>
-              <h1 className="text-lg font-semibold tracking-tight text-foreground">{title}</h1>
-              <p className="mt-1 text-sm text-muted-foreground">
+              <h1 className="text-lg font-semibold tracking-tight text-social-text">{title}</h1>
+              <p className="mt-1 text-sm text-social-text-muted">
                 Chat live or revisit persistent league discussions.
               </p>
             </div>
@@ -187,12 +189,12 @@ export default function LeagueSocialShell({
         ) : null}
         {controller.summary && !controller.summary.standardsAccepted ? (
           <div
-            className={`rounded-xl border border-primary/30 bg-primary/10 p-3 ${
+            className={`rounded-xl border border-social-action bg-social-brand-soft p-3 ${
               compact ? 'm-3' : 'mb-3'
             }`}
           >
-            <p className="text-sm font-semibold text-foreground">Community standards</p>
-            <p className="mt-1 text-sm text-muted-foreground">
+            <p className="text-sm font-semibold text-social-text">Community standards</p>
+            <p className="mt-1 text-sm text-social-text-muted">
               Keep league discussion respectful, safe, and relevant. You can read league social
               content now, but must accept these standards before posting.
             </p>
@@ -212,12 +214,12 @@ export default function LeagueSocialShell({
                   setAcceptingStandards(false);
                 }
               }}
-              className="mt-3 inline-flex min-h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+              className="mt-3 inline-flex min-h-10 items-center justify-center rounded-lg border border-social-action bg-social-action px-4 text-sm font-semibold text-social-action-foreground transition-colors hover:border-social-action-hover hover:bg-social-action-hover active:border-social-action-pressed active:bg-social-action-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus focus-visible:ring-offset-2 focus-visible:ring-offset-social-surface disabled:cursor-not-allowed disabled:border-social-border disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
             >
               {acceptingStandards ? 'Saving…' : 'I accept the community standards'}
             </button>
             {standardsError ? (
-              <p role="alert" className="mt-2 text-sm font-medium text-destructive">
+              <p role="alert" className="mt-2 text-sm font-medium text-social-error">
                 {standardsError}
               </p>
             ) : null}
@@ -230,7 +232,7 @@ export default function LeagueSocialShell({
             className={
               compact
                 ? 'flex h-full min-w-0 flex-1 items-stretch'
-                : 'grid min-w-0 max-w-xl flex-1 grid-cols-3 gap-1 rounded-xl bg-muted p-1'
+                : 'grid min-w-0 max-w-xl flex-1 grid-cols-3 gap-1 rounded-xl bg-social-surface-subtle p-1'
             }
           >
             {tabs.map((tab) => {
@@ -251,24 +253,24 @@ export default function LeagueSocialShell({
                   tabIndex={active ? 0 : -1}
                   onClick={() => selectView(tab.id)}
                   onKeyDown={handleTabKeyDown}
-                  className={`relative inline-flex min-h-10 items-center justify-center gap-1.5 px-2 text-sm transition focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
+                  className={`relative inline-flex min-h-10 items-center justify-center gap-1.5 px-2 text-sm transition-colors focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-social-focus ${
                     compact
                       ? `flex-1 border-b-2 ${
                           active
-                            ? 'border-primary font-semibold text-foreground'
-                            : 'border-transparent font-medium text-muted-foreground hover:text-foreground'
+                            ? 'border-social-action font-semibold text-social-text'
+                            : 'border-transparent font-medium text-social-text-muted hover:bg-social-brand-soft hover:text-social-text active:bg-social-surface-subtle'
                         }`
                       : `rounded-lg font-semibold ${
                           active
-                            ? 'bg-background text-foreground shadow-sm'
-                            : 'text-muted-foreground hover:text-foreground'
+                            ? 'bg-social-surface text-social-text shadow-sm ring-1 ring-social-border'
+                            : 'text-social-text-muted hover:bg-social-brand-soft hover:text-social-text active:bg-social-surface'
                         }`
                   }`}
                 >
                   <Icon className="size-4" aria-hidden="true" />
                   <span>{tab.label}</span>
                   {unread > 0 ? (
-                    <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 py-0.5 text-xs font-semibold text-destructive-foreground">
+                    <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-social-action px-1.5 py-0.5 text-xs font-semibold text-social-action-foreground">
                       <span className="sr-only">{unread} unread</span>
                       <span aria-hidden="true">{unread > 99 ? '99+' : unread}</span>
                     </span>
@@ -287,7 +289,7 @@ export default function LeagueSocialShell({
         aria-labelledby={`${tabSetId}-chat-tab`}
         hidden={activeView !== 'chat'}
         aria-hidden={activeView !== 'chat'}
-        className={`${activeView === 'chat' ? 'flex' : 'hidden'} min-h-0 flex-1 ${
+        className={`${activeView === 'chat' ? 'flex' : 'hidden'} min-h-0 flex-1 bg-social-canvas ${
           compact ? 'p-0' : 'p-3'
         }`}
       >
@@ -345,7 +347,7 @@ export default function LeagueSocialShell({
         aria-labelledby={`${tabSetId}-board-tab`}
         hidden={activeView !== 'board'}
         aria-hidden={activeView !== 'board'}
-        className={`${activeView === 'board' ? 'flex' : 'hidden'} min-h-0 flex-1 ${
+        className={`${activeView === 'board' ? 'flex' : 'hidden'} min-h-0 flex-1 bg-social-canvas ${
           compact ? 'p-0' : 'p-3'
         }`}
       >
@@ -417,7 +419,7 @@ export default function LeagueSocialShell({
         aria-labelledby={`${tabSetId}-activity-tab`}
         hidden={activeView !== 'activity'}
         aria-hidden={activeView !== 'activity'}
-        className={`${activeView === 'activity' ? 'flex' : 'hidden'} min-h-0 flex-1 ${
+        className={`${activeView === 'activity' ? 'flex' : 'hidden'} min-h-0 flex-1 bg-social-canvas ${
           compact ? 'p-0' : 'p-3'
         }`}
       >

--- a/src/components/league/social/LeagueSocialShell.tsx
+++ b/src/components/league/social/LeagueSocialShell.tsx
@@ -15,6 +15,7 @@ import LeagueChatPanel from './LeagueChatPanel';
 import MessageBoardPanel from './MessageBoardPanel';
 import PostThread from './PostThread';
 import SocialPreferencesPanel from './SocialPreferencesPanel';
+import type { SocialComposerSurface } from './socialComposerDraft';
 import { useLeagueSocial } from './useLeagueSocial';
 
 export type LeagueSocialView = SocialChannel;
@@ -29,6 +30,8 @@ export interface LeagueSocialShellProps {
   showHeader?: boolean;
   compact?: boolean;
   visible?: boolean;
+  composerLabel?: string;
+  composerSurface?: SocialComposerSurface;
   composerContext?: SocialDiscussionContext | null;
   onClearComposerContext?: () => void;
   onDiscussActivity?: (activity: SocialMessage) => void;
@@ -50,6 +53,8 @@ export default function LeagueSocialShell({
   showHeader = true,
   compact = false,
   visible = true,
+  composerLabel = 'Message league chat',
+  composerSurface = { type: 'league-chat' },
   composerContext,
   onClearComposerContext,
   onDiscussActivity,
@@ -299,8 +304,28 @@ export default function LeagueSocialShell({
           submitError={controller.submitError}
           visible={visible && activeView === 'chat'}
           compact={compact}
+          composerLabel={composerLabel}
+          draftScope={
+            currentUserId && controller.summary
+              ? {
+                  userId: currentUserId,
+                  leagueId,
+                  leagueSeasonId: controller.summary.seasonId,
+                  surface: composerSurface,
+                  ...(composerContext
+                    ? {
+                        discussion: {
+                          type: composerContext.type,
+                          id: composerContext.id,
+                        },
+                      }
+                    : {}),
+                }
+              : undefined
+          }
           composerContext={composerContext}
           onClearComposerContext={onClearComposerContext}
+          onDismissSubmitError={controller.clearSubmitError}
           onLatestVisibleChange={(isLatestVisible) =>
             handleLatestVisibleChange('chat', isLatestVisible)
           }
@@ -335,6 +360,7 @@ export default function LeagueSocialShell({
             canPublish={controller.summary?.canPublish ?? false}
             error={selectedThread?.error}
             submitError={controller.submitError}
+            onDismissSubmitError={controller.clearSubmitError}
             visible={visible && activeView === 'board'}
             compact={compact}
             onBack={() => {
@@ -343,7 +369,9 @@ export default function LeagueSocialShell({
             }}
             onRetry={() => controller.loadReplies(selectedPost.id)}
             onLoadMore={() => controller.loadReplies(selectedPost.id, true)}
-            onReply={(body) => controller.createReply(selectedPost.id, body)}
+            onReply={(body, idempotencyKey) =>
+              controller.createReply(selectedPost.id, body, idempotencyKey)
+            }
             onUpdatePost={async (input) => {
               await controller.updatePost(selectedPost.id, input);
             }}

--- a/src/components/league/social/LeagueSocialWidget.test.tsx
+++ b/src/components/league/social/LeagueSocialWidget.test.tsx
@@ -87,7 +87,7 @@ describe('LeagueSocialWidget', () => {
 
     const launcher = await screen.findByRole('button', { name: /open league social/i });
     expect(launcher).toHaveAttribute('title', 'League Social');
-    expect(launcher).toHaveClass('size-14', 'rounded-2xl');
+    expect(launcher).toHaveClass('size-14', 'rounded-full', 'bottom-6', 'right-6');
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /5 unread/i })).toBeInTheDocument()
     );
@@ -98,9 +98,13 @@ describe('LeagueSocialWidget', () => {
     expect(await screen.findByText('League Social')).toBeInTheDocument();
     expect(screen.getByText('Premier League')).toBeInTheDocument();
     expect(panel).toHaveClass(
-      'sm:w-[25rem]',
-      'lg:w-[clamp(24rem,29vw,27rem)]',
-      'lg:h-[min(42rem,calc(100dvh-6rem))]'
+      'inset-0',
+      'h-[100dvh]',
+      'w-full',
+      'sm:w-[clamp(26.25rem,32vw,30rem)]',
+      'sm:h-[clamp(36.25rem,76dvh,45rem)]',
+      'sm:max-w-[calc(100vw-3rem)]',
+      'sm:max-h-[calc(100dvh-3rem)]'
     );
     expect(shellControl).toHaveAttribute('data-visible', 'true');
     expect(shellControl).toHaveAttribute('data-show-header', 'false');

--- a/src/components/league/social/LeagueSocialWidget.test.tsx
+++ b/src/components/league/social/LeagueSocialWidget.test.tsx
@@ -94,7 +94,14 @@ describe('LeagueSocialWidget', () => {
 
     const launcher = await screen.findByRole('button', { name: /open league social/i });
     expect(launcher).toHaveAttribute('title', 'League Social');
-    expect(launcher).toHaveClass('size-14', 'rounded-full', 'bottom-6', 'right-6');
+    expect(launcher).toHaveClass(
+      'league-social',
+      'size-14',
+      'rounded-full',
+      'bottom-6',
+      'right-6',
+      'bg-social-brand-strong'
+    );
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /5 unread/i })).toBeInTheDocument()
     );
@@ -103,8 +110,14 @@ describe('LeagueSocialWidget', () => {
     const panel = screen.getByLabelText('League social panel');
     const shellControl = screen.getByTestId('social-shell-control');
     expect(await screen.findByText('League Social')).toBeInTheDocument();
+    expect(screen.getByText('League Social').parentElement?.parentElement).toHaveClass(
+      'bg-social-brand-strong',
+      'text-social-brand-foreground'
+    );
     expect(screen.getByText('Premier League')).toBeInTheDocument();
     expect(panel).toHaveClass(
+      'league-social',
+      'bg-social-canvas',
       'inset-0',
       'h-[100dvh]',
       'w-full',

--- a/src/components/league/social/LeagueSocialWidget.test.tsx
+++ b/src/components/league/social/LeagueSocialWidget.test.tsx
@@ -102,6 +102,7 @@ describe('LeagueSocialWidget', () => {
       'right-6',
       'bg-social-brand-strong'
     );
+    expect(launcher.querySelector('svg')).toHaveClass('size-7');
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /5 unread/i })).toBeInTheDocument()
     );

--- a/src/components/league/social/LeagueSocialWidget.test.tsx
+++ b/src/components/league/social/LeagueSocialWidget.test.tsx
@@ -1,0 +1,203 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import LeagueSocialWidget from './LeagueSocialWidget';
+import { LeagueSocialWidgetProvider } from './LeagueSocialWidgetProvider';
+
+const mocks = vi.hoisted(() => ({
+  authenticatedFetch: vi.fn(),
+}));
+const navigation = vi.hoisted(() => ({ pathname: '/players' }));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => navigation.pathname,
+}));
+
+vi.mock('@/contexts/SocketContext', () => ({
+  useSocket: () => null,
+}));
+
+vi.mock('@/lib/authenticatedFetch', () => ({
+  authenticatedFetch: mocks.authenticatedFetch,
+}));
+
+vi.mock('./LeagueSocialShell', () => ({
+  default: ({
+    visible,
+    composerContext,
+    showHeader,
+    compact,
+    className,
+  }: {
+    visible?: boolean;
+    composerContext?: { title: string } | null;
+    showHeader?: boolean;
+    compact?: boolean;
+    className?: string;
+  }) => (
+    <button
+      type="button"
+      data-testid="social-shell-control"
+      data-visible={visible ? 'true' : 'false'}
+      data-show-header={showHeader ? 'true' : 'false'}
+      data-compact={compact ? 'true' : 'false'}
+      data-class-name={className}
+    >
+      {composerContext?.title ?? 'Composer control'}
+    </button>
+  ),
+}));
+
+describe('LeagueSocialWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    navigation.pathname = '/players';
+    document.cookie = 'statly_last_league_id=league-1; path=/';
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    };
+    mocks.authenticatedFetch.mockImplementation(async (url: string) => ({
+      ok: true,
+      json: async () =>
+        url.endsWith('/social/summary')
+          ? {
+              success: true,
+              data: {
+                unread: { chat: 2, board: 3, activity: 0 },
+              },
+            }
+          : {
+              success: true,
+              data: {
+                league: { id: 'league-1', name: 'Premier League' },
+              },
+            },
+    }));
+  });
+
+  it('keeps the social shell mounted and restores panel focus across minimize and reopen', async () => {
+    const user = userEvent.setup();
+    render(
+      <LeagueSocialWidgetProvider>
+        <LeagueSocialWidget currentUserId="user-1" />
+      </LeagueSocialWidgetProvider>
+    );
+
+    const launcher = await screen.findByRole('button', { name: /open league social/i });
+    expect(launcher).toHaveAttribute('title', 'League Social');
+    expect(launcher).toHaveClass('size-14', 'rounded-2xl');
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /5 unread/i })).toBeInTheDocument()
+    );
+
+    await user.click(launcher);
+    const panel = screen.getByLabelText('League social panel');
+    const shellControl = screen.getByTestId('social-shell-control');
+    expect(await screen.findByText('League Social')).toBeInTheDocument();
+    expect(screen.getByText('Premier League')).toBeInTheDocument();
+    expect(panel).toHaveClass(
+      'sm:w-[25rem]',
+      'lg:w-[clamp(24rem,29vw,27rem)]',
+      'lg:h-[min(42rem,calc(100dvh-6rem))]'
+    );
+    expect(shellControl).toHaveAttribute('data-visible', 'true');
+    expect(shellControl).toHaveAttribute('data-show-header', 'false');
+    expect(shellControl).toHaveAttribute('data-compact', 'true');
+    expect(shellControl).toHaveAttribute(
+      'data-class-name',
+      expect.stringContaining('h-full !min-h-0')
+    );
+    expect(screen.queryByRole('button', { name: /close league social/i })).not.toBeInTheDocument();
+
+    shellControl.focus();
+    await user.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /open league social/i })).toHaveFocus()
+    );
+    expect(screen.getByTestId('social-shell-control')).toHaveAttribute('data-visible', 'false');
+
+    await user.click(screen.getByRole('button', { name: /open league social/i }));
+    await waitFor(() => expect(screen.getByTestId('social-shell-control')).toHaveFocus());
+    expect(screen.getByTestId('social-shell-control')).toHaveAttribute('data-visible', 'true');
+  });
+
+  it('ignores an aborted summary response after the effective league changes', async () => {
+    navigation.pathname = '/leagues/league-a';
+    let resolveLeagueA:
+      | ((value: {
+          ok: boolean;
+          json: () => Promise<{
+            success: boolean;
+            data: { unread: { chat: number; board: number; activity: number } };
+          }>;
+        }) => void)
+      | undefined;
+    const leagueASummary = new Promise<{
+      ok: boolean;
+      json: () => Promise<{
+        success: boolean;
+        data: { unread: { chat: number; board: number; activity: number } };
+      }>;
+    }>((resolve) => {
+      resolveLeagueA = resolve;
+    });
+    mocks.authenticatedFetch.mockImplementation(async (url: string) => {
+      if (url === '/api/leagues/league-a/social/summary') return leagueASummary;
+      if (url === '/api/leagues/league-b/social/summary') {
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            data: { unread: { chat: 1, board: 0, activity: 0 } },
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: { league: { name: url.includes('league-a') ? 'League A' : 'League B' } },
+        }),
+      };
+    });
+
+    const rendered = render(
+      <LeagueSocialWidgetProvider>
+        <LeagueSocialWidget currentUserId="user-1" />
+      </LeagueSocialWidgetProvider>
+    );
+    await waitFor(() =>
+      expect(mocks.authenticatedFetch).toHaveBeenCalledWith(
+        '/api/leagues/league-a/social/summary',
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+        'user-1'
+      )
+    );
+
+    navigation.pathname = '/leagues/league-b';
+    rendered.rerender(
+      <LeagueSocialWidgetProvider>
+        <LeagueSocialWidget currentUserId="user-1" />
+      </LeagueSocialWidgetProvider>
+    );
+    await screen.findByRole('button', { name: /1 unread/i });
+
+    resolveLeagueA?.({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: { unread: { chat: 9, board: 0, activity: 0 } },
+      }),
+    });
+    await Promise.resolve();
+
+    expect(screen.getByRole('button', { name: /1 unread/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /9 unread/i })).not.toBeInTheDocument();
+    const leagueASummaryCall = mocks.authenticatedFetch.mock.calls.find(
+      ([url]) => url === '/api/leagues/league-a/social/summary'
+    );
+    expect((leagueASummaryCall?.[1] as RequestInit).signal).toMatchObject({ aborted: true });
+  });
+});

--- a/src/components/league/social/LeagueSocialWidget.test.tsx
+++ b/src/components/league/social/LeagueSocialWidget.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import LeagueSocialWidget from './LeagueSocialWidget';
+import LeagueSocialWidget, { getDraftIdFromPathname } from './LeagueSocialWidget';
 import { LeagueSocialWidgetProvider } from './LeagueSocialWidgetProvider';
 
 const mocks = vi.hoisted(() => ({
@@ -29,12 +29,16 @@ vi.mock('./LeagueSocialShell', () => ({
     showHeader,
     compact,
     className,
+    composerLabel,
+    composerSurface,
   }: {
     visible?: boolean;
     composerContext?: { title: string } | null;
     showHeader?: boolean;
     compact?: boolean;
     className?: string;
+    composerLabel?: string;
+    composerSurface?: { type: 'league-chat' } | { type: 'draft-chat'; draftId: string };
   }) => (
     <button
       type="button"
@@ -43,6 +47,9 @@ vi.mock('./LeagueSocialShell', () => ({
       data-show-header={showHeader ? 'true' : 'false'}
       data-compact={compact ? 'true' : 'false'}
       data-class-name={className}
+      data-composer-label={composerLabel}
+      data-composer-surface={composerSurface?.type}
+      data-draft-id={composerSurface?.type === 'draft-chat' ? composerSurface.draftId : undefined}
     >
       {composerContext?.title ?? 'Composer control'}
     </button>
@@ -109,6 +116,11 @@ describe('LeagueSocialWidget', () => {
     expect(shellControl).toHaveAttribute('data-visible', 'true');
     expect(shellControl).toHaveAttribute('data-show-header', 'false');
     expect(shellControl).toHaveAttribute('data-compact', 'true');
+    expect(shellControl).toHaveAttribute(
+      'data-composer-label',
+      'Message the members of Premier League'
+    );
+    expect(shellControl).toHaveAttribute('data-composer-surface', 'league-chat');
     expect(shellControl).toHaveAttribute(
       'data-class-name',
       expect.stringContaining('h-full !min-h-0')
@@ -203,5 +215,30 @@ describe('LeagueSocialWidget', () => {
       ([url]) => url === '/api/leagues/league-a/social/summary'
     );
     expect((leagueASummaryCall?.[1] as RequestInit).signal).toMatchObject({ aborted: true });
+  });
+
+  it('scopes the shared composer to the active draft-room route', async () => {
+    navigation.pathname = '/drafts/draft%2042';
+    const user = userEvent.setup();
+    render(
+      <LeagueSocialWidgetProvider>
+        <LeagueSocialWidget currentUserId="user-1" />
+      </LeagueSocialWidgetProvider>
+    );
+
+    await user.click(await screen.findByRole('button', { name: /open league social/i }));
+    const shellControl = screen.getByTestId('social-shell-control');
+
+    expect(shellControl).toHaveAttribute('data-composer-surface', 'draft-chat');
+    expect(shellControl).toHaveAttribute('data-draft-id', 'draft 42');
+  });
+
+  it('recognizes only live draft-room routes as draft composer surfaces', () => {
+    expect(getDraftIdFromPathname('/drafts/draft-42')).toBe('draft-42');
+    expect(getDraftIdFromPathname('/drafts/draft-42/')).toBe('draft-42');
+    expect(getDraftIdFromPathname('/drafts/create')).toBeNull();
+    expect(getDraftIdFromPathname('/drafts/history')).toBeNull();
+    expect(getDraftIdFromPathname('/drafts/settings')).toBeNull();
+    expect(getDraftIdFromPathname('/drafts/draft-42/settings')).toBeNull();
   });
 });

--- a/src/components/league/social/LeagueSocialWidget.tsx
+++ b/src/components/league/social/LeagueSocialWidget.tsx
@@ -284,7 +284,7 @@ export default function LeagueSocialWidget({
           title="League Social"
           className="league-social fixed bottom-6 right-6 z-[55] inline-flex size-14 items-center justify-center rounded-full border border-social-brand-strong bg-social-brand-strong text-social-brand-foreground shadow-lg transition-colors hover:bg-social-action-hover active:bg-social-action-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus focus-visible:ring-offset-2 focus-visible:ring-offset-social-surface"
         >
-          <MessageCircle className="size-5" aria-hidden="true" />
+          <MessageCircle className="size-7" aria-hidden="true" />
           {totalUnread > 0 ? (
             <span className="absolute -right-1 -top-1 inline-flex min-h-5 min-w-5 items-center justify-center rounded-full bg-social-action px-1.5 text-xs font-bold text-social-action-foreground ring-2 ring-social-surface">
               <span className="sr-only">{totalUnread} unread</span>

--- a/src/components/league/social/LeagueSocialWidget.tsx
+++ b/src/components/league/social/LeagueSocialWidget.tsx
@@ -17,6 +17,16 @@ type UnreadCounts = { chat: number; board: number; activity: number };
 const leagueNameCache = new Map<string, string>();
 const EMPTY_UNREAD: UnreadCounts = { chat: 0, board: 0, activity: 0 };
 
+export function getDraftIdFromPathname(pathname: string | null): string | null {
+  const match = pathname?.match(/^\/drafts\/([^/]+)\/?$/);
+  if (!match || ['create', 'history', 'settings'].includes(match[1])) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return null;
+  }
+}
+
 function isLeagueEvent(value: unknown, leagueId: string): boolean {
   if (!value || typeof value !== 'object' || !('leagueId' in value)) return false;
   return (value as Pick<SocialRealtimeEnvelope, 'leagueId'>).leagueId === leagueId;
@@ -61,6 +71,7 @@ export default function LeagueSocialWidget({
   const displayLeagueName = leagueName ?? resolvedLeagueName;
   const isOpen = mode === 'open';
   const isDedicatedSocialPage = /^\/leagues\/[^/]+\/social(?:\/|$)/.test(pathname ?? '');
+  const draftId = getDraftIdFromPathname(pathname);
   const discussActivity = useCallback(
     (activity: SocialMessage) => {
       open({
@@ -334,6 +345,8 @@ export default function LeagueSocialWidget({
             showHeader={false}
             compact
             visible={isOpen}
+            composerLabel={`Message the members of ${displayLeagueName ?? 'this league'}`}
+            composerSurface={draftId ? { type: 'draft-chat', draftId } : { type: 'league-chat' }}
             composerContext={composerContext}
             onClearComposerContext={clearComposerContext}
             onDiscussActivity={discussActivity}

--- a/src/components/league/social/LeagueSocialWidget.tsx
+++ b/src/components/league/social/LeagueSocialWidget.tsx
@@ -1,0 +1,347 @@
+'use client';
+
+import { MessageCircle, Minus, WifiOff } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+
+import { useSocket } from '@/contexts/SocketContext';
+import { authenticatedFetch } from '@/lib/authenticatedFetch';
+import type { LeagueSocialSummary, SocialMessage, SocialRealtimeEnvelope } from '@/types/social';
+
+import LeagueSocialShell from './LeagueSocialShell';
+import { useLeagueSocialWidget } from './LeagueSocialWidgetProvider';
+
+type ConnectionNotice = 'hidden' | 'offline' | 'reconnecting';
+type UnreadCounts = { chat: number; board: number; activity: number };
+
+const leagueNameCache = new Map<string, string>();
+const EMPTY_UNREAD: UnreadCounts = { chat: 0, board: 0, activity: 0 };
+
+function isLeagueEvent(value: unknown, leagueId: string): boolean {
+  if (!value || typeof value !== 'object' || !('leagueId' in value)) return false;
+  return (value as Pick<SocialRealtimeEnvelope, 'leagueId'>).leagueId === leagueId;
+}
+
+function formatUnread(unread: number): string {
+  return unread > 99 ? '99+' : String(unread);
+}
+
+export default function LeagueSocialWidget({
+  currentUserId,
+}: {
+  currentUserId: string;
+}): React.JSX.Element | null {
+  const pathname = usePathname();
+  const socket = useSocket();
+  const {
+    leagueId,
+    leagueName,
+    mode,
+    hasOpened,
+    view,
+    composerContext,
+    open,
+    minimize,
+    clearComposerContext,
+  } = useLeagueSocialWidget();
+  const [unreadState, setUnreadState] = useState<{
+    leagueId: string | null;
+    counts: UnreadCounts;
+  }>({ leagueId: null, counts: EMPTY_UNREAD });
+  const [resolvedLeagueName, setResolvedLeagueName] = useState<string | undefined>(leagueName);
+  const [connectionNotice, setConnectionNotice] = useState<ConnectionNotice>('hidden');
+  const unreadRequestRef = useRef<AbortController | null>(null);
+  const launcherRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLElement | null>(null);
+  const minimizeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const lastPanelFocusRef = useRef<HTMLElement | null>(null);
+  const wasOpenRef = useRef(false);
+  const unread = unreadState.leagueId === leagueId ? unreadState.counts : EMPTY_UNREAD;
+  const totalUnread = unread.chat + unread.board + unread.activity;
+  const displayLeagueName = leagueName ?? resolvedLeagueName;
+  const isOpen = mode === 'open';
+  const isDedicatedSocialPage = /^\/leagues\/[^/]+\/social(?:\/|$)/.test(pathname ?? '');
+  const discussActivity = useCallback(
+    (activity: SocialMessage) => {
+      open({
+        view: 'chat',
+        context: activity.context ?? {
+          type: 'activity',
+          id: activity.relatedEntityId ?? activity.id,
+          title: activity.content,
+        },
+      });
+    },
+    [open]
+  );
+  const handleMinimize = useCallback(() => {
+    const activeElement =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    if (activeElement && panelRef.current?.contains(activeElement)) {
+      lastPanelFocusRef.current = activeElement;
+    }
+    minimize();
+  }, [minimize]);
+
+  const refreshUnread = useCallback(async () => {
+    unreadRequestRef.current?.abort();
+    if (!leagueId) {
+      unreadRequestRef.current = null;
+      setUnreadState({ leagueId: null, counts: EMPTY_UNREAD });
+      return;
+    }
+
+    const requestedLeagueId = leagueId;
+    const controller = new AbortController();
+    unreadRequestRef.current = controller;
+    try {
+      const response = await authenticatedFetch(
+        `/api/leagues/${encodeURIComponent(requestedLeagueId)}/social/summary`,
+        { cache: 'no-store', signal: controller.signal },
+        currentUserId
+      );
+      const payload = (await response.json().catch(() => null)) as {
+        success?: boolean;
+        data?: LeagueSocialSummary;
+      } | null;
+      if (controller.signal.aborted || unreadRequestRef.current !== controller) return;
+      if (!response.ok || payload?.success !== true || !payload.data) return;
+      setUnreadState({
+        leagueId: requestedLeagueId,
+        counts: {
+          chat: payload.data.unread.chat ?? 0,
+          board: payload.data.unread.board ?? 0,
+          activity: payload.data.unread.activity ?? 0,
+        },
+      });
+    } catch {
+      // The social shell owns retry UI. A badge refresh failure should stay unobtrusive.
+    } finally {
+      if (unreadRequestRef.current === controller) unreadRequestRef.current = null;
+    }
+  }, [currentUserId, leagueId]);
+
+  useEffect(() => {
+    void refreshUnread();
+    return () => unreadRequestRef.current?.abort();
+  }, [refreshUnread]);
+
+  useEffect(() => {
+    if (!leagueId) {
+      setResolvedLeagueName(undefined);
+      return;
+    }
+    if (leagueName) {
+      leagueNameCache.set(leagueId, leagueName);
+      setResolvedLeagueName(leagueName);
+      return;
+    }
+
+    const cachedName = leagueNameCache.get(leagueId);
+    if (cachedName) {
+      setResolvedLeagueName(cachedName);
+      return;
+    }
+
+    let cancelled = false;
+    setResolvedLeagueName(undefined);
+    void authenticatedFetch(
+      `/api/leagues/${encodeURIComponent(leagueId)}`,
+      { cache: 'no-store' },
+      currentUserId
+    )
+      .then(async (response) => {
+        if (!response.ok) return;
+        const payload = (await response.json().catch(() => null)) as {
+          name?: string;
+          league?: { name?: string };
+          data?: { name?: string; league?: { name?: string } };
+        } | null;
+        const name =
+          payload?.data?.league?.name ??
+          payload?.data?.name ??
+          payload?.league?.name ??
+          payload?.name;
+        if (!cancelled && name) {
+          leagueNameCache.set(leagueId, name);
+          setResolvedLeagueName(name);
+        }
+      })
+      .catch(() => {
+        // Keep the generic accessible label if league metadata is temporarily unavailable.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentUserId, leagueId, leagueName]);
+
+  useEffect(() => {
+    if (!socket || !leagueId) return;
+    const refreshForLeague = (event: unknown) => {
+      if (isLeagueEvent(event, leagueId)) void refreshUnread();
+    };
+    const events = [
+      'social:message',
+      'social:activity',
+      'social:post',
+      'social:reply',
+      'social:moderation',
+      'social:read-state',
+    ] as const;
+    events.forEach((event) => socket.on(event, refreshForLeague));
+    return () => {
+      events.forEach((event) => socket.off(event, refreshForLeague));
+    };
+  }, [leagueId, refreshUnread, socket]);
+
+  useEffect(() => {
+    const updateForNetwork = () => {
+      setConnectionNotice(navigator.onLine ? 'reconnecting' : 'offline');
+    };
+    const markOffline = () => setConnectionNotice('offline');
+    window.addEventListener('online', updateForNetwork);
+    window.addEventListener('offline', markOffline);
+    if (!navigator.onLine) markOffline();
+    return () => {
+      window.removeEventListener('online', updateForNetwork);
+      window.removeEventListener('offline', markOffline);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!socket) return;
+    const markConnected = () => setConnectionNotice('hidden');
+    const markReconnecting = () =>
+      setConnectionNotice(navigator.onLine ? 'reconnecting' : 'offline');
+    socket.on('connect', markConnected);
+    socket.on('disconnect', markReconnecting);
+    socket.on('connect_error', markReconnecting);
+    socket.io.on('reconnect_attempt', markReconnecting);
+    if (socket.connected) markConnected();
+    return () => {
+      socket.off('connect', markConnected);
+      socket.off('disconnect', markReconnecting);
+      socket.off('connect_error', markReconnecting);
+      socket.io.off('reconnect_attempt', markReconnecting);
+    };
+  }, [socket]);
+
+  useEffect(() => {
+    const wasOpen = wasOpenRef.current;
+    let refreshTimeout: number | undefined;
+    if (isOpen && !wasOpen) {
+      window.requestAnimationFrame(() => {
+        const priorPanelFocus = lastPanelFocusRef.current;
+        if (priorPanelFocus?.isConnected && panelRef.current?.contains(priorPanelFocus)) {
+          priorPanelFocus.focus();
+        } else {
+          minimizeButtonRef.current?.focus();
+        }
+      });
+      refreshTimeout = window.setTimeout(() => void refreshUnread(), 400);
+    } else if (!isOpen && wasOpen) {
+      window.requestAnimationFrame(() => launcherRef.current?.focus());
+    }
+    wasOpenRef.current = isOpen;
+    return () => {
+      if (refreshTimeout !== undefined) window.clearTimeout(refreshTimeout);
+    };
+  }, [isOpen, refreshUnread]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') handleMinimize();
+    };
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, [handleMinimize, isOpen]);
+
+  if (!leagueId || isDedicatedSocialPage) return null;
+
+  return (
+    <>
+      {!isOpen ? (
+        <button
+          ref={launcherRef}
+          type="button"
+          onClick={() => open()}
+          aria-label={
+            totalUnread > 0 ? `Open league social, ${totalUnread} unread` : 'Open league social'
+          }
+          aria-expanded="false"
+          title="League Social"
+          className="fixed bottom-5 right-5 z-[55] inline-flex size-14 items-center justify-center rounded-2xl border border-border bg-primary text-primary-foreground shadow-lg transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          <MessageCircle className="size-5" aria-hidden="true" />
+          {totalUnread > 0 ? (
+            <span className="absolute -right-1 -top-1 inline-flex min-h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-xs font-bold text-destructive-foreground ring-2 ring-background">
+              <span className="sr-only">{totalUnread} unread</span>
+              <span aria-hidden="true">{formatUnread(totalUnread)}</span>
+            </span>
+          ) : null}
+        </button>
+      ) : null}
+
+      {hasOpened ? (
+        <aside
+          ref={panelRef}
+          aria-label="League social panel"
+          aria-hidden={!isOpen}
+          inert={!isOpen}
+          className={`fixed inset-x-2 bottom-2 z-[60] flex h-[min(80dvh,42rem)] min-h-0 w-auto flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl transition-[transform,opacity] duration-200 sm:inset-x-auto sm:bottom-5 sm:right-5 sm:h-[min(75dvh,42rem)] sm:w-[25rem] lg:h-[min(42rem,calc(100dvh-6rem))] lg:w-[clamp(24rem,29vw,27rem)] ${
+            isOpen
+              ? 'translate-y-0 opacity-100 sm:translate-x-0'
+              : 'pointer-events-none translate-y-full opacity-0 sm:translate-x-[calc(100%+2rem)] sm:translate-y-0'
+          }`}
+        >
+          <div className="flex min-h-14 shrink-0 items-center justify-between gap-3 border-b border-border bg-card px-4">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-foreground">League Social</p>
+              <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+                <span className="truncate">{displayLeagueName ?? 'Current league'}</span>
+                {connectionNotice !== 'hidden' ? (
+                  <span
+                    role="status"
+                    className="inline-flex shrink-0 items-center gap-1 font-medium"
+                  >
+                    <span aria-hidden="true">·</span>
+                    <WifiOff className="size-3.5" aria-hidden="true" />
+                    {connectionNotice === 'offline' ? 'Offline' : 'Reconnecting…'}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+            <div className="flex items-center gap-1">
+              <button
+                ref={minimizeButtonRef}
+                type="button"
+                onClick={handleMinimize}
+                className="inline-flex size-10 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label="Minimize league social"
+                title="Minimize"
+              >
+                <Minus className="size-5" aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+
+          <LeagueSocialShell
+            key={leagueId}
+            leagueId={leagueId}
+            currentUserId={currentUserId}
+            initialView={composerContext ? 'chat' : view}
+            showHeader={false}
+            compact
+            visible={isOpen}
+            composerContext={composerContext}
+            onClearComposerContext={clearComposerContext}
+            onDiscussActivity={discussActivity}
+            title={displayLeagueName ? `${displayLeagueName} social` : 'League social'}
+            className="h-full !min-h-0 flex-1 rounded-none border-0 shadow-none"
+          />
+        </aside>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/league/social/LeagueSocialWidget.tsx
+++ b/src/components/league/social/LeagueSocialWidget.tsx
@@ -271,7 +271,7 @@ export default function LeagueSocialWidget({
           }
           aria-expanded="false"
           title="League Social"
-          className="fixed bottom-5 right-5 z-[55] inline-flex size-14 items-center justify-center rounded-2xl border border-border bg-primary text-primary-foreground shadow-lg transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="fixed bottom-6 right-6 z-[55] inline-flex size-14 items-center justify-center rounded-full border border-border bg-primary text-primary-foreground shadow-lg transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           <MessageCircle className="size-5" aria-hidden="true" />
           {totalUnread > 0 ? (
@@ -289,13 +289,13 @@ export default function LeagueSocialWidget({
           aria-label="League social panel"
           aria-hidden={!isOpen}
           inert={!isOpen}
-          className={`fixed inset-x-2 bottom-2 z-[60] flex h-[min(80dvh,42rem)] min-h-0 w-auto flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl transition-[transform,opacity] duration-200 sm:inset-x-auto sm:bottom-5 sm:right-5 sm:h-[min(75dvh,42rem)] sm:w-[25rem] lg:h-[min(42rem,calc(100dvh-6rem))] lg:w-[clamp(24rem,29vw,27rem)] ${
+          className={`fixed inset-0 z-[60] flex h-[100dvh] min-h-0 w-full flex-col overflow-hidden border-0 bg-background shadow-2xl transition-[transform,opacity] duration-200 sm:inset-auto sm:bottom-6 sm:right-6 sm:h-[clamp(36.25rem,76dvh,45rem)] sm:max-h-[calc(100dvh-3rem)] sm:w-[clamp(26.25rem,32vw,30rem)] sm:max-w-[calc(100vw-3rem)] sm:rounded-2xl sm:border sm:border-border ${
             isOpen
               ? 'translate-y-0 opacity-100 sm:translate-x-0'
               : 'pointer-events-none translate-y-full opacity-0 sm:translate-x-[calc(100%+2rem)] sm:translate-y-0'
           }`}
         >
-          <div className="flex min-h-14 shrink-0 items-center justify-between gap-3 border-b border-border bg-card px-4">
+          <div className="flex min-h-14 shrink-0 items-center justify-between gap-3 border-b border-border bg-card px-4 pt-[env(safe-area-inset-top)]">
             <div className="min-w-0">
               <p className="truncate text-sm font-semibold text-foreground">League Social</p>
               <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">

--- a/src/components/league/social/LeagueSocialWidget.tsx
+++ b/src/components/league/social/LeagueSocialWidget.tsx
@@ -282,11 +282,11 @@ export default function LeagueSocialWidget({
           }
           aria-expanded="false"
           title="League Social"
-          className="fixed bottom-6 right-6 z-[55] inline-flex size-14 items-center justify-center rounded-full border border-border bg-primary text-primary-foreground shadow-lg transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="league-social fixed bottom-6 right-6 z-[55] inline-flex size-14 items-center justify-center rounded-full border border-social-brand-strong bg-social-brand-strong text-social-brand-foreground shadow-lg transition-colors hover:bg-social-action-hover active:bg-social-action-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus focus-visible:ring-offset-2 focus-visible:ring-offset-social-surface"
         >
           <MessageCircle className="size-5" aria-hidden="true" />
           {totalUnread > 0 ? (
-            <span className="absolute -right-1 -top-1 inline-flex min-h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-xs font-bold text-destructive-foreground ring-2 ring-background">
+            <span className="absolute -right-1 -top-1 inline-flex min-h-5 min-w-5 items-center justify-center rounded-full bg-social-action px-1.5 text-xs font-bold text-social-action-foreground ring-2 ring-social-surface">
               <span className="sr-only">{totalUnread} unread</span>
               <span aria-hidden="true">{formatUnread(totalUnread)}</span>
             </span>
@@ -300,16 +300,18 @@ export default function LeagueSocialWidget({
           aria-label="League social panel"
           aria-hidden={!isOpen}
           inert={!isOpen}
-          className={`fixed inset-0 z-[60] flex h-[100dvh] min-h-0 w-full flex-col overflow-hidden border-0 bg-background shadow-2xl transition-[transform,opacity] duration-200 sm:inset-auto sm:bottom-6 sm:right-6 sm:h-[clamp(36.25rem,76dvh,45rem)] sm:max-h-[calc(100dvh-3rem)] sm:w-[clamp(26.25rem,32vw,30rem)] sm:max-w-[calc(100vw-3rem)] sm:rounded-2xl sm:border sm:border-border ${
+          className={`league-social fixed inset-0 z-[60] flex h-[100dvh] min-h-0 w-full flex-col overflow-hidden border-0 bg-social-canvas text-social-text shadow-2xl transition-[transform,opacity] duration-200 sm:inset-auto sm:bottom-6 sm:right-6 sm:h-[clamp(36.25rem,76dvh,45rem)] sm:max-h-[calc(100dvh-3rem)] sm:w-[clamp(26.25rem,32vw,30rem)] sm:max-w-[calc(100vw-3rem)] sm:rounded-2xl sm:border sm:border-social-border ${
             isOpen
               ? 'translate-y-0 opacity-100 sm:translate-x-0'
               : 'pointer-events-none translate-y-full opacity-0 sm:translate-x-[calc(100%+2rem)] sm:translate-y-0'
           }`}
         >
-          <div className="flex min-h-14 shrink-0 items-center justify-between gap-3 border-b border-border bg-card px-4 pt-[env(safe-area-inset-top)]">
+          <div className="flex min-h-14 shrink-0 items-center justify-between gap-3 border-b border-social-brand-strong bg-social-brand-strong px-4 pt-[env(safe-area-inset-top)] text-social-brand-foreground">
             <div className="min-w-0">
-              <p className="truncate text-sm font-semibold text-foreground">League Social</p>
-              <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+              <p className="truncate text-sm font-semibold text-social-brand-foreground">
+                League Social
+              </p>
+              <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-social-header-muted">
                 <span className="truncate">{displayLeagueName ?? 'Current league'}</span>
                 {connectionNotice !== 'hidden' ? (
                   <span
@@ -328,7 +330,7 @@ export default function LeagueSocialWidget({
                 ref={minimizeButtonRef}
                 type="button"
                 onClick={handleMinimize}
-                className="inline-flex size-10 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="inline-flex size-10 items-center justify-center rounded-full text-social-brand-foreground transition-colors hover:bg-social-header-control-hover active:bg-social-header-control-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-brand-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-social-brand-strong"
                 aria-label="Minimize league social"
                 title="Minimize"
               >

--- a/src/components/league/social/LeagueSocialWidgetProvider.test.tsx
+++ b/src/components/league/social/LeagueSocialWidgetProvider.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  LeagueSocialWidgetProvider,
+  getLeagueIdFromPathname,
+  resolveLeagueSocialLeagueId,
+  useLeagueSocialWidget,
+} from './LeagueSocialWidgetProvider';
+
+const navigation = vi.hoisted(() => ({ pathname: '/players' }));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => navigation.pathname,
+}));
+
+function WidgetHarness(): React.JSX.Element {
+  const widget = useLeagueSocialWidget();
+  return (
+    <div>
+      <output aria-label="league">{widget.leagueId ?? 'none'}</output>
+      <output aria-label="mode">{widget.mode}</output>
+      <output aria-label="view">{widget.view}</output>
+      <output aria-label="context">{widget.composerContext?.title ?? 'none'}</output>
+      <button type="button" onClick={() => widget.setLeagueContext('draft-league', 'Draft')}>
+        Register draft
+      </button>
+      <button type="button" onClick={() => widget.setLeagueContext(null)}>
+        Clear draft
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          widget.open({
+            leagueId: 'discussion-league',
+            view: 'board',
+            context: {
+              type: 'player',
+              id: 'player-1',
+              title: 'Discuss Alex Stat',
+            },
+          })
+        }
+      >
+        Discuss player
+      </button>
+      <button type="button" onClick={widget.minimize}>
+        Minimize
+      </button>
+      <button type="button" onClick={() => widget.open()}>
+        Reopen
+      </button>
+      <button type="button" onClick={widget.clearComposerContext}>
+        Clear context
+      </button>
+    </div>
+  );
+}
+
+describe('LeagueSocialWidgetProvider', () => {
+  it('resolves explicit league routes and ignores reserved league routes', () => {
+    expect(getLeagueIdFromPathname('/leagues/league%201/trades')).toBe('league 1');
+    expect(getLeagueIdFromPathname('/leagues/new')).toBeNull();
+    expect(getLeagueIdFromPathname('/players')).toBeNull();
+  });
+
+  it('uses route, registered, requested, then cookie league precedence', () => {
+    expect(
+      resolveLeagueSocialLeagueId({
+        pathname: '/leagues/route-league',
+        registeredLeagueId: 'draft-league',
+        requestedLeagueId: 'discussion-league',
+        cookieLeagueId: 'cookie-league',
+      })
+    ).toBe('route-league');
+    expect(
+      resolveLeagueSocialLeagueId({
+        pathname: '/drafts/draft-1',
+        registeredLeagueId: 'draft-league',
+        requestedLeagueId: 'discussion-league',
+        cookieLeagueId: 'cookie-league',
+      })
+    ).toBe('draft-league');
+    expect(
+      resolveLeagueSocialLeagueId({
+        pathname: '/players',
+        registeredLeagueId: null,
+        requestedLeagueId: 'discussion-league',
+        cookieLeagueId: 'cookie-league',
+      })
+    ).toBe('discussion-league');
+  });
+
+  it('opens contextual discussion in chat and preserves it while minimized', async () => {
+    const user = userEvent.setup();
+    render(
+      <LeagueSocialWidgetProvider>
+        <WidgetHarness />
+      </LeagueSocialWidgetProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Discuss player' }));
+    expect(screen.getByLabelText('league')).toHaveTextContent('discussion-league');
+    expect(screen.getByLabelText('mode')).toHaveTextContent('open');
+    expect(screen.getByLabelText('view')).toHaveTextContent('chat');
+    expect(screen.getByLabelText('context')).toHaveTextContent('Discuss Alex Stat');
+
+    await user.click(screen.getByRole('button', { name: 'Minimize' }));
+    expect(screen.getByLabelText('mode')).toHaveTextContent('minimized');
+    expect(screen.getByLabelText('context')).toHaveTextContent('Discuss Alex Stat');
+
+    await user.click(screen.getByRole('button', { name: 'Reopen' }));
+    expect(screen.getByLabelText('mode')).toHaveTextContent('open');
+    expect(screen.getByLabelText('context')).toHaveTextContent('Discuss Alex Stat');
+
+    await user.click(screen.getByRole('button', { name: 'Clear context' }));
+    await waitFor(() => expect(screen.getByLabelText('context')).toHaveTextContent('none'));
+  });
+
+  it('clears composer context when the effective league changes and does not restore it later', async () => {
+    const user = userEvent.setup();
+    render(
+      <LeagueSocialWidgetProvider>
+        <WidgetHarness />
+      </LeagueSocialWidgetProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Discuss player' }));
+    expect(screen.getByLabelText('league')).toHaveTextContent('discussion-league');
+    expect(screen.getByLabelText('context')).toHaveTextContent('Discuss Alex Stat');
+
+    await user.click(screen.getByRole('button', { name: 'Register draft' }));
+    expect(screen.getByLabelText('league')).toHaveTextContent('draft-league');
+    expect(screen.getByLabelText('context')).toHaveTextContent('none');
+
+    await user.click(screen.getByRole('button', { name: 'Clear draft' }));
+    expect(screen.getByLabelText('league')).toHaveTextContent('discussion-league');
+    expect(screen.getByLabelText('context')).toHaveTextContent('none');
+  });
+});

--- a/src/components/league/social/LeagueSocialWidgetProvider.tsx
+++ b/src/components/league/social/LeagueSocialWidgetProvider.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { usePathname } from 'next/navigation';
+
+import { LAST_LEAGUE_ID_COOKIE, readCookieValue } from '@/lib/uiPreferences';
+import type { SocialDiscussionContext } from '@/types/social';
+
+import type { LeagueSocialView } from './LeagueSocialShell';
+
+export interface OpenLeagueSocialWidgetOptions {
+  leagueId?: string;
+  view?: LeagueSocialView;
+  context?: SocialDiscussionContext;
+}
+
+export type LeagueSocialWidgetMode = 'closed' | 'open' | 'minimized';
+
+interface LeagueContext {
+  leagueId: string;
+  name?: string;
+}
+
+interface LeagueBoundComposerContext {
+  leagueId: string;
+  context: SocialDiscussionContext;
+}
+
+export interface LeagueSocialWidgetController {
+  leagueId: string | null;
+  leagueName?: string;
+  mode: LeagueSocialWidgetMode;
+  hasOpened: boolean;
+  view: LeagueSocialView;
+  composerContext: SocialDiscussionContext | null;
+  open: (options?: OpenLeagueSocialWidgetOptions) => void;
+  close: () => void;
+  minimize: () => void;
+  setLeagueContext: (leagueId: string | null, name?: string) => void;
+  clearComposerContext: () => void;
+}
+
+const LeagueSocialWidgetContext = createContext<LeagueSocialWidgetController | null>(null);
+LeagueSocialWidgetContext.displayName = 'LeagueSocialWidgetContext';
+
+const RESERVED_LEAGUE_ROUTES = new Set(['join', 'new']);
+
+export function getLeagueIdFromPathname(pathname: string | null | undefined): string | null {
+  const match = (pathname ?? '').match(/^\/leagues\/([^/]+)(?:\/|$)/);
+  if (!match || RESERVED_LEAGUE_ROUTES.has(match[1])) return null;
+
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+export function resolveLeagueSocialLeagueId({
+  pathname,
+  registeredLeagueId,
+  requestedLeagueId,
+  cookieLeagueId,
+}: {
+  pathname: string | null | undefined;
+  registeredLeagueId: string | null;
+  requestedLeagueId: string | null;
+  cookieLeagueId: string | null;
+}): string | null {
+  return (
+    getLeagueIdFromPathname(pathname) ?? registeredLeagueId ?? requestedLeagueId ?? cookieLeagueId
+  );
+}
+
+export function LeagueSocialWidgetProvider({
+  children,
+}: {
+  children: ReactNode;
+}): React.JSX.Element {
+  const pathname = usePathname();
+  const [registeredLeague, setRegisteredLeague] = useState<LeagueContext | null>(null);
+  const [requestedLeagueId, setRequestedLeagueId] = useState<string | null>(null);
+  const [cookieLeagueId, setCookieLeagueId] = useState<string | null>(null);
+  const [mode, setMode] = useState<LeagueSocialWidgetMode>('closed');
+  const [hasOpened, setHasOpened] = useState(false);
+  const [view, setView] = useState<LeagueSocialView>('chat');
+  const [boundComposerContext, setBoundComposerContext] =
+    useState<LeagueBoundComposerContext | null>(null);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    setCookieLeagueId(readCookieValue(document.cookie, LAST_LEAGUE_ID_COOKIE) ?? null);
+  }, [pathname]);
+
+  const leagueId = resolveLeagueSocialLeagueId({
+    pathname,
+    registeredLeagueId: registeredLeague?.leagueId ?? null,
+    requestedLeagueId,
+    cookieLeagueId,
+  });
+  const leagueName = registeredLeague?.leagueId === leagueId ? registeredLeague.name : undefined;
+  const composerContext =
+    boundComposerContext?.leagueId === leagueId ? boundComposerContext.context : null;
+
+  const open = useCallback(
+    (options: OpenLeagueSocialWidgetOptions = {}) => {
+      if (options.leagueId) setRequestedLeagueId(options.leagueId);
+      if (options.context) {
+        const contextLeagueId = options.leagueId ?? leagueId;
+        setBoundComposerContext(
+          contextLeagueId ? { leagueId: contextLeagueId, context: options.context } : null
+        );
+        setView('chat');
+      } else if (options.view) {
+        setView(options.view);
+      }
+      setHasOpened(true);
+      setMode('open');
+    },
+    [leagueId]
+  );
+
+  const close = useCallback(() => setMode('closed'), []);
+  const minimize = useCallback(() => setMode('minimized'), []);
+  const clearComposerContext = useCallback(() => setBoundComposerContext(null), []);
+  const setLeagueContext = useCallback((nextLeagueId: string | null, name?: string) => {
+    setRegisteredLeague(nextLeagueId ? { leagueId: nextLeagueId, name } : null);
+  }, []);
+
+  useEffect(() => {
+    if (!leagueId && mode !== 'closed') setMode('closed');
+  }, [leagueId, mode]);
+
+  useEffect(() => {
+    setBoundComposerContext((current) => (current?.leagueId === leagueId ? current : null));
+  }, [leagueId]);
+
+  const value = useMemo<LeagueSocialWidgetController>(
+    () => ({
+      leagueId,
+      leagueName,
+      mode,
+      hasOpened,
+      view,
+      composerContext,
+      open,
+      close,
+      minimize,
+      setLeagueContext,
+      clearComposerContext,
+    }),
+    [
+      clearComposerContext,
+      close,
+      composerContext,
+      hasOpened,
+      leagueId,
+      leagueName,
+      minimize,
+      mode,
+      open,
+      setLeagueContext,
+      view,
+    ]
+  );
+
+  return (
+    <LeagueSocialWidgetContext.Provider value={value}>
+      {children}
+    </LeagueSocialWidgetContext.Provider>
+  );
+}
+
+export function useLeagueSocialWidget(): LeagueSocialWidgetController {
+  const context = useContext(LeagueSocialWidgetContext);
+  if (!context) {
+    throw new Error('useLeagueSocialWidget must be used within a LeagueSocialWidgetProvider');
+  }
+  return context;
+}

--- a/src/components/league/social/MessageBoardPanel.test.tsx
+++ b/src/components/league/social/MessageBoardPanel.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SocialBoardCategory, SocialPost } from '@/types/social';
+
+import MessageBoardPanel from './MessageBoardPanel';
+
+const category: SocialBoardCategory = {
+  id: 'category-1',
+  key: 'general',
+  name: 'General',
+  position: 1,
+};
+
+const announcement: SocialPost = {
+  id: 'post-1',
+  leagueId: 'league-1',
+  seasonId: 'season-1',
+  category,
+  author: {
+    userId: 'commissioner-1',
+    displayName: 'Commissioner',
+    teamName: 'League Office',
+  },
+  title: 'Official league update',
+  body: 'Important details for every manager.',
+  isPinned: true,
+  isLocked: true,
+  isAnnouncement: true,
+  replyCount: 2,
+  latestActivityAt: '2026-07-20T10:00:00.000Z',
+  createdAt: '2026-07-20T09:00:00.000Z',
+  updatedAt: '2026-07-20T10:00:00.000Z',
+  moderationStatus: 'active',
+  isOwn: false,
+};
+
+function renderBoard(overrides: Partial<React.ComponentProps<typeof MessageBoardPanel>> = {}) {
+  return render(
+    <MessageBoardPanel
+      posts={[announcement]}
+      categories={[category]}
+      loading={false}
+      loadingMore={false}
+      creating={false}
+      hasMore={false}
+      canPublish
+      canManage
+      onRetry={vi.fn()}
+      onLoadMore={vi.fn()}
+      onSelectPost={vi.fn()}
+      onCreatePost={vi.fn()}
+      sort="latestActivity"
+      onSortChange={vi.fn()}
+      {...overrides}
+    />
+  );
+}
+
+describe('MessageBoardPanel colour hierarchy', () => {
+  it('distinguishes announcements, pinned posts, and locked posts with labels and semantic tokens', () => {
+    renderBoard();
+
+    expect(screen.getByRole('button', { name: /open discussion/i })).toHaveClass(
+      'border-l-social-brand-strong',
+      'bg-social-surface'
+    );
+    expect(screen.getByText('Announcement')).toHaveClass(
+      'bg-social-brand-strong',
+      'text-social-brand-foreground'
+    );
+    expect(screen.getByText('Pinned')).toHaveClass('bg-social-brand-soft');
+    expect(screen.getByText('Locked')).toHaveClass('bg-social-surface-subtle');
+  });
+
+  it('gives unavailable publishing an explicit disabled colour state', () => {
+    renderBoard({ canPublish: false });
+
+    expect(screen.getByRole('button', { name: 'New post' })).toHaveClass(
+      'disabled:bg-social-disabled-bg',
+      'disabled:text-social-disabled-text'
+    );
+  });
+});

--- a/src/components/league/social/MessageBoardPanel.tsx
+++ b/src/components/league/social/MessageBoardPanel.tsx
@@ -21,6 +21,7 @@ interface MessageBoardPanelProps {
   error?: string | null;
   submitError?: string | null;
   visible?: boolean;
+  compact?: boolean;
   onRetry: () => Promise<void> | void;
   onLoadMore: () => Promise<void> | void;
   onSelectPost: (post: SocialPost) => void;
@@ -43,6 +44,7 @@ export default function MessageBoardPanel({
   error,
   submitError,
   visible = true,
+  compact = false,
   onRetry,
   onLoadMore,
   onSelectPost,
@@ -112,16 +114,26 @@ export default function MessageBoardPanel({
   return (
     <section
       aria-labelledby="message-board-heading"
-      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border bg-card text-card-foreground"
+      className={`flex min-h-0 flex-1 flex-col overflow-hidden ${
+        compact
+          ? 'bg-background text-foreground'
+          : 'rounded-2xl border border-border bg-card text-card-foreground'
+      }`}
     >
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3">
+      <header
+        className={`flex flex-wrap items-center justify-between gap-3 border-b border-border ${
+          compact ? 'px-3 py-2.5' : 'px-4 py-3'
+        }`}
+      >
         <div>
           <h2 id="message-board-heading" className="text-base font-semibold text-foreground">
-            Message board
+            {compact ? 'Discussions' : 'Message board'}
           </h2>
-          <p className="text-xs text-muted-foreground">
-            Announcements and persistent league discussions
-          </p>
+          {!compact ? (
+            <p className="text-xs text-muted-foreground">
+              Announcements and persistent league discussions
+            </p>
+          ) : null}
         </div>
         <button
           type="button"
@@ -129,7 +141,9 @@ export default function MessageBoardPanel({
           disabled={!canPublish || muted}
           aria-expanded={showForm}
           aria-controls="create-social-post"
-          className="inline-flex min-h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          className={`inline-flex items-center justify-center rounded-lg bg-primary text-sm font-semibold text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
+            compact ? 'min-h-9 px-3' : 'min-h-10 px-4'
+          }`}
         >
           New post
         </button>
@@ -154,7 +168,7 @@ export default function MessageBoardPanel({
           onSubmit={(event) => void handleCreate(event)}
           className="space-y-4 border-b border-border bg-muted/30 p-4"
         >
-          <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_14rem]">
+          <div className={compact ? 'grid gap-4' : 'grid gap-4 sm:grid-cols-[minmax(0,1fr)_14rem]'}>
             <div>
               <label htmlFor={titleId} className="text-sm font-medium text-foreground">
                 Post title
@@ -199,7 +213,7 @@ export default function MessageBoardPanel({
               value={body}
               onChange={(event) => setBody(event.target.value)}
               maxLength={10000}
-              rows={7}
+              rows={compact ? 5 : 7}
               required
               className="mt-1 block w-full resize-y rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
               placeholder="Add the details league members will need…"
@@ -245,12 +259,12 @@ export default function MessageBoardPanel({
 
       <div
         ref={scrollRef}
-        className="min-h-0 flex-1 overflow-y-auto p-4"
+        className={`min-h-0 flex-1 overflow-y-auto ${compact ? 'p-3' : 'p-4'}`}
         onScroll={(event) => onLatestVisibleChange?.(event.currentTarget.scrollTop <= 72)}
       >
         <div className="mb-3 flex justify-end">
           <label className="flex min-h-10 items-center gap-2 text-sm font-medium text-foreground">
-            Sort discussions
+            {compact ? 'Sort' : 'Sort discussions'}
             <select
               value={sort}
               onChange={(event) => onSortChange(event.target.value as SocialPostSort)}
@@ -286,16 +300,23 @@ export default function MessageBoardPanel({
             </p>
           </div>
         ) : (
-          <ol className="space-y-3" aria-label="League message board posts">
+          <ol
+            className={compact ? 'divide-y divide-border' : 'space-y-3'}
+            aria-label="League message board posts"
+          >
             {sortedPosts.map((post) => (
               <li key={post.id}>
                 <button
                   type="button"
                   onClick={() => onSelectPost(post)}
-                  className={`block w-full rounded-xl border p-4 text-left transition hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
-                    post.isAnnouncement
-                      ? 'border-primary/35 bg-primary/10'
-                      : 'border-border bg-background'
+                  className={`block w-full text-left transition hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                    compact
+                      ? `px-1 py-3 ${post.isAnnouncement ? 'bg-muted/40' : 'bg-background'}`
+                      : `rounded-xl border p-4 ${
+                          post.isAnnouncement
+                            ? 'border-primary/35 bg-primary/10'
+                            : 'border-border bg-background'
+                        }`
                   }`}
                   aria-label={`Open discussion: ${post.title}`}
                 >

--- a/src/components/league/social/MessageBoardPanel.tsx
+++ b/src/components/league/social/MessageBoardPanel.tsx
@@ -1,0 +1,350 @@
+'use client';
+
+import { Lock, Megaphone, MessageSquare, Pin } from 'lucide-react';
+import { useEffect, useId, useState, type FormEvent } from 'react';
+
+import type { CreateSocialPostInput, SocialBoardCategory, SocialPost } from '@/types/social';
+
+import SocialAuthor from './SocialAuthor';
+import type { SocialPostSort } from './useLeagueSocial';
+
+interface MessageBoardPanelProps {
+  posts: SocialPost[];
+  categories: SocialBoardCategory[];
+  loading: boolean;
+  loadingMore: boolean;
+  creating: boolean;
+  hasMore: boolean;
+  canPublish: boolean;
+  canManage: boolean;
+  mutedUntil?: string | null;
+  error?: string | null;
+  submitError?: string | null;
+  onRetry: () => Promise<void> | void;
+  onLoadMore: () => Promise<void> | void;
+  onSelectPost: (post: SocialPost) => void;
+  onCreatePost: (input: Omit<CreateSocialPostInput, 'idempotencyKey'>) => Promise<SocialPost>;
+  sort: SocialPostSort;
+  onSortChange: (sort: SocialPostSort) => void;
+}
+
+export default function MessageBoardPanel({
+  posts,
+  categories,
+  loading,
+  loadingMore,
+  creating,
+  hasMore,
+  canPublish,
+  canManage,
+  mutedUntil,
+  error,
+  submitError,
+  onRetry,
+  onLoadMore,
+  onSelectPost,
+  onCreatePost,
+  sort,
+  onSortChange,
+}: MessageBoardPanelProps): React.JSX.Element {
+  const titleId = useId();
+  const bodyId = useId();
+  const categoryId = useId();
+  const [showForm, setShowForm] = useState(false);
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [selectedCategoryId, setSelectedCategoryId] = useState(categories[0]?.id ?? '');
+  const [isAnnouncement, setIsAnnouncement] = useState(false);
+  const muted = Boolean(mutedUntil && new Date(mutedUntil).getTime() > Date.now());
+  const sortedPosts = [...posts].sort((left, right) => {
+    if (left.isPinned !== right.isPinned) return left.isPinned ? -1 : 1;
+    const leftDate = sort === 'createdAt' ? left.createdAt : left.latestActivityAt;
+    const rightDate = sort === 'createdAt' ? right.createdAt : right.latestActivityAt;
+    return new Date(rightDate).getTime() - new Date(leftDate).getTime();
+  });
+  const canSubmit =
+    !creating &&
+    canPublish &&
+    !muted &&
+    title.trim().length > 0 &&
+    body.trim().length > 0 &&
+    Boolean(selectedCategoryId);
+
+  useEffect(() => {
+    if (!selectedCategoryId && categories[0]) {
+      setSelectedCategoryId(categories[0].id);
+    }
+  }, [categories, selectedCategoryId]);
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    if (!canSubmit) return;
+    try {
+      await onCreatePost({
+        categoryId: selectedCategoryId,
+        title: title.trim(),
+        body: body.trim(),
+        ...(canPublish && isAnnouncement ? { isAnnouncement: true } : {}),
+      });
+      setTitle('');
+      setBody('');
+      setIsAnnouncement(false);
+      setShowForm(false);
+    } catch {
+      // The controller supplies submitError while preserving the member's draft.
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby="message-board-heading"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border bg-card text-card-foreground"
+    >
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3">
+        <div>
+          <h2 id="message-board-heading" className="text-base font-semibold text-foreground">
+            Message board
+          </h2>
+          <p className="text-xs text-muted-foreground">
+            Announcements and persistent league discussions
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowForm((visible) => !visible)}
+          disabled={!canPublish || muted}
+          aria-expanded={showForm}
+          aria-controls="create-social-post"
+          className="inline-flex min-h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          New post
+        </button>
+      </header>
+
+      {muted ? (
+        <p
+          role="status"
+          className="border-b border-border bg-warning/10 px-4 py-3 text-sm text-foreground"
+        >
+          Posting is unavailable until{' '}
+          <time dateTime={mutedUntil ?? undefined}>
+            {mutedUntil ? new Date(mutedUntil).toLocaleString() : 'the mute ends'}
+          </time>
+          .
+        </p>
+      ) : null}
+
+      {showForm ? (
+        <form
+          id="create-social-post"
+          onSubmit={(event) => void handleCreate(event)}
+          className="space-y-4 border-b border-border bg-muted/30 p-4"
+        >
+          <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_14rem]">
+            <div>
+              <label htmlFor={titleId} className="text-sm font-medium text-foreground">
+                Post title
+              </label>
+              <input
+                id={titleId}
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                maxLength={150}
+                required
+                className="mt-1 block h-11 w-full rounded-xl border border-border bg-background px-3 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                placeholder="What should the league discuss?"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">{title.length} / 150</p>
+            </div>
+            <div>
+              <label htmlFor={categoryId} className="text-sm font-medium text-foreground">
+                Category
+              </label>
+              <select
+                id={categoryId}
+                value={selectedCategoryId}
+                onChange={(event) => setSelectedCategoryId(event.target.value)}
+                required
+                className="mt-1 block h-11 w-full rounded-xl border border-border bg-background px-3 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <option value="">Choose category</option>
+                {categories.map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div>
+            <label htmlFor={bodyId} className="text-sm font-medium text-foreground">
+              Post body
+            </label>
+            <textarea
+              id={bodyId}
+              value={body}
+              onChange={(event) => setBody(event.target.value)}
+              maxLength={10000}
+              rows={7}
+              required
+              className="mt-1 block w-full resize-y rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+              placeholder="Add the details league members will need…"
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              {body.length.toLocaleString()} / 10,000
+            </p>
+          </div>
+          {canManage ? (
+            <label className="inline-flex min-h-10 items-center gap-2 text-sm font-medium text-foreground">
+              <input
+                type="checkbox"
+                checked={isAnnouncement}
+                onChange={(event) => setIsAnnouncement(event.target.checked)}
+                className="size-4 rounded border-border text-primary focus:ring-ring"
+              />
+              Publish as an official announcement
+            </label>
+          ) : null}
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="inline-flex min-h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {creating ? 'Publishing…' : 'Publish post'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowForm(false)}
+              className="inline-flex min-h-10 items-center justify-center rounded-lg border border-border bg-background px-4 text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Cancel
+            </button>
+            {submitError ? (
+              <p role="alert" className="text-sm font-medium text-destructive">
+                {submitError}
+              </p>
+            ) : null}
+          </div>
+        </form>
+      ) : null}
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        <div className="mb-3 flex justify-end">
+          <label className="flex min-h-10 items-center gap-2 text-sm font-medium text-foreground">
+            Sort discussions
+            <select
+              value={sort}
+              onChange={(event) => onSortChange(event.target.value as SocialPostSort)}
+              className="h-10 rounded-lg border border-border bg-background px-3 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <option value="latestActivity">Latest activity</option>
+              <option value="createdAt">Creation date</option>
+            </select>
+          </label>
+        </div>
+        {loading && posts.length === 0 ? (
+          <p role="status" className="py-10 text-center text-sm text-muted-foreground">
+            Loading message board…
+          </p>
+        ) : error && posts.length === 0 ? (
+          <div className="mx-auto max-w-sm rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-center">
+            <p role="alert" className="text-sm font-medium text-destructive">
+              {error}
+            </p>
+            <button
+              type="button"
+              onClick={() => void onRetry()}
+              className="mt-3 inline-flex min-h-9 items-center justify-center rounded-lg border border-border bg-background px-3 text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Retry
+            </button>
+          </div>
+        ) : posts.length === 0 ? (
+          <div className="py-10 text-center">
+            <p className="text-sm font-semibold text-foreground">No discussions yet</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Create the first post for your league.
+            </p>
+          </div>
+        ) : (
+          <ol className="space-y-3" aria-label="League message board posts">
+            {sortedPosts.map((post) => (
+              <li key={post.id}>
+                <button
+                  type="button"
+                  onClick={() => onSelectPost(post)}
+                  className={`block w-full rounded-xl border p-4 text-left transition hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                    post.isAnnouncement
+                      ? 'border-primary/35 bg-primary/10'
+                      : 'border-border bg-background'
+                  }`}
+                  aria-label={`Open discussion: ${post.title}`}
+                >
+                  <span className="flex flex-wrap items-center gap-2">
+                    {post.isAnnouncement ? (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-primary px-2.5 py-1 text-xs font-semibold text-primary-foreground">
+                        <Megaphone className="size-3.5" aria-hidden="true" />
+                        Announcement
+                      </span>
+                    ) : null}
+                    {post.isPinned ? (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-foreground">
+                        <Pin className="size-3.5" aria-hidden="true" />
+                        Pinned
+                      </span>
+                    ) : null}
+                    {post.isLocked ? (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-foreground">
+                        <Lock className="size-3.5" aria-hidden="true" />
+                        Locked
+                      </span>
+                    ) : null}
+                    <span className="rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                      {post.category.name}
+                    </span>
+                  </span>
+                  <span className="mt-3 block text-base font-semibold text-foreground">
+                    {post.title}
+                  </span>
+                  <span className="mt-3 block">
+                    <SocialAuthor
+                      author={post.author}
+                      timestamp={post.createdAt}
+                      editedAt={post.editedAt}
+                      compact
+                    />
+                  </span>
+                  <span className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+                    <span className="inline-flex items-center gap-1">
+                      <MessageSquare className="size-3.5" aria-hidden="true" />
+                      {post.replyCount} {post.replyCount === 1 ? 'reply' : 'replies'}
+                    </span>
+                    <span>
+                      Latest activity{' '}
+                      <time dateTime={post.latestActivityAt}>
+                        {new Date(post.latestActivityAt).toLocaleString()}
+                      </time>
+                    </span>
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ol>
+        )}
+        {hasMore ? (
+          <div className="mt-4 flex justify-center">
+            <button
+              type="button"
+              onClick={() => void onLoadMore()}
+              disabled={loadingMore}
+              className="inline-flex min-h-10 items-center justify-center rounded-lg border border-border bg-background px-4 text-sm font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+            >
+              {loadingMore ? 'Loading…' : 'Load more discussions'}
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/league/social/MessageBoardPanel.tsx
+++ b/src/components/league/social/MessageBoardPanel.tsx
@@ -116,21 +116,21 @@ export default function MessageBoardPanel({
       aria-labelledby="message-board-heading"
       className={`flex min-h-0 flex-1 flex-col overflow-hidden ${
         compact
-          ? 'bg-background text-foreground'
-          : 'rounded-2xl border border-border bg-card text-card-foreground'
+          ? 'bg-social-canvas text-social-text'
+          : 'rounded-2xl border border-social-border bg-social-canvas text-social-text'
       }`}
     >
       <header
-        className={`flex flex-wrap items-center justify-between gap-3 border-b border-border ${
+        className={`flex flex-wrap items-center justify-between gap-3 border-b border-social-border bg-social-surface ${
           compact ? 'px-3 py-2.5' : 'px-4 py-3'
         }`}
       >
         <div>
-          <h2 id="message-board-heading" className="text-base font-semibold text-foreground">
+          <h2 id="message-board-heading" className="text-base font-semibold text-social-text">
             {compact ? 'Discussions' : 'Message board'}
           </h2>
           {!compact ? (
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs text-social-text-muted">
               Announcements and persistent league discussions
             </p>
           ) : null}
@@ -141,7 +141,7 @@ export default function MessageBoardPanel({
           disabled={!canPublish || muted}
           aria-expanded={showForm}
           aria-controls="create-social-post"
-          className={`inline-flex items-center justify-center rounded-lg bg-primary text-sm font-semibold text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
+          className={`inline-flex items-center justify-center rounded-lg border border-social-action bg-social-action text-sm font-semibold text-social-action-foreground transition-colors hover:border-social-action-hover hover:bg-social-action-hover active:border-social-action-pressed active:bg-social-action-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus focus-visible:ring-offset-2 focus-visible:ring-offset-social-surface disabled:cursor-not-allowed disabled:border-social-border disabled:bg-social-disabled-bg disabled:text-social-disabled-text ${
             compact ? 'min-h-9 px-3' : 'min-h-10 px-4'
           }`}
         >
@@ -152,7 +152,7 @@ export default function MessageBoardPanel({
       {muted ? (
         <p
           role="status"
-          className="border-b border-border bg-warning/10 px-4 py-3 text-sm text-foreground"
+          className="border-b border-social-warning bg-social-warning-soft px-4 py-3 text-sm text-social-warning-text"
         >
           Posting is unavailable until{' '}
           <time dateTime={mutedUntil ?? undefined}>
@@ -166,11 +166,11 @@ export default function MessageBoardPanel({
         <form
           id="create-social-post"
           onSubmit={(event) => void handleCreate(event)}
-          className="space-y-4 border-b border-border bg-muted/30 p-4"
+          className="space-y-4 border-b border-social-border bg-social-surface-subtle p-4"
         >
           <div className={compact ? 'grid gap-4' : 'grid gap-4 sm:grid-cols-[minmax(0,1fr)_14rem]'}>
             <div>
-              <label htmlFor={titleId} className="text-sm font-medium text-foreground">
+              <label htmlFor={titleId} className="text-sm font-medium text-social-text">
                 Post title
               </label>
               <input
@@ -179,13 +179,13 @@ export default function MessageBoardPanel({
                 onChange={(event) => setTitle(event.target.value)}
                 maxLength={150}
                 required
-                className="mt-1 block h-11 w-full rounded-xl border border-border bg-background px-3 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                className="mt-1 block h-11 w-full rounded-xl border border-social-border bg-social-surface px-3 text-sm text-social-text outline-none placeholder:text-social-text-muted focus-visible:border-social-action focus-visible:ring-2 focus-visible:ring-social-focus"
                 placeholder="What should the league discuss?"
               />
-              <p className="mt-1 text-xs text-muted-foreground">{title.length} / 150</p>
+              <p className="mt-1 text-xs text-social-text-muted">{title.length} / 150</p>
             </div>
             <div>
-              <label htmlFor={categoryId} className="text-sm font-medium text-foreground">
+              <label htmlFor={categoryId} className="text-sm font-medium text-social-text">
                 Category
               </label>
               <select
@@ -193,7 +193,7 @@ export default function MessageBoardPanel({
                 value={selectedCategoryId}
                 onChange={(event) => setSelectedCategoryId(event.target.value)}
                 required
-                className="mt-1 block h-11 w-full rounded-xl border border-border bg-background px-3 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="mt-1 block h-11 w-full rounded-xl border border-social-border bg-social-surface px-3 text-sm text-social-text outline-none focus-visible:border-social-action focus-visible:ring-2 focus-visible:ring-social-focus"
               >
                 <option value="">Choose category</option>
                 {categories.map((category) => (
@@ -205,7 +205,7 @@ export default function MessageBoardPanel({
             </div>
           </div>
           <div>
-            <label htmlFor={bodyId} className="text-sm font-medium text-foreground">
+            <label htmlFor={bodyId} className="text-sm font-medium text-social-text">
               Post body
             </label>
             <textarea
@@ -215,20 +215,20 @@ export default function MessageBoardPanel({
               maxLength={10000}
               rows={compact ? 5 : 7}
               required
-              className="mt-1 block w-full resize-y rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+              className="mt-1 block w-full resize-y rounded-xl border border-social-border bg-social-surface px-3 py-2 text-sm text-social-text outline-none placeholder:text-social-text-muted focus-visible:border-social-action focus-visible:ring-2 focus-visible:ring-social-focus"
               placeholder="Add the details league members will need…"
             />
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className="mt-1 text-xs text-social-text-muted">
               {body.length.toLocaleString()} / 10,000
             </p>
           </div>
           {canManage ? (
-            <label className="inline-flex min-h-10 items-center gap-2 text-sm font-medium text-foreground">
+            <label className="inline-flex min-h-10 items-center gap-2 text-sm font-medium text-social-text">
               <input
                 type="checkbox"
                 checked={isAnnouncement}
                 onChange={(event) => setIsAnnouncement(event.target.checked)}
-                className="size-4 rounded border-border text-primary focus:ring-ring"
+                className="size-4 rounded border-social-border text-social-action focus:ring-social-focus"
               />
               Publish as an official announcement
             </label>
@@ -237,19 +237,19 @@ export default function MessageBoardPanel({
             <button
               type="submit"
               disabled={!canSubmit}
-              className="inline-flex min-h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex min-h-10 items-center justify-center rounded-lg border border-social-action bg-social-action px-4 text-sm font-semibold text-social-action-foreground transition-colors hover:border-social-action-hover hover:bg-social-action-hover active:border-social-action-pressed active:bg-social-action-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:border-social-border disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
             >
               {creating ? 'Publishing…' : 'Publish post'}
             </button>
             <button
               type="button"
               onClick={() => setShowForm(false)}
-              className="inline-flex min-h-10 items-center justify-center rounded-lg border border-border bg-background px-4 text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="inline-flex min-h-10 items-center justify-center rounded-lg border border-social-border bg-social-surface px-4 text-sm font-semibold text-social-text transition-colors hover:border-social-border-strong hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
             >
               Cancel
             </button>
             {submitError ? (
-              <p role="alert" className="text-sm font-medium text-destructive">
+              <p role="alert" className="text-sm font-medium text-social-error">
                 {submitError}
               </p>
             ) : null}
@@ -263,12 +263,12 @@ export default function MessageBoardPanel({
         onScroll={(event) => onLatestVisibleChange?.(event.currentTarget.scrollTop <= 72)}
       >
         <div className="mb-3 flex justify-end">
-          <label className="flex min-h-10 items-center gap-2 text-sm font-medium text-foreground">
+          <label className="flex min-h-10 items-center gap-2 text-sm font-medium text-social-text">
             {compact ? 'Sort' : 'Sort discussions'}
             <select
               value={sort}
               onChange={(event) => onSortChange(event.target.value as SocialPostSort)}
-              className="h-10 rounded-lg border border-border bg-background px-3 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="h-10 rounded-lg border border-social-border bg-social-surface px-3 text-sm text-social-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
             >
               <option value="latestActivity">Latest activity</option>
               <option value="createdAt">Creation date</option>
@@ -276,32 +276,32 @@ export default function MessageBoardPanel({
           </label>
         </div>
         {loading && posts.length === 0 ? (
-          <p role="status" className="py-10 text-center text-sm text-muted-foreground">
+          <p role="status" className="py-10 text-center text-sm text-social-text-muted">
             Loading message board…
           </p>
         ) : error && posts.length === 0 ? (
-          <div className="mx-auto max-w-sm rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-center">
-            <p role="alert" className="text-sm font-medium text-destructive">
+          <div className="mx-auto max-w-sm rounded-xl border border-social-error bg-social-error-soft p-4 text-center">
+            <p role="alert" className="text-sm font-medium text-social-error">
               {error}
             </p>
             <button
               type="button"
               onClick={() => void onRetry()}
-              className="mt-3 inline-flex min-h-9 items-center justify-center rounded-lg border border-border bg-background px-3 text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="mt-3 inline-flex min-h-9 items-center justify-center rounded-lg border border-social-border bg-social-surface px-3 text-sm font-semibold text-social-text transition-colors hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
             >
               Retry
             </button>
           </div>
         ) : posts.length === 0 ? (
           <div className="py-10 text-center">
-            <p className="text-sm font-semibold text-foreground">No discussions yet</p>
-            <p className="mt-1 text-sm text-muted-foreground">
+            <p className="text-sm font-semibold text-social-text">No discussions yet</p>
+            <p className="mt-1 text-sm text-social-text-muted">
               Create the first post for your league.
             </p>
           </div>
         ) : (
           <ol
-            className={compact ? 'divide-y divide-border' : 'space-y-3'}
+            className={compact ? 'divide-y divide-social-border' : 'space-y-3'}
             aria-label="League message board posts"
           >
             {sortedPosts.map((post) => (
@@ -309,41 +309,45 @@ export default function MessageBoardPanel({
                 <button
                   type="button"
                   onClick={() => onSelectPost(post)}
-                  className={`block w-full text-left transition hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                  className={`block w-full border-l-4 text-left transition-colors hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus ${
                     compact
-                      ? `px-1 py-3 ${post.isAnnouncement ? 'bg-muted/40' : 'bg-background'}`
+                      ? `px-2 py-3 ${
+                          post.isAnnouncement
+                            ? 'border-l-social-brand-strong bg-social-surface'
+                            : 'border-l-transparent bg-social-surface'
+                        }`
                       : `rounded-xl border p-4 ${
                           post.isAnnouncement
-                            ? 'border-primary/35 bg-primary/10'
-                            : 'border-border bg-background'
+                            ? 'border-social-border border-l-social-brand-strong bg-social-surface'
+                            : 'border-social-border border-l-transparent bg-social-surface'
                         }`
                   }`}
                   aria-label={`Open discussion: ${post.title}`}
                 >
                   <span className="flex flex-wrap items-center gap-2">
                     {post.isAnnouncement ? (
-                      <span className="inline-flex items-center gap-1 rounded-full bg-primary px-2.5 py-1 text-xs font-semibold text-primary-foreground">
+                      <span className="inline-flex items-center gap-1 rounded-full bg-social-brand-strong px-2.5 py-1 text-xs font-semibold text-social-brand-foreground">
                         <Megaphone className="size-3.5" aria-hidden="true" />
                         Announcement
                       </span>
                     ) : null}
                     {post.isPinned ? (
-                      <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-foreground">
+                      <span className="inline-flex items-center gap-1 rounded-full border border-social-action bg-social-brand-soft px-2.5 py-1 text-xs font-semibold text-social-action-pressed">
                         <Pin className="size-3.5" aria-hidden="true" />
                         Pinned
                       </span>
                     ) : null}
                     {post.isLocked ? (
-                      <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-foreground">
+                      <span className="inline-flex items-center gap-1 rounded-full border border-social-border bg-social-surface-subtle px-2.5 py-1 text-xs font-semibold text-social-text-muted">
                         <Lock className="size-3.5" aria-hidden="true" />
                         Locked
                       </span>
                     ) : null}
-                    <span className="rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                    <span className="rounded-full border border-social-border bg-social-surface-subtle px-2.5 py-1 text-xs font-medium text-social-text-muted">
                       {post.category.name}
                     </span>
                   </span>
-                  <span className="mt-3 block text-base font-semibold text-foreground">
+                  <span className="mt-3 block text-base font-semibold text-social-text">
                     {post.title}
                   </span>
                   <span className="mt-3 block">
@@ -354,7 +358,7 @@ export default function MessageBoardPanel({
                       compact
                     />
                   </span>
-                  <span className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+                  <span className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-social-text-muted">
                     <span className="inline-flex items-center gap-1">
                       <MessageSquare className="size-3.5" aria-hidden="true" />
                       {post.replyCount} {post.replyCount === 1 ? 'reply' : 'replies'}
@@ -377,7 +381,7 @@ export default function MessageBoardPanel({
               type="button"
               onClick={() => void onLoadMore()}
               disabled={loadingMore}
-              className="inline-flex min-h-10 items-center justify-center rounded-lg border border-border bg-background px-4 text-sm font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+              className="inline-flex min-h-10 items-center justify-center rounded-lg border border-social-border bg-social-surface px-4 text-sm font-semibold text-social-text transition-colors hover:border-social-border-strong hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
             >
               {loadingMore ? 'Loading…' : 'Load more discussions'}
             </button>

--- a/src/components/league/social/MessageBoardPanel.tsx
+++ b/src/components/league/social/MessageBoardPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Lock, Megaphone, MessageSquare, Pin } from 'lucide-react';
-import { useEffect, useId, useState, type FormEvent } from 'react';
+import { useEffect, useId, useLayoutEffect, useRef, useState, type FormEvent } from 'react';
 
 import type { CreateSocialPostInput, SocialBoardCategory, SocialPost } from '@/types/social';
 
@@ -20,12 +20,14 @@ interface MessageBoardPanelProps {
   mutedUntil?: string | null;
   error?: string | null;
   submitError?: string | null;
+  visible?: boolean;
   onRetry: () => Promise<void> | void;
   onLoadMore: () => Promise<void> | void;
   onSelectPost: (post: SocialPost) => void;
   onCreatePost: (input: Omit<CreateSocialPostInput, 'idempotencyKey'>) => Promise<SocialPost>;
   sort: SocialPostSort;
   onSortChange: (sort: SocialPostSort) => void;
+  onLatestVisibleChange?: (visible: boolean) => void;
 }
 
 export default function MessageBoardPanel({
@@ -40,12 +42,14 @@ export default function MessageBoardPanel({
   mutedUntil,
   error,
   submitError,
+  visible = true,
   onRetry,
   onLoadMore,
   onSelectPost,
   onCreatePost,
   sort,
   onSortChange,
+  onLatestVisibleChange,
 }: MessageBoardPanelProps): React.JSX.Element {
   const titleId = useId();
   const bodyId = useId();
@@ -55,6 +59,7 @@ export default function MessageBoardPanel({
   const [body, setBody] = useState('');
   const [selectedCategoryId, setSelectedCategoryId] = useState(categories[0]?.id ?? '');
   const [isAnnouncement, setIsAnnouncement] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
   const muted = Boolean(mutedUntil && new Date(mutedUntil).getTime() > Date.now());
   const sortedPosts = [...posts].sort((left, right) => {
     if (left.isPinned !== right.isPinned) return left.isPinned ? -1 : 1;
@@ -75,6 +80,15 @@ export default function MessageBoardPanel({
       setSelectedCategoryId(categories[0].id);
     }
   }, [categories, selectedCategoryId]);
+
+  useLayoutEffect(() => {
+    const element = scrollRef.current;
+    if (!visible || !element) {
+      onLatestVisibleChange?.(false);
+      return;
+    }
+    onLatestVisibleChange?.(element.scrollTop <= 72);
+  }, [onLatestVisibleChange, sortedPosts[0]?.id, visible]);
 
   async function handleCreate(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
@@ -229,7 +243,11 @@ export default function MessageBoardPanel({
         </form>
       ) : null}
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+      <div
+        ref={scrollRef}
+        className="min-h-0 flex-1 overflow-y-auto p-4"
+        onScroll={(event) => onLatestVisibleChange?.(event.currentTarget.scrollTop <= 72)}
+      >
         <div className="mb-3 flex justify-end">
           <label className="flex min-h-10 items-center gap-2 text-sm font-medium text-foreground">
             Sort discussions

--- a/src/components/league/social/PostThread.tsx
+++ b/src/components/league/social/PostThread.tsx
@@ -23,6 +23,7 @@ interface PostThreadProps {
   error?: string | null;
   submitError?: string | null;
   visible?: boolean;
+  compact?: boolean;
   onBack: () => void;
   onRetry: () => Promise<void> | void;
   onLoadMore: () => Promise<void> | void;
@@ -56,6 +57,7 @@ export default function PostThread({
   error,
   submitError,
   visible = true,
+  compact = false,
   onBack,
   onRetry,
   onLoadMore,
@@ -101,7 +103,11 @@ export default function PostThread({
   return (
     <section
       aria-labelledby="social-thread-heading"
-      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border bg-card text-card-foreground"
+      className={`flex min-h-0 flex-1 flex-col overflow-hidden ${
+        compact
+          ? 'bg-background text-foreground'
+          : 'rounded-2xl border border-border bg-card text-card-foreground'
+      }`}
     >
       <header className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
         <button
@@ -127,7 +133,7 @@ export default function PostThread({
         onScroll={(event) => onLatestVisibleChange?.(isNearBottom(event.currentTarget))}
       >
         <article
-          className={`border-b border-border p-4 sm:p-5 ${
+          className={`border-b border-border ${compact ? 'p-3' : 'p-4 sm:p-5'} ${
             post.isAnnouncement ? 'bg-primary/10' : 'bg-background'
           }`}
         >
@@ -215,7 +221,7 @@ export default function PostThread({
           ) : null}
         </article>
 
-        <div className="p-4 sm:p-5">
+        <div className={compact ? 'p-3' : 'p-4 sm:p-5'}>
           <h3 className="inline-flex items-center gap-2 text-sm font-semibold text-foreground">
             <MessageSquare className="size-4" aria-hidden="true" />
             {post.replyCount} {post.replyCount === 1 ? 'reply' : 'replies'}
@@ -243,10 +249,17 @@ export default function PostThread({
               No replies yet.
             </p>
           ) : (
-            <ol className="mt-4 space-y-3" aria-label="Discussion replies">
+            <ol
+              className={compact ? 'mt-3 divide-y divide-border' : 'mt-4 space-y-3'}
+              aria-label="Discussion replies"
+            >
               {replies.map((reply) => (
                 <li key={reply.id}>
-                  <article className="rounded-xl border border-border bg-background p-3">
+                  <article
+                    className={
+                      compact ? 'py-3' : 'rounded-xl border border-border bg-background p-3'
+                    }
+                  >
                     <SocialAuthor
                       author={reply.author}
                       timestamp={reply.createdAt}
@@ -325,6 +338,7 @@ export default function PostThread({
             maxLength={10000}
             pending={replying}
             error={submitError}
+            compact={compact}
             onSubmit={handleReply}
           />
         )}

--- a/src/components/league/social/PostThread.tsx
+++ b/src/components/league/social/PostThread.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowLeft, Link as LinkIcon, Lock, Megaphone, MessageSquare, Pin } from 'lucide-react';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 
 import type { SocialPost, SocialReply, SocialReportReason } from '@/types/social';
 
@@ -22,6 +22,7 @@ interface PostThreadProps {
   canPublish: boolean;
   error?: string | null;
   submitError?: string | null;
+  visible?: boolean;
   onBack: () => void;
   onRetry: () => Promise<void> | void;
   onLoadMore: () => Promise<void> | void;
@@ -35,6 +36,13 @@ interface PostThreadProps {
     reason: SocialReportReason,
     details?: string
   ) => Promise<void>;
+  onLatestVisibleChange?: (visible: boolean) => void;
+}
+
+const BOTTOM_THRESHOLD_PX = 72;
+
+function isNearBottom(element: HTMLElement): boolean {
+  return element.scrollHeight - element.scrollTop - element.clientHeight <= BOTTOM_THRESHOLD_PX;
 }
 
 export default function PostThread({
@@ -47,6 +55,7 @@ export default function PostThread({
   canPublish,
   error,
   submitError,
+  visible = true,
   onBack,
   onRetry,
   onLoadMore,
@@ -55,10 +64,21 @@ export default function PostThread({
   onRemovePost,
   onRemoveReply,
   onReport,
+  onLatestVisibleChange,
 }: PostThreadProps): React.JSX.Element {
   const [replying, setReplying] = useState(false);
   const [moderating, setModerating] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
   const muted = Boolean(mutedUntil && new Date(mutedUntil).getTime() > Date.now());
+
+  useLayoutEffect(() => {
+    const element = scrollRef.current;
+    if (!visible || !element) {
+      onLatestVisibleChange?.(false);
+      return;
+    }
+    onLatestVisibleChange?.(isNearBottom(element));
+  }, [onLatestVisibleChange, post.latestActivityAt, replies.at(-1)?.id, visible]);
 
   async function handleReply(body: string): Promise<void> {
     setReplying(true);
@@ -101,7 +121,11 @@ export default function PostThread({
         </Link>
       </header>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div
+        ref={scrollRef}
+        className="min-h-0 flex-1 overflow-y-auto"
+        onScroll={(event) => onLatestVisibleChange?.(isNearBottom(event.currentTarget))}
+      >
         <article
           className={`border-b border-border p-4 sm:p-5 ${
             post.isAnnouncement ? 'bg-primary/10' : 'bg-background'

--- a/src/components/league/social/PostThread.tsx
+++ b/src/components/league/social/PostThread.tsx
@@ -107,22 +107,22 @@ export default function PostThread({
       aria-labelledby="social-thread-heading"
       className={`flex min-h-0 flex-1 flex-col overflow-hidden ${
         compact
-          ? 'bg-background text-foreground'
-          : 'rounded-2xl border border-border bg-card text-card-foreground'
+          ? 'bg-social-canvas text-social-text'
+          : 'rounded-2xl border border-social-border bg-social-canvas text-social-text'
       }`}
     >
-      <header className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+      <header className="flex items-center justify-between gap-3 border-b border-social-border bg-social-surface px-4 py-3">
         <button
           type="button"
           onClick={onBack}
-          className="inline-flex min-h-10 items-center gap-2 rounded-lg px-2 text-sm font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="inline-flex min-h-10 items-center gap-2 rounded-lg px-2 text-sm font-semibold text-social-text transition-colors hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
         >
           <ArrowLeft className="size-4" aria-hidden="true" />
           Back to discussions
         </button>
         <Link
           href={`/leagues/${encodeURIComponent(post.leagueId)}/social/posts/${encodeURIComponent(post.id)}`}
-          className="inline-flex min-h-10 items-center gap-2 rounded-lg px-2 text-sm font-semibold text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="inline-flex min-h-10 items-center gap-2 rounded-lg px-2 text-sm font-semibold text-social-text-muted transition-colors hover:bg-social-brand-soft hover:text-social-text active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
         >
           <LinkIcon className="size-4" aria-hidden="true" />
           Link
@@ -135,30 +135,32 @@ export default function PostThread({
         onScroll={(event) => onLatestVisibleChange?.(isNearBottom(event.currentTarget))}
       >
         <article
-          className={`border-b border-border ${compact ? 'p-3' : 'p-4 sm:p-5'} ${
-            post.isAnnouncement ? 'bg-primary/10' : 'bg-background'
+          className={`border-b border-l-4 border-social-border ${compact ? 'p-3' : 'p-4 sm:p-5'} ${
+            post.isAnnouncement
+              ? 'border-l-social-brand-strong bg-social-surface'
+              : 'border-l-transparent bg-social-surface'
           }`}
         >
           <div className="flex flex-wrap items-center gap-2">
             {post.isAnnouncement ? (
-              <span className="inline-flex items-center gap-1 rounded-full bg-primary px-2.5 py-1 text-xs font-semibold text-primary-foreground">
+              <span className="inline-flex items-center gap-1 rounded-full bg-social-brand-strong px-2.5 py-1 text-xs font-semibold text-social-brand-foreground">
                 <Megaphone className="size-3.5" aria-hidden="true" />
                 Announcement
               </span>
             ) : null}
             {post.isPinned ? (
-              <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-foreground">
+              <span className="inline-flex items-center gap-1 rounded-full border border-social-action bg-social-brand-soft px-2.5 py-1 text-xs font-semibold text-social-action-pressed">
                 <Pin className="size-3.5" aria-hidden="true" />
                 Pinned
               </span>
             ) : null}
             {post.isLocked ? (
-              <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-foreground">
+              <span className="inline-flex items-center gap-1 rounded-full border border-social-border bg-social-surface-subtle px-2.5 py-1 text-xs font-semibold text-social-text-muted">
                 <Lock className="size-3.5" aria-hidden="true" />
                 Locked
               </span>
             ) : null}
-            <span className="rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+            <span className="rounded-full border border-social-border bg-social-surface-subtle px-2.5 py-1 text-xs font-medium text-social-text-muted">
               {post.category.name}
             </span>
           </div>
@@ -173,7 +175,7 @@ export default function PostThread({
                 onClick={() =>
                   void handleModeration(() => onUpdatePost({ isPinned: !post.isPinned }))
                 }
-                className="inline-flex min-h-9 items-center rounded-lg border border-border bg-background px-3 text-xs font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+                className="inline-flex min-h-9 items-center rounded-lg border border-social-border bg-social-surface px-3 text-xs font-semibold text-social-text transition-colors hover:border-social-border-strong hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
               >
                 {post.isPinned ? 'Unpin' : 'Pin'} discussion
               </button>
@@ -183,7 +185,7 @@ export default function PostThread({
                 onClick={() =>
                   void handleModeration(() => onUpdatePost({ isLocked: !post.isLocked }))
                 }
-                className="inline-flex min-h-9 items-center rounded-lg border border-border bg-background px-3 text-xs font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+                className="inline-flex min-h-9 items-center rounded-lg border border-social-border bg-social-surface px-3 text-xs font-semibold text-social-text transition-colors hover:border-social-border-strong hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
               >
                 {post.isLocked ? 'Unlock' : 'Lock'} discussion
               </button>
@@ -197,7 +199,7 @@ export default function PostThread({
           ) : null}
           <h2
             id="social-thread-heading"
-            className="mt-3 text-xl font-semibold tracking-tight text-foreground"
+            className="mt-3 text-xl font-semibold tracking-tight text-social-text"
           >
             {post.title}
           </h2>
@@ -209,7 +211,7 @@ export default function PostThread({
             />
           </div>
           {post.moderationStatus === 'removed' || post.deletedAt ? (
-            <p className="mt-4 text-sm italic text-muted-foreground">Post removed</p>
+            <p className="mt-4 text-sm italic text-social-text-muted">Post removed</p>
           ) : (
             <SafeSocialText value={post.body} className="mt-4" />
           )}
@@ -224,42 +226,44 @@ export default function PostThread({
         </article>
 
         <div className={compact ? 'p-3' : 'p-4 sm:p-5'}>
-          <h3 className="inline-flex items-center gap-2 text-sm font-semibold text-foreground">
+          <h3 className="inline-flex items-center gap-2 text-sm font-semibold text-social-text">
             <MessageSquare className="size-4" aria-hidden="true" />
             {post.replyCount} {post.replyCount === 1 ? 'reply' : 'replies'}
           </h3>
 
           {loading && replies.length === 0 ? (
-            <p role="status" className="py-8 text-center text-sm text-muted-foreground">
+            <p role="status" className="py-8 text-center text-sm text-social-text-muted">
               Loading replies…
             </p>
           ) : error && replies.length === 0 ? (
-            <div className="mt-4 rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-center">
-              <p role="alert" className="text-sm font-medium text-destructive">
+            <div className="mt-4 rounded-xl border border-social-error bg-social-error-soft p-4 text-center">
+              <p role="alert" className="text-sm font-medium text-social-error">
                 {error}
               </p>
               <button
                 type="button"
                 onClick={() => void onRetry()}
-                className="mt-3 inline-flex min-h-9 items-center justify-center rounded-lg border border-border bg-background px-3 text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="mt-3 inline-flex min-h-9 items-center justify-center rounded-lg border border-social-border bg-social-surface px-3 text-sm font-semibold text-social-text transition-colors hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
               >
                 Retry
               </button>
             </div>
           ) : replies.length === 0 ? (
-            <p className="mt-4 rounded-xl border border-dashed border-border bg-muted/30 px-4 py-6 text-center text-sm text-muted-foreground">
+            <p className="mt-4 rounded-xl border border-dashed border-social-border bg-social-surface-subtle px-4 py-6 text-center text-sm text-social-text-muted">
               No replies yet.
             </p>
           ) : (
             <ol
-              className={compact ? 'mt-3 divide-y divide-border' : 'mt-4 space-y-3'}
+              className={compact ? 'mt-3 divide-y divide-social-border' : 'mt-4 space-y-3'}
               aria-label="Discussion replies"
             >
               {replies.map((reply) => (
                 <li key={reply.id}>
                   <article
                     className={
-                      compact ? 'py-3' : 'rounded-xl border border-border bg-background p-3'
+                      compact
+                        ? 'py-3'
+                        : 'rounded-xl border border-social-border bg-social-surface p-3'
                     }
                   >
                     <SocialAuthor
@@ -269,7 +273,7 @@ export default function PostThread({
                       compact
                     />
                     {reply.moderationStatus === 'removed' || reply.deletedAt ? (
-                      <p className="mt-2 text-sm italic text-muted-foreground">Reply removed</p>
+                      <p className="mt-2 text-sm italic text-social-text-muted">Reply removed</p>
                     ) : (
                       <>
                         <SafeSocialText value={reply.body} className="mt-2" />
@@ -305,7 +309,7 @@ export default function PostThread({
                 type="button"
                 onClick={() => void onLoadMore()}
                 disabled={loading}
-                className="inline-flex min-h-10 items-center justify-center rounded-lg border border-border bg-background px-4 text-sm font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+                className="inline-flex min-h-10 items-center justify-center rounded-lg border border-social-border bg-social-surface px-4 text-sm font-semibold text-social-text transition-colors hover:border-social-border-strong hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
               >
                 {loading ? 'Loading…' : 'Load more replies'}
               </button>
@@ -314,18 +318,18 @@ export default function PostThread({
         </div>
       </div>
 
-      <footer className="border-t border-border bg-background p-3">
+      <footer className="border-t border-social-border bg-social-surface p-3">
         {post.isLocked ? (
-          <p className="flex items-center justify-center gap-2 py-2 text-sm font-medium text-muted-foreground">
+          <p className="flex items-center justify-center gap-2 py-2 text-sm font-medium text-social-text-muted">
             <Lock className="size-4" aria-hidden="true" />
             This discussion is locked and cannot receive replies.
           </p>
         ) : !canPublish && !muted ? (
-          <p role="status" className="py-2 text-center text-sm font-medium text-muted-foreground">
+          <p role="status" className="py-2 text-center text-sm font-medium text-social-text-muted">
             Accept the community standards above before replying.
           </p>
         ) : muted ? (
-          <p role="status" className="py-2 text-center text-sm font-medium text-muted-foreground">
+          <p role="status" className="py-2 text-center text-sm font-medium text-social-text-muted">
             You can read this discussion, but cannot reply until{' '}
             <time dateTime={mutedUntil ?? undefined}>
               {mutedUntil ? new Date(mutedUntil).toLocaleString() : 'the mute ends'}

--- a/src/components/league/social/PostThread.tsx
+++ b/src/components/league/social/PostThread.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+import { ArrowLeft, Link as LinkIcon, Lock, Megaphone, MessageSquare, Pin } from 'lucide-react';
+import Link from 'next/link';
+import { useState } from 'react';
+
+import type { SocialPost, SocialReply, SocialReportReason } from '@/types/social';
+
+import SafeSocialText from './SafeSocialText';
+import SocialAuthor from './SocialAuthor';
+import SocialComposer from './SocialComposer';
+import SocialReportButton from './SocialReportButton';
+import SocialRemoveButton from './SocialRemoveButton';
+
+interface PostThreadProps {
+  post: SocialPost;
+  replies: SocialReply[];
+  loading: boolean;
+  hasMore: boolean;
+  mutedUntil?: string | null;
+  canManage: boolean;
+  canPublish: boolean;
+  error?: string | null;
+  submitError?: string | null;
+  onBack: () => void;
+  onRetry: () => Promise<void> | void;
+  onLoadMore: () => Promise<void> | void;
+  onReply: (body: string) => Promise<void>;
+  onUpdatePost: (input: { isPinned?: boolean; isLocked?: boolean }) => Promise<void>;
+  onRemovePost: (reason: string) => Promise<void>;
+  onRemoveReply: (replyId: string, reason: string) => Promise<void>;
+  onReport: (
+    contentType: 'post' | 'reply',
+    contentId: string,
+    reason: SocialReportReason,
+    details?: string
+  ) => Promise<void>;
+}
+
+export default function PostThread({
+  post,
+  replies,
+  loading,
+  hasMore,
+  mutedUntil,
+  canManage,
+  canPublish,
+  error,
+  submitError,
+  onBack,
+  onRetry,
+  onLoadMore,
+  onReply,
+  onUpdatePost,
+  onRemovePost,
+  onRemoveReply,
+  onReport,
+}: PostThreadProps): React.JSX.Element {
+  const [replying, setReplying] = useState(false);
+  const [moderating, setModerating] = useState(false);
+  const muted = Boolean(mutedUntil && new Date(mutedUntil).getTime() > Date.now());
+
+  async function handleReply(body: string): Promise<void> {
+    setReplying(true);
+    try {
+      await onReply(body);
+    } finally {
+      setReplying(false);
+    }
+  }
+
+  async function handleModeration(action: () => Promise<void>): Promise<void> {
+    setModerating(true);
+    try {
+      await action();
+    } finally {
+      setModerating(false);
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby="social-thread-heading"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-border bg-card text-card-foreground"
+    >
+      <header className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className="inline-flex min-h-10 items-center gap-2 rounded-lg px-2 text-sm font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Back to discussions
+        </button>
+        <Link
+          href={`/leagues/${encodeURIComponent(post.leagueId)}/social/posts/${encodeURIComponent(post.id)}`}
+          className="inline-flex min-h-10 items-center gap-2 rounded-lg px-2 text-sm font-semibold text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <LinkIcon className="size-4" aria-hidden="true" />
+          Link
+        </Link>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <article
+          className={`border-b border-border p-4 sm:p-5 ${
+            post.isAnnouncement ? 'bg-primary/10' : 'bg-background'
+          }`}
+        >
+          <div className="flex flex-wrap items-center gap-2">
+            {post.isAnnouncement ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-primary px-2.5 py-1 text-xs font-semibold text-primary-foreground">
+                <Megaphone className="size-3.5" aria-hidden="true" />
+                Announcement
+              </span>
+            ) : null}
+            {post.isPinned ? (
+              <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-foreground">
+                <Pin className="size-3.5" aria-hidden="true" />
+                Pinned
+              </span>
+            ) : null}
+            {post.isLocked ? (
+              <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-foreground">
+                <Lock className="size-3.5" aria-hidden="true" />
+                Locked
+              </span>
+            ) : null}
+            <span className="rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+              {post.category.name}
+            </span>
+          </div>
+          {canManage ? (
+            <div
+              className="mt-3 flex flex-wrap items-center gap-2"
+              aria-label="Commissioner discussion controls"
+            >
+              <button
+                type="button"
+                disabled={moderating}
+                onClick={() =>
+                  void handleModeration(() => onUpdatePost({ isPinned: !post.isPinned }))
+                }
+                className="inline-flex min-h-9 items-center rounded-lg border border-border bg-background px-3 text-xs font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+              >
+                {post.isPinned ? 'Unpin' : 'Pin'} discussion
+              </button>
+              <button
+                type="button"
+                disabled={moderating}
+                onClick={() =>
+                  void handleModeration(() => onUpdatePost({ isLocked: !post.isLocked }))
+                }
+                className="inline-flex min-h-9 items-center rounded-lg border border-border bg-background px-3 text-xs font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+              >
+                {post.isLocked ? 'Unlock' : 'Lock'} discussion
+              </button>
+              {!post.deletedAt ? (
+                <SocialRemoveButton
+                  label="discussion"
+                  onRemove={(reason) => handleModeration(() => onRemovePost(reason))}
+                />
+              ) : null}
+            </div>
+          ) : null}
+          <h2
+            id="social-thread-heading"
+            className="mt-3 text-xl font-semibold tracking-tight text-foreground"
+          >
+            {post.title}
+          </h2>
+          <div className="mt-3">
+            <SocialAuthor
+              author={post.author}
+              timestamp={post.createdAt}
+              editedAt={post.editedAt}
+            />
+          </div>
+          {post.moderationStatus === 'removed' || post.deletedAt ? (
+            <p className="mt-4 text-sm italic text-muted-foreground">Post removed</p>
+          ) : (
+            <SafeSocialText value={post.body} className="mt-4" />
+          )}
+          {!post.isOwn && !post.deletedAt ? (
+            <div className="mt-3 flex justify-end">
+              <SocialReportButton
+                label="post"
+                onReport={(reason, details) => onReport('post', post.id, reason, details)}
+              />
+            </div>
+          ) : null}
+        </article>
+
+        <div className="p-4 sm:p-5">
+          <h3 className="inline-flex items-center gap-2 text-sm font-semibold text-foreground">
+            <MessageSquare className="size-4" aria-hidden="true" />
+            {post.replyCount} {post.replyCount === 1 ? 'reply' : 'replies'}
+          </h3>
+
+          {loading && replies.length === 0 ? (
+            <p role="status" className="py-8 text-center text-sm text-muted-foreground">
+              Loading replies…
+            </p>
+          ) : error && replies.length === 0 ? (
+            <div className="mt-4 rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-center">
+              <p role="alert" className="text-sm font-medium text-destructive">
+                {error}
+              </p>
+              <button
+                type="button"
+                onClick={() => void onRetry()}
+                className="mt-3 inline-flex min-h-9 items-center justify-center rounded-lg border border-border bg-background px-3 text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                Retry
+              </button>
+            </div>
+          ) : replies.length === 0 ? (
+            <p className="mt-4 rounded-xl border border-dashed border-border bg-muted/30 px-4 py-6 text-center text-sm text-muted-foreground">
+              No replies yet.
+            </p>
+          ) : (
+            <ol className="mt-4 space-y-3" aria-label="Discussion replies">
+              {replies.map((reply) => (
+                <li key={reply.id}>
+                  <article className="rounded-xl border border-border bg-background p-3">
+                    <SocialAuthor
+                      author={reply.author}
+                      timestamp={reply.createdAt}
+                      editedAt={reply.editedAt}
+                      compact
+                    />
+                    {reply.moderationStatus === 'removed' || reply.deletedAt ? (
+                      <p className="mt-2 text-sm italic text-muted-foreground">Reply removed</p>
+                    ) : (
+                      <>
+                        <SafeSocialText value={reply.body} className="mt-2" />
+                        {!reply.isOwn ? (
+                          <div className="mt-2 flex justify-end">
+                            <SocialReportButton
+                              label="reply"
+                              onReport={(reason, details) =>
+                                onReport('reply', reply.id, reason, details)
+                              }
+                            />
+                          </div>
+                        ) : null}
+                        {canManage ? (
+                          <div className="mt-2 flex justify-end">
+                            <SocialRemoveButton
+                              label="reply"
+                              onRemove={(reason) => onRemoveReply(reply.id, reason)}
+                            />
+                          </div>
+                        ) : null}
+                      </>
+                    )}
+                  </article>
+                </li>
+              ))}
+            </ol>
+          )}
+
+          {hasMore ? (
+            <div className="mt-4 flex justify-center">
+              <button
+                type="button"
+                onClick={() => void onLoadMore()}
+                disabled={loading}
+                className="inline-flex min-h-10 items-center justify-center rounded-lg border border-border bg-background px-4 text-sm font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+              >
+                {loading ? 'Loading…' : 'Load more replies'}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <footer className="border-t border-border bg-background p-3">
+        {post.isLocked ? (
+          <p className="flex items-center justify-center gap-2 py-2 text-sm font-medium text-muted-foreground">
+            <Lock className="size-4" aria-hidden="true" />
+            This discussion is locked and cannot receive replies.
+          </p>
+        ) : !canPublish && !muted ? (
+          <p role="status" className="py-2 text-center text-sm font-medium text-muted-foreground">
+            Accept the community standards above before replying.
+          </p>
+        ) : muted ? (
+          <p role="status" className="py-2 text-center text-sm font-medium text-muted-foreground">
+            You can read this discussion, but cannot reply until{' '}
+            <time dateTime={mutedUntil ?? undefined}>
+              {mutedUntil ? new Date(mutedUntil).toLocaleString() : 'the mute ends'}
+            </time>
+            .
+          </p>
+        ) : (
+          <SocialComposer
+            label={`Reply to ${post.title}`}
+            placeholder="Write a reply…"
+            submitLabel="Reply"
+            maxLength={10000}
+            pending={replying}
+            error={submitError}
+            onSubmit={handleReply}
+          />
+        )}
+      </footer>
+    </section>
+  );
+}

--- a/src/components/league/social/PostThread.tsx
+++ b/src/components/league/social/PostThread.tsx
@@ -24,10 +24,11 @@ interface PostThreadProps {
   submitError?: string | null;
   visible?: boolean;
   compact?: boolean;
+  onDismissSubmitError?: () => void;
   onBack: () => void;
   onRetry: () => Promise<void> | void;
   onLoadMore: () => Promise<void> | void;
-  onReply: (body: string) => Promise<void>;
+  onReply: (body: string, idempotencyKey: string) => Promise<void>;
   onUpdatePost: (input: { isPinned?: boolean; isLocked?: boolean }) => Promise<void>;
   onRemovePost: (reason: string) => Promise<void>;
   onRemoveReply: (replyId: string, reason: string) => Promise<void>;
@@ -58,6 +59,7 @@ export default function PostThread({
   submitError,
   visible = true,
   compact = false,
+  onDismissSubmitError,
   onBack,
   onRetry,
   onLoadMore,
@@ -82,10 +84,10 @@ export default function PostThread({
     onLatestVisibleChange?.(isNearBottom(element));
   }, [onLatestVisibleChange, post.latestActivityAt, replies.at(-1)?.id, visible]);
 
-  async function handleReply(body: string): Promise<void> {
+  async function handleReply(body: string, idempotencyKey: string): Promise<void> {
     setReplying(true);
     try {
-      await onReply(body);
+      await onReply(body, idempotencyKey);
     } finally {
       setReplying(false);
     }
@@ -338,6 +340,7 @@ export default function PostThread({
             maxLength={10000}
             pending={replying}
             error={submitError}
+            onDismissError={onDismissSubmitError}
             compact={compact}
             onSubmit={handleReply}
           />

--- a/src/components/league/social/SafeSocialText.tsx
+++ b/src/components/league/social/SafeSocialText.tsx
@@ -1,0 +1,42 @@
+const URL_PATTERN = /(https?:\/\/[^\s<]+)/gi;
+
+interface SafeSocialTextProps {
+  value: string;
+  className?: string;
+}
+
+function safeExternalUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+export default function SafeSocialText({
+  value,
+  className = '',
+}: SafeSocialTextProps): React.JSX.Element {
+  const parts = value.split(URL_PATTERN);
+
+  return (
+    <p className={`whitespace-pre-wrap break-words text-sm leading-6 text-foreground ${className}`}>
+      {parts.map((part, index) => {
+        const href = safeExternalUrl(part);
+        if (!href) return <span key={`${index}:${part}`}>{part}</span>;
+        return (
+          <a
+            key={`${index}:${part}`}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-primary underline decoration-primary/40 underline-offset-2 hover:decoration-primary focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {part}
+          </a>
+        );
+      })}
+    </p>
+  );
+}

--- a/src/components/league/social/SafeSocialText.tsx
+++ b/src/components/league/social/SafeSocialText.tsx
@@ -21,7 +21,9 @@ export default function SafeSocialText({
   const parts = value.split(URL_PATTERN);
 
   return (
-    <p className={`whitespace-pre-wrap break-words text-sm leading-6 text-foreground ${className}`}>
+    <p
+      className={`whitespace-pre-wrap break-words text-sm leading-6 text-social-text ${className}`}
+    >
       {parts.map((part, index) => {
         const href = safeExternalUrl(part);
         if (!href) return <span key={`${index}:${part}`}>{part}</span>;
@@ -31,7 +33,7 @@ export default function SafeSocialText({
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            className="font-medium text-primary underline decoration-primary/40 underline-offset-2 hover:decoration-primary focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="font-medium text-social-action underline decoration-social-action underline-offset-2 transition-colors hover:text-social-action-hover active:text-social-action-pressed focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
           >
             {part}
           </a>

--- a/src/components/league/social/SocialAuthor.tsx
+++ b/src/components/league/social/SocialAuthor.tsx
@@ -46,7 +46,7 @@ export default function SocialAuthor({
   return (
     <div className="flex min-w-0 items-center gap-3">
       <span
-        className={`${compact ? 'size-8' : 'size-10'} flex shrink-0 items-center justify-center overflow-hidden rounded-full border border-border bg-muted text-xs font-semibold text-muted-foreground`}
+        className={`${compact ? 'size-8' : 'size-10'} flex shrink-0 items-center justify-center overflow-hidden rounded-full border border-social-border bg-social-surface-subtle text-xs font-semibold text-social-text-muted`}
         aria-hidden="true"
       >
         {author?.avatarUrl ? (
@@ -62,10 +62,10 @@ export default function SocialAuthor({
       </span>
       <span className="min-w-0">
         <span className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-          <span className="truncate text-sm font-semibold text-foreground">{displayName}</span>
-          <span className="truncate text-xs text-muted-foreground">{teamName}</span>
+          <span className="truncate text-sm font-semibold text-social-text">{displayName}</span>
+          <span className="truncate text-xs text-social-text-muted">{teamName}</span>
         </span>
-        <span className="block text-xs text-muted-foreground">
+        <span className="block text-xs text-social-text-muted">
           <time dateTime={timestamp}>{formattedTimestamp}</time>
           {editedAt ? <span aria-label="Edited"> · Edited</span> : null}
         </span>

--- a/src/components/league/social/SocialAuthor.tsx
+++ b/src/components/league/social/SocialAuthor.tsx
@@ -5,6 +5,7 @@ interface SocialAuthorProps {
   timestamp: string;
   editedAt?: string;
   compact?: boolean;
+  timestampStyle?: 'date-and-time' | 'time';
 }
 
 function getInitials(value: string): string {
@@ -17,9 +18,14 @@ function getInitials(value: string): string {
   return initials || 'S';
 }
 
-function formatTimestamp(value: string): string {
+function formatTimestamp(value: string, style: 'date-and-time' | 'time'): string {
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return 'Unknown time';
+  if (style === 'time') {
+    return new Intl.DateTimeFormat('en-AU', {
+      timeStyle: 'short',
+    }).format(parsed);
+  }
   return new Intl.DateTimeFormat('en-AU', {
     dateStyle: 'medium',
     timeStyle: 'short',
@@ -31,10 +37,11 @@ export default function SocialAuthor({
   timestamp,
   editedAt,
   compact = false,
+  timestampStyle = 'date-and-time',
 }: SocialAuthorProps): React.JSX.Element {
   const displayName = author?.displayName || 'Former member';
   const teamName = author?.teamName || 'Team unavailable';
-  const formattedTimestamp = formatTimestamp(timestamp);
+  const formattedTimestamp = formatTimestamp(timestamp, timestampStyle);
 
   return (
     <div className="flex min-w-0 items-center gap-3">

--- a/src/components/league/social/SocialAuthor.tsx
+++ b/src/components/league/social/SocialAuthor.tsx
@@ -1,0 +1,68 @@
+import type { SocialAuthor as SocialAuthorIdentity } from '@/types/social';
+
+interface SocialAuthorProps {
+  author: SocialAuthorIdentity | null;
+  timestamp: string;
+  editedAt?: string;
+  compact?: boolean;
+}
+
+function getInitials(value: string): string {
+  const initials = value
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join('');
+  return initials || 'S';
+}
+
+function formatTimestamp(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return 'Unknown time';
+  return new Intl.DateTimeFormat('en-AU', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(parsed);
+}
+
+export default function SocialAuthor({
+  author,
+  timestamp,
+  editedAt,
+  compact = false,
+}: SocialAuthorProps): React.JSX.Element {
+  const displayName = author?.displayName || 'Former member';
+  const teamName = author?.teamName || 'Team unavailable';
+  const formattedTimestamp = formatTimestamp(timestamp);
+
+  return (
+    <div className="flex min-w-0 items-center gap-3">
+      <span
+        className={`${compact ? 'size-8' : 'size-10'} flex shrink-0 items-center justify-center overflow-hidden rounded-full border border-border bg-muted text-xs font-semibold text-muted-foreground`}
+        aria-hidden="true"
+      >
+        {author?.avatarUrl ? (
+          <img
+            src={author.avatarUrl}
+            alt=""
+            className="h-full w-full object-cover"
+            referrerPolicy="no-referrer"
+          />
+        ) : (
+          getInitials(displayName)
+        )}
+      </span>
+      <span className="min-w-0">
+        <span className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          <span className="truncate text-sm font-semibold text-foreground">{displayName}</span>
+          <span className="truncate text-xs text-muted-foreground">{teamName}</span>
+        </span>
+        <span className="block text-xs text-muted-foreground">
+          <time dateTime={timestamp}>{formattedTimestamp}</time>
+          {editedAt ? <span aria-label="Edited"> · Edited</span> : null}
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/src/components/league/social/SocialComposer.test.tsx
+++ b/src/components/league/social/SocialComposer.test.tsx
@@ -1,68 +1,205 @@
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { SocialComposerDraftScope } from './socialComposerDraft';
 import SocialComposer from './SocialComposer';
 
+const leagueScope: SocialComposerDraftScope = {
+  userId: 'user-1',
+  leagueId: 'league-1',
+  leagueSeasonId: 'season-1',
+  surface: { type: 'league-chat' },
+};
+
+function setFinePointer(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn(() => ({
+      matches,
+      media: '(pointer: fine)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function renderComposer(
+  overrides: Partial<React.ComponentProps<typeof SocialComposer>> = {}
+): ReturnType<typeof render> {
+  return render(
+    <SocialComposer
+      label="League message"
+      placeholder="Message"
+      submitLabel="Send message"
+      maxLength={1000}
+      submitOnEnter
+      compact
+      onSubmit={vi.fn()}
+      {...overrides}
+    />
+  );
+}
+
 describe('SocialComposer', () => {
-  it('sends trimmed chat text with Enter and keeps Shift+Enter as a newline', async () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setFinePointer(true);
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    };
+  });
+
+  it('sends trimmed text with a stable attempt key and keeps Shift+Enter as a newline', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn().mockResolvedValue(undefined);
-    render(
-      <SocialComposer
-        label="League message"
-        placeholder="Message"
-        submitLabel="Send"
-        maxLength={1000}
-        submitOnEnter
-        onSubmit={onSubmit}
-      />
-    );
+    renderComposer({ onSubmit });
 
     const input = screen.getByRole('textbox', { name: 'League message' });
     await user.type(input, 'First line{shift>}{enter}{/shift}Second line');
     expect(input).toHaveValue('First line\nSecond line');
 
     await user.keyboard('{Enter}');
-    expect(onSubmit).toHaveBeenCalledWith('First line\nSecond line');
+    expect(onSubmit).toHaveBeenCalledWith(
+      'First line\nSecond line',
+      expect.stringMatching(/^chat:/)
+    );
     expect(input).toHaveValue('');
+    expect(input).toHaveFocus();
   });
 
-  it('does not submit empty or whitespace-only content', async () => {
+  it('does not submit empty, touch-return, or active IME composition events', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
-    render(
-      <SocialComposer
-        label="League message"
-        placeholder="Message"
-        submitLabel="Send"
-        maxLength={1000}
-        submitOnEnter
-        onSubmit={onSubmit}
-      />
-    );
+    const rendered = renderComposer({ onSubmit });
+    const input = screen.getByRole('textbox', { name: 'League message' });
 
-    await user.type(screen.getByRole('textbox', { name: 'League message' }), '   {Enter}');
+    await user.type(input, '   {Enter}');
     expect(onSubmit).not.toHaveBeenCalled();
-    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+
+    await user.clear(input);
+    await user.type(input, 'IME message');
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    rendered.unmount();
+    setFinePointer(false);
+    renderComposer({ onSubmit });
+    const touchInput = screen.getByRole('textbox', { name: 'League message' });
+    await user.type(touchInput, 'Touch message');
+    expect(fireEvent.keyDown(touchInput, { key: 'Enter' })).toBe(true);
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it('renders a one-row compact composer with an integrated leading action', () => {
-    render(
+  it('caps autosizing at four lines and reveals the counter only near the limit', () => {
+    renderComposer();
+    const input = screen.getByRole('textbox', { name: 'League message' });
+    Object.defineProperty(input, 'scrollHeight', { configurable: true, value: 180 });
+
+    fireEvent.change(input, { target: { value: 'a'.repeat(799) } });
+    expect(screen.queryByText('799 / 1,000')).not.toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: 'a'.repeat(800) } });
+    expect(screen.getByText('800 / 1,000')).toBeInTheDocument();
+    expect(input).toHaveStyle({ height: '96px' });
+
+    fireEvent.change(input, { target: { value: 'a'.repeat(1000) } });
+    expect(screen.getByText('1,000 / 1,000 · Limit reached')).toHaveClass('text-destructive');
+  });
+
+  it('preserves scoped drafts across unmounts and isolates Draft Room drafts', async () => {
+    const user = userEvent.setup();
+    const rendered = renderComposer({ draftScope: leagueScope });
+    const input = screen.getByRole('textbox', { name: 'League message' });
+    await user.type(input, 'League draft');
+    rendered.unmount();
+
+    const restored = renderComposer({ draftScope: leagueScope });
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', { name: 'League message' })).toHaveValue('League draft')
+    );
+    restored.rerender(
       <SocialComposer
         label="League message"
         placeholder="Message"
-        submitLabel="Send"
+        submitLabel="Send message"
         maxLength={1000}
         submitOnEnter
         compact
-        leadingAction={<button type="button">GIF action</button>}
+        draftScope={{
+          ...leagueScope,
+          surface: { type: 'draft-chat', draftId: 'draft-1' },
+        }}
         onSubmit={vi.fn()}
       />
     );
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', { name: 'League message' })).toHaveValue('')
+    );
+  });
 
-    expect(screen.getByRole('textbox', { name: 'League message' })).toHaveAttribute('rows', '1');
-    expect(screen.getByRole('button', { name: 'GIF action' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Send' })).toHaveClass('rounded-full');
+  it('retains failed content and reuses the original idempotency key for retry', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Connection interrupted'))
+      .mockResolvedValueOnce(undefined);
+    renderComposer({ onSubmit, draftScope: leagueScope });
+
+    const input = screen.getByRole('textbox', { name: 'League message' });
+    await user.type(input, 'Retry this');
+    await user.keyboard('{Enter}');
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Connection interrupted');
+    expect(input).toHaveValue('Retry this');
+    const firstAttemptKey = onSubmit.mock.calls[0]?.[1];
+    await user.click(screen.getByRole('button', { name: 'Retry sending message' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+    expect(onSubmit.mock.calls[1]?.[1]).toBe(firstAttemptKey);
+    expect(input).toHaveValue('');
+  });
+
+  it('guards rapid repeated activation while a submission is pending', async () => {
+    const user = userEvent.setup();
+    let resolveSubmission: (() => void) | undefined;
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSubmission = resolve;
+        })
+    );
+    renderComposer({ onSubmit });
+
+    await user.type(screen.getByRole('textbox', { name: 'League message' }), 'Only once');
+    const send = screen.getByRole('button', { name: 'Send message' });
+    await user.dblClick(send);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Sending message' })).toBeDisabled();
+
+    await act(async () => resolveSubmission?.());
+  });
+
+  it('preserves the draft and explains when sending is unavailable offline', async () => {
+    const user = userEvent.setup();
+    renderComposer({ draftScope: leagueScope });
+    await user.type(screen.getByRole('textbox', { name: 'League message' }), 'Offline draft');
+
+    act(() => {
+      Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent(/offline/i);
+    expect(
+      screen.getByRole('button', { name: 'Sending unavailable while offline' })
+    ).toBeDisabled();
+    expect(screen.getByRole('textbox', { name: 'League message' })).toHaveValue('Offline draft');
   });
 });

--- a/src/components/league/social/SocialComposer.test.tsx
+++ b/src/components/league/social/SocialComposer.test.tsx
@@ -46,4 +46,23 @@ describe('SocialComposer', () => {
     expect(onSubmit).not.toHaveBeenCalled();
     expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
   });
+
+  it('renders a one-row compact composer with an integrated leading action', () => {
+    render(
+      <SocialComposer
+        label="League message"
+        placeholder="Message"
+        submitLabel="Send"
+        maxLength={1000}
+        submitOnEnter
+        compact
+        leadingAction={<button type="button">GIF action</button>}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('textbox', { name: 'League message' })).toHaveAttribute('rows', '1');
+    expect(screen.getByRole('button', { name: 'GIF action' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Send' })).toHaveClass('rounded-full');
+  });
 });

--- a/src/components/league/social/SocialComposer.test.tsx
+++ b/src/components/league/social/SocialComposer.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import SocialComposer from './SocialComposer';
+
+describe('SocialComposer', () => {
+  it('sends trimmed chat text with Enter and keeps Shift+Enter as a newline', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <SocialComposer
+        label="League message"
+        placeholder="Message"
+        submitLabel="Send"
+        maxLength={1000}
+        submitOnEnter
+        onSubmit={onSubmit}
+      />
+    );
+
+    const input = screen.getByRole('textbox', { name: 'League message' });
+    await user.type(input, 'First line{shift>}{enter}{/shift}Second line');
+    expect(input).toHaveValue('First line\nSecond line');
+
+    await user.keyboard('{Enter}');
+    expect(onSubmit).toHaveBeenCalledWith('First line\nSecond line');
+    expect(input).toHaveValue('');
+  });
+
+  it('does not submit empty or whitespace-only content', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <SocialComposer
+        label="League message"
+        placeholder="Message"
+        submitLabel="Send"
+        maxLength={1000}
+        submitOnEnter
+        onSubmit={onSubmit}
+      />
+    );
+
+    await user.type(screen.getByRole('textbox', { name: 'League message' }), '   {Enter}');
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+  });
+});

--- a/src/components/league/social/SocialComposer.test.tsx
+++ b/src/components/league/social/SocialComposer.test.tsx
@@ -74,6 +74,38 @@ describe('SocialComposer', () => {
     expect(input).toHaveFocus();
   });
 
+  it('distinguishes empty, enabled, loading, and error controls without opacity alone', async () => {
+    const user = userEvent.setup();
+    let rejectSubmission: ((error: Error) => void) | undefined;
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSubmission = reject;
+        })
+    );
+    renderComposer({ onSubmit });
+
+    const send = screen.getByRole('button', { name: 'Send message' });
+    expect(send).toBeDisabled();
+    expect(send).toHaveClass(
+      'disabled:bg-social-disabled-bg',
+      'disabled:text-social-disabled-text'
+    );
+
+    await user.type(screen.getByRole('textbox', { name: 'League message' }), 'State check');
+    expect(send).toBeEnabled();
+    expect(send).toHaveClass('bg-social-action', 'text-social-action-foreground');
+
+    await user.click(send);
+    const loading = screen.getByRole('button', { name: 'Sending message' });
+    expect(loading).toBeDisabled();
+    expect(loading).toHaveClass('cursor-wait', 'bg-social-action');
+
+    await act(async () => rejectSubmission?.(new Error('Connection interrupted')));
+    const retry = await screen.findByRole('button', { name: 'Retry sending message' });
+    expect(retry).toHaveClass('border-social-error', 'bg-social-surface', 'text-social-error');
+  });
+
   it('does not submit empty, touch-return, or active IME composition events', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
@@ -110,7 +142,7 @@ describe('SocialComposer', () => {
     expect(input).toHaveStyle({ height: '96px' });
 
     fireEvent.change(input, { target: { value: 'a'.repeat(1000) } });
-    expect(screen.getByText('1,000 / 1,000 · Limit reached')).toHaveClass('text-destructive');
+    expect(screen.getByText('1,000 / 1,000 · Limit reached')).toHaveClass('text-social-error');
   });
 
   it('preserves scoped drafts across unmounts and isolates Draft Room drafts', async () => {

--- a/src/components/league/social/SocialComposer.tsx
+++ b/src/components/league/social/SocialComposer.tsx
@@ -83,10 +83,10 @@ export default function SocialComposer({
   const showCounter = value.length >= Math.min(800, maxLength);
   const counterTone =
     value.length >= maxLength
-      ? 'font-semibold text-destructive'
+      ? 'font-semibold text-social-error'
       : value.length >= Math.min(950, maxLength)
-        ? 'font-semibold text-warning'
-        : 'text-muted-foreground';
+        ? 'font-semibold text-social-warning-text'
+        : 'text-social-text-muted';
   const sendLabel = isSubmitting
     ? 'Sending message'
     : hasFailure
@@ -94,6 +94,11 @@ export default function SocialComposer({
       : !online
         ? 'Sending unavailable while offline'
         : submitLabel;
+  const submitButtonTone = isSubmitting
+    ? 'cursor-wait border-social-action bg-social-action text-social-action-foreground'
+    : hasFailure
+      ? 'border-social-error bg-social-surface text-social-error hover:bg-social-error-soft active:bg-social-error-soft'
+      : 'border-social-action bg-social-action text-social-action-foreground hover:border-social-action-hover hover:bg-social-action-hover active:border-social-action-pressed active:bg-social-action-pressed disabled:border-social-border disabled:bg-social-disabled-bg disabled:text-social-disabled-text';
 
   useEffect(() => {
     if (!draftKey || typeof window === 'undefined') return;
@@ -243,7 +248,11 @@ export default function SocialComposer({
       <div
         className={
           compact
-            ? 'flex min-h-14 items-end gap-0.5 rounded-xl border border-border bg-background p-1.5 shadow-sm transition focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/30'
+            ? `flex min-h-14 items-end gap-0.5 rounded-xl border bg-social-surface p-1.5 shadow-sm transition-colors focus-within:ring-2 focus-within:ring-social-focus/30 ${
+                visibleError
+                  ? 'border-social-error focus-within:border-social-error'
+                  : 'border-social-border focus-within:border-social-action'
+              }`
             : undefined
         }
       >
@@ -265,19 +274,17 @@ export default function SocialComposer({
           aria-describedby={`${helpId} ${statusId}${visibleError ? ` ${errorId}` : ''}`}
           className={
             compact
-              ? 'block min-h-11 max-h-24 min-w-0 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-2 py-3 text-sm leading-5 text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-60'
-              : 'block w-full resize-y rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60'
+              ? 'block min-h-11 max-h-24 min-w-0 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-2 py-3 text-sm leading-5 text-social-text outline-none placeholder:text-social-text-muted disabled:cursor-not-allowed disabled:bg-social-disabled-bg disabled:text-social-disabled-text'
+              : 'block w-full resize-y rounded-xl border border-social-border bg-social-surface px-3 py-2 text-sm text-social-text outline-none placeholder:text-social-text-muted focus-visible:border-social-action focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:bg-social-disabled-bg disabled:text-social-disabled-text'
           }
         />
         <button
           type="submit"
           disabled={!canSubmit}
           aria-label={compact ? sendLabel : undefined}
-          className={
-            compact
-              ? 'inline-flex size-11 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-40'
-              : 'inline-flex min-h-11 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'
-          }
+          className={`inline-flex shrink-0 items-center justify-center rounded-lg border font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus focus-visible:ring-offset-2 focus-visible:ring-offset-social-surface disabled:cursor-not-allowed ${
+            compact ? 'size-11' : 'min-h-11 px-4 text-sm'
+          } ${submitButtonTone}`}
         >
           {compact ? (
             isSubmitting ? (
@@ -318,7 +325,7 @@ export default function SocialComposer({
       ) : null}
 
       {!online ? (
-        <p role="status" className="px-1 text-xs font-medium text-muted-foreground">
+        <p role="status" className="px-1 text-xs font-medium text-social-text-muted">
           You’re offline. Your draft is saved and sending is unavailable.
         </p>
       ) : null}
@@ -327,13 +334,13 @@ export default function SocialComposer({
         <div
           id={errorId}
           role="alert"
-          className="flex items-start justify-between gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2"
+          className="flex items-start justify-between gap-2 rounded-lg border border-social-error bg-social-error-soft px-3 py-2"
         >
-          <p className="text-sm font-medium text-destructive">{visibleError}</p>
+          <p className="text-sm font-medium text-social-error">{visibleError}</p>
           <button
             type="button"
             onClick={dismissError}
-            className="inline-flex size-11 shrink-0 items-center justify-center rounded-lg text-destructive transition hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="inline-flex size-11 shrink-0 items-center justify-center rounded-lg text-social-error transition-colors hover:bg-social-surface active:bg-social-error-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
             aria-label="Dismiss send error"
           >
             <X className="size-4" aria-hidden="true" />

--- a/src/components/league/social/SocialComposer.tsx
+++ b/src/components/league/social/SocialComposer.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { LoaderCircle, SendHorizontal } from 'lucide-react';
+import { LoaderCircle, RotateCcw, SendHorizontal, X } from 'lucide-react';
 import {
+  useEffect,
   useId,
   useLayoutEffect,
   useRef,
@@ -11,12 +12,22 @@ import {
   type ReactNode,
 } from 'react';
 
+import {
+  clearSocialComposerDraft,
+  createSocialComposerAttemptKey,
+  getSocialComposerDraftKey,
+  readSocialComposerDraft,
+  writeSocialComposerDraft,
+  type SocialComposerDraftScope,
+} from './socialComposerDraft';
+
 interface SocialComposerProps {
   label: string;
   placeholder: string;
   submitLabel: string;
   maxLength: number;
-  onSubmit: (value: string) => Promise<void> | void;
+  onSubmit: (value: string, idempotencyKey: string) => Promise<void> | void;
+  onDismissError?: () => void;
   submitOnEnter?: boolean;
   disabled?: boolean;
   pending?: boolean;
@@ -24,7 +35,12 @@ interface SocialComposerProps {
   initialValue?: string;
   compact?: boolean;
   leadingAction?: ReactNode;
+  draftScope?: SocialComposerDraftScope;
 }
+
+type SubmissionState = 'idle' | 'submitting' | 'failed';
+
+const COMPOSER_MAX_HEIGHT_PX = 96;
 
 export default function SocialComposer({
   label,
@@ -32,6 +48,7 @@ export default function SocialComposer({
   submitLabel,
   maxLength,
   onSubmit,
+  onDismissError,
   submitOnEnter = false,
   disabled = false,
   pending = false,
@@ -39,30 +56,144 @@ export default function SocialComposer({
   initialValue = '',
   compact = false,
   leadingAction,
+  draftScope,
 }: SocialComposerProps): React.JSX.Element {
   const inputId = useId();
   const helpId = `${inputId}-help`;
   const errorId = `${inputId}-error`;
+  const statusId = `${inputId}-status`;
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const submittingRef = useRef(false);
+  const skipNextPersistRef = useRef(false);
   const [value, setValue] = useState(initialValue);
+  const [attemptKey, setAttemptKey] = useState<string | undefined>();
+  const [submissionState, setSubmissionState] = useState<SubmissionState>('idle');
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [externalErrorDismissed, setExternalErrorDismissed] = useState(false);
+  const [announcement, setAnnouncement] = useState('');
+  const [online, setOnline] = useState(() => typeof navigator === 'undefined' || navigator.onLine);
+  const [finePointer, setFinePointer] = useState(true);
+  const draftKey = draftScope ? getSocialComposerDraftKey(draftScope) : null;
   const trimmedValue = value.trim();
-  const canSubmit = !disabled && !pending && trimmedValue.length > 0 && value.length <= maxLength;
-  const nearLimit = value.length >= maxLength * 0.8;
+  const isSubmitting = submissionState === 'submitting' || pending;
+  const visibleError = localError ?? (!externalErrorDismissed ? error : null);
+  const hasFailure = submissionState === 'failed' || Boolean(visibleError);
+  const canSubmit =
+    !disabled && online && !isSubmitting && trimmedValue.length > 0 && value.length <= maxLength;
+  const showCounter = value.length >= Math.min(800, maxLength);
+  const counterTone =
+    value.length >= maxLength
+      ? 'font-semibold text-destructive'
+      : value.length >= Math.min(950, maxLength)
+        ? 'font-semibold text-warning'
+        : 'text-muted-foreground';
+  const sendLabel = isSubmitting
+    ? 'Sending message'
+    : hasFailure
+      ? 'Retry sending message'
+      : !online
+        ? 'Sending unavailable while offline'
+        : submitLabel;
+
+  useEffect(() => {
+    if (!draftKey || typeof window === 'undefined') return;
+    const restored = readSocialComposerDraft(window.localStorage, draftKey);
+    skipNextPersistRef.current = true;
+    setValue(restored?.value ?? initialValue);
+    setAttemptKey(restored?.attemptKey);
+    setSubmissionState(restored?.attemptKey ? 'failed' : 'idle');
+    setLocalError(
+      restored?.attemptKey
+        ? 'Message delivery was not confirmed. Retry to reconcile this message.'
+        : null
+    );
+    setExternalErrorDismissed(false);
+  }, [draftKey, initialValue]);
+
+  useEffect(() => {
+    if (!draftKey || typeof window === 'undefined') return;
+    if (skipNextPersistRef.current) {
+      skipNextPersistRef.current = false;
+      return;
+    }
+    writeSocialComposerDraft(window.localStorage, draftKey, { value, attemptKey });
+  }, [attemptKey, draftKey, value]);
+
+  useEffect(() => {
+    const markOnline = () => {
+      setOnline(true);
+      setAnnouncement('Connection restored. Your draft is ready to send.');
+    };
+    const markOffline = () => {
+      setOnline(false);
+      setAnnouncement('You are offline. Your message draft has been preserved.');
+    };
+    window.addEventListener('online', markOnline);
+    window.addEventListener('offline', markOffline);
+    return () => {
+      window.removeEventListener('online', markOnline);
+      window.removeEventListener('offline', markOffline);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return;
+    const pointerQuery = window.matchMedia('(pointer: fine)');
+    const updatePointer = () => setFinePointer(pointerQuery.matches);
+    updatePointer();
+    pointerQuery.addEventListener?.('change', updatePointer);
+    return () => pointerQuery.removeEventListener?.('change', updatePointer);
+  }, []);
+
+  useEffect(() => {
+    if (error) setExternalErrorDismissed(false);
+  }, [error]);
 
   useLayoutEffect(() => {
     if (!compact || !inputRef.current) return;
     const input = inputRef.current;
     input.style.height = '0px';
-    input.style.height = `${Math.min(input.scrollHeight, 128)}px`;
+    input.style.height = `${Math.min(input.scrollHeight, COMPOSER_MAX_HEIGHT_PX)}px`;
   }, [compact, value]);
 
+  function persistAttempt(nextAttemptKey: string): void {
+    if (!draftKey || typeof window === 'undefined') return;
+    writeSocialComposerDraft(window.localStorage, draftKey, {
+      value,
+      attemptKey: nextAttemptKey,
+    });
+  }
+
   async function submit(): Promise<void> {
-    if (!canSubmit) return;
+    if (!canSubmit || submittingRef.current) return;
+    const nextAttemptKey = attemptKey ?? createSocialComposerAttemptKey('chat');
+    submittingRef.current = true;
+    setAttemptKey(nextAttemptKey);
+    setSubmissionState('submitting');
+    setLocalError(null);
+    setExternalErrorDismissed(false);
+    setAnnouncement('Sending message.');
+    persistAttempt(nextAttemptKey);
+
     try {
-      await onSubmit(trimmedValue);
+      await onSubmit(trimmedValue, nextAttemptKey);
       setValue('');
-    } catch {
-      // The owning controller exposes the actionable error beside the composer.
+      setAttemptKey(undefined);
+      setSubmissionState('idle');
+      setAnnouncement('Message sent.');
+      if (draftKey && typeof window !== 'undefined') {
+        clearSocialComposerDraft(window.localStorage, draftKey);
+      }
+      window.requestAnimationFrame(() => inputRef.current?.focus());
+    } catch (submissionError) {
+      const message =
+        submissionError instanceof Error ? submissionError.message : 'Message could not be sent.';
+      setSubmissionState('failed');
+      setLocalError(message);
+      setAnnouncement(`${message} Your message was preserved.`);
+      persistAttempt(nextAttemptKey);
+    } finally {
+      submittingRef.current = false;
     }
   }
 
@@ -74,6 +205,7 @@ export default function SocialComposer({
   function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>): void {
     if (
       !submitOnEnter ||
+      !finePointer ||
       event.key !== 'Enter' ||
       event.shiftKey ||
       event.nativeEvent.isComposing
@@ -85,81 +217,128 @@ export default function SocialComposer({
     void submit();
   }
 
+  function handleValueChange(nextValue: string): void {
+    setValue(nextValue.slice(0, maxLength));
+    if (attemptKey || hasFailure) {
+      setAttemptKey(undefined);
+      setSubmissionState('idle');
+      setLocalError(null);
+      setExternalErrorDismissed(false);
+      onDismissError?.();
+    }
+  }
+
+  function dismissError(): void {
+    setLocalError(null);
+    setExternalErrorDismissed(true);
+    onDismissError?.();
+    inputRef.current?.focus();
+  }
+
   return (
-    <form className={compact ? 'group space-y-1.5' : 'space-y-2'} onSubmit={handleSubmit}>
+    <form className="relative space-y-2" onSubmit={handleSubmit}>
       <label htmlFor={inputId} className="sr-only">
         {label}
       </label>
       <div
         className={
           compact
-            ? 'flex min-h-12 items-end gap-1 rounded-2xl border border-border bg-background p-1 shadow-sm transition focus-within:ring-2 focus-within:ring-ring'
+            ? 'flex min-h-14 items-end gap-0.5 rounded-xl border border-border bg-background p-1.5 shadow-sm transition focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/30'
             : undefined
         }
       >
         {compact && leadingAction ? (
-          <div className="flex min-h-10 shrink-0 items-center">{leadingAction}</div>
+          <div className="flex min-h-11 shrink-0 items-center">{leadingAction}</div>
         ) : null}
         <textarea
           ref={inputRef}
           id={inputId}
           value={value}
-          onChange={(event) => setValue(event.target.value)}
+          onChange={(event) => handleValueChange(event.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           maxLength={maxLength}
           rows={compact ? 1 : submitOnEnter ? 3 : 6}
-          disabled={disabled || pending}
-          aria-invalid={Boolean(error)}
-          aria-describedby={`${helpId}${error ? ` ${errorId}` : ''}`}
+          disabled={disabled}
+          readOnly={isSubmitting}
+          aria-invalid={Boolean(visibleError)}
+          aria-describedby={`${helpId} ${statusId}${visibleError ? ` ${errorId}` : ''}`}
           className={
             compact
-              ? 'block min-h-10 max-h-32 min-w-0 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-2 py-2.5 text-sm leading-5 text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-60'
+              ? 'block min-h-11 max-h-24 min-w-0 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-2 py-3 text-sm leading-5 text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-60'
               : 'block w-full resize-y rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60'
           }
         />
         <button
           type="submit"
           disabled={!canSubmit}
-          aria-label={compact ? submitLabel : undefined}
+          aria-label={compact ? sendLabel : undefined}
           className={
             compact
-              ? 'inline-flex size-10 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40'
-              : 'inline-flex min-h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'
+              ? 'inline-flex size-11 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-40'
+              : 'inline-flex min-h-11 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'
           }
         >
           {compact ? (
-            pending ? (
-              <LoaderCircle className="size-4 animate-spin" aria-hidden="true" />
+            isSubmitting ? (
+              <LoaderCircle className="size-4 motion-safe:animate-spin" aria-hidden="true" />
+            ) : hasFailure ? (
+              <RotateCcw className="size-4" aria-hidden="true" />
             ) : (
               <SendHorizontal className="size-4" aria-hidden="true" />
             )
-          ) : pending ? (
+          ) : isSubmitting ? (
             'Sending…'
+          ) : hasFailure ? (
+            'Retry'
           ) : (
             submitLabel
           )}
         </button>
       </div>
-      <p id={helpId} className={compact ? 'sr-only' : 'text-xs text-muted-foreground'}>
-        {submitOnEnter ? 'Enter to send · Shift+Enter for a new line · ' : ''}
-        {value.length.toLocaleString()} / {maxLength.toLocaleString()}
+
+      <p id={helpId} className="sr-only">
+        {submitOnEnter && finePointer
+          ? 'Enter to send. Shift plus Enter inserts a new line. '
+          : 'Use the send button to submit. '}
+        {value.length.toLocaleString()} of {maxLength.toLocaleString()} characters used.
       </p>
-      {compact ? (
-        <div
+      <p id={statusId} aria-live="polite" className="sr-only">
+        {announcement}
+      </p>
+
+      {showCounter ? (
+        <p
           aria-hidden="true"
-          className={`justify-end px-2 text-xs text-muted-foreground ${
-            nearLimit ? 'flex' : 'hidden group-focus-within:flex'
-          }`}
+          className={`pointer-events-none absolute -top-5 right-1 text-xs tabular-nums ${counterTone}`}
         >
-          {submitOnEnter ? 'Enter to send · Shift+Enter for a new line · ' : ''}
           {value.length.toLocaleString()} / {maxLength.toLocaleString()}
-        </div>
-      ) : null}
-      {error ? (
-        <p id={errorId} role="alert" className="text-sm font-medium text-destructive">
-          {error}
+          {value.length >= maxLength ? ' · Limit reached' : ''}
         </p>
+      ) : null}
+
+      {!online ? (
+        <p role="status" className="px-1 text-xs font-medium text-muted-foreground">
+          You’re offline. Your draft is saved and sending is unavailable.
+        </p>
+      ) : null}
+
+      {visibleError ? (
+        <div
+          id={errorId}
+          role="alert"
+          className="flex items-start justify-between gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2"
+        >
+          <p className="text-sm font-medium text-destructive">{visibleError}</p>
+          <button
+            type="button"
+            onClick={dismissError}
+            className="inline-flex size-11 shrink-0 items-center justify-center rounded-lg text-destructive transition hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Dismiss send error"
+          >
+            <X className="size-4" aria-hidden="true" />
+          </button>
+        </div>
       ) : null}
     </form>
   );

--- a/src/components/league/social/SocialComposer.tsx
+++ b/src/components/league/social/SocialComposer.tsx
@@ -1,6 +1,15 @@
 'use client';
 
-import { useId, useState, type FormEvent, type KeyboardEvent } from 'react';
+import { LoaderCircle, SendHorizontal } from 'lucide-react';
+import {
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
 
 interface SocialComposerProps {
   label: string;
@@ -13,6 +22,8 @@ interface SocialComposerProps {
   pending?: boolean;
   error?: string | null;
   initialValue?: string;
+  compact?: boolean;
+  leadingAction?: ReactNode;
 }
 
 export default function SocialComposer({
@@ -26,13 +37,24 @@ export default function SocialComposer({
   pending = false,
   error,
   initialValue = '',
+  compact = false,
+  leadingAction,
 }: SocialComposerProps): React.JSX.Element {
   const inputId = useId();
   const helpId = `${inputId}-help`;
   const errorId = `${inputId}-error`;
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const [value, setValue] = useState(initialValue);
   const trimmedValue = value.trim();
   const canSubmit = !disabled && !pending && trimmedValue.length > 0 && value.length <= maxLength;
+  const nearLimit = value.length >= maxLength * 0.8;
+
+  useLayoutEffect(() => {
+    if (!compact || !inputRef.current) return;
+    const input = inputRef.current;
+    input.style.height = '0px';
+    input.style.height = `${Math.min(input.scrollHeight, 128)}px`;
+  }, [compact, value]);
 
   async function submit(): Promise<void> {
     if (!canSubmit) return;
@@ -64,36 +86,76 @@ export default function SocialComposer({
   }
 
   return (
-    <form className="space-y-2" onSubmit={handleSubmit}>
+    <form className={compact ? 'group space-y-1.5' : 'space-y-2'} onSubmit={handleSubmit}>
       <label htmlFor={inputId} className="sr-only">
         {label}
       </label>
-      <textarea
-        id={inputId}
-        value={value}
-        onChange={(event) => setValue(event.target.value)}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        maxLength={maxLength}
-        rows={submitOnEnter ? 3 : 6}
-        disabled={disabled || pending}
-        aria-invalid={Boolean(error)}
-        aria-describedby={`${helpId}${error ? ` ${errorId}` : ''}`}
-        className="block w-full resize-y rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
-      />
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <p id={helpId} className="text-xs text-muted-foreground">
-          {submitOnEnter ? 'Enter to send · Shift+Enter for a new line · ' : ''}
-          {value.length.toLocaleString()} / {maxLength.toLocaleString()}
-        </p>
+      <div
+        className={
+          compact
+            ? 'flex min-h-12 items-end gap-1 rounded-2xl border border-border bg-background p-1 shadow-sm transition focus-within:ring-2 focus-within:ring-ring'
+            : undefined
+        }
+      >
+        {compact && leadingAction ? (
+          <div className="flex min-h-10 shrink-0 items-center">{leadingAction}</div>
+        ) : null}
+        <textarea
+          ref={inputRef}
+          id={inputId}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          maxLength={maxLength}
+          rows={compact ? 1 : submitOnEnter ? 3 : 6}
+          disabled={disabled || pending}
+          aria-invalid={Boolean(error)}
+          aria-describedby={`${helpId}${error ? ` ${errorId}` : ''}`}
+          className={
+            compact
+              ? 'block min-h-10 max-h-32 min-w-0 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-2 py-2.5 text-sm leading-5 text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-60'
+              : 'block w-full resize-y rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60'
+          }
+        />
         <button
           type="submit"
           disabled={!canSubmit}
-          className="inline-flex min-h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label={compact ? submitLabel : undefined}
+          className={
+            compact
+              ? 'inline-flex size-10 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40'
+              : 'inline-flex min-h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'
+          }
         >
-          {pending ? 'Sending…' : submitLabel}
+          {compact ? (
+            pending ? (
+              <LoaderCircle className="size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <SendHorizontal className="size-4" aria-hidden="true" />
+            )
+          ) : pending ? (
+            'Sending…'
+          ) : (
+            submitLabel
+          )}
         </button>
       </div>
+      <p id={helpId} className={compact ? 'sr-only' : 'text-xs text-muted-foreground'}>
+        {submitOnEnter ? 'Enter to send · Shift+Enter for a new line · ' : ''}
+        {value.length.toLocaleString()} / {maxLength.toLocaleString()}
+      </p>
+      {compact ? (
+        <div
+          aria-hidden="true"
+          className={`justify-end px-2 text-xs text-muted-foreground ${
+            nearLimit ? 'flex' : 'hidden group-focus-within:flex'
+          }`}
+        >
+          {submitOnEnter ? 'Enter to send · Shift+Enter for a new line · ' : ''}
+          {value.length.toLocaleString()} / {maxLength.toLocaleString()}
+        </div>
+      ) : null}
       {error ? (
         <p id={errorId} role="alert" className="text-sm font-medium text-destructive">
           {error}

--- a/src/components/league/social/SocialComposer.tsx
+++ b/src/components/league/social/SocialComposer.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useId, useState, type FormEvent, type KeyboardEvent } from 'react';
+
+interface SocialComposerProps {
+  label: string;
+  placeholder: string;
+  submitLabel: string;
+  maxLength: number;
+  onSubmit: (value: string) => Promise<void> | void;
+  submitOnEnter?: boolean;
+  disabled?: boolean;
+  pending?: boolean;
+  error?: string | null;
+  initialValue?: string;
+}
+
+export default function SocialComposer({
+  label,
+  placeholder,
+  submitLabel,
+  maxLength,
+  onSubmit,
+  submitOnEnter = false,
+  disabled = false,
+  pending = false,
+  error,
+  initialValue = '',
+}: SocialComposerProps): React.JSX.Element {
+  const inputId = useId();
+  const helpId = `${inputId}-help`;
+  const errorId = `${inputId}-error`;
+  const [value, setValue] = useState(initialValue);
+  const trimmedValue = value.trim();
+  const canSubmit = !disabled && !pending && trimmedValue.length > 0 && value.length <= maxLength;
+
+  async function submit(): Promise<void> {
+    if (!canSubmit) return;
+    try {
+      await onSubmit(trimmedValue);
+      setValue('');
+    } catch {
+      // The owning controller exposes the actionable error beside the composer.
+    }
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    void submit();
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>): void {
+    if (
+      !submitOnEnter ||
+      event.key !== 'Enter' ||
+      event.shiftKey ||
+      event.nativeEvent.isComposing
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    void submit();
+  }
+
+  return (
+    <form className="space-y-2" onSubmit={handleSubmit}>
+      <label htmlFor={inputId} className="sr-only">
+        {label}
+      </label>
+      <textarea
+        id={inputId}
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        maxLength={maxLength}
+        rows={submitOnEnter ? 3 : 6}
+        disabled={disabled || pending}
+        aria-invalid={Boolean(error)}
+        aria-describedby={`${helpId}${error ? ` ${errorId}` : ''}`}
+        className="block w-full resize-y rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+      />
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p id={helpId} className="text-xs text-muted-foreground">
+          {submitOnEnter ? 'Enter to send · Shift+Enter for a new line · ' : ''}
+          {value.length.toLocaleString()} / {maxLength.toLocaleString()}
+        </p>
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="inline-flex min-h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {pending ? 'Sending…' : submitLabel}
+        </button>
+      </div>
+      {error ? (
+        <p id={errorId} role="alert" className="text-sm font-medium text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </form>
+  );
+}

--- a/src/components/league/social/SocialDrawer.tsx
+++ b/src/components/league/social/SocialDrawer.tsx
@@ -37,7 +37,7 @@ export default function SocialDrawer({
       role="dialog"
       aria-modal="false"
       aria-labelledby={titleId}
-      className="fixed inset-x-0 bottom-0 z-[60] flex h-[72dvh] flex-col rounded-t-3xl border border-border bg-background shadow-2xl sm:inset-y-0 sm:left-auto sm:h-full sm:w-[min(42rem,48vw)] sm:rounded-none sm:border-y-0 sm:border-r-0"
+      className="league-social fixed inset-x-0 bottom-0 z-[60] flex h-[72dvh] flex-col rounded-t-3xl border border-social-border bg-social-surface text-social-text shadow-2xl sm:inset-y-0 sm:left-auto sm:h-full sm:w-[min(42rem,48vw)] sm:rounded-none sm:border-y-0 sm:border-r-0"
     >
       <h2 id={titleId} className="sr-only">
         League social
@@ -45,7 +45,7 @@ export default function SocialDrawer({
       <button
         type="button"
         onClick={onClose}
-        className="absolute right-16 top-3 z-20 inline-flex size-10 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-sm transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="absolute right-16 top-3 z-20 inline-flex size-10 items-center justify-center rounded-full border border-social-border bg-social-surface text-social-text-muted shadow-sm transition-colors hover:bg-social-brand-soft hover:text-social-text active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
         aria-label="Close league social"
       >
         <X className="size-5" aria-hidden="true" />

--- a/src/components/league/social/SocialDrawer.tsx
+++ b/src/components/league/social/SocialDrawer.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { X } from 'lucide-react';
+import { useEffect, useId } from 'react';
+
+import LeagueSocialShell, { type LeagueSocialView } from './LeagueSocialShell';
+
+interface SocialDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  leagueId: string;
+  currentUserId?: string;
+  initialView?: LeagueSocialView;
+}
+
+export default function SocialDrawer({
+  open,
+  onClose,
+  leagueId,
+  currentUserId,
+  initialView = 'chat',
+}: SocialDrawerProps): React.JSX.Element {
+  const titleId = useId();
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose, open]);
+
+  if (!open) return <></>;
+
+  return (
+    <aside
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={titleId}
+      className="fixed inset-x-0 bottom-0 z-[60] flex h-[72dvh] flex-col rounded-t-3xl border border-border bg-background shadow-2xl sm:inset-y-0 sm:left-auto sm:h-full sm:w-[min(42rem,48vw)] sm:rounded-none sm:border-y-0 sm:border-r-0"
+    >
+      <h2 id={titleId} className="sr-only">
+        League social
+      </h2>
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute right-16 top-3 z-20 inline-flex size-10 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-sm transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label="Close league social"
+      >
+        <X className="size-5" aria-hidden="true" />
+      </button>
+      <LeagueSocialShell
+        leagueId={leagueId}
+        currentUserId={currentUserId}
+        initialView={initialView}
+        className="h-full min-h-0 rounded-none border-0 shadow-none"
+      />
+    </aside>
+  );
+}

--- a/src/components/league/social/SocialPreferencesPanel.tsx
+++ b/src/components/league/social/SocialPreferencesPanel.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useId, useState } from 'react';
+
+import type { SocialNotificationPreferences } from '@/types/social';
+
+const preferenceLabels: Array<{
+  key: keyof SocialNotificationPreferences;
+  label: string;
+  description: string;
+}> = [
+  {
+    key: 'chatInApp',
+    label: 'League chat',
+    description: 'Show in-app activity for new chat messages.',
+  },
+  {
+    key: 'boardPosts',
+    label: 'All message-board posts',
+    description: 'Notify me when any new discussion is created.',
+  },
+  {
+    key: 'ownPostReplies',
+    label: 'Replies to my posts',
+    description: 'Notify me when someone replies to my discussion.',
+  },
+  {
+    key: 'announcements',
+    label: 'Commissioner announcements',
+    description: 'Notify me about official league announcements.',
+  },
+  {
+    key: 'tradeDiscussions',
+    label: 'Trade discussions',
+    description: 'Notify me about activity in the Trades category.',
+  },
+  {
+    key: 'mentions',
+    label: 'Mentions',
+    description: 'Notify me when another member mentions me.',
+  },
+  {
+    key: 'systemActivityInApp',
+    label: 'League activity',
+    description: 'Show draft, transaction, and scoring events in chat.',
+  },
+];
+
+export default function SocialPreferencesPanel({
+  preferences,
+  onSave,
+  onClose,
+}: {
+  preferences: SocialNotificationPreferences;
+  onSave: (preferences: SocialNotificationPreferences) => Promise<void>;
+  onClose: () => void;
+}): React.JSX.Element {
+  const [draft, setDraft] = useState(preferences);
+  const fieldPrefix = useId();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save(): Promise<void> {
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(draft);
+      onClose();
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : 'Failed to save preferences.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby="social-preferences-heading"
+      className="border-b border-border bg-background p-4"
+    >
+      <h2 id="social-preferences-heading" className="text-base font-semibold text-foreground">
+        Social notifications
+      </h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Choose which league conversations contribute to your notifications.
+      </p>
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        {preferenceLabels.map((preference) => (
+          <div
+            key={preference.key}
+            className="flex min-h-16 items-start gap-3 rounded-xl border border-border bg-card p-3"
+          >
+            <input
+              id={`${fieldPrefix}-${preference.key}`}
+              type="checkbox"
+              aria-label={preference.label}
+              checked={draft[preference.key]}
+              onChange={(event) =>
+                setDraft((current) => ({
+                  ...current,
+                  [preference.key]: event.target.checked,
+                }))
+              }
+              className="mt-1 size-4 rounded border-border text-primary focus:ring-ring"
+            />
+            <span>
+              <span className="block text-sm font-semibold text-foreground">
+                {preference.label}
+              </span>
+              <span className="mt-0.5 block text-xs leading-5 text-muted-foreground">
+                {preference.description}
+              </span>
+            </span>
+          </div>
+        ))}
+      </div>
+      {error ? (
+        <p role="alert" className="mt-3 text-sm font-medium text-destructive">
+          {error}
+        </p>
+      ) : null}
+      <div className="mt-4 flex gap-3">
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={saving}
+          className="inline-flex min-h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+        >
+          {saving ? 'Saving…' : 'Save preferences'}
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={saving}
+          className="inline-flex min-h-10 items-center justify-center rounded-lg border border-border bg-background px-4 text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+        >
+          Cancel
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/league/social/SocialPreferencesPanel.tsx
+++ b/src/components/league/social/SocialPreferencesPanel.tsx
@@ -76,19 +76,19 @@ export default function SocialPreferencesPanel({
   return (
     <section
       aria-labelledby="social-preferences-heading"
-      className="border-b border-border bg-background p-4"
+      className="border-b border-social-border bg-social-surface p-4 text-social-text"
     >
-      <h2 id="social-preferences-heading" className="text-base font-semibold text-foreground">
+      <h2 id="social-preferences-heading" className="text-base font-semibold text-social-text">
         Social notifications
       </h2>
-      <p className="mt-1 text-sm text-muted-foreground">
+      <p className="mt-1 text-sm text-social-text-muted">
         Choose which league conversations contribute to your notifications.
       </p>
       <div className="mt-4 grid gap-3 sm:grid-cols-2">
         {preferenceLabels.map((preference) => (
           <div
             key={preference.key}
-            className="flex min-h-16 items-start gap-3 rounded-xl border border-border bg-card p-3"
+            className="flex min-h-16 items-start gap-3 rounded-xl border border-social-border bg-social-surface p-3"
           >
             <input
               id={`${fieldPrefix}-${preference.key}`}
@@ -101,13 +101,13 @@ export default function SocialPreferencesPanel({
                   [preference.key]: event.target.checked,
                 }))
               }
-              className="mt-1 size-4 rounded border-border text-primary focus:ring-ring"
+              className="mt-1 size-4 rounded border-social-border text-social-action focus:ring-social-focus"
             />
             <span>
-              <span className="block text-sm font-semibold text-foreground">
+              <span className="block text-sm font-semibold text-social-text">
                 {preference.label}
               </span>
-              <span className="mt-0.5 block text-xs leading-5 text-muted-foreground">
+              <span className="mt-0.5 block text-xs leading-5 text-social-text-muted">
                 {preference.description}
               </span>
             </span>
@@ -115,7 +115,7 @@ export default function SocialPreferencesPanel({
         ))}
       </div>
       {error ? (
-        <p role="alert" className="mt-3 text-sm font-medium text-destructive">
+        <p role="alert" className="mt-3 text-sm font-medium text-social-error">
           {error}
         </p>
       ) : null}
@@ -124,7 +124,7 @@ export default function SocialPreferencesPanel({
           type="button"
           onClick={() => void save()}
           disabled={saving}
-          className="inline-flex min-h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+          className="inline-flex min-h-10 items-center justify-center rounded-lg border border-social-action bg-social-action px-4 text-sm font-semibold text-social-action-foreground transition-colors hover:border-social-action-hover hover:bg-social-action-hover active:border-social-action-pressed active:bg-social-action-pressed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:border-social-border disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
         >
           {saving ? 'Saving…' : 'Save preferences'}
         </button>
@@ -132,7 +132,7 @@ export default function SocialPreferencesPanel({
           type="button"
           onClick={onClose}
           disabled={saving}
-          className="inline-flex min-h-10 items-center justify-center rounded-lg border border-border bg-background px-4 text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+          className="inline-flex min-h-10 items-center justify-center rounded-lg border border-social-border bg-social-surface px-4 text-sm font-semibold text-social-text transition-colors hover:border-social-border-strong hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
         >
           Cancel
         </button>

--- a/src/components/league/social/SocialRemoveButton.tsx
+++ b/src/components/league/social/SocialRemoveButton.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+export default function SocialRemoveButton({
+  label,
+  onRemove,
+}: {
+  label: string;
+  onRemove: (reason: string) => Promise<void>;
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(): Promise<void> {
+    const normalizedReason = reason.trim();
+    if (!normalizedReason) {
+      setError('Add a reason for the moderation record.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onRemove(normalizedReason);
+      setOpen(false);
+    } catch (removeError) {
+      setError(removeError instanceof Error ? removeError.message : `Could not remove ${label}.`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <span className="relative inline-flex">
+      <button
+        type="button"
+        onClick={() => setOpen((visible) => !visible)}
+        aria-expanded={open}
+        className="inline-flex min-h-8 items-center gap-1 rounded-md px-2 text-xs font-medium text-destructive hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <Trash2 className="size-3.5" aria-hidden="true" />
+        Remove
+      </button>
+      {open ? (
+        <span className="absolute right-0 top-full z-20 mt-1 block w-72 rounded-xl border border-border bg-popover p-3 text-popover-foreground shadow-lg">
+          <span className="block text-sm font-semibold">Remove {label}</span>
+          <label className="mt-2 block text-xs font-medium">
+            Moderation reason
+            <textarea
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              maxLength={2000}
+              rows={3}
+              required
+              className="mt-1 block w-full resize-y rounded-lg border border-border bg-background px-2 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          </label>
+          {error ? (
+            <span role="alert" className="mt-2 block text-xs font-medium text-destructive">
+              {error}
+            </span>
+          ) : null}
+          <span className="mt-3 flex gap-2">
+            <button
+              type="button"
+              disabled={submitting}
+              onClick={() => void submit()}
+              className="inline-flex min-h-9 items-center rounded-lg bg-destructive px-3 text-xs font-semibold text-destructive-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+            >
+              {submitting ? 'Removing…' : 'Confirm removal'}
+            </button>
+            <button
+              type="button"
+              disabled={submitting}
+              onClick={() => setOpen(false)}
+              className="inline-flex min-h-9 items-center rounded-lg border border-border px-3 text-xs font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Cancel
+            </button>
+          </span>
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/components/league/social/SocialRemoveButton.tsx
+++ b/src/components/league/social/SocialRemoveButton.tsx
@@ -39,13 +39,13 @@ export default function SocialRemoveButton({
         type="button"
         onClick={() => setOpen((visible) => !visible)}
         aria-expanded={open}
-        className="inline-flex min-h-8 items-center gap-1 rounded-md px-2 text-xs font-medium text-destructive hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="inline-flex min-h-8 items-center gap-1 rounded-md px-2 text-xs font-medium text-social-error transition-colors hover:bg-social-error-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
       >
         <Trash2 className="size-3.5" aria-hidden="true" />
         Remove
       </button>
       {open ? (
-        <span className="absolute right-0 top-full z-20 mt-1 block w-72 rounded-xl border border-border bg-popover p-3 text-popover-foreground shadow-lg">
+        <span className="absolute right-0 top-full z-20 mt-1 block w-72 rounded-xl border border-social-border bg-social-surface p-3 text-social-text shadow-lg">
           <span className="block text-sm font-semibold">Remove {label}</span>
           <label className="mt-2 block text-xs font-medium">
             Moderation reason
@@ -55,11 +55,11 @@ export default function SocialRemoveButton({
               maxLength={2000}
               rows={3}
               required
-              className="mt-1 block w-full resize-y rounded-lg border border-border bg-background px-2 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="mt-1 block w-full resize-y rounded-lg border border-social-border bg-social-surface px-2 py-1.5 text-sm text-social-text focus-visible:border-social-action focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
             />
           </label>
           {error ? (
-            <span role="alert" className="mt-2 block text-xs font-medium text-destructive">
+            <span role="alert" className="mt-2 block text-xs font-medium text-social-error">
               {error}
             </span>
           ) : null}
@@ -68,7 +68,7 @@ export default function SocialRemoveButton({
               type="button"
               disabled={submitting}
               onClick={() => void submit()}
-              className="inline-flex min-h-9 items-center rounded-lg bg-destructive px-3 text-xs font-semibold text-destructive-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+              className="inline-flex min-h-9 items-center rounded-lg border border-social-error bg-social-error px-3 text-xs font-semibold text-social-error-foreground transition-colors hover:bg-social-error-soft hover:text-social-error active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:border-social-border disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
             >
               {submitting ? 'Removing…' : 'Confirm removal'}
             </button>
@@ -76,7 +76,7 @@ export default function SocialRemoveButton({
               type="button"
               disabled={submitting}
               onClick={() => setOpen(false)}
-              className="inline-flex min-h-9 items-center rounded-lg border border-border px-3 text-xs font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="inline-flex min-h-9 items-center rounded-lg border border-social-border bg-social-surface px-3 text-xs font-semibold text-social-text transition-colors hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
             >
               Cancel
             </button>

--- a/src/components/league/social/SocialReportButton.tsx
+++ b/src/components/league/social/SocialReportButton.tsx
@@ -35,7 +35,7 @@ export default function SocialReportButton({
 
   if (submitted) {
     return (
-      <span role="status" className="text-xs font-medium text-muted-foreground">
+      <span role="status" className="text-xs font-medium text-social-success">
         Report submitted
       </span>
     );
@@ -47,20 +47,20 @@ export default function SocialReportButton({
         type="button"
         onClick={() => setOpen((visible) => !visible)}
         aria-expanded={open}
-        className="inline-flex min-h-8 items-center gap-1 rounded-md px-2 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="inline-flex min-h-8 items-center gap-1 rounded-md px-2 text-xs font-medium text-social-text-muted transition-colors hover:bg-social-brand-soft hover:text-social-text active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
       >
         <Flag className="size-3.5" aria-hidden="true" />
         Report
       </button>
       {open ? (
-        <span className="absolute right-0 top-full z-20 mt-1 block w-72 rounded-xl border border-border bg-popover p-3 text-popover-foreground shadow-lg">
+        <span className="absolute right-0 top-full z-20 mt-1 block w-72 rounded-xl border border-social-border bg-social-surface p-3 text-social-text shadow-lg">
           <span className="block text-sm font-semibold">Report {label}</span>
           <label className="mt-2 block text-xs font-medium">
             Reason
             <select
               value={reason}
               onChange={(event) => setReason(event.target.value as SocialReportReason)}
-              className="mt-1 block h-10 w-full rounded-lg border border-border bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="mt-1 block h-10 w-full rounded-lg border border-social-border bg-social-surface px-2 text-sm text-social-text focus-visible:border-social-action focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
             >
               <option value="harassment">Harassment</option>
               <option value="hate">Hateful content</option>
@@ -71,7 +71,7 @@ export default function SocialReportButton({
             </select>
           </label>
           {error ? (
-            <span role="alert" className="mt-2 block text-xs font-medium text-destructive">
+            <span role="alert" className="mt-2 block text-xs font-medium text-social-error">
               {error}
             </span>
           ) : null}
@@ -82,7 +82,7 @@ export default function SocialReportButton({
               onChange={(event) => setDetails(event.target.value)}
               maxLength={2000}
               rows={3}
-              className="mt-1 block w-full resize-y rounded-lg border border-border bg-background px-2 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="mt-1 block w-full resize-y rounded-lg border border-social-border bg-social-surface px-2 py-1.5 text-sm text-social-text focus-visible:border-social-action focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus"
             />
           </label>
           <span className="mt-3 flex gap-2">
@@ -90,7 +90,7 @@ export default function SocialReportButton({
               type="button"
               disabled={submitting}
               onClick={() => void submit()}
-              className="inline-flex min-h-9 items-center rounded-lg bg-destructive px-3 text-xs font-semibold text-destructive-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+              className="inline-flex min-h-9 items-center rounded-lg border border-social-error bg-social-error px-3 text-xs font-semibold text-social-error-foreground transition-colors hover:bg-social-error-soft hover:text-social-error active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:border-social-border disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
             >
               {submitting ? 'Submitting…' : 'Submit report'}
             </button>
@@ -98,7 +98,7 @@ export default function SocialReportButton({
               type="button"
               disabled={submitting}
               onClick={() => setOpen(false)}
-              className="inline-flex min-h-9 items-center rounded-lg border border-border px-3 text-xs font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="inline-flex min-h-9 items-center rounded-lg border border-social-border bg-social-surface px-3 text-xs font-semibold text-social-text transition-colors hover:bg-social-brand-soft active:bg-social-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-social-focus disabled:cursor-not-allowed disabled:bg-social-disabled-bg disabled:text-social-disabled-text"
             >
               Cancel
             </button>

--- a/src/components/league/social/SocialReportButton.tsx
+++ b/src/components/league/social/SocialReportButton.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { Flag } from 'lucide-react';
+import { useState } from 'react';
+
+import type { SocialReportReason } from '@/types/social';
+
+export default function SocialReportButton({
+  label,
+  onReport,
+}: {
+  label: string;
+  onReport: (reason: SocialReportReason, details?: string) => Promise<void>;
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState<SocialReportReason>('harassment');
+  const [details, setDetails] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(): Promise<void> {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onReport(reason, details.trim() || undefined);
+      setSubmitted(true);
+      setOpen(false);
+    } catch (reportError) {
+      setError(reportError instanceof Error ? reportError.message : 'Could not submit report.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (submitted) {
+    return (
+      <span role="status" className="text-xs font-medium text-muted-foreground">
+        Report submitted
+      </span>
+    );
+  }
+
+  return (
+    <span className="relative inline-flex">
+      <button
+        type="button"
+        onClick={() => setOpen((visible) => !visible)}
+        aria-expanded={open}
+        className="inline-flex min-h-8 items-center gap-1 rounded-md px-2 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <Flag className="size-3.5" aria-hidden="true" />
+        Report
+      </button>
+      {open ? (
+        <span className="absolute right-0 top-full z-20 mt-1 block w-72 rounded-xl border border-border bg-popover p-3 text-popover-foreground shadow-lg">
+          <span className="block text-sm font-semibold">Report {label}</span>
+          <label className="mt-2 block text-xs font-medium">
+            Reason
+            <select
+              value={reason}
+              onChange={(event) => setReason(event.target.value as SocialReportReason)}
+              className="mt-1 block h-10 w-full rounded-lg border border-border bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <option value="harassment">Harassment</option>
+              <option value="hate">Hateful content</option>
+              <option value="spam">Spam</option>
+              <option value="threats">Threats</option>
+              <option value="unsafe-link">Unsafe link</option>
+              <option value="other">Other</option>
+            </select>
+          </label>
+          {error ? (
+            <span role="alert" className="mt-2 block text-xs font-medium text-destructive">
+              {error}
+            </span>
+          ) : null}
+          <label className="mt-2 block text-xs font-medium">
+            Details (optional)
+            <textarea
+              value={details}
+              onChange={(event) => setDetails(event.target.value)}
+              maxLength={2000}
+              rows={3}
+              className="mt-1 block w-full resize-y rounded-lg border border-border bg-background px-2 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          </label>
+          <span className="mt-3 flex gap-2">
+            <button
+              type="button"
+              disabled={submitting}
+              onClick={() => void submit()}
+              className="inline-flex min-h-9 items-center rounded-lg bg-destructive px-3 text-xs font-semibold text-destructive-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+            >
+              {submitting ? 'Submitting…' : 'Submit report'}
+            </button>
+            <button
+              type="button"
+              disabled={submitting}
+              onClick={() => setOpen(false)}
+              className="inline-flex min-h-9 items-center rounded-lg border border-border px-3 text-xs font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Cancel
+            </button>
+          </span>
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/components/league/social/giphyClient.ts
+++ b/src/components/league/social/giphyClient.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { pingback } from '@giphy/js-analytics';
+import { GiphyFetch } from '@giphy/js-fetch-api';
+
+export type GiphyGif = Awaited<ReturnType<GiphyFetch['gif']>>['data'];
+
+export const GIPHY_WEB_SDK_KEY = process.env.NEXT_PUBLIC_GIPHY_WEB_SDK_KEY?.trim() ?? '';
+
+const clients = new Map<string, GiphyFetch>();
+
+export function getGiphyClient(apiKey = GIPHY_WEB_SDK_KEY): GiphyFetch | null {
+  if (!apiKey) return null;
+
+  const existing = clients.get(apiKey);
+  if (existing) return existing;
+
+  const client = new GiphyFetch(apiKey);
+  clients.set(apiKey, client);
+  return client;
+}
+
+export function registerGiphySent(gif: GiphyGif): void {
+  if (!gif.analytics_response_payload) return;
+
+  try {
+    pingback({
+      analyticsResponsePayload: gif.analytics_response_payload,
+      actionType: 'SENT',
+    });
+  } catch {
+    // Analytics must never turn a successfully persisted chat message into a send error.
+  }
+}

--- a/src/components/league/social/index.ts
+++ b/src/components/league/social/index.ts
@@ -6,5 +6,18 @@ export { default as PostThread } from './PostThread';
 export { default as SocialAuthor } from './SocialAuthor';
 export { default as SocialComposer } from './SocialComposer';
 export { default as SocialDrawer } from './SocialDrawer';
+export { default as LeagueSocialAppProvider } from './LeagueSocialAppProvider';
+export { default as LeagueSocialWidget } from './LeagueSocialWidget';
+export {
+  LeagueSocialWidgetProvider,
+  getLeagueIdFromPathname,
+  resolveLeagueSocialLeagueId,
+  useLeagueSocialWidget,
+} from './LeagueSocialWidgetProvider';
+export type {
+  LeagueSocialWidgetController,
+  LeagueSocialWidgetMode,
+  OpenLeagueSocialWidgetOptions,
+} from './LeagueSocialWidgetProvider';
 export { useLeagueSocial } from './useLeagueSocial';
 export type { LeagueSocialController } from './useLeagueSocial';

--- a/src/components/league/social/index.ts
+++ b/src/components/league/social/index.ts
@@ -1,0 +1,10 @@
+export { default as LeagueChatPanel } from './LeagueChatPanel';
+export { default as LeagueSocialShell } from './LeagueSocialShell';
+export type { LeagueSocialView } from './LeagueSocialShell';
+export { default as MessageBoardPanel } from './MessageBoardPanel';
+export { default as PostThread } from './PostThread';
+export { default as SocialAuthor } from './SocialAuthor';
+export { default as SocialComposer } from './SocialComposer';
+export { default as SocialDrawer } from './SocialDrawer';
+export { useLeagueSocial } from './useLeagueSocial';
+export type { LeagueSocialController } from './useLeagueSocial';

--- a/src/components/league/social/socialColorSystem.test.ts
+++ b/src/components/league/social/socialColorSystem.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(join(process.cwd(), 'src/index.css'), 'utf8');
+
+function readVariableBlock(selector: string): Map<string, string> {
+  const blockStart = css.indexOf(`${selector} {`);
+  if (blockStart < 0) throw new Error(`Missing ${selector} colour block.`);
+  const declarationStart = css.indexOf('{', blockStart) + 1;
+  const declarationEnd = css.indexOf('}', declarationStart);
+  const declarations = css.slice(declarationStart, declarationEnd);
+  return new Map(
+    [...declarations.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/gi)].map((match) => [
+      match[1],
+      match[2].trim(),
+    ])
+  );
+}
+
+const variables = new Map([...readVariableBlock(':root'), ...readVariableBlock('.league-social')]);
+
+function resolveHex(variable: string, visited = new Set<string>()): string {
+  if (visited.has(variable)) throw new Error(`Circular colour token: ${variable}`);
+  const value = variables.get(variable);
+  if (!value) throw new Error(`Missing colour token: ${variable}`);
+  const reference = value.match(/^var\((--[a-z0-9-]+)\)$/i);
+  if (reference) {
+    visited.add(variable);
+    return resolveHex(reference[1], visited);
+  }
+  if (/^#[0-9a-f]{3}$/i.test(value)) {
+    return `#${[...value.slice(1)].map((character) => character.repeat(2)).join('')}`;
+  }
+  if (!/^#[0-9a-f]{6}$/i.test(value)) {
+    throw new Error(`${variable} does not resolve to a six-digit hex colour: ${value}`);
+  }
+  return value;
+}
+
+function relativeLuminance(hex: string): number {
+  const channels = hex
+    .slice(1)
+    .match(/.{2}/g)
+    ?.map((channel) => Number.parseInt(channel, 16) / 255);
+  if (!channels || channels.length !== 3) throw new Error(`Invalid colour: ${hex}`);
+  const [red, green, blue] = channels.map((channel) =>
+    channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+  );
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const foregroundLuminance = relativeLuminance(resolveHex(foreground));
+  const backgroundLuminance = relativeLuminance(resolveHex(background));
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  );
+}
+
+describe('League Social colour system', () => {
+  it.each([
+    ['primary text', '--social-text', '--social-surface', 4.5],
+    ['secondary text', '--social-text-muted', '--social-surface', 4.5],
+    ['action label', '--social-action-foreground', '--social-action', 4.5],
+    ['header title', '--social-brand-foreground', '--social-brand-strong', 4.5],
+    ['header metadata', '--social-header-muted', '--social-brand-strong', 4.5],
+    ['disabled label', '--social-disabled-text', '--social-disabled-bg', 4.5],
+    ['success feedback', '--social-success', '--social-success-soft', 4.5],
+    ['warning feedback', '--social-warning-text', '--social-warning-soft', 4.5],
+    ['error feedback', '--social-error', '--social-error-soft', 4.5],
+    ['error action label', '--social-error-foreground', '--social-error', 4.5],
+    ['mention label', '--social-mention-text', '--social-mention-bg', 4.5],
+    ['focus indicator', '--social-focus', '--social-surface', 3],
+  ])('%s meets its WCAG contrast target', (_label, foreground, background, minimum) => {
+    expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(minimum);
+  });
+
+  it('defines distinct resting, hover, pressed, disabled, loading, and error roles', () => {
+    const requiredTokens = [
+      '--social-action',
+      '--social-action-hover',
+      '--social-action-pressed',
+      '--social-disabled-bg',
+      '--social-disabled-text',
+      '--social-focus',
+      '--social-error',
+      '--social-error-foreground',
+      '--social-error-soft',
+    ];
+
+    requiredTokens.forEach((token) => expect(variables.has(token), token).toBe(true));
+    expect(resolveHex('--social-action-hover')).not.toBe(resolveHex('--social-action'));
+    expect(resolveHex('--social-action-pressed')).not.toBe(resolveHex('--social-action-hover'));
+    expect(resolveHex('--social-disabled-bg')).not.toBe(resolveHex('--social-action'));
+  });
+});

--- a/src/components/league/social/socialComposerDraft.test.ts
+++ b/src/components/league/social/socialComposerDraft.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  SOCIAL_COMPOSER_DRAFT_TTL_MS,
+  createSocialComposerAttemptKey,
+  getSocialComposerDraftKey,
+  readSocialComposerDraft,
+  writeSocialComposerDraft,
+} from './socialComposerDraft';
+
+describe('socialComposerDraft', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('isolates league, draft-room, and contextual drafts', () => {
+    const base = {
+      userId: 'user-1',
+      leagueId: 'league-1',
+      leagueSeasonId: 'season-1',
+    };
+
+    const leagueKey = getSocialComposerDraftKey({
+      ...base,
+      surface: { type: 'league-chat' },
+    });
+    const draftKey = getSocialComposerDraftKey({
+      ...base,
+      surface: { type: 'draft-chat', draftId: 'draft-1' },
+    });
+    const contextualKey = getSocialComposerDraftKey({
+      ...base,
+      surface: { type: 'league-chat' },
+      discussion: { type: 'player', id: 'player-1' },
+    });
+
+    expect(new Set([leagueKey, draftKey, contextualKey]).size).toBe(3);
+  });
+
+  it('round-trips a draft and its stable retry key', () => {
+    writeSocialComposerDraft(
+      localStorage,
+      'composer-key',
+      { value: 'Unfinished message', attemptKey: 'chat:attempt-1' },
+      100
+    );
+
+    expect(readSocialComposerDraft(localStorage, 'composer-key', 200)).toEqual({
+      value: 'Unfinished message',
+      attemptKey: 'chat:attempt-1',
+      updatedAt: 100,
+    });
+  });
+
+  it('expires abandoned drafts and removes empty drafts', () => {
+    writeSocialComposerDraft(localStorage, 'expired', { value: 'Old draft' }, 100);
+    expect(
+      readSocialComposerDraft(localStorage, 'expired', 100 + SOCIAL_COMPOSER_DRAFT_TTL_MS + 1)
+    ).toBeNull();
+    expect(localStorage.getItem('expired')).toBeNull();
+
+    localStorage.setItem('empty', 'stale');
+    writeSocialComposerDraft(localStorage, 'empty', { value: '' });
+    expect(localStorage.getItem('empty')).toBeNull();
+  });
+
+  it('creates server-compatible attempt keys', () => {
+    vi.stubGlobal('crypto', { randomUUID: () => 'attempt-uuid' });
+    expect(createSocialComposerAttemptKey('chat')).toBe('chat:attempt-uuid');
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/components/league/social/socialComposerDraft.ts
+++ b/src/components/league/social/socialComposerDraft.ts
@@ -1,0 +1,114 @@
+export const SOCIAL_COMPOSER_DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1_000;
+
+export type SocialComposerSurface =
+  | { type: 'league-chat' }
+  | { type: 'draft-chat'; draftId: string };
+
+export interface SocialComposerDraftScope {
+  userId: string;
+  leagueId: string;
+  leagueSeasonId: string;
+  surface: SocialComposerSurface;
+  discussion?: { type: string; id: string };
+}
+
+export interface SocialComposerDraftRecord {
+  value: string;
+  attemptKey?: string;
+  updatedAt: number;
+}
+
+interface ComposerDraftStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+}
+
+function keyPart(value: string): string {
+  return encodeURIComponent(value.trim());
+}
+
+export function getSocialComposerDraftKey(scope: SocialComposerDraftScope): string {
+  const surface =
+    scope.surface.type === 'draft-chat'
+      ? `draft-chat:${keyPart(scope.surface.draftId)}`
+      : 'league-chat';
+  const discussion = scope.discussion
+    ? `${keyPart(scope.discussion.type)}:${keyPart(scope.discussion.id)}`
+    : 'general';
+
+  return [
+    'statly',
+    'social-composer',
+    'v1',
+    keyPart(scope.userId),
+    keyPart(scope.leagueId),
+    keyPart(scope.leagueSeasonId),
+    surface,
+    discussion,
+  ].join(':');
+}
+
+export function createSocialComposerAttemptKey(prefix = 'chat'): string {
+  const id =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `${prefix}:${id}`;
+}
+
+export function readSocialComposerDraft(
+  storage: ComposerDraftStorage,
+  key: string,
+  now = Date.now()
+): SocialComposerDraftRecord | null {
+  try {
+    const serialized = storage.getItem(key);
+    if (!serialized) return null;
+    const parsed = JSON.parse(serialized) as Partial<SocialComposerDraftRecord>;
+    if (
+      typeof parsed.value !== 'string' ||
+      typeof parsed.updatedAt !== 'number' ||
+      !Number.isFinite(parsed.updatedAt)
+    ) {
+      storage.removeItem(key);
+      return null;
+    }
+    if (now - parsed.updatedAt > SOCIAL_COMPOSER_DRAFT_TTL_MS) {
+      storage.removeItem(key);
+      return null;
+    }
+    return {
+      value: parsed.value,
+      updatedAt: parsed.updatedAt,
+      ...(typeof parsed.attemptKey === 'string' ? { attemptKey: parsed.attemptKey } : {}),
+    };
+  } catch {
+    storage.removeItem(key);
+    return null;
+  }
+}
+
+export function writeSocialComposerDraft(
+  storage: ComposerDraftStorage,
+  key: string,
+  draft: Pick<SocialComposerDraftRecord, 'value' | 'attemptKey'>,
+  now = Date.now()
+): void {
+  if (!draft.value) {
+    storage.removeItem(key);
+    return;
+  }
+  storage.setItem(
+    key,
+    JSON.stringify({
+      value: draft.value,
+      updatedAt: now,
+      ...(draft.attemptKey ? { attemptKey: draft.attemptKey } : {}),
+    } satisfies SocialComposerDraftRecord)
+  );
+}
+
+export function clearSocialComposerDraft(storage: ComposerDraftStorage, key: string): void {
+  storage.removeItem(key);
+}

--- a/src/components/league/social/useLeagueSocial.test.tsx
+++ b/src/components/league/social/useLeagueSocial.test.tsx
@@ -192,6 +192,7 @@ describe('useLeagueSocial', () => {
       await result.current.sendMessage({
         content: '',
         gif: { provider: 'giphy', id: 'xT9IgG50Fb7Mi0prBC' },
+        idempotencyKey: 'chat:stable-attempt',
       });
     });
 
@@ -202,9 +203,64 @@ describe('useLeagueSocial', () => {
     expect(JSON.parse(String(sendRequest?.[1]?.body))).toEqual({
       content: '',
       gif: { provider: 'giphy', id: 'xT9IgG50Fb7Mi0prBC' },
-      idempotencyKey: expect.stringMatching(/^chat:/),
+      idempotencyKey: 'chat:stable-attempt',
     });
     expect(result.current.messages.at(-1)).toEqual(sentMessage);
+  });
+
+  it('retries the same logical message with one idempotency key and reconciles one result', async () => {
+    const sentMessage: SocialMessage = {
+      ...memberMessage,
+      id: 'message-retry',
+      content: 'Retry this once',
+      author: { ...memberMessage.author!, userId: 'user-1' },
+      isOwn: true,
+    };
+    let sendAttempts = 0;
+    mocks.authenticatedFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.endsWith('/messages') && init?.method === 'POST') {
+        sendAttempts += 1;
+        if (sendAttempts === 1) {
+          return Promise.resolve({
+            ok: false,
+            status: 503,
+            json: vi.fn().mockResolvedValue({
+              success: false,
+              error: 'Connection interrupted',
+            }),
+          } as unknown as Response);
+        }
+        return Promise.resolve(response(sentMessage));
+      }
+      return Promise.resolve(initialResponse(url));
+    });
+
+    const { result } = renderHook(() => useLeagueSocial('league-1', 'user-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const input = {
+      content: 'Retry this once',
+      idempotencyKey: 'chat:one-logical-attempt',
+    };
+
+    await act(async () => {
+      await expect(result.current.sendMessage(input)).rejects.toThrow('Connection interrupted');
+    });
+    expect(result.current.submitError).toBe('Connection interrupted');
+
+    act(() => result.current.clearSubmitError());
+    expect(result.current.submitError).toBeNull();
+
+    await act(async () => {
+      await result.current.sendMessage(input);
+    });
+
+    const sendBodies = mocks.authenticatedFetch.mock.calls
+      .filter(([url, init]) => String(url).endsWith('/messages') && init?.method === 'POST')
+      .map(([, init]) => JSON.parse(String(init?.body)));
+    expect(sendBodies).toEqual([input, input]);
+    expect(result.current.messages.filter((message) => message.id === sentMessage.id)).toHaveLength(
+      1
+    );
   });
 
   it('does not let a stale cross-device read event clear newer unread content', async () => {

--- a/src/components/league/social/useLeagueSocial.test.tsx
+++ b/src/components/league/social/useLeagueSocial.test.tsx
@@ -169,6 +169,44 @@ describe('useLeagueSocial', () => {
     expect(mocks.socket.emit).toHaveBeenCalledWith('social:leave', { leagueId: 'league-1' });
   });
 
+  it('posts and reconciles a structured GIF-only chat message', async () => {
+    const sentMessage: SocialMessage = {
+      ...memberMessage,
+      id: 'message-giphy',
+      content: '',
+      gif: { provider: 'giphy', id: 'xT9IgG50Fb7Mi0prBC' },
+      author: { ...memberMessage.author!, userId: 'user-1' },
+      isOwn: true,
+    };
+    mocks.authenticatedFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.endsWith('/messages') && init?.method === 'POST') {
+        return Promise.resolve(response(sentMessage));
+      }
+      return Promise.resolve(initialResponse(url));
+    });
+
+    const { result } = renderHook(() => useLeagueSocial('league-1', 'user-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.sendMessage({
+        content: '',
+        gif: { provider: 'giphy', id: 'xT9IgG50Fb7Mi0prBC' },
+      });
+    });
+
+    const sendRequest = mocks.authenticatedFetch.mock.calls.find(
+      ([url, init]) => String(url).endsWith('/messages') && init?.method === 'POST'
+    );
+    expect(sendRequest).toBeDefined();
+    expect(JSON.parse(String(sendRequest?.[1]?.body))).toEqual({
+      content: '',
+      gif: { provider: 'giphy', id: 'xT9IgG50Fb7Mi0prBC' },
+      idempotencyKey: expect.stringMatching(/^chat:/),
+    });
+    expect(result.current.messages.at(-1)).toEqual(sentMessage);
+  });
+
   it('does not let a stale cross-device read event clear newer unread content', async () => {
     const { result } = renderHook(() => useLeagueSocial('league-1', 'user-1'));
     await waitFor(() => expect(result.current.loading).toBe(false));

--- a/src/components/league/social/useLeagueSocial.test.tsx
+++ b/src/components/league/social/useLeagueSocial.test.tsx
@@ -1,0 +1,414 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  LeagueSocialSummary,
+  SocialMessage,
+  SocialPost,
+  SocialRealtimeEnvelope,
+} from '@/types/social';
+
+import { useLeagueSocial } from './useLeagueSocial';
+
+const mocks = vi.hoisted(() => {
+  const handlers = new Map<string, (value?: unknown) => void>();
+  return {
+    handlers,
+    socket: {
+      connected: false,
+      emit: vi.fn(),
+      on: vi.fn((event: string, handler: (value?: unknown) => void) => {
+        handlers.set(event, handler);
+      }),
+      off: vi.fn((event: string) => {
+        handlers.delete(event);
+      }),
+    },
+    authenticatedFetch: vi.fn(),
+  };
+});
+
+vi.mock('@/contexts/SocketContext', () => ({
+  useSocket: () => mocks.socket,
+}));
+
+vi.mock('@/lib/authenticatedFetch', () => ({
+  authenticatedFetch: mocks.authenticatedFetch,
+}));
+
+const summary: LeagueSocialSummary = {
+  leagueId: 'league-1',
+  seasonId: 'season-1',
+  canManage: false,
+  canPublish: true,
+  standardsAccepted: true,
+  mutedUntil: null,
+  unread: { chat: 1, board: 0, activity: 0 },
+  latestSequence: { chat: 10, board: 0, activity: 0 },
+  preferences: {
+    chatInApp: true,
+    boardPosts: false,
+    ownPostReplies: true,
+    announcements: true,
+    tradeDiscussions: false,
+    mentions: true,
+    systemActivityInApp: true,
+  },
+  categories: [],
+};
+
+const memberMessage: SocialMessage = {
+  id: 'message-1',
+  leagueId: 'league-1',
+  seasonId: 'season-1',
+  type: 'member',
+  content: 'Member message',
+  author: {
+    userId: 'user-2',
+    displayName: 'Other Member',
+    teamName: 'Other Team',
+  },
+  createdAt: '2026-07-19T10:00:00.000Z',
+  moderationStatus: 'active',
+  isOwn: false,
+};
+
+const systemActivity: SocialMessage = {
+  ...memberMessage,
+  id: 'activity-1',
+  type: 'system',
+  content: 'Player drafted',
+  author: null,
+};
+
+function response<T>(data: T): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue({ success: true, data }),
+  } as unknown as Response;
+}
+
+function initialResponse(url: string): Response {
+  if (url.endsWith('/summary')) return response(summary);
+  if (url.includes('/messages?')) {
+    return response({ items: [memberMessage, systemActivity], nextCursor: null });
+  }
+  if (url.includes('/activity?')) {
+    return response({ items: [systemActivity, memberMessage], nextCursor: 'activity-cursor' });
+  }
+  if (url.includes('/posts?')) return response({ items: [], nextCursor: null });
+  throw new Error(`Unexpected request: ${url}`);
+}
+
+function envelope(
+  event: SocialRealtimeEnvelope['event'],
+  channel: SocialRealtimeEnvelope['channel'],
+  sequence: number,
+  payload: SocialRealtimeEnvelope['payload']
+): SocialRealtimeEnvelope {
+  return {
+    id: `event-${sequence}`,
+    sequence,
+    leagueId: 'league-1',
+    seasonId: 'season-1',
+    channel,
+    event,
+    payload,
+    occurredAt: '2026-07-19T10:01:00.000Z',
+  };
+}
+
+describe('useLeagueSocial', () => {
+  beforeEach(() => {
+    mocks.handlers.clear();
+    mocks.socket.emit.mockReset();
+    mocks.socket.emit.mockImplementation(
+      (event: string, _payload: unknown, acknowledge?: (result: { ok: boolean }) => void) => {
+        if (event === 'social:join') acknowledge?.({ ok: true });
+      }
+    );
+    mocks.socket.on.mockClear();
+    mocks.socket.off.mockClear();
+    mocks.authenticatedFetch.mockReset();
+    mocks.authenticatedFetch.mockImplementation((url: string) =>
+      Promise.resolve(initialResponse(url))
+    );
+  });
+
+  it('keeps member chat and system activity separate while receiving both in realtime', async () => {
+    const { result, unmount } = renderHook(() => useLeagueSocial('league-1', 'user-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.messages.map((item) => item.id)).toEqual(['message-1']);
+    expect(result.current.activity.map((item) => item.id)).toEqual(['activity-1']);
+    expect(result.current.activityCursor).toBe('activity-cursor');
+    expect(mocks.socket.emit).toHaveBeenCalledWith(
+      'social:join',
+      { leagueId: 'league-1' },
+      expect.any(Function)
+    );
+
+    act(() => {
+      mocks.handlers.get('social:message')?.(
+        envelope('social:message', 'chat', 11, { ...memberMessage, id: 'message-2' })
+      );
+      mocks.handlers.get('social:activity')?.(
+        envelope('social:activity', 'activity', 12, {
+          ...systemActivity,
+          id: 'activity-2',
+        })
+      );
+    });
+
+    expect(result.current.messages.map((item) => item.id)).toEqual(['message-1', 'message-2']);
+    expect(result.current.activity.map((item) => item.id)).toEqual(['activity-1', 'activity-2']);
+    expect(result.current.summary?.unread).toEqual({ chat: 2, board: 0, activity: 1 });
+
+    unmount();
+    expect(mocks.socket.emit).toHaveBeenCalledWith('social:leave', { leagueId: 'league-1' });
+  });
+
+  it('does not let a stale cross-device read event clear newer unread content', async () => {
+    const { result } = renderHook(() => useLeagueSocial('league-1', 'user-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      mocks.handlers.get('social:message')?.(
+        envelope('social:message', 'chat', 11, { ...memberMessage, id: 'message-2' })
+      );
+      mocks.handlers.get('social:read-state')?.(
+        envelope('social:read-state', 'chat', 12, {
+          userId: 'user-1',
+          channel: 'chat',
+          sequence: 10,
+        })
+      );
+    });
+
+    expect(result.current.summary?.latestSequence.chat).toBe(11);
+    expect(result.current.summary?.unread.chat).toBe(2);
+  });
+
+  it('preserves unread content that arrives while an older read request is in flight', async () => {
+    let resolveReadRequest: ((value: Response) => void) | undefined;
+    mocks.authenticatedFetch.mockImplementation((url: string) => {
+      if (url.endsWith('/read-state')) {
+        return new Promise<Response>((resolve) => {
+          resolveReadRequest = resolve;
+        });
+      }
+      return Promise.resolve(initialResponse(url));
+    });
+
+    const { result } = renderHook(() => useLeagueSocial('league-1', 'user-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let readPromise: Promise<void> | undefined;
+    act(() => {
+      readPromise = result.current.markRead('chat');
+    });
+    await waitFor(() => expect(result.current.summary?.unread.chat).toBe(0));
+
+    act(() => {
+      mocks.handlers.get('social:message')?.(
+        envelope('social:message', 'chat', 11, { ...memberMessage, id: 'message-2' })
+      );
+      resolveReadRequest?.(response({ channel: 'chat', sequence: 10 }));
+    });
+    await act(async () => {
+      await readPromise;
+    });
+
+    expect(result.current.summary?.latestSequence.chat).toBe(11);
+    expect(result.current.summary?.unread.chat).toBe(1);
+  });
+
+  it('coalesces visibility restoration with the reconnect catch-up resync', async () => {
+    const { result } = renderHook(() => useLeagueSocial('league-1', 'user-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mocks.authenticatedFetch).toHaveBeenCalledTimes(8);
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    });
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      mocks.handlers.get('connect')?.();
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mocks.authenticatedFetch).toHaveBeenCalledTimes(12);
+    expect(mocks.socket.emit).toHaveBeenLastCalledWith(
+      'social:join',
+      {
+        leagueId: 'league-1',
+      },
+      expect.any(Function)
+    );
+  });
+
+  it('loads authorized REST content while the socket is disconnected', async () => {
+    mocks.socket.emit.mockImplementation(() => undefined);
+
+    const { result, unmount } = renderHook(() => useLeagueSocial('league-1', 'user-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mocks.authenticatedFetch).toHaveBeenCalledTimes(4);
+    expect(result.current.messages.map((message) => message.id)).toEqual(['message-1']);
+    expect(result.current.activity.map((message) => message.id)).toEqual(['activity-1']);
+    expect(result.current.error).toBeNull();
+    unmount();
+  });
+
+  it('always starts a trailing snapshot after join acknowledgement', async () => {
+    let acknowledgeJoin: ((result: { ok: boolean }) => void) | undefined;
+    const pendingRequests: Array<{
+      url: string;
+      resolve: (value: Response) => void;
+    }> = [];
+    mocks.socket.emit.mockImplementation(
+      (event: string, _payload: unknown, acknowledge?: (result: { ok: boolean }) => void) => {
+        if (event === 'social:join') acknowledgeJoin = acknowledge;
+      }
+    );
+    mocks.authenticatedFetch.mockImplementation(
+      (url: string) =>
+        new Promise<Response>((resolve) => {
+          pendingRequests.push({ url, resolve });
+        })
+    );
+
+    const { result } = renderHook(() => useLeagueSocial('league-1', 'user-1'));
+    await waitFor(() => expect(pendingRequests).toHaveLength(4));
+    await waitFor(() => expect(acknowledgeJoin).toBeTypeOf('function'));
+
+    act(() => acknowledgeJoin?.({ ok: true }));
+    expect(pendingRequests).toHaveLength(4);
+
+    act(() => {
+      pendingRequests.slice(0, 4).forEach(({ url, resolve }) => resolve(initialResponse(url)));
+    });
+    await waitFor(() => expect(pendingRequests).toHaveLength(8));
+
+    act(() => {
+      pendingRequests.slice(4, 8).forEach(({ url, resolve }) => resolve(initialResponse(url)));
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mocks.authenticatedFetch).toHaveBeenCalledTimes(8);
+  });
+
+  it('waits for successful room authorization before reconnect catch-up resync', async () => {
+    let acknowledgeJoin: ((result: { ok: boolean }) => void) | undefined;
+    mocks.socket.emit.mockImplementation(
+      (event: string, _payload: unknown, acknowledge?: (result: { ok: boolean }) => void) => {
+        if (event === 'social:join') acknowledgeJoin = acknowledge;
+      }
+    );
+
+    const { result } = renderHook(() => useLeagueSocial('league-1', 'user-1'));
+    await waitFor(() => expect(acknowledgeJoin).toBeTypeOf('function'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mocks.authenticatedFetch).toHaveBeenCalledTimes(4);
+
+    act(() => acknowledgeJoin?.({ ok: false }));
+    await waitFor(() =>
+      expect(result.current.error).toBe('League social realtime authorization failed.')
+    );
+    expect(mocks.authenticatedFetch).toHaveBeenCalledTimes(4);
+
+    acknowledgeJoin = undefined;
+    act(() => {
+      void mocks.handlers.get('connect')?.();
+    });
+    await waitFor(() => expect(acknowledgeJoin).toBeTypeOf('function'));
+    expect(mocks.authenticatedFetch).toHaveBeenCalledTimes(4);
+    act(() => acknowledgeJoin?.({ ok: true }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mocks.authenticatedFetch).toHaveBeenCalledTimes(8);
+  });
+
+  it('reconciles stale reconnect snapshots with realtime events received during resync', async () => {
+    const { result } = renderHook(() => useLeagueSocial('league-1', 'user-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const pendingRequests: Array<{
+      url: string;
+      resolve: (value: Response) => void;
+    }> = [];
+    mocks.authenticatedFetch.mockImplementation(
+      (url: string) =>
+        new Promise<Response>((resolve) => {
+          pendingRequests.push({ url, resolve });
+        })
+    );
+
+    act(() => {
+      void mocks.handlers.get('connect')?.();
+    });
+    await waitFor(() => expect(pendingRequests).toHaveLength(4));
+
+    const realtimePost: SocialPost = {
+      id: 'post-realtime',
+      leagueId: 'league-1',
+      seasonId: 'season-1',
+      category: { id: 'category-1', key: 'general', name: 'General', position: 1 },
+      author: {
+        userId: 'user-2',
+        displayName: 'Other Member',
+        teamName: 'Other Team',
+      },
+      title: 'Realtime post',
+      body: 'Arrived while snapshots were loading.',
+      isPinned: false,
+      isLocked: false,
+      isAnnouncement: false,
+      replyCount: 0,
+      latestActivityAt: '2026-07-19T10:03:00.000Z',
+      createdAt: '2026-07-19T10:03:00.000Z',
+      updatedAt: '2026-07-19T10:03:00.000Z',
+      moderationStatus: 'active',
+      isOwn: false,
+    };
+    act(() => {
+      mocks.handlers.get('social:message')?.(
+        envelope('social:message', 'chat', 11, {
+          ...memberMessage,
+          content: 'Realtime version',
+        })
+      );
+      mocks.handlers.get('social:activity')?.(
+        envelope('social:activity', 'activity', 12, {
+          ...systemActivity,
+          content: 'Realtime activity version',
+        })
+      );
+      mocks.handlers.get('social:post')?.(envelope('social:post', 'board', 13, realtimePost));
+      pendingRequests.forEach(({ url, resolve }) => resolve(initialResponse(url)));
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.messages).toEqual([
+      expect.objectContaining({ id: 'message-1', content: 'Realtime version' }),
+    ]);
+    expect(result.current.activity).toEqual([
+      expect.objectContaining({
+        id: 'activity-1',
+        content: 'Realtime activity version',
+      }),
+    ]);
+    expect(result.current.posts).toEqual([expect.objectContaining({ id: 'post-realtime' })]);
+    expect(result.current.summary?.latestSequence).toEqual({
+      chat: 11,
+      activity: 12,
+      board: 13,
+    });
+    expect(result.current.summary?.unread).toEqual({
+      chat: 2,
+      activity: 1,
+      board: 1,
+    });
+  });
+});

--- a/src/components/league/social/useLeagueSocial.ts
+++ b/src/components/league/social/useLeagueSocial.ts
@@ -11,7 +11,6 @@ import type {
   LeagueSocialSummary,
   SocialChannel,
   SocialCursorPage,
-  SocialDiscussionContext,
   SocialMessage,
   SocialNotificationPreferences,
   SocialPost,
@@ -200,7 +199,7 @@ export interface LeagueSocialController extends LeagueSocialState {
   loadEarlierMessages: () => Promise<void>;
   loadEarlierActivity: () => Promise<void>;
   loadMorePosts: () => Promise<void>;
-  sendMessage: (content: string, context?: SocialDiscussionContext | null) => Promise<void>;
+  sendMessage: (input: Omit<CreateSocialMessageInput, 'idempotencyKey'>) => Promise<void>;
   createPost: (input: Omit<CreateSocialPostInput, 'idempotencyKey'>) => Promise<SocialPost>;
   updatePost: (
     postId: string,
@@ -595,13 +594,12 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
   }, [apiRequest, postSort, state.loadingMorePosts, state.postsCursor]);
 
   const sendMessage = useCallback(
-    async (content: string, context?: SocialDiscussionContext | null): Promise<void> => {
+    async (messageInput: Omit<CreateSocialMessageInput, 'idempotencyKey'>): Promise<void> => {
       setState((current) => ({ ...current, sendingMessage: true, submitError: null }));
       try {
         const input: CreateSocialMessageInput = {
-          content,
+          ...messageInput,
           idempotencyKey: createIdempotencyKey('chat'),
-          ...(context ? { context } : {}),
         };
         const message = await apiRequest<SocialMessage>('/messages', {
           method: 'POST',

--- a/src/components/league/social/useLeagueSocial.ts
+++ b/src/components/league/social/useLeagueSocial.ts
@@ -195,11 +195,12 @@ function updateRealtimeSummary(
 }
 
 export interface LeagueSocialController extends LeagueSocialState {
+  clearSubmitError: () => void;
   retry: () => Promise<void>;
   loadEarlierMessages: () => Promise<void>;
   loadEarlierActivity: () => Promise<void>;
   loadMorePosts: () => Promise<void>;
-  sendMessage: (input: Omit<CreateSocialMessageInput, 'idempotencyKey'>) => Promise<void>;
+  sendMessage: (input: CreateSocialMessageInput) => Promise<void>;
   createPost: (input: Omit<CreateSocialPostInput, 'idempotencyKey'>) => Promise<SocialPost>;
   updatePost: (
     postId: string,
@@ -222,7 +223,7 @@ export interface LeagueSocialController extends LeagueSocialState {
     reason: string
   ) => Promise<void>;
   loadReplies: (postId: string, loadMore?: boolean) => Promise<void>;
-  createReply: (postId: string, body: string) => Promise<void>;
+  createReply: (postId: string, body: string, idempotencyKey: string) => Promise<void>;
   markRead: (channel: SocialChannel) => Promise<void>;
   postSort: SocialPostSort;
   setPostSort: (sort: SocialPostSort) => void;
@@ -243,6 +244,12 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
     },
     [basePath, currentUserId]
   );
+
+  const clearSubmitError = useCallback((): void => {
+    setState((current) =>
+      current.submitError === null ? current : { ...current, submitError: null }
+    );
+  }, []);
 
   const loadSummary = useCallback(async (): Promise<void> => {
     const summary = await apiRequest<LeagueSocialSummary>('/summary');
@@ -594,13 +601,9 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
   }, [apiRequest, postSort, state.loadingMorePosts, state.postsCursor]);
 
   const sendMessage = useCallback(
-    async (messageInput: Omit<CreateSocialMessageInput, 'idempotencyKey'>): Promise<void> => {
+    async (input: CreateSocialMessageInput): Promise<void> => {
       setState((current) => ({ ...current, sendingMessage: true, submitError: null }));
       try {
-        const input: CreateSocialMessageInput = {
-          ...messageInput,
-          idempotencyKey: createIdempotencyKey('chat'),
-        };
         const message = await apiRequest<SocialMessage>('/messages', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -842,12 +845,12 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
   );
 
   const createReply = useCallback(
-    async (postId: string, body: string): Promise<void> => {
+    async (postId: string, body: string, idempotencyKey: string): Promise<void> => {
       setState((current) => ({ ...current, submitError: null }));
       try {
         const input: CreateSocialReplyInput = {
           body,
-          idempotencyKey: createIdempotencyKey('reply'),
+          idempotencyKey,
         };
         const reply = await apiRequest<SocialReply>(
           `/posts/${encodeURIComponent(postId)}/replies`,
@@ -940,6 +943,7 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
 
   return {
     ...state,
+    clearSubmitError,
     retry: loadInitial,
     loadEarlierMessages,
     loadEarlierActivity,

--- a/src/components/league/social/useLeagueSocial.ts
+++ b/src/components/league/social/useLeagueSocial.ts
@@ -1,0 +1,732 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useSocket } from '@/contexts/SocketContext';
+import { authenticatedFetch } from '@/lib/authenticatedFetch';
+import type {
+  CreateSocialMessageInput,
+  CreateSocialPostInput,
+  CreateSocialReplyInput,
+  LeagueSocialSummary,
+  SocialChannel,
+  SocialCursorPage,
+  SocialMessage,
+  SocialNotificationPreferences,
+  SocialPost,
+  SocialPostThread,
+  SocialRealtimeEnvelope,
+  SocialReportReason,
+  SocialReply,
+} from '@/types/social';
+
+type ThreadState = SocialCursorPage<SocialReply> & {
+  loading: boolean;
+  error: string | null;
+};
+
+export type SocialPostSort = 'latestActivity' | 'createdAt';
+
+interface LeagueSocialState {
+  summary: LeagueSocialSummary | null;
+  messages: SocialMessage[];
+  posts: SocialPost[];
+  threads: Record<string, ThreadState>;
+  messagesCursor: string | null;
+  postsCursor: string | null;
+  loading: boolean;
+  loadingEarlierMessages: boolean;
+  loadingMorePosts: boolean;
+  sendingMessage: boolean;
+  creatingPost: boolean;
+  error: string | null;
+  submitError: string | null;
+}
+
+const initialState: LeagueSocialState = {
+  summary: null,
+  messages: [],
+  posts: [],
+  threads: {},
+  messagesCursor: null,
+  postsCursor: null,
+  loading: true,
+  loadingEarlierMessages: false,
+  loadingMorePosts: false,
+  sendingMessage: false,
+  creatingPost: false,
+  error: null,
+  submitError: null,
+};
+
+function createIdempotencyKey(prefix: string): string {
+  const id =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `${prefix}:${id}`;
+}
+
+async function readApiData<T>(response: Response): Promise<T> {
+  const body = (await response.json().catch(() => null)) as {
+    success?: boolean;
+    data?: T;
+    error?: string | { message?: string };
+  } | null;
+
+  if (!response.ok || body?.success !== true || body.data === undefined) {
+    const errorMessage =
+      typeof body?.error === 'string'
+        ? body.error
+        : body?.error?.message || `Request failed (${response.status})`;
+    throw new Error(errorMessage);
+  }
+
+  return body.data;
+}
+
+function sortMessages(messages: SocialMessage[]): SocialMessage[] {
+  return [...messages].sort(
+    (left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime()
+  );
+}
+
+function sortPosts(posts: SocialPost[]): SocialPost[] {
+  return [...posts].sort((left, right) => {
+    if (left.isPinned !== right.isPinned) return left.isPinned ? -1 : 1;
+    return new Date(right.latestActivityAt).getTime() - new Date(left.latestActivityAt).getTime();
+  });
+}
+
+function upsertById<T extends { id: string }>(items: T[], item: T): T[] {
+  return [...items.filter((candidate) => candidate.id !== item.id), item];
+}
+
+function getRealtimePayload<T>(value: T | SocialRealtimeEnvelope, leagueId: string): T | null {
+  if (!value || typeof value !== 'object') return null;
+  if ('leagueId' in value && value.leagueId !== leagueId) return null;
+  if ('payload' in value && 'event' in value) return value.payload as T;
+  return value as T;
+}
+
+function getRealtimeSequence(
+  value: SocialMessage | SocialPost | SocialReply | SocialRealtimeEnvelope
+): number | null {
+  return 'sequence' in value && Number.isInteger(value.sequence) ? value.sequence : null;
+}
+
+function updateRealtimeSummary(
+  summary: LeagueSocialSummary | null,
+  channel: SocialChannel,
+  sequence: number | null,
+  isOwn: boolean
+): LeagueSocialSummary | null {
+  if (!summary || sequence === null || sequence <= summary.latestSequence[channel]) {
+    return summary;
+  }
+
+  return {
+    ...summary,
+    latestSequence: {
+      ...summary.latestSequence,
+      [channel]: sequence,
+    },
+    unread: {
+      ...summary.unread,
+      [channel]: isOwn ? summary.unread[channel] : summary.unread[channel] + 1,
+    },
+  };
+}
+
+export interface LeagueSocialController extends LeagueSocialState {
+  retry: () => Promise<void>;
+  loadEarlierMessages: () => Promise<void>;
+  loadMorePosts: () => Promise<void>;
+  sendMessage: (content: string) => Promise<void>;
+  createPost: (input: Omit<CreateSocialPostInput, 'idempotencyKey'>) => Promise<SocialPost>;
+  updatePost: (
+    postId: string,
+    input: { isPinned?: boolean; isLocked?: boolean }
+  ) => Promise<SocialPost>;
+  deletePost: (postId: string) => Promise<SocialPost>;
+  updatePreferences: (
+    preferences: SocialNotificationPreferences
+  ) => Promise<SocialNotificationPreferences>;
+  acceptStandards: () => Promise<void>;
+  reportContent: (
+    contentType: 'message' | 'post' | 'reply',
+    contentId: string,
+    reason: SocialReportReason,
+    details?: string
+  ) => Promise<void>;
+  moderateContent: (
+    contentType: 'message' | 'post' | 'reply',
+    contentId: string,
+    reason: string
+  ) => Promise<void>;
+  loadReplies: (postId: string, loadMore?: boolean) => Promise<void>;
+  createReply: (postId: string, body: string) => Promise<void>;
+  markRead: (channel: SocialChannel) => Promise<void>;
+  postSort: SocialPostSort;
+  setPostSort: (sort: SocialPostSort) => void;
+}
+
+export function useLeagueSocial(leagueId: string, currentUserId?: string): LeagueSocialController {
+  const socket = useSocket();
+  const [state, setState] = useState<LeagueSocialState>(initialState);
+  const [postSort, setPostSort] = useState<SocialPostSort>('latestActivity');
+  const basePath = useMemo(() => `/api/leagues/${encodeURIComponent(leagueId)}/social`, [leagueId]);
+
+  const apiRequest = useCallback(
+    async <T>(path: string, init: RequestInit = {}): Promise<T> => {
+      const response = await authenticatedFetch(`${basePath}${path}`, init, currentUserId);
+      return readApiData<T>(response);
+    },
+    [basePath, currentUserId]
+  );
+
+  const loadInitial = useCallback(async (): Promise<void> => {
+    setState((current) => ({ ...current, loading: true, error: null }));
+    try {
+      const [summary, messagePage, postPage] = await Promise.all([
+        apiRequest<LeagueSocialSummary>('/summary'),
+        apiRequest<SocialCursorPage<SocialMessage>>('/messages?limit=50'),
+        apiRequest<SocialCursorPage<SocialPost>>(`/posts?limit=30&sort=${postSort}`),
+      ]);
+      setState((current) => ({
+        ...current,
+        summary,
+        messages: sortMessages(messagePage.items),
+        posts: sortPosts(postPage.items),
+        messagesCursor: messagePage.nextCursor,
+        postsCursor: postPage.nextCursor,
+        loading: false,
+        error: null,
+      }));
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        loading: false,
+        error: error instanceof Error ? error.message : 'Failed to load league social activity.',
+      }));
+    }
+  }, [apiRequest, postSort]);
+
+  useEffect(() => {
+    void loadInitial();
+  }, [loadInitial]);
+
+  useEffect(() => {
+    if (!socket || !leagueId) return;
+
+    const joinLeagueSocial = () => {
+      socket.emit('social:join', { leagueId });
+    };
+    joinLeagueSocial();
+    socket.on('connect', joinLeagueSocial);
+
+    const handleMessage = (value: SocialMessage | SocialRealtimeEnvelope) => {
+      const payload = getRealtimePayload<SocialMessage>(value, leagueId);
+      if (!payload?.id || !payload.createdAt) return;
+      const sequence = getRealtimeSequence(value);
+      const isOwn = Boolean(currentUserId && payload.author?.userId === currentUserId);
+      const message = { ...payload, isOwn };
+      setState((current) => ({
+        ...current,
+        summary: updateRealtimeSummary(current.summary, 'chat', sequence, isOwn),
+        messages: sortMessages(upsertById(current.messages, message)),
+      }));
+    };
+    const handlePost = (value: SocialPost | SocialRealtimeEnvelope) => {
+      const payload = getRealtimePayload<SocialPost>(value, leagueId);
+      if (!payload?.id || !payload.latestActivityAt) return;
+      const sequence = getRealtimeSequence(value);
+      const isOwn = Boolean(currentUserId && payload.author?.userId === currentUserId);
+      const post = { ...payload, isOwn };
+      setState((current) => ({
+        ...current,
+        summary: updateRealtimeSummary(current.summary, 'board', sequence, isOwn),
+        posts: sortPosts(upsertById(current.posts, post)),
+      }));
+    };
+    const handleReply = (value: SocialReply | SocialRealtimeEnvelope) => {
+      const payload = getRealtimePayload<SocialReply>(value, leagueId);
+      if (!payload?.id || !payload.postId) return;
+      const sequence = getRealtimeSequence(value);
+      const isOwn = Boolean(currentUserId && payload.author?.userId === currentUserId);
+      const reply = { ...payload, isOwn };
+      setState((current) => {
+        const thread = current.threads[reply.postId];
+        const replyAlreadyLoaded = Boolean(
+          thread?.items.some((candidate) => candidate.id === reply.id)
+        );
+        return {
+          ...current,
+          summary: updateRealtimeSummary(current.summary, 'board', sequence, isOwn),
+          threads: thread
+            ? {
+                ...current.threads,
+                [reply.postId]: {
+                  ...thread,
+                  items: upsertById(thread.items, reply),
+                },
+              }
+            : current.threads,
+          posts: current.posts.map((post) =>
+            post.id === reply.postId
+              ? {
+                  ...post,
+                  replyCount: replyAlreadyLoaded ? post.replyCount : post.replyCount + 1,
+                  latestActivityAt: reply.createdAt,
+                }
+              : post
+          ),
+        };
+      });
+    };
+    const handleModeration = () => {
+      void loadInitial();
+    };
+    const handleReadState = (value: SocialRealtimeEnvelope) => {
+      const readState = getRealtimePayload<{
+        userId: string;
+        channel: SocialChannel;
+        sequence: number;
+      }>(value, leagueId);
+      if (!readState || readState.userId !== currentUserId) return;
+      setState((current) => ({
+        ...current,
+        summary: current.summary
+          ? {
+              ...current.summary,
+              unread: {
+                ...current.summary.unread,
+                [readState.channel]: 0,
+              },
+            }
+          : current.summary,
+      }));
+    };
+
+    socket.on('social:message', handleMessage);
+    socket.on('social:post', handlePost);
+    socket.on('social:reply', handleReply);
+    socket.on('social:moderation', handleModeration);
+    socket.on('social:read-state', handleReadState);
+
+    return () => {
+      socket.off('connect', joinLeagueSocial);
+      socket.off('social:message', handleMessage);
+      socket.off('social:post', handlePost);
+      socket.off('social:reply', handleReply);
+      socket.off('social:moderation', handleModeration);
+      socket.off('social:read-state', handleReadState);
+      socket.emit('social:leave', { leagueId });
+    };
+  }, [currentUserId, leagueId, loadInitial, socket]);
+
+  const loadEarlierMessages = useCallback(async (): Promise<void> => {
+    if (!state.messagesCursor || state.loadingEarlierMessages) return;
+    setState((current) => ({ ...current, loadingEarlierMessages: true }));
+    try {
+      const page = await apiRequest<SocialCursorPage<SocialMessage>>(
+        `/messages?limit=50&cursor=${encodeURIComponent(state.messagesCursor)}`
+      );
+      setState((current) => ({
+        ...current,
+        messages: sortMessages([
+          ...page.items,
+          ...current.messages.filter(
+            (message) => !page.items.some((candidate) => candidate.id === message.id)
+          ),
+        ]),
+        messagesCursor: page.nextCursor,
+        loadingEarlierMessages: false,
+      }));
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        loadingEarlierMessages: false,
+        error: error instanceof Error ? error.message : 'Failed to load earlier messages.',
+      }));
+    }
+  }, [apiRequest, state.loadingEarlierMessages, state.messagesCursor]);
+
+  const loadMorePosts = useCallback(async (): Promise<void> => {
+    if (!state.postsCursor || state.loadingMorePosts) return;
+    setState((current) => ({ ...current, loadingMorePosts: true }));
+    try {
+      const page = await apiRequest<SocialCursorPage<SocialPost>>(
+        `/posts?limit=30&sort=${postSort}&cursor=${encodeURIComponent(state.postsCursor)}`
+      );
+      setState((current) => ({
+        ...current,
+        posts: sortPosts([
+          ...current.posts,
+          ...page.items.filter(
+            (post) => !current.posts.some((candidate) => candidate.id === post.id)
+          ),
+        ]),
+        postsCursor: page.nextCursor,
+        loadingMorePosts: false,
+      }));
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        loadingMorePosts: false,
+        error: error instanceof Error ? error.message : 'Failed to load more posts.',
+      }));
+    }
+  }, [apiRequest, postSort, state.loadingMorePosts, state.postsCursor]);
+
+  const sendMessage = useCallback(
+    async (content: string): Promise<void> => {
+      setState((current) => ({ ...current, sendingMessage: true, submitError: null }));
+      try {
+        const input: CreateSocialMessageInput = {
+          content,
+          idempotencyKey: createIdempotencyKey('chat'),
+        };
+        const message = await apiRequest<SocialMessage>('/messages', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        });
+        setState((current) => ({
+          ...current,
+          messages: sortMessages(upsertById(current.messages, message)),
+          sendingMessage: false,
+        }));
+      } catch (error) {
+        setState((current) => ({
+          ...current,
+          sendingMessage: false,
+          submitError: error instanceof Error ? error.message : 'Failed to send message.',
+        }));
+        throw error;
+      }
+    },
+    [apiRequest]
+  );
+
+  const createPost = useCallback(
+    async (input: Omit<CreateSocialPostInput, 'idempotencyKey'>): Promise<SocialPost> => {
+      setState((current) => ({ ...current, creatingPost: true, submitError: null }));
+      try {
+        const post = await apiRequest<SocialPost>('/posts', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...input,
+            idempotencyKey: createIdempotencyKey('post'),
+          } satisfies CreateSocialPostInput),
+        });
+        setState((current) => ({
+          ...current,
+          posts: sortPosts(upsertById(current.posts, post)),
+          creatingPost: false,
+        }));
+        return post;
+      } catch (error) {
+        setState((current) => ({
+          ...current,
+          creatingPost: false,
+          submitError: error instanceof Error ? error.message : 'Failed to create post.',
+        }));
+        throw error;
+      }
+    },
+    [apiRequest]
+  );
+
+  const updatePost = useCallback(
+    async (
+      postId: string,
+      input: { isPinned?: boolean; isLocked?: boolean }
+    ): Promise<SocialPost> => {
+      const post = await apiRequest<SocialPost>(`/posts/${encodeURIComponent(postId)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+      setState((current) => ({
+        ...current,
+        posts: sortPosts(upsertById(current.posts, post)),
+      }));
+      return post;
+    },
+    [apiRequest]
+  );
+
+  const deletePost = useCallback(
+    async (postId: string): Promise<SocialPost> => {
+      const post = await apiRequest<SocialPost>(`/posts/${encodeURIComponent(postId)}`, {
+        method: 'DELETE',
+      });
+      setState((current) => ({
+        ...current,
+        posts: sortPosts(upsertById(current.posts, post)),
+      }));
+      return post;
+    },
+    [apiRequest]
+  );
+
+  const updatePreferences = useCallback(
+    async (preferences: SocialNotificationPreferences): Promise<SocialNotificationPreferences> => {
+      const updated = await apiRequest<SocialNotificationPreferences>('/preferences', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(preferences),
+      });
+      setState((current) => ({
+        ...current,
+        summary: current.summary
+          ? {
+              ...current.summary,
+              preferences: updated,
+            }
+          : current.summary,
+      }));
+      return updated;
+    },
+    [apiRequest]
+  );
+
+  const acceptStandards = useCallback(async (): Promise<void> => {
+    await apiRequest<{ acceptedAt: string }>('/standards', { method: 'POST' });
+    setState((current) => ({
+      ...current,
+      summary: current.summary
+        ? {
+            ...current.summary,
+            standardsAccepted: true,
+            canPublish: !current.summary.mutedUntil,
+          }
+        : current.summary,
+      submitError: null,
+    }));
+  }, [apiRequest]);
+
+  const reportContent = useCallback(
+    async (
+      contentType: 'message' | 'post' | 'reply',
+      contentId: string,
+      reason: SocialReportReason,
+      details?: string
+    ): Promise<void> => {
+      await apiRequest('/reports', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contentType, contentId, reason, details }),
+      });
+    },
+    [apiRequest]
+  );
+
+  const moderateContent = useCallback(
+    async (
+      contentType: 'message' | 'post' | 'reply',
+      contentId: string,
+      reason: string
+    ): Promise<void> => {
+      const updated = await apiRequest<SocialMessage | SocialPost | SocialReply>('/moderation', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'remove', contentType, contentId, reason }),
+      });
+      setState((current) => {
+        if (contentType === 'message') {
+          return {
+            ...current,
+            messages: sortMessages(upsertById(current.messages, updated as SocialMessage)),
+          };
+        }
+        if (contentType === 'post') {
+          return {
+            ...current,
+            posts: sortPosts(upsertById(current.posts, updated as SocialPost)),
+          };
+        }
+        const reply = updated as SocialReply;
+        const thread = current.threads[reply.postId];
+        return {
+          ...current,
+          threads: thread
+            ? {
+                ...current.threads,
+                [reply.postId]: {
+                  ...thread,
+                  items: upsertReplies(thread.items, [reply]),
+                },
+              }
+            : current.threads,
+        };
+      });
+    },
+    [apiRequest]
+  );
+
+  const loadReplies = useCallback(
+    async (postId: string, loadMore = false): Promise<void> => {
+      const thread = state.threads[postId];
+      if (thread?.loading || (loadMore && !thread?.nextCursor)) return;
+      setState((current) => ({
+        ...current,
+        threads: {
+          ...current.threads,
+          [postId]: {
+            items: current.threads[postId]?.items ?? [],
+            nextCursor: current.threads[postId]?.nextCursor ?? null,
+            loading: true,
+            error: null,
+          },
+        },
+      }));
+      try {
+        const cursor =
+          loadMore && thread?.nextCursor ? `&cursor=${encodeURIComponent(thread.nextCursor)}` : '';
+        const response = await apiRequest<SocialCursorPage<SocialReply> | SocialPostThread>(
+          `/posts/${encodeURIComponent(postId)}/replies?limit=50${cursor}`
+        );
+        const page = 'post' in response ? response.replies : response;
+        setState((current) => {
+          const existing = loadMore ? (current.threads[postId]?.items ?? []) : [];
+          return {
+            ...current,
+            posts:
+              'post' in response
+                ? sortPosts(upsertById(current.posts, response.post))
+                : current.posts,
+            threads: {
+              ...current.threads,
+              [postId]: {
+                items: upsertReplies(existing, page.items),
+                nextCursor: page.nextCursor,
+                loading: false,
+                error: null,
+              },
+            },
+          };
+        });
+      } catch (error) {
+        setState((current) => ({
+          ...current,
+          threads: {
+            ...current.threads,
+            [postId]: {
+              items: current.threads[postId]?.items ?? [],
+              nextCursor: current.threads[postId]?.nextCursor ?? null,
+              loading: false,
+              error: error instanceof Error ? error.message : 'Failed to load replies.',
+            },
+          },
+        }));
+      }
+    },
+    [apiRequest, state.threads]
+  );
+
+  const createReply = useCallback(
+    async (postId: string, body: string): Promise<void> => {
+      setState((current) => ({ ...current, submitError: null }));
+      try {
+        const input: CreateSocialReplyInput = {
+          body,
+          idempotencyKey: createIdempotencyKey('reply'),
+        };
+        const reply = await apiRequest<SocialReply>(
+          `/posts/${encodeURIComponent(postId)}/replies`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(input),
+          }
+        );
+        setState((current) => {
+          const thread = current.threads[postId] ?? {
+            items: [],
+            nextCursor: null,
+            loading: false,
+            error: null,
+          };
+          return {
+            ...current,
+            threads: {
+              ...current.threads,
+              [postId]: { ...thread, items: upsertReplies(thread.items, [reply]) },
+            },
+          };
+        });
+      } catch (error) {
+        setState((current) => ({
+          ...current,
+          submitError: error instanceof Error ? error.message : 'Failed to send reply.',
+        }));
+        throw error;
+      }
+    },
+    [apiRequest]
+  );
+
+  const chatLatestSequence = state.summary?.latestSequence.chat;
+  const boardLatestSequence = state.summary?.latestSequence.board;
+
+  const markRead = useCallback(
+    async (channel: SocialChannel): Promise<void> => {
+      setState((current) =>
+        current.summary
+          ? {
+              ...current,
+              summary: {
+                ...current.summary,
+                unread: { ...current.summary.unread, [channel]: 0 },
+              },
+            }
+          : current
+      );
+      try {
+        const sequence = channel === 'chat' ? chatLatestSequence : boardLatestSequence;
+        await apiRequest<{ channel: SocialChannel; sequence: number }>('/read-state', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            channel,
+            ...(sequence === undefined ? {} : { sequence }),
+          }),
+        });
+      } catch {
+        void loadInitial();
+      }
+    },
+    [apiRequest, boardLatestSequence, chatLatestSequence, loadInitial]
+  );
+
+  return {
+    ...state,
+    retry: loadInitial,
+    loadEarlierMessages,
+    loadMorePosts,
+    sendMessage,
+    createPost,
+    updatePost,
+    deletePost,
+    updatePreferences,
+    acceptStandards,
+    reportContent,
+    moderateContent,
+    loadReplies,
+    createReply,
+    markRead,
+    postSort,
+    setPostSort,
+  };
+}
+
+function upsertReplies(existing: SocialReply[], incoming: SocialReply[]): SocialReply[] {
+  const byId = new Map(existing.map((reply) => [reply.id, reply]));
+  incoming.forEach((reply) => byId.set(reply.id, reply));
+  return [...byId.values()].sort(
+    (left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime()
+  );
+}

--- a/src/components/league/social/useLeagueSocial.ts
+++ b/src/components/league/social/useLeagueSocial.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useSocket } from '@/contexts/SocketContext';
 import { authenticatedFetch } from '@/lib/authenticatedFetch';
@@ -11,6 +11,7 @@ import type {
   LeagueSocialSummary,
   SocialChannel,
   SocialCursorPage,
+  SocialDiscussionContext,
   SocialMessage,
   SocialNotificationPreferences,
   SocialPost,
@@ -30,12 +31,15 @@ export type SocialPostSort = 'latestActivity' | 'createdAt';
 interface LeagueSocialState {
   summary: LeagueSocialSummary | null;
   messages: SocialMessage[];
+  activity: SocialMessage[];
   posts: SocialPost[];
   threads: Record<string, ThreadState>;
   messagesCursor: string | null;
+  activityCursor: string | null;
   postsCursor: string | null;
   loading: boolean;
   loadingEarlierMessages: boolean;
+  loadingEarlierActivity: boolean;
   loadingMorePosts: boolean;
   sendingMessage: boolean;
   creatingPost: boolean;
@@ -46,12 +50,15 @@ interface LeagueSocialState {
 const initialState: LeagueSocialState = {
   summary: null,
   messages: [],
+  activity: [],
   posts: [],
   threads: {},
   messagesCursor: null,
+  activityCursor: null,
   postsCursor: null,
   loading: true,
   loadingEarlierMessages: false,
+  loadingEarlierActivity: false,
   loadingMorePosts: false,
   sendingMessage: false,
   creatingPost: false,
@@ -91,6 +98,14 @@ function sortMessages(messages: SocialMessage[]): SocialMessage[] {
   );
 }
 
+function memberMessagesOnly(messages: SocialMessage[]): SocialMessage[] {
+  return messages.filter((message) => message.type !== 'system');
+}
+
+function activityMessagesOnly(messages: SocialMessage[]): SocialMessage[] {
+  return messages.filter((message) => message.type === 'system');
+}
+
 function sortPosts(posts: SocialPost[]): SocialPost[] {
   return [...posts].sort((left, right) => {
     if (left.isPinned !== right.isPinned) return left.isPinned ? -1 : 1;
@@ -100,6 +115,48 @@ function sortPosts(posts: SocialPost[]): SocialPost[] {
 
 function upsertById<T extends { id: string }>(items: T[], item: T): T[] {
   return [...items.filter((candidate) => candidate.id !== item.id), item];
+}
+
+function reconcileById<T extends { id: string }>(
+  current: T[],
+  snapshot: T[],
+  preferCurrent: boolean
+): T[] {
+  const reconciled = new Map<string, T>();
+  const first = preferCurrent ? snapshot : current;
+  const second = preferCurrent ? current : snapshot;
+  first.forEach((item) => reconciled.set(item.id, item));
+  second.forEach((item) => reconciled.set(item.id, item));
+  return [...reconciled.values()];
+}
+
+function reconcileSummary(
+  current: LeagueSocialSummary | null,
+  snapshot: LeagueSocialSummary
+): LeagueSocialSummary {
+  if (
+    !current ||
+    current.leagueId !== snapshot.leagueId ||
+    current.seasonId !== snapshot.seasonId
+  ) {
+    return snapshot;
+  }
+
+  const channels: SocialChannel[] = ['chat', 'board', 'activity'];
+  return channels.reduce<LeagueSocialSummary>((result, channel) => {
+    if (current.latestSequence[channel] <= snapshot.latestSequence[channel]) return result;
+    return {
+      ...result,
+      latestSequence: {
+        ...result.latestSequence,
+        [channel]: current.latestSequence[channel],
+      },
+      unread: {
+        ...result.unread,
+        [channel]: current.unread[channel],
+      },
+    };
+  }, snapshot);
 }
 
 function getRealtimePayload<T>(value: T | SocialRealtimeEnvelope, leagueId: string): T | null {
@@ -141,8 +198,9 @@ function updateRealtimeSummary(
 export interface LeagueSocialController extends LeagueSocialState {
   retry: () => Promise<void>;
   loadEarlierMessages: () => Promise<void>;
+  loadEarlierActivity: () => Promise<void>;
   loadMorePosts: () => Promise<void>;
-  sendMessage: (content: string) => Promise<void>;
+  sendMessage: (content: string, context?: SocialDiscussionContext | null) => Promise<void>;
   createPost: (input: Omit<CreateSocialPostInput, 'idempotencyKey'>) => Promise<SocialPost>;
   updatePost: (
     postId: string,
@@ -175,6 +233,8 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
   const socket = useSocket();
   const [state, setState] = useState<LeagueSocialState>(initialState);
   const [postSort, setPostSort] = useState<SocialPostSort>('latestActivity');
+  const inFlightReadSequences = useRef<Partial<Record<SocialChannel, number>>>({});
+  const resyncPromiseRef = useRef<Promise<void> | null>(null);
   const basePath = useMemo(() => `/api/leagues/${encodeURIComponent(leagueId)}/social`, [leagueId]);
 
   const apiRequest = useCallback(
@@ -185,24 +245,65 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
     [basePath, currentUserId]
   );
 
+  const loadSummary = useCallback(async (): Promise<void> => {
+    const summary = await apiRequest<LeagueSocialSummary>('/summary');
+    setState((current) => ({ ...current, summary }));
+  }, [apiRequest]);
+
   const loadInitial = useCallback(async (): Promise<void> => {
     setState((current) => ({ ...current, loading: true, error: null }));
     try {
-      const [summary, messagePage, postPage] = await Promise.all([
+      const [summary, messagePage, activityPage, postPage] = await Promise.all([
         apiRequest<LeagueSocialSummary>('/summary'),
         apiRequest<SocialCursorPage<SocialMessage>>('/messages?limit=50'),
+        apiRequest<SocialCursorPage<SocialMessage>>('/activity?limit=50'),
         apiRequest<SocialCursorPage<SocialPost>>(`/posts?limit=30&sort=${postSort}`),
       ]);
-      setState((current) => ({
-        ...current,
-        summary,
-        messages: sortMessages(messagePage.items),
-        posts: sortPosts(postPage.items),
-        messagesCursor: messagePage.nextCursor,
-        postsCursor: postPage.nextCursor,
-        loading: false,
-        error: null,
-      }));
+      setState((current) => {
+        const reconciledSummary = reconcileSummary(current.summary, summary);
+        const sameScope =
+          current.summary?.leagueId === summary.leagueId &&
+          current.summary.seasonId === summary.seasonId;
+        const chatAdvanced =
+          sameScope &&
+          current.summary !== null &&
+          current.summary.latestSequence.chat > summary.latestSequence.chat;
+        const activityAdvanced =
+          sameScope &&
+          current.summary !== null &&
+          current.summary.latestSequence.activity > summary.latestSequence.activity;
+        const boardAdvanced =
+          sameScope &&
+          current.summary !== null &&
+          current.summary.latestSequence.board > summary.latestSequence.board;
+
+        return {
+          ...current,
+          summary: reconciledSummary,
+          messages: sortMessages(
+            reconcileById(
+              sameScope ? current.messages : [],
+              memberMessagesOnly(messagePage.items),
+              chatAdvanced
+            )
+          ),
+          activity: sortMessages(
+            reconcileById(
+              sameScope ? current.activity : [],
+              activityMessagesOnly(activityPage.items),
+              activityAdvanced
+            )
+          ),
+          posts: sortPosts(
+            reconcileById(sameScope ? current.posts : [], postPage.items, boardAdvanced)
+          ),
+          messagesCursor: messagePage.nextCursor,
+          activityCursor: activityPage.nextCursor,
+          postsCursor: postPage.nextCursor,
+          loading: false,
+          error: null,
+        };
+      });
     } catch (error) {
       setState((current) => ({
         ...current,
@@ -212,22 +313,87 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
     }
   }, [apiRequest, postSort]);
 
-  useEffect(() => {
-    void loadInitial();
+  const resync = useCallback((): Promise<void> => {
+    if (resyncPromiseRef.current) return resyncPromiseRef.current;
+
+    const request = loadInitial().finally(() => {
+      if (resyncPromiseRef.current === request) {
+        resyncPromiseRef.current = null;
+      }
+    });
+    resyncPromiseRef.current = request;
+    return request;
   }, [loadInitial]);
+
+  useEffect(() => {
+    void resync();
+  }, [resync]);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && (!socket || socket.connected)) {
+        void resync();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [resync, socket]);
 
   useEffect(() => {
     if (!socket || !leagueId) return;
 
-    const joinLeagueSocial = () => {
-      socket.emit('social:join', { leagueId });
+    let cancelled = false;
+    let joinPromise: Promise<boolean> | null = null;
+    let joinTimeoutId: number | null = null;
+
+    const joinLeagueSocial = (): Promise<boolean> => {
+      if (joinPromise) return joinPromise;
+
+      const request = new Promise<boolean>((resolve) => {
+        joinTimeoutId = window.setTimeout(() => {
+          joinTimeoutId = null;
+          resolve(false);
+        }, 5_000);
+        socket.emit(
+          'social:join',
+          { leagueId },
+          (acknowledgement: { ok?: boolean } | undefined) => {
+            if (joinTimeoutId !== null) {
+              window.clearTimeout(joinTimeoutId);
+              joinTimeoutId = null;
+            }
+            resolve(acknowledgement?.ok === true);
+          }
+        );
+      }).finally(() => {
+        if (joinPromise === request) joinPromise = null;
+      });
+      joinPromise = request;
+      return request;
     };
-    joinLeagueSocial();
-    socket.on('connect', joinLeagueSocial);
+    const rejoinAndResync = async () => {
+      const authorized = await joinLeagueSocial();
+      if (cancelled) return;
+      if (!authorized) {
+        setState((current) => ({
+          ...current,
+          loading: false,
+          error: 'League social realtime authorization failed.',
+        }));
+        return;
+      }
+
+      const preAuthorizationResync = resyncPromiseRef.current;
+      if (preAuthorizationResync) {
+        await preAuthorizationResync;
+      }
+      if (cancelled) return;
+      await resync();
+    };
 
     const handleMessage = (value: SocialMessage | SocialRealtimeEnvelope) => {
       const payload = getRealtimePayload<SocialMessage>(value, leagueId);
-      if (!payload?.id || !payload.createdAt) return;
+      if (!payload?.id || !payload.createdAt || payload.type === 'system') return;
       const sequence = getRealtimeSequence(value);
       const isOwn = Boolean(currentUserId && payload.author?.userId === currentUserId);
       const message = { ...payload, isOwn };
@@ -235,6 +401,16 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
         ...current,
         summary: updateRealtimeSummary(current.summary, 'chat', sequence, isOwn),
         messages: sortMessages(upsertById(current.messages, message)),
+      }));
+    };
+    const handleActivity = (value: SocialMessage | SocialRealtimeEnvelope) => {
+      const payload = getRealtimePayload<SocialMessage>(value, leagueId);
+      if (!payload?.id || !payload.createdAt || payload.type !== 'system') return;
+      const sequence = getRealtimeSequence(value);
+      setState((current) => ({
+        ...current,
+        summary: updateRealtimeSummary(current.summary, 'activity', sequence, false),
+        activity: sortMessages(upsertById(current.activity, { ...payload, isOwn: false })),
       }));
     };
     const handlePost = (value: SocialPost | SocialRealtimeEnvelope) => {
@@ -301,7 +477,10 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
               ...current.summary,
               unread: {
                 ...current.summary.unread,
-                [readState.channel]: 0,
+                [readState.channel]:
+                  readState.sequence >= current.summary.latestSequence[readState.channel]
+                    ? 0
+                    : current.summary.unread[readState.channel],
               },
             }
           : current.summary,
@@ -309,21 +488,30 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
     };
 
     socket.on('social:message', handleMessage);
+    socket.on('social:activity', handleActivity);
     socket.on('social:post', handlePost);
     socket.on('social:reply', handleReply);
     socket.on('social:moderation', handleModeration);
     socket.on('social:read-state', handleReadState);
+    socket.on('connect', rejoinAndResync);
+    void rejoinAndResync();
 
     return () => {
-      socket.off('connect', joinLeagueSocial);
+      cancelled = true;
+      if (joinTimeoutId !== null) {
+        window.clearTimeout(joinTimeoutId);
+        joinTimeoutId = null;
+      }
+      socket.off('connect', rejoinAndResync);
       socket.off('social:message', handleMessage);
+      socket.off('social:activity', handleActivity);
       socket.off('social:post', handlePost);
       socket.off('social:reply', handleReply);
       socket.off('social:moderation', handleModeration);
       socket.off('social:read-state', handleReadState);
       socket.emit('social:leave', { leagueId });
     };
-  }, [currentUserId, leagueId, loadInitial, socket]);
+  }, [currentUserId, leagueId, loadInitial, resync, socket]);
 
   const loadEarlierMessages = useCallback(async (): Promise<void> => {
     if (!state.messagesCursor || state.loadingEarlierMessages) return;
@@ -351,6 +539,33 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
       }));
     }
   }, [apiRequest, state.loadingEarlierMessages, state.messagesCursor]);
+
+  const loadEarlierActivity = useCallback(async (): Promise<void> => {
+    if (!state.activityCursor || state.loadingEarlierActivity) return;
+    setState((current) => ({ ...current, loadingEarlierActivity: true }));
+    try {
+      const page = await apiRequest<SocialCursorPage<SocialMessage>>(
+        `/activity?limit=50&cursor=${encodeURIComponent(state.activityCursor)}`
+      );
+      setState((current) => ({
+        ...current,
+        activity: sortMessages([
+          ...activityMessagesOnly(page.items),
+          ...current.activity.filter(
+            (message) => !page.items.some((candidate) => candidate.id === message.id)
+          ),
+        ]),
+        activityCursor: page.nextCursor,
+        loadingEarlierActivity: false,
+      }));
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        loadingEarlierActivity: false,
+        error: error instanceof Error ? error.message : 'Failed to load earlier league activity.',
+      }));
+    }
+  }, [apiRequest, state.activityCursor, state.loadingEarlierActivity]);
 
   const loadMorePosts = useCallback(async (): Promise<void> => {
     if (!state.postsCursor || state.loadingMorePosts) return;
@@ -380,12 +595,13 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
   }, [apiRequest, postSort, state.loadingMorePosts, state.postsCursor]);
 
   const sendMessage = useCallback(
-    async (content: string): Promise<void> => {
+    async (content: string, context?: SocialDiscussionContext | null): Promise<void> => {
       setState((current) => ({ ...current, sendingMessage: true, submitError: null }));
       try {
         const input: CreateSocialMessageInput = {
           content,
           idempotencyKey: createIdempotencyKey('chat'),
+          ...(context ? { context } : {}),
         };
         const message = await apiRequest<SocialMessage>('/messages', {
           method: 'POST',
@@ -669,43 +885,66 @@ export function useLeagueSocial(leagueId: string, currentUserId?: string): Leagu
     [apiRequest]
   );
 
-  const chatLatestSequence = state.summary?.latestSequence.chat;
-  const boardLatestSequence = state.summary?.latestSequence.board;
-
   const markRead = useCallback(
     async (channel: SocialChannel): Promise<void> => {
-      setState((current) =>
-        current.summary
-          ? {
-              ...current,
-              summary: {
-                ...current.summary,
-                unread: { ...current.summary.unread, [channel]: 0 },
-              },
-            }
-          : current
-      );
+      const summary = state.summary;
+      if (!summary || summary.unread[channel] === 0) return;
+
+      const sequence = summary.latestSequence[channel];
+      if ((inFlightReadSequences.current[channel] ?? -1) >= sequence) return;
+      inFlightReadSequences.current[channel] = sequence;
+
+      setState((current) => {
+        if (!current.summary || current.summary.latestSequence[channel] > sequence) return current;
+        return {
+          ...current,
+          summary: {
+            ...current.summary,
+            unread: { ...current.summary.unread, [channel]: 0 },
+          },
+        };
+      });
+
       try {
-        const sequence = channel === 'chat' ? chatLatestSequence : boardLatestSequence;
-        await apiRequest<{ channel: SocialChannel; sequence: number }>('/read-state', {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            channel,
-            ...(sequence === undefined ? {} : { sequence }),
-          }),
+        const readState = await apiRequest<{ channel: SocialChannel; sequence: number }>(
+          '/read-state',
+          {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ channel, sequence }),
+          }
+        );
+        setState((current) => {
+          if (
+            !current.summary ||
+            readState.sequence < current.summary.latestSequence[readState.channel]
+          ) {
+            return current;
+          }
+          return {
+            ...current,
+            summary: {
+              ...current.summary,
+              unread: { ...current.summary.unread, [readState.channel]: 0 },
+            },
+          };
         });
       } catch {
-        void loadInitial();
+        void loadSummary();
+      } finally {
+        if (inFlightReadSequences.current[channel] === sequence) {
+          delete inFlightReadSequences.current[channel];
+        }
       }
     },
-    [apiRequest, boardLatestSequence, chatLatestSequence, loadInitial]
+    [apiRequest, loadSummary, state.summary]
   );
 
   return {
     ...state,
     retry: loadInitial,
     loadEarlierMessages,
+    loadEarlierActivity,
     loadMorePosts,
     sendMessage,
     createPost,

--- a/src/index.css
+++ b/src/index.css
@@ -42,9 +42,41 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-social-brand-strong: var(--social-brand-strong);
+  --color-social-brand-foreground: var(--social-brand-foreground);
+  --color-social-header-muted: var(--social-header-muted);
+  --color-social-header-control-hover: var(--social-header-control-hover);
+  --color-social-header-control-pressed: var(--social-header-control-pressed);
+  --color-social-action: var(--social-action);
+  --color-social-action-hover: var(--social-action-hover);
+  --color-social-action-pressed: var(--social-action-pressed);
+  --color-social-action-foreground: var(--social-action-foreground);
+  --color-social-focus: var(--social-focus);
+  --color-social-brand-soft: var(--social-brand-soft);
+  --color-social-canvas: var(--social-canvas);
+  --color-social-surface: var(--social-surface);
+  --color-social-surface-subtle: var(--social-surface-subtle);
+  --color-social-border: var(--social-border);
+  --color-social-border-strong: var(--social-border-strong);
+  --color-social-text: var(--social-text);
+  --color-social-text-muted: var(--social-text-muted);
+  --color-social-disabled-bg: var(--social-disabled-bg);
+  --color-social-disabled-text: var(--social-disabled-text);
+  --color-social-success: var(--social-success);
+  --color-social-success-soft: var(--social-success-soft);
+  --color-social-warning: var(--social-warning);
+  --color-social-warning-text: var(--social-warning-text);
+  --color-social-warning-soft: var(--social-warning-soft);
+  --color-social-error: var(--social-error);
+  --color-social-error-foreground: var(--social-error-foreground);
+  --color-social-error-soft: var(--social-error-soft);
+  --color-social-mention-bg: var(--social-mention-bg);
+  --color-social-mention-text: var(--social-mention-text);
 }
 
 :root {
+  --statly-navy: #18324a;
+  --statly-blue: #3772df;
   --radius: 4px; /* From --border-radius-default */
   --background: #fff; /* From --base-background-content */
   --foreground: #2b2c2d; /* From --base-text-primary */
@@ -52,7 +84,7 @@
   --card-foreground: #2b2c2d;
   --popover: #fff;
   --popover-foreground: #2b2c2d;
-  --primary: #3772df; /* From --color-interaction-resting */
+  --primary: var(--statly-blue); /* From --color-interaction-resting */
   --primary-foreground: #fff;
   --secondary: #dee8fa; /* From --color-combo-blue10-blue100 */
   --secondary-foreground: #1a49a0; /* From --color-combo-blue20-blue80 */
@@ -90,7 +122,7 @@
   --league-border: #d9d0c3;
   --league-text: #171611;
   --league-text-muted: #6d665d;
-  --league-primary: #18324a;
+  --league-primary: var(--statly-navy);
   --league-primary-foreground: #fff;
   --league-primary-hover: #23445f;
   --league-primary-soft: #e6edf3;
@@ -133,6 +165,39 @@
   --draft-broadcast-shadow-deep: rgba(1, 6, 15, 0.92);
 }
 
+.league-social {
+  --social-brand-strong: var(--statly-navy);
+  --social-brand-foreground: var(--league-primary-foreground);
+  --social-header-muted: #c5d4e5;
+  --social-header-control-hover: rgb(255 255 255 / 12%);
+  --social-header-control-pressed: rgb(255 255 255 / 20%);
+  --social-action: var(--statly-blue);
+  --social-action-hover: #1d4ed8;
+  --social-action-pressed: #1e40af;
+  --social-action-foreground: var(--league-primary-foreground);
+  --social-focus: var(--statly-blue);
+  --social-brand-soft: var(--secondary);
+  --social-canvas: var(--muted);
+  --social-surface: var(--background);
+  --social-surface-subtle: var(--league-primary-soft);
+  --social-border: var(--border);
+  --social-border-strong: #aeb7c7;
+  --social-text: var(--foreground);
+  --social-text-muted: var(--muted-foreground);
+  --social-disabled-bg: var(--muted);
+  --social-disabled-text: var(--muted-foreground);
+  --social-success: var(--league-success);
+  --social-success-soft: var(--league-success-soft);
+  --social-warning: var(--league-warning);
+  --social-warning-text: #684100;
+  --social-warning-soft: var(--league-warning-soft);
+  --social-error: var(--league-danger);
+  --social-error-foreground: var(--league-primary-foreground);
+  --social-error-soft: var(--league-danger-soft);
+  --social-mention-bg: #fff3c4;
+  --social-mention-text: #684100;
+}
+
 .dark {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
@@ -168,6 +233,28 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+}
+
+.dark .league-social {
+  --social-brand-soft: var(--secondary);
+  --social-canvas: var(--background);
+  --social-surface: var(--card);
+  --social-surface-subtle: var(--muted);
+  --social-border: var(--border);
+  --social-border-strong: oklch(0.556 0 0);
+  --social-text: var(--foreground);
+  --social-text-muted: var(--muted-foreground);
+  --social-disabled-bg: var(--muted);
+  --social-disabled-text: var(--muted-foreground);
+  --social-success: #7dd3b0;
+  --social-success-soft: rgb(47 107 88 / 24%);
+  --social-warning: #f0b65a;
+  --social-warning-text: #ffe39a;
+  --social-warning-soft: rgb(157 114 52 / 24%);
+  --social-error: #f28b82;
+  --social-error-soft: rgb(168 79 68 / 24%);
+  --social-mention-bg: #3f3212;
+  --social-mention-text: #ffe39a;
 }
 
 @layer base {

--- a/src/lib/prismaLeagueBridge.ts
+++ b/src/lib/prismaLeagueBridge.ts
@@ -315,11 +315,15 @@ export async function syncPrismaLeagueMember(
       if (!member) {
         return { synced: false, reason: 'member-not-found' as const };
       }
-      if (await memberHasDraftDependencies(tx, member.id)) {
-        return { synced: false, reason: 'member-has-draft-dependencies' as const };
-      }
-      await tx.leagueMember.delete({ where: { id: member.id } });
-      return { synced: true, action: 'deleted' as const };
+      await tx.leagueMember.update({
+        where: { id: member.id },
+        data: {
+          isActive: false,
+          status: 'REMOVED',
+          leftAt: new Date(),
+        },
+      });
+      return { synced: true, action: 'deactivated' as const };
     }
 
     const member = toMirrorMember(
@@ -398,8 +402,14 @@ async function syncActiveMembers(
 
   for (const member of existingMembers) {
     if (activeUserIds.has(member.userId)) continue;
-    if (await memberHasDraftDependencies(tx, member.id)) continue;
-    await tx.leagueMember.delete({ where: { id: member.id } });
+    await tx.leagueMember.update({
+      where: { id: member.id },
+      data: {
+        isActive: false,
+        status: 'REMOVED',
+        leftAt: new Date(),
+      },
+    });
   }
 }
 
@@ -441,6 +451,9 @@ async function upsertPrismaMember(
     teamLogoPositionY: member.teamLogoPositionY,
     teamLogoZoom: member.teamLogoZoom,
     draftSlot: member.draftSlot,
+    isActive: true,
+    status: 'ACTIVE',
+    leftAt: null,
   };
 
   if (existingMember) {
@@ -471,17 +484,6 @@ async function getAvailableInviteCode(
     return inviteCode;
   }
   return `FS_${leagueId}`;
-}
-
-async function memberHasDraftDependencies(tx: PrismaTx, memberId: string): Promise<boolean> {
-  const counts = await Promise.all([
-    tx.draftOrder.count({ where: { memberId } }),
-    tx.pick.count({ where: { memberId } }),
-    tx.draftWatchlist.count({ where: { memberId } }),
-    tx.preDraftQueue.count({ where: { memberId } }),
-    tx.lobbyActivity.count({ where: { memberId } }),
-  ]);
-  return counts.some((count) => count > 0);
 }
 
 function toMirrorMember(

--- a/src/server/draft/services/DraftRealtimePublisher.ts
+++ b/src/server/draft/services/DraftRealtimePublisher.ts
@@ -1,6 +1,7 @@
 import { logger } from '@/lib/logger';
 import { revalidateTags } from '@/lib/cache';
 import { tags } from '@/lib/cacheTags';
+import { publishLeagueSystemMessage } from '@/server/leagues/social/socialSystemEvents';
 
 import { draftRepository } from '../repository/DraftRepository';
 import { draftRealtimeDispatcher } from './DraftRealtimeDispatcher';
@@ -123,6 +124,30 @@ export class DraftRealtimePublisher {
     );
   }
 
+  private async publishSocialDraftActivity(events: DraftOutboxEventRecord[]): Promise<void> {
+    const pickEvents = events.filter(
+      (
+        event
+      ): event is DraftOutboxEventRecord & {
+        payload: DraftPickEventPayload;
+      } =>
+        (event.event === 'draft:pick-made' || event.event === 'draft:auto-pick') &&
+        Boolean(event.payload)
+    );
+    if (pickEvents.length === 0) return;
+
+    await Promise.all(
+      pickEvents.map((event) =>
+        publishLeagueSystemMessage({
+          leagueId: event.leagueId,
+          eventType: 'PLAYER_DRAFTED',
+          relatedEntityId: event.payload.id || event.id,
+          content: `${event.payload.member.displayName} drafted ${event.payload.player.name}.`,
+        })
+      )
+    );
+  }
+
   private async drainOutboxEvents(
     events: DraftOutboxEventRecord[]
   ): Promise<LiveDraftState | null> {
@@ -157,6 +182,7 @@ export class DraftRealtimePublisher {
     let state: LiveDraftState | null = null;
     try {
       state = await this.drainOutboxEvents(outboxEvents);
+      await this.publishSocialDraftActivity(outboxEvents);
       await this.markOutboxPublished(outboxEvents.map((event) => event.id));
     } catch (error) {
       await this.markOutboxFailed(
@@ -187,6 +213,7 @@ export class DraftRealtimePublisher {
 
     try {
       const state = await this.drainOutboxEvents(outboxEvents);
+      await this.publishSocialDraftActivity(outboxEvents);
       await this.markOutboxPublished(outboxEvents.map((event) => event.id));
       return state;
     } catch (error) {
@@ -206,6 +233,7 @@ export class DraftRealtimePublisher {
 
     try {
       await this.drainOutboxEvents(outboxEvents);
+      await this.publishSocialDraftActivity(outboxEvents);
       await this.markOutboxPublished(outboxEvents.map((event) => event.id));
       return outboxEvents.length;
     } catch (error) {

--- a/src/server/leagues/leagueDetail.ts
+++ b/src/server/leagues/leagueDetail.ts
@@ -5,7 +5,10 @@ import { listActiveLeagueMembers } from '@/lib/leagueMembership';
 import { logger } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
 import { getLeagueDraftOperationalReadiness } from '@/server/draft/services/DraftReadinessService';
-import { getLeagueMembershipAccess } from '@/server/leagues/membership';
+import {
+  getLeagueMembershipAccess,
+  isActivePrismaMembership,
+} from '@/server/leagues/membership';
 import { REAL_DATA_NINE_CATEGORY_PRESET, type FantasyCategoryKey } from '@/types/fantasyCategories';
 import type { League, LeagueMember } from '@/types/leagues';
 
@@ -74,7 +77,8 @@ async function loadLeagueDetail(leagueId: string): Promise<LeagueDetailResult> {
           select: { memberId: true },
         }),
       ]);
-      const members = prismaLeague.members.map((member) => ({
+      const activeMembers = prismaLeague.members.filter(isActivePrismaMembership);
+      const members = activeMembers.map((member) => ({
         id: member.id,
         leagueId: member.leagueId,
         userId: member.userId,
@@ -111,7 +115,7 @@ async function loadLeagueDetail(leagueId: string): Promise<LeagueDetailResult> {
           code: prismaLeague.inviteCode,
           ownerId: prismaLeague.ownerId,
           maxTeams: prismaLeague.settings?.maxTeams || 12,
-          currentTeams: prismaLeague.members.length,
+          currentTeams: activeMembers.length,
           status: toLeagueStatus(prismaLeague.drafts[0]?.status),
           type: 'private',
           description: `${prismaLeague.name} Fantasy League`,

--- a/src/server/leagues/membership.test.ts
+++ b/src/server/leagues/membership.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  leagueFindUnique: vi.fn(),
+  getLeagueMembership: vi.fn(),
+  isLeagueManagerRole: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    league: { findUnique: mocks.leagueFindUnique },
+    draft: { findUnique: vi.fn() },
+  },
+}));
+vi.mock('@/lib/firebaseAdmin', () => ({
+  adminDb: {
+    collection: vi.fn(() => ({
+      doc: vi.fn(() => ({ get: vi.fn() })),
+    })),
+  },
+}));
+vi.mock('@/lib/leagueMembership', () => ({
+  getLeagueMembership: mocks.getLeagueMembership,
+  isLeagueManagerRole: mocks.isLeagueManagerRole,
+}));
+
+import { getLeagueMembershipAccess } from './membership';
+
+describe('Prisma league membership access', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not grant commissioner powers to an ordinary MANAGER-role member', async () => {
+    mocks.leagueFindUnique.mockResolvedValue({
+      ownerId: 'owner',
+      members: [
+        {
+          id: 'member-1',
+          role: 'MANAGER',
+          isActive: true,
+          status: 'ACTIVE',
+          isCoCommissioner: false,
+        },
+      ],
+    });
+
+    await expect(getLeagueMembershipAccess('league-1', 'member-user')).resolves.toMatchObject({
+      isMember: true,
+      canManage: false,
+    });
+  });
+
+  it('grants commissioner powers to the owner or an explicit co-commissioner', async () => {
+    mocks.leagueFindUnique
+      .mockResolvedValueOnce({
+        ownerId: 'owner',
+        members: [
+          {
+            id: 'owner-member',
+            role: 'OWNER',
+            isActive: true,
+            status: 'ACTIVE',
+            isCoCommissioner: false,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ownerId: 'owner',
+        members: [
+          {
+            id: 'co-member',
+            role: 'MANAGER',
+            isActive: true,
+            status: 'ACTIVE',
+            isCoCommissioner: true,
+          },
+        ],
+      });
+
+    await expect(getLeagueMembershipAccess('league-1', 'owner')).resolves.toMatchObject({
+      canManage: true,
+    });
+    await expect(getLeagueMembershipAccess('league-1', 'co-user')).resolves.toMatchObject({
+      canManage: true,
+    });
+  });
+});

--- a/src/server/leagues/membership.ts
+++ b/src/server/leagues/membership.ts
@@ -21,7 +21,13 @@ export async function getLeagueMembershipAccess(
       ownerId: true,
       members: {
         where: { userId },
-        select: { id: true, role: true },
+        select: {
+          id: true,
+          role: true,
+          isActive: true,
+          status: true,
+          isCoCommissioner: true,
+        },
         take: 1,
       },
     },
@@ -29,28 +35,18 @@ export async function getLeagueMembershipAccess(
 
   if (prismaLeague) {
     const member = prismaLeague.members[0];
-    const isOwner = prismaLeague.ownerId === userId;
-    const role = member?.role ?? (isOwner ? 'OWNER' : undefined);
-    const canManage = isOwner || isLeagueManagerRole(role);
-
-    if (canManage) {
+    if (!member || !isActivePrismaMembership(member)) {
       return {
         leagueId,
         userId,
-        ...(member?.id ? { memberId: member.id } : {}),
-        ...(role ? { role } : {}),
-        isMember: true,
-        canManage,
+        isMember: false,
+        canManage: false,
       };
     }
-  }
 
-  const membership = await getLeagueMembership(leagueId, userId);
-  const firestoreOwner = await isFirestoreLeagueOwner(leagueId, userId);
-
-  if (prismaLeague?.members[0]) {
-    const member = prismaLeague.members[0];
-    const role = String(member.role);
+    const isOwner = prismaLeague.ownerId === userId;
+    const role = member.role;
+    const canManage = isOwner || member.isCoCommissioner;
 
     return {
       leagueId,
@@ -58,9 +54,12 @@ export async function getLeagueMembershipAccess(
       memberId: member.id,
       role,
       isMember: true,
-      canManage: firestoreOwner,
+      canManage,
     };
   }
+
+  const membership = await getLeagueMembership(leagueId, userId);
+  const firestoreOwner = await isFirestoreLeagueOwner(leagueId, userId);
 
   if (!membership.isMember) {
     return {
@@ -83,6 +82,14 @@ export async function getLeagueMembershipAccess(
     isMember: true,
     canManage,
   };
+}
+
+function isActivePrismaMembership(member: { isActive: boolean; status: string }): boolean {
+  if (!member.isActive) {
+    return false;
+  }
+
+  return !['declined', 'inactive', 'removed'].includes(member.status.trim().toLowerCase());
 }
 
 export async function canManageLeague(leagueId: string, userId: string): Promise<boolean> {

--- a/src/server/leagues/membership.ts
+++ b/src/server/leagues/membership.ts
@@ -84,7 +84,10 @@ export async function getLeagueMembershipAccess(
   };
 }
 
-function isActivePrismaMembership(member: { isActive: boolean; status: string }): boolean {
+export function isActivePrismaMembership(member: {
+  isActive: boolean;
+  status: string;
+}): boolean {
   if (!member.isActive) {
     return false;
   }

--- a/src/server/leagues/social/socialAccess.test.ts
+++ b/src/server/leagues/social/socialAccess.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const tx = {
+    league: { findUnique: vi.fn(), update: vi.fn() },
+    leagueSeason: { findFirst: vi.fn(), upsert: vi.fn() },
+    socialBoardCategory: { upsert: vi.fn() },
+  };
+  return {
+    getLeagueMembershipAccess: vi.fn(),
+    socialMuteFindFirst: vi.fn(),
+    leagueMemberFindFirst: vi.fn(),
+    tx,
+    transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+  };
+});
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/server/leagues/membership', () => ({
+  getLeagueMembershipAccess: mocks.getLeagueMembershipAccess,
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    $transaction: mocks.transaction,
+    socialMute: { findFirst: mocks.socialMuteFindFirst },
+    leagueMember: { findFirst: mocks.leagueMemberFindFirst },
+  },
+}));
+
+import { requireLeagueSocialAccess, requireSocialPublishingAccess } from './socialAccess';
+
+describe('league social access', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tx.league.findUnique.mockResolvedValue({
+      id: 'league-1',
+      activeSeasonId: 'season-1',
+      settings: { startAt: new Date('2026-01-01T00:00:00.000Z') },
+    });
+    mocks.tx.leagueSeason.findFirst.mockResolvedValue({ id: 'season-1' });
+    mocks.socialMuteFindFirst.mockResolvedValue(null);
+    mocks.leagueMemberFindFirst.mockResolvedValue({
+      socialStandardsAcceptedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+  });
+
+  it('denies non-members before social data is read', async () => {
+    mocks.getLeagueMembershipAccess.mockResolvedValue({
+      leagueId: 'league-1',
+      userId: 'outsider',
+      isMember: false,
+      canManage: false,
+    });
+
+    await expect(requireLeagueSocialAccess('league-1', 'outsider')).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      status: 403,
+    });
+    expect(mocks.transaction).not.toHaveBeenCalled();
+    expect(mocks.socialMuteFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('returns the active season and commissioner permission for a current member', async () => {
+    mocks.getLeagueMembershipAccess.mockResolvedValue({
+      leagueId: 'league-1',
+      userId: 'owner',
+      memberId: 'member-1',
+      isMember: true,
+      canManage: true,
+    });
+
+    await expect(requireLeagueSocialAccess('league-1', 'owner')).resolves.toEqual({
+      leagueId: 'league-1',
+      seasonId: 'season-1',
+      userId: 'owner',
+      memberId: 'member-1',
+      canManage: true,
+      mutedUntil: null,
+      standardsAccepted: true,
+      canPublish: true,
+    });
+  });
+
+  it('allows muted members to read while rejecting publication', async () => {
+    const expiresAt = new Date('2026-07-20T00:00:00.000Z');
+    mocks.getLeagueMembershipAccess.mockResolvedValue({
+      leagueId: 'league-1',
+      userId: 'member',
+      memberId: 'member-2',
+      isMember: true,
+      canManage: false,
+    });
+    mocks.socialMuteFindFirst.mockResolvedValue({ expiresAt });
+
+    const access = await requireLeagueSocialAccess('league-1', 'member');
+    expect(access.canPublish).toBe(false);
+    expect(() => requireSocialPublishingAccess(access)).toThrow(/cannot publish/i);
+  });
+
+  it('seeds default categories for a migrated league with an existing active season', async () => {
+    mocks.getLeagueMembershipAccess.mockResolvedValue({
+      leagueId: 'league-1',
+      userId: 'member',
+      memberId: 'member-2',
+      isMember: true,
+      canManage: false,
+    });
+
+    await requireLeagueSocialAccess('league-1', 'member');
+
+    expect(mocks.tx.socialBoardCategory.upsert).toHaveBeenCalledTimes(4);
+    expect(mocks.tx.socialBoardCategory.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { seasonId_slug: { seasonId: 'season-1', slug: 'announcements' } },
+      })
+    );
+  });
+
+  it('requires community standards acceptance before publication', async () => {
+    mocks.getLeagueMembershipAccess.mockResolvedValue({
+      leagueId: 'league-1',
+      userId: 'member',
+      memberId: 'member-2',
+      isMember: true,
+      canManage: false,
+    });
+    mocks.leagueMemberFindFirst.mockResolvedValue({ socialStandardsAcceptedAt: null });
+
+    const access = await requireLeagueSocialAccess('league-1', 'member');
+
+    expect(access.standardsAccepted).toBe(false);
+    expect(access.canPublish).toBe(false);
+    expect(() => requireSocialPublishingAccess(access)).toThrow(/community standards/i);
+  });
+});

--- a/src/server/leagues/social/socialAccess.ts
+++ b/src/server/leagues/social/socialAccess.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 import { prisma } from '@/lib/prisma';
 import { getLeagueMembershipAccess } from '@/server/leagues/membership';
 

--- a/src/server/leagues/social/socialAccess.ts
+++ b/src/server/leagues/social/socialAccess.ts
@@ -1,0 +1,190 @@
+import 'server-only';
+
+import { prisma } from '@/lib/prisma';
+import { getLeagueMembershipAccess } from '@/server/leagues/membership';
+
+import { SocialError } from './socialErrors';
+
+const DEFAULT_BOARD_CATEGORIES = [
+  {
+    slug: 'announcements',
+    name: 'Announcements',
+    description: 'Official league updates from commissioners.',
+    sortOrder: 0,
+  },
+  {
+    slug: 'general',
+    name: 'General discussion',
+    description: 'League-wide conversation and coordination.',
+    sortOrder: 1,
+  },
+  {
+    slug: 'trades',
+    name: 'Trades',
+    description: 'Trade ideas, negotiations, and discussion.',
+    sortOrder: 2,
+  },
+  {
+    slug: 'rules',
+    name: 'Rules and league decisions',
+    description: 'League rules, proposals, and recorded decisions.',
+    sortOrder: 3,
+  },
+] as const;
+
+export interface LeagueSocialAccess {
+  leagueId: string;
+  seasonId: string;
+  userId: string;
+  memberId: string;
+  canManage: boolean;
+  mutedUntil: Date | null;
+  standardsAccepted: boolean;
+  canPublish: boolean;
+}
+
+export async function requireLeagueSocialAccess(
+  leagueId: string,
+  userId: string
+): Promise<LeagueSocialAccess> {
+  const membership = await getLeagueMembershipAccess(leagueId, userId);
+  if (!membership.isMember) {
+    throw new SocialError('FORBIDDEN', 'You are not an active member of this league');
+  }
+  if (!membership.memberId) {
+    throw new SocialError(
+      'CONFLICT',
+      'Your league membership must finish syncing before social features are available'
+    );
+  }
+
+  const seasonId = await ensureActiveLeagueSeason(leagueId);
+  const now = new Date();
+  const [mute, member] = await Promise.all([
+    prisma.socialMute.findFirst({
+      where: {
+        leagueId,
+        seasonId,
+        mutedUserId: userId,
+        revokedAt: null,
+        startsAt: { lte: now },
+        OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+      },
+      orderBy: { createdAt: 'desc' },
+      select: { expiresAt: true },
+    }),
+    prisma.leagueMember.findFirst({
+      where: { id: membership.memberId, leagueId, userId, isActive: true },
+      select: { socialStandardsAcceptedAt: true },
+    }),
+  ]);
+  if (!member) {
+    throw new SocialError('FORBIDDEN', 'Active league membership is required');
+  }
+
+  return {
+    leagueId,
+    seasonId,
+    userId,
+    memberId: membership.memberId,
+    canManage: membership.canManage,
+    mutedUntil: mute?.expiresAt ?? null,
+    standardsAccepted: Boolean(member.socialStandardsAcceptedAt),
+    canPublish: !mute && Boolean(member.socialStandardsAcceptedAt),
+  };
+}
+
+export function requireSocialPublishingAccess(access: LeagueSocialAccess): void {
+  if (!access.canPublish) {
+    if (!access.standardsAccepted) {
+      throw new SocialError(
+        'FORBIDDEN',
+        'Accept the Statly community standards before publishing league social content'
+      );
+    }
+    throw new SocialError(
+      'MUTED',
+      access.mutedUntil
+        ? `You cannot publish league social content until ${access.mutedUntil.toISOString()}`
+        : 'You cannot publish league social content'
+    );
+  }
+}
+
+export function requireSocialManager(access: LeagueSocialAccess): void {
+  if (!access.canManage) {
+    throw new SocialError('FORBIDDEN', 'Commissioner permission is required');
+  }
+}
+
+export async function ensureActiveLeagueSeason(leagueId: string): Promise<string> {
+  return prisma.$transaction(async (tx) => {
+    const ensureDefaultCategories = async (seasonId: string): Promise<void> => {
+      for (const category of DEFAULT_BOARD_CATEGORIES) {
+        await tx.socialBoardCategory.upsert({
+          where: {
+            seasonId_slug: {
+              seasonId,
+              slug: category.slug,
+            },
+          },
+          update: {
+            name: category.name,
+            description: category.description,
+            sortOrder: category.sortOrder,
+          },
+          create: {
+            leagueId,
+            seasonId,
+            ...category,
+          },
+        });
+      }
+    };
+
+    const league = await tx.league.findUnique({
+      where: { id: leagueId },
+      select: {
+        id: true,
+        activeSeasonId: true,
+        settings: { select: { startAt: true } },
+      },
+    });
+    if (!league) {
+      throw new SocialError('NOT_FOUND', 'League not found');
+    }
+
+    if (league.activeSeasonId) {
+      const activeSeason = await tx.leagueSeason.findFirst({
+        where: { id: league.activeSeasonId, leagueId },
+        select: { id: true },
+      });
+      if (activeSeason) {
+        await ensureDefaultCategories(activeSeason.id);
+        return activeSeason.id;
+      }
+    }
+
+    const year = (league.settings.startAt ?? new Date()).getUTCFullYear();
+    const season = await tx.leagueSeason.upsert({
+      where: { leagueId_year: { leagueId, year } },
+      update: {},
+      create: {
+        leagueId,
+        year,
+        label: String(year),
+        startsAt: league.settings.startAt,
+      },
+      select: { id: true },
+    });
+
+    await tx.league.update({
+      where: { id: leagueId },
+      data: { activeSeasonId: season.id },
+    });
+
+    await ensureDefaultCategories(season.id);
+
+    return season.id;
+  });
+}

--- a/src/server/leagues/social/socialCommands.test.ts
+++ b/src/server/leagues/social/socialCommands.test.ts
@@ -51,6 +51,7 @@ vi.mock('./socialDto', () => ({
     type: 'member',
     content: record.content,
     context: record.contextJson ? JSON.parse(record.contextJson) : undefined,
+    gif: record.giphyId ? { provider: 'giphy', id: record.giphyId } : undefined,
     author: null,
     createdAt: record.createdAt.toISOString(),
     moderationStatus: 'active',
@@ -113,6 +114,31 @@ describe('league social Activity commands', () => {
         contextJson: JSON.stringify(context),
       }),
       include: {},
+    });
+  });
+
+  it('persists a GIF-only message and includes its identity in the realtime outbox', async () => {
+    await createSocialMessage('league-1', 'user-1', {
+      content: '',
+      gif: { provider: 'giphy', id: 'xT9IgG50Fb7Mi0prBC' },
+      idempotencyKey: 'message:giphy-1',
+    });
+
+    expect(mocks.tx.socialMessage.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        content: '',
+        giphyId: 'xT9IgG50Fb7Mi0prBC',
+      }),
+      include: {},
+    });
+    expect(mocks.tx.socialOutboxEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        channel: 'CHAT',
+        eventType: 'social:message',
+        payloadJson: expect.stringContaining(
+          '"gif":{"provider":"giphy","id":"xT9IgG50Fb7Mi0prBC"}'
+        ),
+      }),
     });
   });
 

--- a/src/server/leagues/social/socialCommands.test.ts
+++ b/src/server/leagues/social/socialCommands.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const tx = {
+    socialCommand: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    socialMessage: {
+      create: vi.fn(),
+    },
+    socialOutboxEvent: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+    socialReadState: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+    },
+  };
+  return {
+    requireLeagueSocialAccess: vi.fn(),
+    transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    tx,
+  };
+});
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    $transaction: mocks.transaction,
+  },
+}));
+
+vi.mock('./socialAccess', () => ({
+  requireLeagueSocialAccess: mocks.requireLeagueSocialAccess,
+  requireSocialPublishingAccess: vi.fn(),
+  requireSocialManager: vi.fn(),
+}));
+
+vi.mock('./socialDto', () => ({
+  socialMessageInclude: {},
+  socialPostInclude: {},
+  socialReplyInclude: {},
+  toSocialMessage: vi.fn((record) => ({
+    id: record.id,
+    leagueId: record.leagueId,
+    seasonId: record.seasonId,
+    type: 'member',
+    content: record.content,
+    context: record.contextJson ? JSON.parse(record.contextJson) : undefined,
+    author: null,
+    createdAt: record.createdAt.toISOString(),
+    moderationStatus: 'active',
+    isOwn: true,
+  })),
+  toSocialPost: vi.fn((record) => record),
+  toSocialReply: vi.fn((record) => record),
+}));
+
+import { createSocialMessage, markSocialChannelRead } from './socialCommands';
+
+describe('league social Activity commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireLeagueSocialAccess.mockResolvedValue({
+      leagueId: 'league-1',
+      seasonId: 'season-1',
+      userId: 'user-1',
+      memberId: 'member-1',
+      canManage: false,
+      canPublish: true,
+      standardsAccepted: true,
+      mutedUntil: null,
+    });
+    mocks.tx.socialCommand.findUnique.mockResolvedValue(null);
+    mocks.tx.socialCommand.create.mockResolvedValue({ id: 'command-1' });
+    mocks.tx.socialCommand.update.mockResolvedValue({});
+    mocks.tx.socialMessage.create.mockImplementation(({ data }) =>
+      Promise.resolve({
+        id: 'message-1',
+        ...data,
+        createdAt: new Date('2026-07-19T10:00:00.000Z'),
+      })
+    );
+    mocks.tx.socialOutboxEvent.create.mockResolvedValue({ sequence: 22 });
+    mocks.tx.socialReadState.findUnique.mockResolvedValue(null);
+    mocks.tx.socialReadState.upsert.mockResolvedValue({});
+  });
+
+  it('persists validated discussion context with an idempotent member message', async () => {
+    const context = {
+      type: 'trade' as const,
+      id: 'trade-1',
+      title: 'Trade proposal',
+      subtitle: 'Two-player swap',
+      metadata: { status: 'Pending' },
+    };
+
+    await createSocialMessage('league-1', 'user-1', {
+      content: 'Would you accept this?',
+      context,
+      idempotencyKey: 'message:context-1',
+    });
+
+    expect(mocks.tx.socialMessage.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        leagueId: 'league-1',
+        seasonId: 'season-1',
+        authorUserId: 'user-1',
+        contextJson: JSON.stringify(context),
+      }),
+      include: {},
+    });
+  });
+
+  it('stores Activity read state and publishes its cross-device cursor on Activity', async () => {
+    mocks.tx.socialOutboxEvent.findFirst.mockResolvedValueOnce({ sequence: 22 });
+
+    await expect(
+      markSocialChannelRead('league-1', 'user-1', {
+        channel: 'activity',
+        sequence: 22,
+      })
+    ).resolves.toEqual({ channel: 'activity', sequence: 22 });
+
+    expect(mocks.tx.socialOutboxEvent.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          sequence: 22,
+          channel: 'ACTIVITY',
+        }),
+      })
+    );
+    expect(mocks.tx.socialReadState.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ channel: 'ACTIVITY', lastReadSequence: 22 }),
+      })
+    );
+    expect(mocks.tx.socialOutboxEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        channel: 'ACTIVITY',
+        eventType: 'social:read-state',
+        payloadJson: expect.stringContaining('"channel":"activity"'),
+      }),
+    });
+  });
+});

--- a/src/server/leagues/social/socialCommands.ts
+++ b/src/server/leagues/social/socialCommands.ts
@@ -69,6 +69,7 @@ export async function createSocialMessage(
           authorMemberId: access.memberId,
           content: parsed.data.content,
           contextJson: parsed.data.context ? JSON.stringify(parsed.data.context) : null,
+          giphyId: parsed.data.gif?.id ?? null,
         },
         include: socialMessageInclude,
       });
@@ -160,7 +161,7 @@ export async function deleteSocialMessage(
       reason: moderationReason,
       targetUserId: existing.authorUserId,
       targetMemberId: existing.authorMemberId,
-      retainedContent: { content: existing.content },
+      retainedContent: { content: existing.content, giphyId: existing.giphyId },
     });
     const message = toSocialMessage(record, userId);
     await enqueueSocialEvent(

--- a/src/server/leagues/social/socialCommands.ts
+++ b/src/server/leagues/social/socialCommands.ts
@@ -1,0 +1,1007 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+
+import { Prisma, type SocialChannel } from '@prisma/client';
+
+import { prisma } from '@/lib/prisma';
+import type {
+  SocialMessage,
+  SocialPost,
+  SocialRealtimeEnvelope,
+  SocialReply,
+} from '@/types/social';
+
+import {
+  requireLeagueSocialAccess,
+  requireSocialManager,
+  requireSocialPublishingAccess,
+  type LeagueSocialAccess,
+} from './socialAccess';
+import {
+  socialMessageInclude,
+  socialPostInclude,
+  socialReplyInclude,
+  toSocialMessage,
+  toSocialPost,
+  toSocialReply,
+} from './socialDto';
+import { SocialError } from './socialErrors';
+import {
+  createMessageSchema,
+  createPostSchema,
+  createReplySchema,
+  editMessageSchema,
+  editPostSchema,
+  editReplySchema,
+  markReadSchema,
+  moderationActionSchema,
+  reportContentSchema,
+  socialPreferencesSchema,
+} from './socialValidation';
+
+type Transaction = Prisma.TransactionClient;
+type SocialContentType = 'message' | 'post' | 'reply';
+
+export async function createSocialMessage(
+  leagueId: string,
+  userId: string,
+  input: unknown
+): Promise<SocialMessage> {
+  const parsed = createMessageSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new SocialError('VALIDATION', 'Message is invalid', parsed.error.flatten());
+  }
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  requireSocialPublishingAccess(access);
+
+  return executeIdempotentCommand(
+    access,
+    parsed.data.idempotencyKey,
+    'CREATE_MESSAGE',
+    parsed.data,
+    async (tx) => {
+      const record = await tx.socialMessage.create({
+        data: {
+          leagueId,
+          seasonId: access.seasonId,
+          authorUserId: userId,
+          authorMemberId: access.memberId,
+          content: parsed.data.content,
+        },
+        include: socialMessageInclude,
+      });
+      const message = toSocialMessage(record, userId);
+      await enqueueSocialEvent(tx, access, 'CHAT', 'social:message', 'message', record.id, message);
+      return { resultType: 'message', resultId: record.id, value: message };
+    }
+  );
+}
+
+export async function editSocialMessage(
+  leagueId: string,
+  userId: string,
+  messageId: string,
+  input: unknown
+): Promise<SocialMessage> {
+  const parsed = editMessageSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new SocialError('VALIDATION', 'Message is invalid', parsed.error.flatten());
+  }
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  requireSocialPublishingAccess(access);
+
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.socialMessage.findFirst({
+      where: { id: messageId, leagueId, seasonId: access.seasonId },
+      select: { authorUserId: true, deletedAt: true },
+    });
+    if (!existing) throw new SocialError('NOT_FOUND', 'Message not found');
+    if (existing.authorUserId !== userId) {
+      throw new SocialError('FORBIDDEN', 'You can only edit your own messages');
+    }
+    if (existing.deletedAt) throw new SocialError('CONFLICT', 'Removed messages cannot be edited');
+
+    const record = await tx.socialMessage.update({
+      where: { id: messageId },
+      data: {
+        content: parsed.data.content,
+        editedAt: new Date(),
+      },
+      include: socialMessageInclude,
+    });
+    const message = toSocialMessage(record, userId);
+    await enqueueSocialEvent(
+      tx,
+      access,
+      'CHAT',
+      'social:moderation',
+      'message',
+      record.id,
+      message
+    );
+    return message;
+  });
+}
+
+export async function deleteSocialMessage(
+  leagueId: string,
+  userId: string,
+  messageId: string,
+  moderationReason?: string
+): Promise<SocialMessage> {
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.socialMessage.findFirst({
+      where: { id: messageId, leagueId, seasonId: access.seasonId },
+      include: socialMessageInclude,
+    });
+    if (!existing) throw new SocialError('NOT_FOUND', 'Message not found');
+    if (existing.authorUserId !== userId && !access.canManage) {
+      throw new SocialError('FORBIDDEN', 'You cannot remove this message');
+    }
+    if (existing.deletedAt) return toSocialMessage(existing, userId);
+
+    const removedAt = new Date();
+    const record = await tx.socialMessage.update({
+      where: { id: messageId },
+      data: {
+        deletedAt: removedAt,
+        moderationStatus: 'REMOVED',
+      },
+      include: socialMessageInclude,
+    });
+    await retainModerationRecord(tx, access, {
+      contentType: 'message',
+      contentId: messageId,
+      action: existing.authorUserId === userId ? 'SELF_DELETE' : 'REMOVE',
+      reason: moderationReason,
+      targetUserId: existing.authorUserId,
+      targetMemberId: existing.authorMemberId,
+      retainedContent: { content: existing.content },
+    });
+    const message = toSocialMessage(record, userId);
+    await enqueueSocialEvent(
+      tx,
+      access,
+      'CHAT',
+      'social:moderation',
+      'message',
+      record.id,
+      message
+    );
+    return message;
+  });
+}
+
+export async function createSocialPost(
+  leagueId: string,
+  userId: string,
+  input: unknown
+): Promise<SocialPost> {
+  const parsed = createPostSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new SocialError('VALIDATION', 'Post is invalid', parsed.error.flatten());
+  }
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  requireSocialPublishingAccess(access);
+  if (parsed.data.isAnnouncement) requireSocialManager(access);
+
+  return executeIdempotentCommand(
+    access,
+    parsed.data.idempotencyKey,
+    'CREATE_POST',
+    parsed.data,
+    async (tx) => {
+      const category = await tx.socialBoardCategory.findFirst({
+        where: {
+          id: parsed.data.categoryId,
+          leagueId,
+          seasonId: access.seasonId,
+          archivedAt: null,
+        },
+        select: { id: true, slug: true },
+      });
+      if (!category) throw new SocialError('VALIDATION', 'Board category is invalid');
+      if (parsed.data.isAnnouncement && category.slug !== 'announcements') {
+        throw new SocialError('VALIDATION', 'Announcements must use the Announcements category');
+      }
+
+      const now = new Date();
+      const record = await tx.socialPost.create({
+        data: {
+          leagueId,
+          seasonId: access.seasonId,
+          categoryId: category.id,
+          authorUserId: userId,
+          authorMemberId: access.memberId,
+          title: parsed.data.title,
+          body: parsed.data.body,
+          isAnnouncement: parsed.data.isAnnouncement,
+          isPinned: parsed.data.isAnnouncement,
+          pinnedAt: parsed.data.isAnnouncement ? now : null,
+          latestActivityAt: now,
+        },
+        include: socialPostInclude,
+      });
+      const post = toSocialPost(record, userId);
+      await enqueueSocialEvent(tx, access, 'BOARD', 'social:post', 'post', record.id, post);
+      return { resultType: 'post', resultId: record.id, value: post };
+    }
+  );
+}
+
+export async function editSocialPost(
+  leagueId: string,
+  userId: string,
+  postId: string,
+  input: unknown
+): Promise<SocialPost> {
+  const parsed = editPostSchema.safeParse(input);
+  if (!parsed.success || Object.keys(parsed.data).length === 0) {
+    throw new SocialError(
+      'VALIDATION',
+      'Post update is invalid',
+      parsed.success ? undefined : parsed.error.flatten()
+    );
+  }
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  requireSocialPublishingAccess(access);
+
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.socialPost.findFirst({
+      where: { id: postId, leagueId, seasonId: access.seasonId },
+      select: {
+        authorUserId: true,
+        deletedAt: true,
+        isPinned: true,
+        isLocked: true,
+      },
+    });
+    if (!existing) throw new SocialError('NOT_FOUND', 'Discussion not found');
+    const changesContent = parsed.data.title !== undefined || parsed.data.body !== undefined;
+    const changesModeration =
+      parsed.data.isPinned !== undefined || parsed.data.isLocked !== undefined;
+    if (changesContent && existing.authorUserId !== userId && !access.canManage) {
+      throw new SocialError('FORBIDDEN', 'You cannot edit this discussion');
+    }
+    if (changesModeration) requireSocialManager(access);
+    if (existing.deletedAt && changesContent) {
+      throw new SocialError('CONFLICT', 'Removed discussions cannot be edited');
+    }
+
+    const now = new Date();
+    const record = await tx.socialPost.update({
+      where: { id: postId },
+      data: {
+        ...(parsed.data.title !== undefined ? { title: parsed.data.title } : {}),
+        ...(parsed.data.body !== undefined ? { body: parsed.data.body } : {}),
+        ...(changesContent ? { editedAt: now } : {}),
+        ...(parsed.data.isPinned !== undefined
+          ? {
+              isPinned: parsed.data.isPinned,
+              pinnedAt: parsed.data.isPinned ? now : null,
+            }
+          : {}),
+        ...(parsed.data.isLocked !== undefined
+          ? {
+              isLocked: parsed.data.isLocked,
+              lockedAt: parsed.data.isLocked ? now : null,
+            }
+          : {}),
+      },
+      include: socialPostInclude,
+    });
+    const post = toSocialPost(record, userId);
+    await enqueueSocialEvent(
+      tx,
+      access,
+      'BOARD',
+      changesModeration ? 'social:moderation' : 'social:post',
+      'post',
+      record.id,
+      post
+    );
+    return post;
+  });
+}
+
+export async function deleteSocialPost(
+  leagueId: string,
+  userId: string,
+  postId: string,
+  moderationReason?: string
+): Promise<SocialPost> {
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.socialPost.findFirst({
+      where: { id: postId, leagueId, seasonId: access.seasonId },
+      include: socialPostInclude,
+    });
+    if (!existing) throw new SocialError('NOT_FOUND', 'Discussion not found');
+    if (existing.authorUserId !== userId && !access.canManage) {
+      throw new SocialError('FORBIDDEN', 'You cannot remove this discussion');
+    }
+    if (existing.deletedAt) return toSocialPost(existing, userId);
+
+    const record = await tx.socialPost.update({
+      where: { id: postId },
+      data: {
+        deletedAt: new Date(),
+        moderationStatus: 'REMOVED',
+        isPinned: false,
+        pinnedAt: null,
+        isLocked: true,
+        lockedAt: new Date(),
+      },
+      include: socialPostInclude,
+    });
+    await retainModerationRecord(tx, access, {
+      contentType: 'post',
+      contentId: postId,
+      action: existing.authorUserId === userId ? 'SELF_DELETE' : 'REMOVE',
+      reason: moderationReason,
+      targetUserId: existing.authorUserId,
+      targetMemberId: existing.authorMemberId,
+      retainedContent: { title: existing.title, body: existing.body },
+    });
+    const post = toSocialPost(record, userId);
+    await enqueueSocialEvent(tx, access, 'BOARD', 'social:moderation', 'post', record.id, post);
+    return post;
+  });
+}
+
+export async function createSocialReply(
+  leagueId: string,
+  userId: string,
+  postId: string,
+  input: unknown
+): Promise<SocialReply> {
+  const parsed = createReplySchema.safeParse(input);
+  if (!parsed.success) {
+    throw new SocialError('VALIDATION', 'Reply is invalid', parsed.error.flatten());
+  }
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  requireSocialPublishingAccess(access);
+
+  return executeIdempotentCommand(
+    access,
+    parsed.data.idempotencyKey,
+    'CREATE_REPLY',
+    { postId, ...parsed.data },
+    async (tx) => {
+      const post = await tx.socialPost.findFirst({
+        where: { id: postId, leagueId, seasonId: access.seasonId },
+        select: { id: true, isLocked: true, deletedAt: true },
+      });
+      if (!post) throw new SocialError('NOT_FOUND', 'Discussion not found');
+      if (post.isLocked || post.deletedAt) {
+        throw new SocialError('CONFLICT', 'This discussion is locked');
+      }
+
+      const now = new Date();
+      const record = await tx.socialReply.create({
+        data: {
+          leagueId,
+          seasonId: access.seasonId,
+          postId,
+          authorUserId: userId,
+          authorMemberId: access.memberId,
+          body: parsed.data.body,
+        },
+        include: socialReplyInclude,
+      });
+      await tx.socialPost.update({
+        where: { id: postId },
+        data: {
+          replyCount: { increment: 1 },
+          latestActivityAt: now,
+        },
+      });
+      const reply = toSocialReply(record, userId);
+      await enqueueSocialEvent(tx, access, 'BOARD', 'social:reply', 'reply', record.id, reply);
+      return { resultType: 'reply', resultId: record.id, value: reply };
+    }
+  );
+}
+
+export async function editSocialReply(
+  leagueId: string,
+  userId: string,
+  replyId: string,
+  input: unknown
+): Promise<SocialReply> {
+  const parsed = editReplySchema.safeParse(input);
+  if (!parsed.success) {
+    throw new SocialError('VALIDATION', 'Reply is invalid', parsed.error.flatten());
+  }
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  requireSocialPublishingAccess(access);
+
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.socialReply.findFirst({
+      where: { id: replyId, leagueId, seasonId: access.seasonId },
+      select: { authorUserId: true, deletedAt: true },
+    });
+    if (!existing) throw new SocialError('NOT_FOUND', 'Reply not found');
+    if (existing.authorUserId !== userId) {
+      throw new SocialError('FORBIDDEN', 'You can only edit your own replies');
+    }
+    if (existing.deletedAt) throw new SocialError('CONFLICT', 'Removed replies cannot be edited');
+
+    const record = await tx.socialReply.update({
+      where: { id: replyId },
+      data: { body: parsed.data.body, editedAt: new Date() },
+      include: socialReplyInclude,
+    });
+    const reply = toSocialReply(record, userId);
+    await enqueueSocialEvent(tx, access, 'BOARD', 'social:moderation', 'reply', record.id, reply);
+    return reply;
+  });
+}
+
+export async function deleteSocialReply(
+  leagueId: string,
+  userId: string,
+  replyId: string,
+  moderationReason?: string
+): Promise<SocialReply> {
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.socialReply.findFirst({
+      where: { id: replyId, leagueId, seasonId: access.seasonId },
+      include: socialReplyInclude,
+    });
+    if (!existing) throw new SocialError('NOT_FOUND', 'Reply not found');
+    if (existing.authorUserId !== userId && !access.canManage) {
+      throw new SocialError('FORBIDDEN', 'You cannot remove this reply');
+    }
+    if (existing.deletedAt) return toSocialReply(existing, userId);
+
+    const record = await tx.socialReply.update({
+      where: { id: replyId },
+      data: { deletedAt: new Date(), moderationStatus: 'REMOVED' },
+      include: socialReplyInclude,
+    });
+    await retainModerationRecord(tx, access, {
+      contentType: 'reply',
+      contentId: replyId,
+      action: existing.authorUserId === userId ? 'SELF_DELETE' : 'REMOVE',
+      reason: moderationReason,
+      targetUserId: existing.authorUserId,
+      targetMemberId: existing.authorMemberId,
+      retainedContent: { body: existing.body },
+    });
+    const reply = toSocialReply(record, userId);
+    await enqueueSocialEvent(tx, access, 'BOARD', 'social:moderation', 'reply', record.id, reply);
+    return reply;
+  });
+}
+
+export async function markSocialChannelRead(
+  leagueId: string,
+  userId: string,
+  input: unknown
+): Promise<{ channel: 'chat' | 'board'; sequence: number }> {
+  const parsed = markReadSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new SocialError('VALIDATION', 'Read state is invalid', parsed.error.flatten());
+  }
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  const channel: SocialChannel = parsed.data.channel === 'chat' ? 'CHAT' : 'BOARD';
+
+  return prisma.$transaction(async (tx) => {
+    const requestedSequence =
+      parsed.data.sequence ??
+      (
+        await tx.socialOutboxEvent.findFirst({
+          where: {
+            leagueId,
+            seasonId: access.seasonId,
+            channel,
+            eventType: { not: 'social:read-state' },
+          },
+          orderBy: { sequence: 'desc' },
+          select: { sequence: true },
+        })
+      )?.sequence ??
+      0;
+
+    if (requestedSequence > 0) {
+      const event = await tx.socialOutboxEvent.findFirst({
+        where: {
+          sequence: requestedSequence,
+          leagueId,
+          seasonId: access.seasonId,
+          channel,
+          eventType: { not: 'social:read-state' },
+        },
+        select: { sequence: true },
+      });
+      if (!event) throw new SocialError('VALIDATION', 'Read sequence is invalid');
+    }
+
+    const existing = await tx.socialReadState.findUnique({
+      where: {
+        seasonId_userId_channel: {
+          seasonId: access.seasonId,
+          userId,
+          channel,
+        },
+      },
+      select: { id: true, lastReadSequence: true },
+    });
+    const sequence = Math.max(existing?.lastReadSequence ?? 0, requestedSequence);
+    await tx.socialReadState.upsert({
+      where: {
+        seasonId_userId_channel: {
+          seasonId: access.seasonId,
+          userId,
+          channel,
+        },
+      },
+      update: {
+        lastReadSequence: sequence,
+        lastReadAt: new Date(),
+        memberId: access.memberId,
+      },
+      create: {
+        leagueId,
+        seasonId: access.seasonId,
+        userId,
+        memberId: access.memberId,
+        channel,
+        lastReadSequence: sequence,
+        lastReadAt: new Date(),
+      },
+    });
+    await enqueueSocialEvent(
+      tx,
+      access,
+      channel,
+      'social:read-state',
+      'read-state',
+      `${access.memberId}:${parsed.data.channel}`,
+      {
+        userId,
+        channel: parsed.data.channel,
+        sequence,
+      }
+    );
+    return { channel: parsed.data.channel, sequence };
+  });
+}
+
+export async function reportSocialContent(
+  leagueId: string,
+  userId: string,
+  input: unknown
+): Promise<{ id: string; status: string }> {
+  const parsed = reportContentSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new SocialError('VALIDATION', 'Report is invalid', parsed.error.flatten());
+  }
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+
+  return prisma.$transaction(async (tx) => {
+    const content = await findSocialContentAuthor(
+      tx,
+      access,
+      parsed.data.contentType,
+      parsed.data.contentId
+    );
+    const report = await tx.socialReport.create({
+      data: {
+        leagueId,
+        seasonId: access.seasonId,
+        reporterUserId: userId,
+        reporterMemberId: access.memberId,
+        authorUserId: content.authorUserId,
+        authorMemberId: content.authorMemberId,
+        contentType: parsed.data.contentType,
+        contentId: parsed.data.contentId,
+        reason: parsed.data.reason,
+        details: parsed.data.details,
+      },
+      select: { id: true, status: true },
+    });
+    return report;
+  });
+}
+
+export async function updateSocialPreferences(leagueId: string, userId: string, input: unknown) {
+  const parsed = socialPreferencesSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new SocialError('VALIDATION', 'Social notification preferences are invalid');
+  }
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  const member = await prisma.leagueMember.findFirst({
+    where: { id: access.memberId, leagueId, isActive: true },
+    select: { id: true, notificationSettingsJson: true },
+  });
+  if (!member) throw new SocialError('FORBIDDEN', 'Active league membership is required');
+
+  let existing: Record<string, unknown> = {};
+  if (member.notificationSettingsJson) {
+    try {
+      const parsedExisting = JSON.parse(member.notificationSettingsJson) as unknown;
+      if (parsedExisting && typeof parsedExisting === 'object' && !Array.isArray(parsedExisting)) {
+        existing = parsedExisting as Record<string, unknown>;
+      }
+    } catch {
+      existing = {};
+    }
+  }
+  await prisma.leagueMember.update({
+    where: { id: member.id },
+    data: {
+      notificationSettingsJson: JSON.stringify({
+        ...existing,
+        social: parsed.data,
+      }),
+    },
+  });
+  return parsed.data;
+}
+
+export async function acceptSocialStandards(
+  leagueId: string,
+  userId: string
+): Promise<{ acceptedAt: string }> {
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  const acceptedAt = new Date();
+  const updated = await prisma.leagueMember.updateMany({
+    where: {
+      id: access.memberId,
+      leagueId,
+      userId,
+      isActive: true,
+    },
+    data: { socialStandardsAcceptedAt: acceptedAt },
+  });
+  if (updated.count !== 1) {
+    throw new SocialError('FORBIDDEN', 'Active league membership is required');
+  }
+  return { acceptedAt: acceptedAt.toISOString() };
+}
+
+export async function moderateSocialContent(
+  leagueId: string,
+  userId: string,
+  input: unknown
+): Promise<unknown> {
+  const parsed = moderationActionSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new SocialError('VALIDATION', 'Moderation action is invalid', parsed.error.flatten());
+  }
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  requireSocialManager(access);
+
+  if (parsed.data.action === 'mute' || parsed.data.action === 'unmute') {
+    return moderateSocialMute(access, parsed.data);
+  }
+  const contentAction = parsed.data;
+
+  const content = await findSocialContentAuthor(
+    prisma,
+    access,
+    contentAction.contentType,
+    contentAction.contentId
+  );
+  if (contentAction.action === 'remove') {
+    if (contentAction.contentType === 'message') {
+      return deleteSocialMessage(leagueId, userId, contentAction.contentId, contentAction.reason);
+    }
+    if (contentAction.contentType === 'post') {
+      return deleteSocialPost(leagueId, userId, contentAction.contentId, contentAction.reason);
+    }
+    return deleteSocialReply(leagueId, userId, contentAction.contentId, contentAction.reason);
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const now = new Date();
+    if (contentAction.contentType === 'message') {
+      await tx.socialMessage.update({
+        where: { id: contentAction.contentId },
+        data: { deletedAt: null, moderationStatus: 'ACTIVE' },
+      });
+    } else if (contentAction.contentType === 'post') {
+      await tx.socialPost.update({
+        where: { id: contentAction.contentId },
+        data: { deletedAt: null, moderationStatus: 'ACTIVE' },
+      });
+    } else {
+      await tx.socialReply.update({
+        where: { id: contentAction.contentId },
+        data: { deletedAt: null, moderationStatus: 'ACTIVE' },
+      });
+    }
+    await retainModerationRecord(tx, access, {
+      contentType: contentAction.contentType,
+      contentId: contentAction.contentId,
+      action: 'RESTORE',
+      reason: contentAction.reason,
+      targetUserId: content.authorUserId,
+      targetMemberId: content.authorMemberId,
+    });
+    await enqueueSocialEvent(
+      tx,
+      access,
+      contentAction.contentType === 'message' ? 'CHAT' : 'BOARD',
+      'social:moderation',
+      contentAction.contentType,
+      contentAction.contentId,
+      {
+        contentType: contentAction.contentType,
+        contentId: contentAction.contentId,
+        action: 'restore',
+        occurredAt: now.toISOString(),
+      }
+    );
+    return {
+      contentType: contentAction.contentType,
+      contentId: contentAction.contentId,
+      action: 'restore',
+    };
+  });
+}
+
+async function moderateSocialMute(
+  access: LeagueSocialAccess,
+  action:
+    | { action: 'mute'; userId: string; until: string; reason: string }
+    | { action: 'unmute'; userId: string; reason: string }
+): Promise<Record<string, unknown>> {
+  if (action.userId === access.userId) {
+    throw new SocialError('VALIDATION', 'Commissioners cannot mute themselves');
+  }
+  const target = await prisma.leagueMember.findFirst({
+    where: {
+      leagueId: access.leagueId,
+      userId: action.userId,
+      isActive: true,
+      status: 'ACTIVE',
+    },
+    select: { id: true },
+  });
+  if (!target) throw new SocialError('NOT_FOUND', 'Active league member not found');
+
+  if (action.action === 'mute') {
+    const until = new Date(action.until);
+    if (until <= new Date())
+      throw new SocialError('VALIDATION', 'Mute expiry must be in the future');
+    const mute = await prisma.socialMute.create({
+      data: {
+        leagueId: access.leagueId,
+        seasonId: access.seasonId,
+        mutedUserId: action.userId,
+        mutedMemberId: target.id,
+        createdByUserId: access.userId,
+        createdByMemberId: access.memberId,
+        reason: action.reason,
+        expiresAt: until,
+      },
+      select: { id: true, expiresAt: true },
+    });
+    return {
+      action: 'mute',
+      userId: action.userId,
+      muteId: mute.id,
+      expiresAt: mute.expiresAt?.toISOString() ?? null,
+    };
+  }
+
+  await prisma.socialMute.updateMany({
+    where: {
+      leagueId: access.leagueId,
+      seasonId: access.seasonId,
+      mutedUserId: action.userId,
+      revokedAt: null,
+    },
+    data: {
+      revokedAt: new Date(),
+      revokedByUserId: access.userId,
+    },
+  });
+  return { action: 'unmute', userId: action.userId };
+}
+
+async function executeIdempotentCommand<T>(
+  access: LeagueSocialAccess,
+  idempotencyKey: string,
+  commandType: string,
+  request: unknown,
+  execute: (tx: Transaction) => Promise<{ resultType: string; resultId: string; value: T }>
+): Promise<T> {
+  const requestHash = createHash('sha256').update(stableStringify(request)).digest('hex');
+
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const existing = await tx.socialCommand.findUnique({
+        where: {
+          leagueId_actorUserId_idempotencyKey: {
+            leagueId: access.leagueId,
+            actorUserId: access.userId,
+            idempotencyKey,
+          },
+        },
+      });
+      if (existing) return readIdempotentResult<T>(existing, commandType, requestHash);
+
+      const command = await tx.socialCommand.create({
+        data: {
+          leagueId: access.leagueId,
+          seasonId: access.seasonId,
+          actorUserId: access.userId,
+          actorMemberId: access.memberId,
+          idempotencyKey,
+          commandType,
+          requestHash,
+        },
+      });
+      const result = await execute(tx);
+      await tx.socialCommand.update({
+        where: { id: command.id },
+        data: {
+          resultType: result.resultType,
+          resultId: result.resultId,
+          responseJson: JSON.stringify(result.value),
+        },
+      });
+      return result.value;
+    });
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+    const existing = await prisma.socialCommand.findUnique({
+      where: {
+        leagueId_actorUserId_idempotencyKey: {
+          leagueId: access.leagueId,
+          actorUserId: access.userId,
+          idempotencyKey,
+        },
+      },
+    });
+    if (!existing) throw error;
+    return readIdempotentResult<T>(existing, commandType, requestHash);
+  }
+}
+
+function readIdempotentResult<T>(
+  command: {
+    commandType: string;
+    requestHash: string;
+    responseJson: string | null;
+  },
+  commandType: string,
+  requestHash: string
+): T {
+  if (command.commandType !== commandType || command.requestHash !== requestHash) {
+    throw new SocialError('CONFLICT', 'Idempotency key was already used for another request');
+  }
+  if (!command.responseJson) {
+    throw new SocialError('CONFLICT', 'The original request is still being processed');
+  }
+  return JSON.parse(command.responseJson) as T;
+}
+
+async function enqueueSocialEvent(
+  tx: Transaction,
+  access: LeagueSocialAccess,
+  channel: SocialChannel,
+  event: SocialRealtimeEnvelope['event'],
+  aggregateType: string,
+  aggregateId: string,
+  payload: SocialRealtimeEnvelope['payload']
+): Promise<void> {
+  const outbox = await tx.socialOutboxEvent.create({
+    data: {
+      leagueId: access.leagueId,
+      seasonId: access.seasonId,
+      channel,
+      actorUserId: access.userId,
+      eventType: event,
+      aggregateType,
+      aggregateId,
+      payloadJson: JSON.stringify(payload),
+    },
+    select: { id: true, sequence: true, createdAt: true },
+  });
+  const envelope: SocialRealtimeEnvelope = {
+    id: outbox.id,
+    sequence: outbox.sequence,
+    leagueId: access.leagueId,
+    seasonId: access.seasonId,
+    channel: channel === 'CHAT' ? 'chat' : 'board',
+    event,
+    payload,
+    occurredAt: outbox.createdAt.toISOString(),
+  };
+  await tx.socialOutboxEvent.update({
+    where: { sequence: outbox.sequence },
+    data: { payloadJson: JSON.stringify(envelope) },
+  });
+}
+
+async function retainModerationRecord(
+  tx: Transaction,
+  access: LeagueSocialAccess,
+  input: {
+    contentType: SocialContentType;
+    contentId: string;
+    action: string;
+    reason?: string;
+    targetUserId?: string | null;
+    targetMemberId?: string | null;
+    retainedContent?: unknown;
+  }
+): Promise<void> {
+  await tx.socialModerationRecord.create({
+    data: {
+      leagueId: access.leagueId,
+      seasonId: access.seasonId,
+      actorUserId: access.userId,
+      actorMemberId: access.memberId,
+      targetUserId: input.targetUserId,
+      targetMemberId: input.targetMemberId,
+      contentType: input.contentType,
+      contentId: input.contentId,
+      action: input.action,
+      reason: input.reason,
+      retainedContentJson:
+        input.retainedContent === undefined ? undefined : JSON.stringify(input.retainedContent),
+    },
+  });
+}
+
+async function findSocialContentAuthor(
+  client: Pick<Transaction, 'socialMessage' | 'socialPost' | 'socialReply'>,
+  access: LeagueSocialAccess,
+  contentType: SocialContentType,
+  contentId: string
+): Promise<{ authorUserId: string | null; authorMemberId: string | null }> {
+  const where = {
+    id: contentId,
+    leagueId: access.leagueId,
+    seasonId: access.seasonId,
+  };
+  if (contentType === 'message') {
+    const record = await client.socialMessage.findFirst({
+      where,
+      select: { authorUserId: true, authorMemberId: true },
+    });
+    if (!record) throw new SocialError('NOT_FOUND', 'Message not found');
+    return record;
+  }
+  if (contentType === 'post') {
+    const record = await client.socialPost.findFirst({
+      where,
+      select: { authorUserId: true, authorMemberId: true },
+    });
+    if (!record) throw new SocialError('NOT_FOUND', 'Discussion not found');
+    return record;
+  }
+  const record = await client.socialReply.findFirst({
+    where,
+    select: { authorUserId: true, authorMemberId: true },
+  });
+  if (!record) throw new SocialError('NOT_FOUND', 'Reply not found');
+  return record;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002';
+}

--- a/src/server/leagues/social/socialCommands.ts
+++ b/src/server/leagues/social/socialCommands.ts
@@ -68,6 +68,7 @@ export async function createSocialMessage(
           authorUserId: userId,
           authorMemberId: access.memberId,
           content: parsed.data.content,
+          contextJson: parsed.data.context ? JSON.stringify(parsed.data.context) : null,
         },
         include: socialMessageInclude,
       });
@@ -485,13 +486,18 @@ export async function markSocialChannelRead(
   leagueId: string,
   userId: string,
   input: unknown
-): Promise<{ channel: 'chat' | 'board'; sequence: number }> {
+): Promise<{ channel: 'chat' | 'board' | 'activity'; sequence: number }> {
   const parsed = markReadSchema.safeParse(input);
   if (!parsed.success) {
     throw new SocialError('VALIDATION', 'Read state is invalid', parsed.error.flatten());
   }
   const access = await requireLeagueSocialAccess(leagueId, userId);
-  const channel: SocialChannel = parsed.data.channel === 'chat' ? 'CHAT' : 'BOARD';
+  const channel: SocialChannel =
+    parsed.data.channel === 'chat'
+      ? 'CHAT'
+      : parsed.data.channel === 'board'
+        ? 'BOARD'
+        : 'ACTIVITY';
 
   return prisma.$transaction(async (tx) => {
     const requestedSequence =
@@ -896,7 +902,7 @@ async function enqueueSocialEvent(
   aggregateId: string,
   payload: SocialRealtimeEnvelope['payload']
 ): Promise<void> {
-  const outbox = await tx.socialOutboxEvent.create({
+  await tx.socialOutboxEvent.create({
     data: {
       leagueId: access.leagueId,
       seasonId: access.seasonId,
@@ -907,21 +913,6 @@ async function enqueueSocialEvent(
       aggregateId,
       payloadJson: JSON.stringify(payload),
     },
-    select: { id: true, sequence: true, createdAt: true },
-  });
-  const envelope: SocialRealtimeEnvelope = {
-    id: outbox.id,
-    sequence: outbox.sequence,
-    leagueId: access.leagueId,
-    seasonId: access.seasonId,
-    channel: channel === 'CHAT' ? 'chat' : 'board',
-    event,
-    payload,
-    occurredAt: outbox.createdAt.toISOString(),
-  };
-  await tx.socialOutboxEvent.update({
-    where: { sequence: outbox.sequence },
-    data: { payloadJson: JSON.stringify(envelope) },
   });
 }
 

--- a/src/server/leagues/social/socialDto.ts
+++ b/src/server/leagues/social/socialDto.ts
@@ -3,10 +3,13 @@ import type { Prisma } from '@prisma/client';
 import type {
   SocialAuthor,
   SocialBoardCategory,
+  SocialDiscussionContext,
   SocialMessage,
   SocialPost,
   SocialReply,
 } from '@/types/social';
+
+import { socialDiscussionContextSchema } from './socialValidation';
 
 export const socialAuthorMemberSelect = {
   id: true,
@@ -77,12 +80,14 @@ export function toSocialCategory(
 
 export function toSocialMessage(record: MessageRecord, currentUserId: string): SocialMessage {
   const isRemoved = record.deletedAt !== null || record.moderationStatus === 'REMOVED';
+  const context = isRemoved ? null : parseSocialDiscussionContext(record.contextJson);
   return {
     id: record.id,
     leagueId: record.leagueId,
     seasonId: record.seasonId,
     type: record.type === 'SYSTEM' ? 'system' : 'member',
     content: isRemoved ? 'Message removed' : record.content,
+    ...(context ? { context } : {}),
     author: toSocialAuthor(record.authorMember, record.authorUserId),
     ...(record.relatedEntityId ? { relatedEntityId: record.relatedEntityId } : {}),
     createdAt: record.createdAt.toISOString(),
@@ -133,4 +138,14 @@ export function toSocialReply(record: ReplyRecord, currentUserId: string): Socia
     moderationStatus: isRemoved ? 'removed' : 'active',
     isOwn: record.authorUserId === currentUserId,
   };
+}
+
+function parseSocialDiscussionContext(value: string | null): SocialDiscussionContext | null {
+  if (!value) return null;
+  try {
+    const parsed = socialDiscussionContextSchema.safeParse(JSON.parse(value));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
 }

--- a/src/server/leagues/social/socialDto.ts
+++ b/src/server/leagues/social/socialDto.ts
@@ -1,0 +1,136 @@
+import type { Prisma } from '@prisma/client';
+
+import type {
+  SocialAuthor,
+  SocialBoardCategory,
+  SocialMessage,
+  SocialPost,
+  SocialReply,
+} from '@/types/social';
+
+export const socialAuthorMemberSelect = {
+  id: true,
+  userId: true,
+  teamName: true,
+  teamLogoUrl: true,
+  user: {
+    select: {
+      displayName: true,
+    },
+  },
+} satisfies Prisma.LeagueMemberSelect;
+
+export const socialMessageInclude = {
+  authorMember: { select: socialAuthorMemberSelect },
+} satisfies Prisma.SocialMessageInclude;
+
+export const socialPostInclude = {
+  category: true,
+  authorMember: { select: socialAuthorMemberSelect },
+} satisfies Prisma.SocialPostInclude;
+
+export const socialReplyInclude = {
+  authorMember: { select: socialAuthorMemberSelect },
+} satisfies Prisma.SocialReplyInclude;
+
+type AuthorMember = Prisma.LeagueMemberGetPayload<{
+  select: typeof socialAuthorMemberSelect;
+}>;
+
+type MessageRecord = Prisma.SocialMessageGetPayload<{
+  include: typeof socialMessageInclude;
+}>;
+
+type PostRecord = Prisma.SocialPostGetPayload<{
+  include: typeof socialPostInclude;
+}>;
+
+type ReplyRecord = Prisma.SocialReplyGetPayload<{
+  include: typeof socialReplyInclude;
+}>;
+
+export function toSocialAuthor(
+  member: AuthorMember | null,
+  userId?: string | null
+): SocialAuthor | null {
+  if (!member && !userId) return null;
+
+  return {
+    userId: member?.userId ?? userId ?? '',
+    ...(member?.id ? { memberId: member.id, teamId: member.id } : {}),
+    displayName: member?.user.displayName || 'Former league member',
+    teamName: member?.teamName || 'Former team',
+    ...(member?.teamLogoUrl ? { avatarUrl: member.teamLogoUrl } : {}),
+  };
+}
+
+export function toSocialCategory(
+  category: Pick<Prisma.SocialBoardCategoryGetPayload<object>, 'id' | 'slug' | 'name' | 'sortOrder'>
+): SocialBoardCategory {
+  return {
+    id: category.id,
+    key: category.slug,
+    name: category.name,
+    position: category.sortOrder,
+  };
+}
+
+export function toSocialMessage(record: MessageRecord, currentUserId: string): SocialMessage {
+  const isRemoved = record.deletedAt !== null || record.moderationStatus === 'REMOVED';
+  return {
+    id: record.id,
+    leagueId: record.leagueId,
+    seasonId: record.seasonId,
+    type: record.type === 'SYSTEM' ? 'system' : 'member',
+    content: isRemoved ? 'Message removed' : record.content,
+    author: toSocialAuthor(record.authorMember, record.authorUserId),
+    ...(record.relatedEntityId ? { relatedEntityId: record.relatedEntityId } : {}),
+    createdAt: record.createdAt.toISOString(),
+    ...(record.editedAt ? { editedAt: record.editedAt.toISOString() } : {}),
+    ...(record.deletedAt ? { deletedAt: record.deletedAt.toISOString() } : {}),
+    moderationStatus: isRemoved ? 'removed' : 'active',
+    isOwn: record.authorUserId === currentUserId,
+  };
+}
+
+export function toSocialPost(record: PostRecord, currentUserId: string): SocialPost {
+  const isRemoved = record.deletedAt !== null || record.moderationStatus === 'REMOVED';
+  return {
+    id: record.id,
+    leagueId: record.leagueId,
+    seasonId: record.seasonId,
+    category: toSocialCategory(record.category),
+    author: toSocialAuthor(record.authorMember, record.authorUserId),
+    title: isRemoved ? 'Post removed' : record.title,
+    body: isRemoved ? 'Post removed' : record.body,
+    isPinned: record.isPinned,
+    isLocked: record.isLocked,
+    isAnnouncement: record.isAnnouncement,
+    replyCount: record.replyCount,
+    latestActivityAt: record.latestActivityAt.toISOString(),
+    createdAt: record.createdAt.toISOString(),
+    updatedAt: record.updatedAt.toISOString(),
+    ...(record.editedAt ? { editedAt: record.editedAt.toISOString() } : {}),
+    ...(record.deletedAt ? { deletedAt: record.deletedAt.toISOString() } : {}),
+    moderationStatus: isRemoved ? 'removed' : 'active',
+    isOwn: record.authorUserId === currentUserId,
+  };
+}
+
+export function toSocialReply(record: ReplyRecord, currentUserId: string): SocialReply {
+  const isRemoved = record.deletedAt !== null || record.moderationStatus === 'REMOVED';
+  return {
+    id: record.id,
+    postId: record.postId,
+    leagueId: record.leagueId,
+    seasonId: record.seasonId,
+    author: toSocialAuthor(record.authorMember, record.authorUserId),
+    body: isRemoved ? 'Reply removed' : record.body,
+    createdAt: record.createdAt.toISOString(),
+    updatedAt: record.updatedAt.toISOString(),
+    ...(record.editedAt ? { editedAt: record.editedAt.toISOString() } : {}),
+    ...(record.deletedAt ? { deletedAt: record.deletedAt.toISOString() } : {}),
+    moderationStatus: isRemoved ? 'removed' : 'active',
+    isOwn: record.authorUserId === currentUserId,
+  };
+}

--- a/src/server/leagues/social/socialDto.ts
+++ b/src/server/leagues/social/socialDto.ts
@@ -88,6 +88,9 @@ export function toSocialMessage(record: MessageRecord, currentUserId: string): S
     type: record.type === 'SYSTEM' ? 'system' : 'member',
     content: isRemoved ? 'Message removed' : record.content,
     ...(context ? { context } : {}),
+    ...(!isRemoved && record.giphyId
+      ? { gif: { provider: 'giphy' as const, id: record.giphyId } }
+      : {}),
     author: toSocialAuthor(record.authorMember, record.authorUserId),
     ...(record.relatedEntityId ? { relatedEntityId: record.relatedEntityId } : {}),
     createdAt: record.createdAt.toISOString(),

--- a/src/server/leagues/social/socialErrors.ts
+++ b/src/server/leagues/social/socialErrors.ts
@@ -1,0 +1,63 @@
+export type SocialErrorCode =
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'VALIDATION'
+  | 'CONFLICT'
+  | 'RATE_LIMITED'
+  | 'MUTED'
+  | 'INTERNAL';
+
+const SOCIAL_ERROR_STATUS: Record<SocialErrorCode, number> = {
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  VALIDATION: 400,
+  CONFLICT: 409,
+  RATE_LIMITED: 429,
+  MUTED: 403,
+  INTERNAL: 500,
+};
+
+export class SocialError extends Error {
+  readonly code: SocialErrorCode;
+  readonly status: number;
+  readonly details?: unknown;
+
+  constructor(code: SocialErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = 'SocialError';
+    this.code = code;
+    this.status = SOCIAL_ERROR_STATUS[code];
+    this.details = details;
+  }
+}
+
+export function toSocialErrorResponse(error: unknown): {
+  status: number;
+  body: {
+    success: false;
+    error: {
+      code: SocialErrorCode;
+      message: string;
+      details?: unknown;
+    };
+  };
+} {
+  const socialError =
+    error instanceof SocialError
+      ? error
+      : new SocialError('INTERNAL', 'League social content is temporarily unavailable');
+
+  return {
+    status: socialError.status,
+    body: {
+      success: false,
+      error: {
+        code: socialError.code,
+        message: socialError.message,
+        ...(socialError.details === undefined ? {} : { details: socialError.details }),
+      },
+    },
+  };
+}

--- a/src/server/leagues/social/socialPubSub.ts
+++ b/src/server/leagues/social/socialPubSub.ts
@@ -1,0 +1,103 @@
+import type { Cluster as IORedisCluster, Redis as IORedisClient } from 'ioredis';
+import { z } from 'zod';
+
+import { logger } from '@/lib/logger';
+import { shouldDisableRedisClients } from '@/lib/redisConfig';
+import { getPublisherClient, getSubscriberClient } from '@/server/realtime/scalableConnection';
+import type { SocialRealtimeEnvelope } from '@/types/social';
+
+const SocialEnvelopeSchema = z.object({
+  id: z.string().min(1),
+  sequence: z.number().int().nonnegative(),
+  leagueId: z.string().min(1),
+  seasonId: z.string().min(1),
+  channel: z.enum(['chat', 'board']),
+  event: z.enum([
+    'social:message',
+    'social:post',
+    'social:reply',
+    'social:moderation',
+    'social:read-state',
+  ]),
+  payload: z.unknown(),
+  occurredAt: z.string().min(1),
+});
+
+const PubSubEnvelopeSchema = z.object({
+  version: z.literal(1),
+  instanceId: z.string().min(1),
+  event: SocialEnvelopeSchema,
+});
+
+const INSTANCE_ID = `${process.pid}-${Math.random().toString(36).slice(2)}`;
+
+function channelPrefix(): string {
+  return process.env.SOCIAL_REALTIME_CHANNEL_PREFIX || 'social-events';
+}
+
+function channelForLeague(leagueId: string): string {
+  return `${channelPrefix()}:${leagueId}`;
+}
+
+type RedisPubSubClient = IORedisClient | IORedisCluster;
+
+class SocialPubSub {
+  private publisher?: RedisPubSubClient;
+  private subscriber?: RedisPubSubClient;
+  private started = false;
+
+  async start(onEvent: (event: SocialRealtimeEnvelope) => Promise<void> | void): Promise<void> {
+    if (shouldDisableRedisClients() || this.started) return;
+
+    const pattern = `${channelPrefix()}:*`;
+    const subscriber = (this.subscriber ??= getSubscriberClient());
+    await subscriber.psubscribe(pattern);
+    subscriber.on('pmessage', (matchedPattern: unknown, _channel: unknown, message: unknown) => {
+      if (matchedPattern !== pattern || typeof message !== 'string') return;
+      const parsed = PubSubEnvelopeSchema.safeParse(parseJson(message));
+      if (!parsed.success) {
+        logger.warn('Ignored invalid league social pubsub event', {
+          issues: parsed.error.issues.map((issue) => ({
+            path: issue.path,
+            code: issue.code,
+          })),
+        });
+        return;
+      }
+      if (parsed.data.instanceId === INSTANCE_ID) return;
+      const event = parsed.data.event as SocialRealtimeEnvelope;
+      void Promise.resolve(onEvent(event)).catch((error) => {
+        logger.warn('Failed to dispatch league social pubsub event', {
+          leagueId: event.leagueId,
+          eventId: event.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    });
+    this.started = true;
+    logger.info('League social pubsub subscriber started', { pattern });
+  }
+
+  async publish(event: SocialRealtimeEnvelope): Promise<void> {
+    if (shouldDisableRedisClients()) return;
+    const publisher = (this.publisher ??= getPublisherClient());
+    await publisher.publish(
+      channelForLeague(event.leagueId),
+      JSON.stringify({
+        version: 1,
+        instanceId: INSTANCE_ID,
+        event,
+      })
+    );
+  }
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+export const socialPubSub = new SocialPubSub();

--- a/src/server/leagues/social/socialPubSub.ts
+++ b/src/server/leagues/social/socialPubSub.ts
@@ -11,9 +11,10 @@ const SocialEnvelopeSchema = z.object({
   sequence: z.number().int().nonnegative(),
   leagueId: z.string().min(1),
   seasonId: z.string().min(1),
-  channel: z.enum(['chat', 'board']),
+  channel: z.enum(['chat', 'board', 'activity']),
   event: z.enum([
     'social:message',
+    'social:activity',
     'social:post',
     'social:reply',
     'social:moderation',

--- a/src/server/leagues/social/socialPublisher.test.ts
+++ b/src/server/leagues/social/socialPublisher.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  outboxFindMany: vi.fn(),
+  outboxUpdateMany: vi.fn(),
+  outboxUpdate: vi.fn(),
+  publishRealtime: vi.fn(),
+  loggerWarn: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    socialOutboxEvent: {
+      findMany: mocks.outboxFindMany,
+      updateMany: mocks.outboxUpdateMany,
+      update: mocks.outboxUpdate,
+    },
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: mocks.loggerWarn },
+}));
+
+vi.mock('./socialSocket', () => ({
+  publishLeagueSocialRealtimeEvent: mocks.publishRealtime,
+}));
+
+import { flushSocialOutboxBatch } from './socialPublisher';
+
+describe('league social outbox publisher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.outboxUpdateMany.mockResolvedValue({ count: 1 });
+    mocks.outboxUpdate.mockResolvedValue({});
+    mocks.publishRealtime.mockResolvedValue(undefined);
+  });
+
+  it('uses authoritative outbox routing while extracting payloads from legacy envelopes', async () => {
+    const createdAt = new Date('2026-07-19T10:00:00.000Z');
+    mocks.outboxFindMany.mockResolvedValueOnce([{ sequence: 12 }]).mockResolvedValueOnce([
+      {
+        sequence: 12,
+        id: 'outbox-12',
+        leagueId: 'league-1',
+        seasonId: 'season-1',
+        channel: 'ACTIVITY',
+        actorUserId: null,
+        eventType: 'social:activity',
+        aggregateType: 'activity',
+        aggregateId: 'message-1',
+        payloadJson: JSON.stringify({
+          id: 'legacy-id',
+          sequence: 2,
+          leagueId: 'wrong-league',
+          seasonId: 'wrong-season',
+          channel: 'chat',
+          event: 'social:message',
+          payload: {
+            id: 'message-1',
+            type: 'system',
+            content: 'Jordan Example was drafted.',
+          },
+          occurredAt: '2025-01-01T00:00:00.000Z',
+        }),
+        status: 'PROCESSING',
+        attempts: 1,
+        availableAt: createdAt,
+        lockedAt: createdAt,
+        lockedBy: 'claim',
+        publishedAt: null,
+        lastError: null,
+        createdAt,
+      },
+    ]);
+
+    await expect(flushSocialOutboxBatch({} as never)).resolves.toBe(1);
+
+    expect(mocks.publishRealtime).toHaveBeenCalledWith(
+      {},
+      {
+        id: 'outbox-12',
+        sequence: 12,
+        leagueId: 'league-1',
+        seasonId: 'season-1',
+        channel: 'activity',
+        event: 'social:activity',
+        payload: {
+          id: 'message-1',
+          type: 'system',
+          content: 'Jordan Example was drafted.',
+        },
+        occurredAt: createdAt.toISOString(),
+      }
+    );
+  });
+});

--- a/src/server/leagues/social/socialPublisher.ts
+++ b/src/server/leagues/social/socialPublisher.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 import { randomUUID } from 'node:crypto';
 
 import type { SocialOutboxEvent } from '@prisma/client';

--- a/src/server/leagues/social/socialPublisher.ts
+++ b/src/server/leagues/social/socialPublisher.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { randomUUID } from 'node:crypto';
 
+import type { SocialOutboxEvent } from '@prisma/client';
 import type { Server as SocketIOServer } from 'socket.io';
 
 import { logger } from '@/lib/logger';
@@ -12,6 +13,14 @@ import { publishLeagueSocialRealtimeEvent } from './socialSocket';
 
 const MAX_ATTEMPTS = 8;
 const STALE_LOCK_MS = 60_000;
+const SOCIAL_REALTIME_EVENTS = new Set<SocialRealtimeEnvelope['event']>([
+  'social:message',
+  'social:activity',
+  'social:post',
+  'social:reply',
+  'social:moderation',
+  'social:read-state',
+]);
 
 export async function flushSocialOutboxBatch(io: SocketIOServer, batchSize = 50): Promise<number> {
   const now = new Date();
@@ -68,7 +77,7 @@ export async function flushSocialOutboxBatch(io: SocketIOServer, batchSize = 50)
   let published = 0;
   for (const event of claimed) {
     try {
-      const envelope = parseEnvelope(event.payloadJson);
+      const envelope = buildEnvelope(event);
       await publishLeagueSocialRealtimeEvent(io, envelope);
       await prisma.socialOutboxEvent.update({
         where: { sequence: event.sequence },
@@ -106,19 +115,40 @@ export async function flushSocialOutboxBatch(io: SocketIOServer, batchSize = 50)
   return published;
 }
 
-function parseEnvelope(value: string): SocialRealtimeEnvelope {
-  const parsed = JSON.parse(value) as Partial<SocialRealtimeEnvelope>;
-  if (
-    typeof parsed.id !== 'string' ||
-    typeof parsed.sequence !== 'number' ||
-    typeof parsed.leagueId !== 'string' ||
-    typeof parsed.seasonId !== 'string' ||
-    (parsed.channel !== 'chat' && parsed.channel !== 'board') ||
-    typeof parsed.event !== 'string' ||
-    typeof parsed.occurredAt !== 'string' ||
-    !parsed.payload
-  ) {
-    throw new Error('Invalid league social realtime envelope');
+function buildEnvelope(event: SocialOutboxEvent): SocialRealtimeEnvelope {
+  if (!SOCIAL_REALTIME_EVENTS.has(event.eventType as SocialRealtimeEnvelope['event'])) {
+    throw new Error('Invalid league social realtime event type');
   }
-  return parsed as SocialRealtimeEnvelope;
+
+  return {
+    id: event.id,
+    sequence: event.sequence,
+    leagueId: event.leagueId,
+    seasonId: event.seasonId,
+    channel: event.channel === 'CHAT' ? 'chat' : event.channel === 'BOARD' ? 'board' : 'activity',
+    event: event.eventType as SocialRealtimeEnvelope['event'],
+    payload: parseStoredPayload(event.payloadJson),
+    occurredAt: event.createdAt.toISOString(),
+  };
+}
+
+function parseStoredPayload(value: string): SocialRealtimeEnvelope['payload'] {
+  const parsed = JSON.parse(value) as unknown;
+  if (
+    parsed &&
+    typeof parsed === 'object' &&
+    'payload' in parsed &&
+    'event' in parsed &&
+    'channel' in parsed &&
+    'sequence' in parsed
+  ) {
+    const legacyPayload = (parsed as { payload?: unknown }).payload;
+    if (legacyPayload !== null && legacyPayload !== undefined) {
+      return legacyPayload as SocialRealtimeEnvelope['payload'];
+    }
+  }
+  if (parsed === null || parsed === undefined) {
+    throw new Error('Invalid league social realtime payload');
+  }
+  return parsed as SocialRealtimeEnvelope['payload'];
 }

--- a/src/server/leagues/social/socialPublisher.ts
+++ b/src/server/leagues/social/socialPublisher.ts
@@ -1,0 +1,124 @@
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+
+import type { Server as SocketIOServer } from 'socket.io';
+
+import { logger } from '@/lib/logger';
+import { prisma } from '@/lib/prisma';
+import type { SocialRealtimeEnvelope } from '@/types/social';
+
+import { publishLeagueSocialRealtimeEvent } from './socialSocket';
+
+const MAX_ATTEMPTS = 8;
+const STALE_LOCK_MS = 60_000;
+
+export async function flushSocialOutboxBatch(io: SocketIOServer, batchSize = 50): Promise<number> {
+  const now = new Date();
+  const staleLockBefore = new Date(now.getTime() - STALE_LOCK_MS);
+  const candidates = await prisma.socialOutboxEvent.findMany({
+    where: {
+      attempts: { lt: MAX_ATTEMPTS },
+      OR: [
+        {
+          status: { in: ['PENDING', 'FAILED'] },
+          availableAt: { lte: now },
+        },
+        {
+          status: 'PROCESSING',
+          lockedAt: { lte: staleLockBefore },
+        },
+      ],
+    },
+    orderBy: [{ sequence: 'asc' }],
+    take: Math.max(1, Math.min(batchSize, 200)),
+    select: { sequence: true },
+  });
+  if (candidates.length === 0) return 0;
+
+  const claimToken = `${process.pid}:${randomUUID()}`;
+  await prisma.socialOutboxEvent.updateMany({
+    where: {
+      sequence: { in: candidates.map((candidate) => candidate.sequence) },
+      attempts: { lt: MAX_ATTEMPTS },
+      OR: [
+        {
+          status: { in: ['PENDING', 'FAILED'] },
+          availableAt: { lte: now },
+        },
+        {
+          status: 'PROCESSING',
+          lockedAt: { lte: staleLockBefore },
+        },
+      ],
+    },
+    data: {
+      status: 'PROCESSING',
+      lockedAt: now,
+      lockedBy: claimToken,
+      attempts: { increment: 1 },
+    },
+  });
+
+  const claimed = await prisma.socialOutboxEvent.findMany({
+    where: { lockedBy: claimToken, status: 'PROCESSING' },
+    orderBy: { sequence: 'asc' },
+  });
+
+  let published = 0;
+  for (const event of claimed) {
+    try {
+      const envelope = parseEnvelope(event.payloadJson);
+      await publishLeagueSocialRealtimeEvent(io, envelope);
+      await prisma.socialOutboxEvent.update({
+        where: { sequence: event.sequence },
+        data: {
+          status: 'PUBLISHED',
+          publishedAt: new Date(),
+          lockedAt: null,
+          lockedBy: null,
+          lastError: null,
+        },
+      });
+      published += 1;
+    } catch (error) {
+      const retryDelayMs = Math.min(60_000, 1_000 * 2 ** Math.max(0, event.attempts));
+      await prisma.socialOutboxEvent.update({
+        where: { sequence: event.sequence },
+        data: {
+          status: 'FAILED',
+          availableAt: new Date(Date.now() + retryDelayMs),
+          lockedAt: null,
+          lockedBy: null,
+          lastError: error instanceof Error ? error.message.slice(0, 2_000) : String(error),
+        },
+      });
+      logger.warn('Failed to publish league social event', {
+        eventId: event.id,
+        sequence: event.sequence,
+        leagueId: event.leagueId,
+        attempts: event.attempts,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return published;
+}
+
+function parseEnvelope(value: string): SocialRealtimeEnvelope {
+  const parsed = JSON.parse(value) as Partial<SocialRealtimeEnvelope>;
+  if (
+    typeof parsed.id !== 'string' ||
+    typeof parsed.sequence !== 'number' ||
+    typeof parsed.leagueId !== 'string' ||
+    typeof parsed.seasonId !== 'string' ||
+    (parsed.channel !== 'chat' && parsed.channel !== 'board') ||
+    typeof parsed.event !== 'string' ||
+    typeof parsed.occurredAt !== 'string' ||
+    !parsed.payload
+  ) {
+    throw new Error('Invalid league social realtime envelope');
+  }
+  return parsed as SocialRealtimeEnvelope;
+}

--- a/src/server/leagues/social/socialQueries.test.ts
+++ b/src/server/leagues/social/socialQueries.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  requireLeagueSocialAccess: vi.fn(),
+  socialMessageFindMany: vi.fn(),
+  socialBoardCategoryFindMany: vi.fn(),
+  socialReadStateFindMany: vi.fn(),
+  socialOutboxAggregate: vi.fn(),
+  socialOutboxCount: vi.fn(),
+  leagueMemberFindFirst: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('./socialAccess', () => ({
+  requireLeagueSocialAccess: mocks.requireLeagueSocialAccess,
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    socialMessage: { findMany: mocks.socialMessageFindMany },
+    socialBoardCategory: { findMany: mocks.socialBoardCategoryFindMany },
+    socialReadState: { findMany: mocks.socialReadStateFindMany },
+    socialOutboxEvent: {
+      aggregate: mocks.socialOutboxAggregate,
+      count: mocks.socialOutboxCount,
+    },
+    leagueMember: { findFirst: mocks.leagueMemberFindFirst },
+  },
+}));
+
+vi.mock('./socialDto', () => ({
+  socialMessageInclude: {},
+  socialPostInclude: {},
+  socialReplyInclude: {},
+  toSocialCategory: vi.fn((category) => category),
+  toSocialMessage: vi.fn((message) => ({ ...message, type: message.type.toLowerCase() })),
+  toSocialPost: vi.fn((post) => post),
+  toSocialReply: vi.fn((reply) => reply),
+}));
+
+import { getLeagueSocialSummary, listSocialActivity, listSocialMessages } from './socialQueries';
+
+describe('league social activity queries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireLeagueSocialAccess.mockResolvedValue({
+      leagueId: 'league-1',
+      seasonId: 'season-1',
+      userId: 'user-1',
+      memberId: 'member-1',
+      canManage: false,
+      canPublish: true,
+      standardsAccepted: true,
+      mutedUntil: null,
+    });
+    mocks.socialMessageFindMany.mockResolvedValue([]);
+    mocks.socialBoardCategoryFindMany.mockResolvedValue([]);
+    mocks.socialReadStateFindMany.mockResolvedValue([]);
+    mocks.socialOutboxAggregate.mockImplementation(
+      ({ where }: { where: { channel: 'CHAT' | 'BOARD' | 'ACTIVITY' } }) =>
+        Promise.resolve({
+          _max: {
+            sequence: where.channel === 'CHAT' ? 10 : where.channel === 'BOARD' ? 20 : 30,
+          },
+        })
+    );
+    mocks.socialOutboxCount.mockImplementation(
+      ({ where }: { where: { channel: 'CHAT' | 'BOARD' | 'ACTIVITY' } }) =>
+        Promise.resolve(where.channel === 'CHAT' ? 1 : where.channel === 'BOARD' ? 2 : 3)
+    );
+    mocks.leagueMemberFindFirst.mockResolvedValue({ notificationSettingsJson: null });
+  });
+
+  it('keeps member chat and automated activity in separate league-season queries', async () => {
+    await listSocialMessages('league-1', 'user-1', { limit: 25 });
+    expect(mocks.socialMessageFindMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          leagueId: 'league-1',
+          seasonId: 'season-1',
+          type: 'MEMBER',
+        }),
+      })
+    );
+
+    await listSocialActivity('league-1', 'user-1', { limit: 25 });
+    expect(mocks.socialMessageFindMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          leagueId: 'league-1',
+          seasonId: 'season-1',
+          type: 'SYSTEM',
+        }),
+      })
+    );
+  });
+
+  it('reports independent chat, board, and activity cursors and unread counts', async () => {
+    await expect(getLeagueSocialSummary('league-1', 'user-1')).resolves.toMatchObject({
+      unread: { chat: 1, board: 2, activity: 3 },
+      latestSequence: { chat: 10, board: 20, activity: 30 },
+    });
+
+    expect(mocks.socialOutboxAggregate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ channel: 'ACTIVITY' }),
+      })
+    );
+    expect(mocks.socialOutboxCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          channel: 'ACTIVITY',
+          sequence: { gt: 0 },
+          eventType: { not: 'social:read-state' },
+        }),
+      })
+    );
+  });
+});

--- a/src/server/leagues/social/socialQueries.ts
+++ b/src/server/leagues/social/socialQueries.ts
@@ -1,0 +1,388 @@
+import 'server-only';
+
+import { prisma } from '@/lib/prisma';
+import type {
+  LeagueSocialSummary,
+  SocialCursorPage,
+  SocialMessage,
+  SocialPost,
+  SocialPostThread,
+  SocialReply,
+} from '@/types/social';
+import { DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES } from '@/types/social';
+
+import { requireLeagueSocialAccess } from './socialAccess';
+import {
+  socialMessageInclude,
+  socialPostInclude,
+  socialReplyInclude,
+  toSocialCategory,
+  toSocialMessage,
+  toSocialPost,
+  toSocialReply,
+} from './socialDto';
+import { SocialError } from './socialErrors';
+import { decodeSocialCursor, encodeSocialCursor, type SocialPageCursor } from './socialValidation';
+
+interface ListSocialOptions {
+  cursor?: string | null;
+  limit: number;
+}
+
+interface SocialPostCursor extends SocialPageCursor {
+  pinned: boolean;
+}
+
+export async function getLeagueSocialSummary(
+  leagueId: string,
+  userId: string
+): Promise<LeagueSocialSummary> {
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  const [categories, readStates, latestChat, latestBoard, member] = await Promise.all([
+    prisma.socialBoardCategory.findMany({
+      where: {
+        leagueId,
+        seasonId: access.seasonId,
+        archivedAt: null,
+      },
+      orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }],
+    }),
+    prisma.socialReadState.findMany({
+      where: {
+        leagueId,
+        seasonId: access.seasonId,
+        userId,
+      },
+      select: { channel: true, lastReadSequence: true },
+    }),
+    prisma.socialOutboxEvent.aggregate({
+      where: {
+        leagueId,
+        seasonId: access.seasonId,
+        channel: 'CHAT',
+        eventType: { not: 'social:read-state' },
+      },
+      _max: { sequence: true },
+    }),
+    prisma.socialOutboxEvent.aggregate({
+      where: {
+        leagueId,
+        seasonId: access.seasonId,
+        channel: 'BOARD',
+        eventType: { not: 'social:read-state' },
+      },
+      _max: { sequence: true },
+    }),
+    prisma.leagueMember.findFirst({
+      where: { id: access.memberId, leagueId, isActive: true },
+      select: { notificationSettingsJson: true },
+    }),
+  ]);
+
+  const readSequence = new Map(readStates.map((state) => [state.channel, state.lastReadSequence]));
+  const [unreadChat, unreadBoard] = await Promise.all([
+    countUnreadEvents({
+      leagueId,
+      seasonId: access.seasonId,
+      userId,
+      channel: 'CHAT',
+      lastReadSequence: readSequence.get('CHAT') ?? 0,
+    }),
+    countUnreadEvents({
+      leagueId,
+      seasonId: access.seasonId,
+      userId,
+      channel: 'BOARD',
+      lastReadSequence: readSequence.get('BOARD') ?? 0,
+    }),
+  ]);
+
+  return {
+    leagueId,
+    seasonId: access.seasonId,
+    canManage: access.canManage,
+    canPublish: access.canPublish,
+    standardsAccepted: access.standardsAccepted,
+    mutedUntil: access.mutedUntil?.toISOString() ?? null,
+    unread: {
+      chat: unreadChat,
+      board: unreadBoard,
+    },
+    latestSequence: {
+      chat: latestChat._max.sequence ?? 0,
+      board: latestBoard._max.sequence ?? 0,
+    },
+    preferences: parseSocialPreferences(member?.notificationSettingsJson),
+    categories: categories.map(toSocialCategory),
+  };
+}
+
+function parseSocialPreferences(value: string | null | undefined) {
+  if (!value) return DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES;
+  try {
+    const stored = JSON.parse(value) as Record<string, unknown>;
+    const social =
+      stored.social && typeof stored.social === 'object' && !Array.isArray(stored.social)
+        ? (stored.social as Record<string, unknown>)
+        : {};
+    return Object.fromEntries(
+      Object.entries(DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES).map(([key, fallback]) => [
+        key,
+        typeof social[key] === 'boolean' ? social[key] : fallback,
+      ])
+    ) as typeof DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES;
+  } catch {
+    return DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES;
+  }
+}
+
+async function countUnreadEvents({
+  leagueId,
+  seasonId,
+  userId,
+  channel,
+  lastReadSequence,
+}: {
+  leagueId: string;
+  seasonId: string;
+  userId: string;
+  channel: 'CHAT' | 'BOARD';
+  lastReadSequence: number;
+}): Promise<number> {
+  return prisma.socialOutboxEvent.count({
+    where: {
+      leagueId,
+      seasonId,
+      channel,
+      sequence: { gt: lastReadSequence },
+      eventType: { not: 'social:read-state' },
+      OR: [{ actorUserId: null }, { actorUserId: { not: userId } }],
+    },
+  });
+}
+
+export async function listSocialMessages(
+  leagueId: string,
+  userId: string,
+  options: ListSocialOptions
+): Promise<SocialCursorPage<SocialMessage>> {
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  const cursor = decodeSocialCursor(options.cursor ?? null);
+  if (options.cursor && !cursor) {
+    throw new SocialError('VALIDATION', 'Invalid message cursor');
+  }
+
+  const records = await prisma.socialMessage.findMany({
+    where: {
+      leagueId,
+      seasonId: access.seasonId,
+      ...(cursor
+        ? {
+            OR: [
+              { createdAt: { lt: new Date(cursor.createdAt) } },
+              { createdAt: new Date(cursor.createdAt), id: { lt: cursor.id } },
+            ],
+          }
+        : {}),
+    },
+    include: socialMessageInclude,
+    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+    take: options.limit + 1,
+  });
+
+  const hasMore = records.length > options.limit;
+  if (hasMore) records.pop();
+  const oldest = records.at(-1);
+
+  return {
+    items: records.reverse().map((record) => toSocialMessage(record, userId)),
+    nextCursor:
+      hasMore && oldest
+        ? encodeSocialCursor({
+            createdAt: oldest.createdAt.toISOString(),
+            id: oldest.id,
+          })
+        : null,
+  };
+}
+
+export async function listSocialPosts(
+  leagueId: string,
+  userId: string,
+  options: ListSocialOptions & {
+    categoryId?: string | null;
+    sort?: 'latestActivity' | 'createdAt';
+  }
+): Promise<SocialCursorPage<SocialPost>> {
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  const sort = options.sort ?? 'latestActivity';
+  const cursor = decodePostCursor(options.cursor ?? null);
+  if (options.cursor && !cursor) {
+    throw new SocialError('VALIDATION', 'Invalid post cursor');
+  }
+
+  const records = await prisma.socialPost.findMany({
+    where: {
+      leagueId,
+      seasonId: access.seasonId,
+      ...(options.categoryId ? { categoryId: options.categoryId } : {}),
+      ...(cursor ? postCursorWhere(cursor, sort) : {}),
+    },
+    include: socialPostInclude,
+    orderBy:
+      sort === 'createdAt'
+        ? [{ isPinned: 'desc' }, { createdAt: 'desc' }, { id: 'desc' }]
+        : [{ isPinned: 'desc' }, { latestActivityAt: 'desc' }, { id: 'desc' }],
+    take: options.limit + 1,
+  });
+
+  const hasMore = records.length > options.limit;
+  if (hasMore) records.pop();
+  const last = records.at(-1);
+
+  return {
+    items: records.map((record) => toSocialPost(record, userId)),
+    nextCursor:
+      hasMore && last
+        ? encodePostCursor({
+            pinned: last.isPinned,
+            createdAt:
+              sort === 'createdAt'
+                ? last.createdAt.toISOString()
+                : last.latestActivityAt.toISOString(),
+            id: last.id,
+          })
+        : null,
+  };
+}
+
+export async function getSocialPostThread(
+  leagueId: string,
+  userId: string,
+  postId: string,
+  options: ListSocialOptions
+): Promise<SocialPostThread> {
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  const post = await prisma.socialPost.findFirst({
+    where: {
+      id: postId,
+      leagueId,
+      seasonId: access.seasonId,
+    },
+    include: socialPostInclude,
+  });
+  if (!post) throw new SocialError('NOT_FOUND', 'Discussion not found');
+
+  const replies = await listSocialReplies(leagueId, userId, postId, options, access.seasonId);
+  return {
+    post: toSocialPost(post, userId),
+    replies,
+  };
+}
+
+export async function listSocialReplies(
+  leagueId: string,
+  userId: string,
+  postId: string,
+  options: ListSocialOptions,
+  knownSeasonId?: string
+): Promise<SocialCursorPage<SocialReply>> {
+  const seasonId = knownSeasonId ?? (await requireLeagueSocialAccess(leagueId, userId)).seasonId;
+  const cursor = decodeSocialCursor(options.cursor ?? null);
+  if (options.cursor && !cursor) {
+    throw new SocialError('VALIDATION', 'Invalid reply cursor');
+  }
+
+  const records = await prisma.socialReply.findMany({
+    where: {
+      postId,
+      leagueId,
+      seasonId,
+      ...(cursor
+        ? {
+            OR: [
+              { createdAt: { lt: new Date(cursor.createdAt) } },
+              { createdAt: new Date(cursor.createdAt), id: { lt: cursor.id } },
+            ],
+          }
+        : {}),
+    },
+    include: socialReplyInclude,
+    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+    take: options.limit + 1,
+  });
+
+  const hasMore = records.length > options.limit;
+  if (hasMore) records.pop();
+  const oldest = records.at(-1);
+
+  return {
+    items: records.reverse().map((record) => toSocialReply(record, userId)),
+    nextCursor:
+      hasMore && oldest
+        ? encodeSocialCursor({
+            createdAt: oldest.createdAt.toISOString(),
+            id: oldest.id,
+          })
+        : null,
+  };
+}
+
+function postCursorWhere(cursor: SocialPostCursor, sort: 'latestActivity' | 'createdAt') {
+  const orderCursor =
+    sort === 'createdAt'
+      ? [
+          { createdAt: { lt: new Date(cursor.createdAt) } },
+          { createdAt: new Date(cursor.createdAt), id: { lt: cursor.id } },
+        ]
+      : [
+          { latestActivityAt: { lt: new Date(cursor.createdAt) } },
+          { latestActivityAt: new Date(cursor.createdAt), id: { lt: cursor.id } },
+        ];
+  return {
+    OR: cursor.pinned
+      ? [
+          {
+            isPinned: true,
+            OR: orderCursor,
+          },
+          { isPinned: false },
+        ]
+      : [
+          {
+            isPinned: false,
+            OR: orderCursor,
+          },
+        ],
+  };
+}
+
+function encodePostCursor(cursor: SocialPostCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+function decodePostCursor(value: string | null): SocialPostCursor | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as Record<
+      string,
+      unknown
+    >;
+    if (
+      typeof parsed.pinned !== 'boolean' ||
+      typeof parsed.createdAt !== 'string' ||
+      Number.isNaN(new Date(parsed.createdAt).getTime()) ||
+      typeof parsed.id !== 'string' ||
+      !parsed.id
+    ) {
+      return null;
+    }
+    return {
+      pinned: parsed.pinned,
+      createdAt: parsed.createdAt,
+      id: parsed.id,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/server/leagues/social/socialQueries.ts
+++ b/src/server/leagues/social/socialQueries.ts
@@ -38,49 +38,59 @@ export async function getLeagueSocialSummary(
   userId: string
 ): Promise<LeagueSocialSummary> {
   const access = await requireLeagueSocialAccess(leagueId, userId);
-  const [categories, readStates, latestChat, latestBoard, member] = await Promise.all([
-    prisma.socialBoardCategory.findMany({
-      where: {
-        leagueId,
-        seasonId: access.seasonId,
-        archivedAt: null,
-      },
-      orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }],
-    }),
-    prisma.socialReadState.findMany({
-      where: {
-        leagueId,
-        seasonId: access.seasonId,
-        userId,
-      },
-      select: { channel: true, lastReadSequence: true },
-    }),
-    prisma.socialOutboxEvent.aggregate({
-      where: {
-        leagueId,
-        seasonId: access.seasonId,
-        channel: 'CHAT',
-        eventType: { not: 'social:read-state' },
-      },
-      _max: { sequence: true },
-    }),
-    prisma.socialOutboxEvent.aggregate({
-      where: {
-        leagueId,
-        seasonId: access.seasonId,
-        channel: 'BOARD',
-        eventType: { not: 'social:read-state' },
-      },
-      _max: { sequence: true },
-    }),
-    prisma.leagueMember.findFirst({
-      where: { id: access.memberId, leagueId, isActive: true },
-      select: { notificationSettingsJson: true },
-    }),
-  ]);
+  const [categories, readStates, latestChat, latestBoard, latestActivity, member] =
+    await Promise.all([
+      prisma.socialBoardCategory.findMany({
+        where: {
+          leagueId,
+          seasonId: access.seasonId,
+          archivedAt: null,
+        },
+        orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }],
+      }),
+      prisma.socialReadState.findMany({
+        where: {
+          leagueId,
+          seasonId: access.seasonId,
+          userId,
+        },
+        select: { channel: true, lastReadSequence: true },
+      }),
+      prisma.socialOutboxEvent.aggregate({
+        where: {
+          leagueId,
+          seasonId: access.seasonId,
+          channel: 'CHAT',
+          eventType: { not: 'social:read-state' },
+        },
+        _max: { sequence: true },
+      }),
+      prisma.socialOutboxEvent.aggregate({
+        where: {
+          leagueId,
+          seasonId: access.seasonId,
+          channel: 'BOARD',
+          eventType: { not: 'social:read-state' },
+        },
+        _max: { sequence: true },
+      }),
+      prisma.socialOutboxEvent.aggregate({
+        where: {
+          leagueId,
+          seasonId: access.seasonId,
+          channel: 'ACTIVITY',
+          eventType: { not: 'social:read-state' },
+        },
+        _max: { sequence: true },
+      }),
+      prisma.leagueMember.findFirst({
+        where: { id: access.memberId, leagueId, isActive: true },
+        select: { notificationSettingsJson: true },
+      }),
+    ]);
 
   const readSequence = new Map(readStates.map((state) => [state.channel, state.lastReadSequence]));
-  const [unreadChat, unreadBoard] = await Promise.all([
+  const [unreadChat, unreadBoard, unreadActivity] = await Promise.all([
     countUnreadEvents({
       leagueId,
       seasonId: access.seasonId,
@@ -95,6 +105,13 @@ export async function getLeagueSocialSummary(
       channel: 'BOARD',
       lastReadSequence: readSequence.get('BOARD') ?? 0,
     }),
+    countUnreadEvents({
+      leagueId,
+      seasonId: access.seasonId,
+      userId,
+      channel: 'ACTIVITY',
+      lastReadSequence: readSequence.get('ACTIVITY') ?? 0,
+    }),
   ]);
 
   return {
@@ -107,10 +124,12 @@ export async function getLeagueSocialSummary(
     unread: {
       chat: unreadChat,
       board: unreadBoard,
+      activity: unreadActivity,
     },
     latestSequence: {
       chat: latestChat._max.sequence ?? 0,
       board: latestBoard._max.sequence ?? 0,
+      activity: latestActivity._max.sequence ?? 0,
     },
     preferences: parseSocialPreferences(member?.notificationSettingsJson),
     categories: categories.map(toSocialCategory),
@@ -146,7 +165,7 @@ async function countUnreadEvents({
   leagueId: string;
   seasonId: string;
   userId: string;
-  channel: 'CHAT' | 'BOARD';
+  channel: 'CHAT' | 'BOARD' | 'ACTIVITY';
   lastReadSequence: number;
 }): Promise<number> {
   return prisma.socialOutboxEvent.count({
@@ -176,6 +195,7 @@ export async function listSocialMessages(
     where: {
       leagueId,
       seasonId: access.seasonId,
+      type: 'MEMBER',
       ...(cursor
         ? {
             OR: [
@@ -196,6 +216,52 @@ export async function listSocialMessages(
 
   return {
     items: records.reverse().map((record) => toSocialMessage(record, userId)),
+    nextCursor:
+      hasMore && oldest
+        ? encodeSocialCursor({
+            createdAt: oldest.createdAt.toISOString(),
+            id: oldest.id,
+          })
+        : null,
+  };
+}
+
+export async function listSocialActivity(
+  leagueId: string,
+  userId: string,
+  options: ListSocialOptions
+): Promise<SocialCursorPage<SocialMessage>> {
+  const access = await requireLeagueSocialAccess(leagueId, userId);
+  const cursor = decodeSocialCursor(options.cursor ?? null);
+  if (options.cursor && !cursor) {
+    throw new SocialError('VALIDATION', 'Invalid activity cursor');
+  }
+
+  const records = await prisma.socialMessage.findMany({
+    where: {
+      leagueId,
+      seasonId: access.seasonId,
+      type: 'SYSTEM',
+      ...(cursor
+        ? {
+            OR: [
+              { createdAt: { lt: new Date(cursor.createdAt) } },
+              { createdAt: new Date(cursor.createdAt), id: { lt: cursor.id } },
+            ],
+          }
+        : {}),
+    },
+    include: socialMessageInclude,
+    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+    take: options.limit + 1,
+  });
+
+  const hasMore = records.length > options.limit;
+  if (hasMore) records.pop();
+  const oldest = records.at(-1);
+
+  return {
+    items: records.map((record) => toSocialMessage(record, '')),
     nextCursor:
       hasMore && oldest
         ? encodeSocialCursor({

--- a/src/server/leagues/social/socialRateLimit.test.ts
+++ b/src/server/leagues/social/socialRateLimit.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/lib/redis', () => ({
+  redisClient: { getClient: () => null },
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: vi.fn() },
+}));
+
+import { enforceSocialRateLimit } from './socialRateLimit';
+
+describe('social rate limiting', () => {
+  it('rejects requests above the configured process-fallback limit', async () => {
+    const input = {
+      leagueId: 'league-rate-test',
+      userId: 'user-rate-test',
+      action: 'message-rate-test',
+      maxRequests: 2,
+      windowSeconds: 60,
+    };
+
+    await expect(enforceSocialRateLimit(input)).resolves.toBeUndefined();
+    await expect(enforceSocialRateLimit(input)).resolves.toBeUndefined();
+    await expect(enforceSocialRateLimit(input)).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+      status: 429,
+    });
+  });
+});

--- a/src/server/leagues/social/socialRateLimit.ts
+++ b/src/server/leagues/social/socialRateLimit.ts
@@ -1,0 +1,66 @@
+import 'server-only';
+
+import { logger } from '@/lib/logger';
+import { redisClient } from '@/lib/redis';
+
+import { SocialError } from './socialErrors';
+
+const fallbackCounters = new Map<string, { count: number; expiresAt: number }>();
+
+export async function enforceSocialRateLimit({
+  leagueId,
+  userId,
+  action,
+  maxRequests,
+  windowSeconds,
+}: {
+  leagueId: string;
+  userId: string;
+  action: string;
+  maxRequests: number;
+  windowSeconds: number;
+}): Promise<void> {
+  const bucket = Math.floor(Date.now() / (windowSeconds * 1_000));
+  const key = `social-rate:${leagueId}:${userId}:${action}:${bucket}`;
+  const redis = redisClient.getClient();
+
+  if (redis) {
+    try {
+      const results = await redis
+        .multi()
+        .incr(key)
+        .expire(key, windowSeconds + 1)
+        .exec();
+      const count = Number(results?.[0]?.[1] ?? 0);
+      if (count > maxRequests) {
+        throw new SocialError('RATE_LIMITED', 'You are posting too quickly');
+      }
+      return;
+    } catch (error) {
+      if (error instanceof SocialError) throw error;
+      logger.warn('Social Redis rate limit failed; using process fallback', {
+        leagueId,
+        userId,
+        action,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const now = Date.now();
+  const current = fallbackCounters.get(key);
+  const counter =
+    current && current.expiresAt > now
+      ? { count: current.count + 1, expiresAt: current.expiresAt }
+      : { count: 1, expiresAt: now + windowSeconds * 1_000 };
+  fallbackCounters.set(key, counter);
+  if (counter.count > maxRequests) {
+    throw new SocialError('RATE_LIMITED', 'You are posting too quickly');
+  }
+
+  if (fallbackCounters.size > 10_000) {
+    for (const [counterKey, value] of fallbackCounters) {
+      if (value.expiresAt <= now) fallbackCounters.delete(counterKey);
+    }
+  }
+}

--- a/src/server/leagues/social/socialSocket.test.ts
+++ b/src/server/leagues/social/socialSocket.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Server as SocketIOServer, Socket as SocketIOSocket } from 'socket.io';
+
+import type { SocialRealtimeEnvelope } from '@/types/social';
+
+const mocks = vi.hoisted(() => ({
+  getLeagueMembershipAccess: vi.fn(),
+  loggerError: vi.fn(),
+  pubSubPublish: vi.fn(),
+  pubSubStart: vi.fn(),
+}));
+
+vi.mock('@/server/leagues/membership', () => ({
+  getLeagueMembershipAccess: mocks.getLeagueMembershipAccess,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: mocks.loggerError,
+  },
+}));
+
+vi.mock('./socialPubSub', () => ({
+  socialPubSub: {
+    publish: mocks.pubSubPublish,
+    start: mocks.pubSubStart,
+  },
+}));
+
+import {
+  attachLeagueSocialSocketHandlers,
+  broadcastLeagueSocialEvent,
+  getLeagueSocialRoom,
+  publishLeagueSocialRealtimeEvent,
+  type SocialSocketAcknowledgement,
+} from './socialSocket';
+
+type EventHandler = (...args: any[]) => unknown;
+
+function createSocket(userId: string | null = 'user-1') {
+  const handlers = new Map<string, EventHandler>();
+  const socket = {
+    id: 'socket-1',
+    data: userId ? { userId } : {},
+    on: vi.fn((event: string, handler: EventHandler) => {
+      handlers.set(event, handler);
+      return socket;
+    }),
+    join: vi.fn(async () => undefined),
+    leave: vi.fn(async () => undefined),
+    emit: vi.fn(),
+  };
+
+  return {
+    handlers,
+    socket: socket as unknown as SocketIOSocket,
+    join: socket.join,
+    leave: socket.leave,
+    emit: socket.emit,
+  };
+}
+
+function attachSocket(socket: SocketIOSocket) {
+  let connectionHandler: EventHandler | undefined;
+  const emit = vi.fn();
+  const to = vi.fn(() => ({ emit }));
+  const inRoom = vi.fn(() => ({ fetchSockets: vi.fn(async () => [socket]) }));
+  const io = {
+    on: vi.fn((event: string, handler: EventHandler) => {
+      if (event === 'connection') connectionHandler = handler;
+      return io;
+    }),
+    to,
+    in: inRoom,
+  };
+
+  attachLeagueSocialSocketHandlers(io as unknown as SocketIOServer);
+  expect(connectionHandler).toBeTypeOf('function');
+  connectionHandler?.(socket);
+
+  return {
+    emit,
+    io: io as unknown as SocketIOServer,
+    to,
+    inRoom,
+  };
+}
+
+async function invokeWithAcknowledgement(
+  handler: EventHandler | undefined,
+  request: unknown
+): Promise<SocialSocketAcknowledgement> {
+  if (!handler) throw new Error('Socket handler was not registered');
+
+  return new Promise((resolve, reject) => {
+    Promise.resolve(handler(request, resolve)).catch(reject);
+  });
+}
+
+describe('league social socket sidecar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getLeagueMembershipAccess.mockResolvedValue({
+      leagueId: 'league-1',
+      userId: 'user-1',
+      memberId: 'member-1',
+      isMember: true,
+      canManage: false,
+    });
+    mocks.pubSubPublish.mockResolvedValue(undefined);
+  });
+
+  it('rechecks current membership on every join and joins only the league social room', async () => {
+    const socketState = createSocket();
+    attachSocket(socketState.socket);
+
+    const first = await invokeWithAcknowledgement(socketState.handlers.get('social:join'), {
+      leagueId: 'league-1',
+    });
+    const second = await invokeWithAcknowledgement(socketState.handlers.get('social:join'), {
+      leagueId: 'league-1',
+    });
+
+    expect(mocks.getLeagueMembershipAccess).toHaveBeenCalledTimes(2);
+    expect(mocks.getLeagueMembershipAccess).toHaveBeenNthCalledWith(1, 'league-1', 'user-1');
+    expect(mocks.getLeagueMembershipAccess).toHaveBeenNthCalledWith(2, 'league-1', 'user-1');
+    expect(socketState.join).toHaveBeenCalledTimes(2);
+    expect(socketState.join).toHaveBeenCalledWith('social:league:league-1');
+    expect(first).toEqual({
+      ok: true,
+      leagueId: 'league-1',
+      room: 'social:league:league-1',
+    });
+    expect(second).toEqual(first);
+  });
+
+  it('acknowledges unauthenticated, invalid, and non-member joins without joining', async () => {
+    const unauthenticated = createSocket(null);
+    attachSocket(unauthenticated.socket);
+
+    await expect(
+      invokeWithAcknowledgement(unauthenticated.handlers.get('social:join'), {
+        leagueId: 'league-1',
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'UNAUTHORIZED' },
+    });
+    expect(mocks.getLeagueMembershipAccess).not.toHaveBeenCalled();
+    expect(unauthenticated.join).not.toHaveBeenCalled();
+
+    const authenticated = createSocket();
+    attachSocket(authenticated.socket);
+    await expect(
+      invokeWithAcknowledgement(authenticated.handlers.get('social:join'), {
+        leagueId: '   ',
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'VALIDATION' },
+    });
+
+    mocks.getLeagueMembershipAccess.mockResolvedValueOnce({
+      leagueId: 'league-1',
+      userId: 'user-1',
+      isMember: false,
+      canManage: false,
+    });
+    await expect(
+      invokeWithAcknowledgement(authenticated.handlers.get('social:join'), {
+        leagueId: 'league-1',
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'FORBIDDEN' },
+    });
+    expect(authenticated.join).not.toHaveBeenCalled();
+  });
+
+  it('leaves the scoped room and exposes no socket handlers for social writes', async () => {
+    const socketState = createSocket();
+    attachSocket(socketState.socket);
+
+    const result = await invokeWithAcknowledgement(socketState.handlers.get('social:leave'), {
+      leagueId: 'league-1',
+    });
+
+    expect(socketState.leave).toHaveBeenCalledWith('social:league:league-1');
+    expect(result).toEqual({
+      ok: true,
+      leagueId: 'league-1',
+      room: 'social:league:league-1',
+    });
+    expect(Array.from(socketState.handlers.keys()).sort()).toEqual(['social:join', 'social:leave']);
+  });
+
+  it('rate limits repeated join attempts per socket', async () => {
+    const socketState = createSocket();
+    attachSocket(socketState.socket);
+    const joinHandler = socketState.handlers.get('social:join');
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      await expect(
+        invokeWithAcknowledgement(joinHandler, { leagueId: 'league-1' })
+      ).resolves.toMatchObject({ ok: true });
+    }
+
+    await expect(
+      invokeWithAcknowledgement(joinHandler, { leagueId: 'league-1' })
+    ).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: 'RATE_LIMITED',
+        retryAfterMs: expect.any(Number),
+      },
+    });
+    expect(mocks.getLeagueMembershipAccess).toHaveBeenCalledTimes(10);
+    expect(socketState.join).toHaveBeenCalledTimes(10);
+  });
+
+  it('broadcasts typed envelopes only to current members in their league social room', async () => {
+    const socketState = createSocket();
+    const ioState = attachSocket(socketState.socket);
+    const envelope: SocialRealtimeEnvelope = {
+      id: 'event-1',
+      sequence: 7,
+      leagueId: 'league-1',
+      seasonId: 'season-2026',
+      channel: 'chat',
+      event: 'social:message',
+      payload: { messageId: 'message-1' },
+      occurredAt: '2026-07-19T10:00:00.000Z',
+    };
+
+    await broadcastLeagueSocialEvent(ioState.io, envelope);
+
+    expect(getLeagueSocialRoom('league-1')).toBe('social:league:league-1');
+    expect(ioState.inRoom).toHaveBeenCalledWith('social:league:league-1');
+    expect(socketState.emit).toHaveBeenCalledWith('social:message', envelope);
+  });
+
+  it('removes former members from the room before delivering future events', async () => {
+    const socketState = createSocket();
+    const ioState = attachSocket(socketState.socket);
+    mocks.getLeagueMembershipAccess.mockResolvedValueOnce({
+      leagueId: 'league-1',
+      userId: 'user-1',
+      isMember: false,
+      canManage: false,
+    });
+    const envelope: SocialRealtimeEnvelope = {
+      id: 'event-2',
+      sequence: 8,
+      leagueId: 'league-1',
+      seasonId: 'season-2026',
+      channel: 'chat',
+      event: 'social:message',
+      payload: { messageId: 'message-2' },
+      occurredAt: '2026-07-19T10:00:01.000Z',
+    };
+
+    await broadcastLeagueSocialEvent(ioState.io, envelope);
+
+    expect(socketState.leave).toHaveBeenCalledWith('social:league:league-1');
+    expect(socketState.emit).not.toHaveBeenCalled();
+  });
+
+  it('fans published events out locally and through shared pubsub', async () => {
+    const socketState = createSocket();
+    const ioState = attachSocket(socketState.socket);
+    const envelope: SocialRealtimeEnvelope = {
+      id: 'event-3',
+      sequence: 9,
+      leagueId: 'league-1',
+      seasonId: 'season-2026',
+      channel: 'board',
+      event: 'social:post',
+      payload: { postId: 'post-1' },
+      occurredAt: '2026-07-19T10:00:02.000Z',
+    };
+
+    await publishLeagueSocialRealtimeEvent(ioState.io, envelope);
+
+    expect(socketState.emit).toHaveBeenCalledWith('social:post', envelope);
+    expect(mocks.pubSubPublish).toHaveBeenCalledWith(envelope);
+  });
+});

--- a/src/server/leagues/social/socialSocket.ts
+++ b/src/server/leagues/social/socialSocket.ts
@@ -1,0 +1,244 @@
+import type { Server as SocketIOServer, Socket as SocketIOSocket } from 'socket.io';
+
+import { logger } from '@/lib/logger';
+import { getLeagueMembershipAccess } from '@/server/leagues/membership';
+import type { SocialRealtimeEnvelope } from '@/types/social';
+
+import { socialPubSub } from './socialPubSub';
+
+const SOCIAL_ROOM_PREFIX = 'social:league:';
+const SOCIAL_JOIN_RATE_LIMIT_WINDOW_MS = 60_000;
+const SOCIAL_JOIN_RATE_LIMIT_MAX_ATTEMPTS = 10;
+const SOCIAL_LEAGUE_ID_MAX_LENGTH = 128;
+
+type SocialRoomRequest = {
+  leagueId?: unknown;
+};
+
+type SocialSocketErrorCode =
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'VALIDATION'
+  | 'RATE_LIMITED'
+  | 'INTERNAL';
+
+export type SocialSocketAcknowledgement =
+  | {
+      ok: true;
+      leagueId: string;
+      room: string;
+    }
+  | {
+      ok: false;
+      error: {
+        code: SocialSocketErrorCode;
+        message: string;
+        retryAfterMs?: number;
+      };
+    };
+
+type SocialSocketAcknowledge = (result: SocialSocketAcknowledgement) => void;
+
+function acknowledge(
+  callback: SocialSocketAcknowledge | undefined,
+  result: SocialSocketAcknowledgement
+): void {
+  callback?.(result);
+}
+
+function parseLeagueId(request: SocialRoomRequest | null | undefined): string | null {
+  if (typeof request?.leagueId !== 'string') return null;
+
+  const leagueId = request.leagueId.trim();
+  if (!leagueId || leagueId.length > SOCIAL_LEAGUE_ID_MAX_LENGTH) return null;
+
+  return leagueId;
+}
+
+export function getLeagueSocialRoom(leagueId: string): string {
+  return `${SOCIAL_ROOM_PREFIX}${leagueId}`;
+}
+
+function getAuthenticatedSocketUserId(socket: SocketIOSocket): string | null {
+  const userId = socket.data.userId;
+  return typeof userId === 'string' && userId.trim() ? userId.trim() : null;
+}
+
+function consumeJoinAttempt(attempts: number[], now = Date.now()): number | null {
+  const windowStart = now - SOCIAL_JOIN_RATE_LIMIT_WINDOW_MS;
+
+  while (attempts.length > 0 && attempts[0] <= windowStart) {
+    attempts.shift();
+  }
+
+  if (attempts.length >= SOCIAL_JOIN_RATE_LIMIT_MAX_ATTEMPTS) {
+    return Math.max(1, SOCIAL_JOIN_RATE_LIMIT_WINDOW_MS - (now - (attempts[0] ?? now)));
+  }
+
+  attempts.push(now);
+  return null;
+}
+
+function invalidRequestAcknowledgement(): SocialSocketAcknowledgement {
+  return {
+    ok: false,
+    error: {
+      code: 'VALIDATION',
+      message: 'A valid league ID is required',
+    },
+  };
+}
+
+function unauthorizedAcknowledgement(): SocialSocketAcknowledgement {
+  return {
+    ok: false,
+    error: {
+      code: 'UNAUTHORIZED',
+      message: 'Authentication is required',
+    },
+  };
+}
+
+function attachSocketHandlers(socket: SocketIOSocket): void {
+  const joinAttempts: number[] = [];
+
+  socket.on(
+    'social:join',
+    async (request: SocialRoomRequest | null | undefined, callback?: SocialSocketAcknowledge) => {
+      const retryAfterMs = consumeJoinAttempt(joinAttempts);
+      if (retryAfterMs !== null) {
+        acknowledge(callback, {
+          ok: false,
+          error: {
+            code: 'RATE_LIMITED',
+            message: 'Too many social room join attempts',
+            retryAfterMs,
+          },
+        });
+        return;
+      }
+
+      const userId = getAuthenticatedSocketUserId(socket);
+      if (!userId) {
+        acknowledge(callback, unauthorizedAcknowledgement());
+        return;
+      }
+
+      const leagueId = parseLeagueId(request);
+      if (!leagueId) {
+        acknowledge(callback, invalidRequestAcknowledgement());
+        return;
+      }
+
+      try {
+        const access = await getLeagueMembershipAccess(leagueId, userId);
+        if (!access.isMember) {
+          acknowledge(callback, {
+            ok: false,
+            error: {
+              code: 'FORBIDDEN',
+              message: 'Current league membership is required',
+            },
+          });
+          return;
+        }
+
+        const room = getLeagueSocialRoom(leagueId);
+        await socket.join(room);
+        acknowledge(callback, { ok: true, leagueId, room });
+      } catch (error) {
+        logger.error('Failed to authorize league social socket join', {
+          socketId: socket.id,
+          leagueId,
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        acknowledge(callback, {
+          ok: false,
+          error: {
+            code: 'INTERNAL',
+            message: 'League social realtime is temporarily unavailable',
+          },
+        });
+      }
+    }
+  );
+
+  socket.on(
+    'social:leave',
+    async (request: SocialRoomRequest | null | undefined, callback?: SocialSocketAcknowledge) => {
+      if (!getAuthenticatedSocketUserId(socket)) {
+        acknowledge(callback, unauthorizedAcknowledgement());
+        return;
+      }
+
+      const leagueId = parseLeagueId(request);
+      if (!leagueId) {
+        acknowledge(callback, invalidRequestAcknowledgement());
+        return;
+      }
+
+      const room = getLeagueSocialRoom(leagueId);
+      try {
+        await socket.leave(room);
+        acknowledge(callback, { ok: true, leagueId, room });
+      } catch (error) {
+        logger.error('Failed to leave league social socket room', {
+          socketId: socket.id,
+          leagueId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        acknowledge(callback, {
+          ok: false,
+          error: {
+            code: 'INTERNAL',
+            message: 'League social realtime is temporarily unavailable',
+          },
+        });
+      }
+    }
+  );
+}
+
+export function attachLeagueSocialSocketHandlers(io: SocketIOServer): void {
+  io.on('connection', attachSocketHandlers);
+}
+
+export async function broadcastLeagueSocialEvent(
+  io: SocketIOServer,
+  envelope: SocialRealtimeEnvelope
+): Promise<void> {
+  const room = getLeagueSocialRoom(envelope.leagueId);
+  const sockets = await io.in(room).fetchSockets();
+  await Promise.all(
+    sockets.map(async (socket) => {
+      const userId =
+        typeof socket.data.userId === 'string' && socket.data.userId.trim()
+          ? socket.data.userId.trim()
+          : null;
+      if (!userId) {
+        await socket.leave(room);
+        return;
+      }
+
+      const access = await getLeagueMembershipAccess(envelope.leagueId, userId);
+      if (!access.isMember) {
+        await socket.leave(room);
+        return;
+      }
+      socket.emit(envelope.event, envelope);
+    })
+  );
+}
+
+export async function startLeagueSocialRealtime(io: SocketIOServer): Promise<void> {
+  await socialPubSub.start((envelope) => broadcastLeagueSocialEvent(io, envelope));
+}
+
+export async function publishLeagueSocialRealtimeEvent(
+  io: SocketIOServer,
+  envelope: SocialRealtimeEnvelope
+): Promise<void> {
+  await broadcastLeagueSocialEvent(io, envelope);
+  await socialPubSub.publish(envelope);
+}

--- a/src/server/leagues/social/socialSystemEvents.test.ts
+++ b/src/server/leagues/social/socialSystemEvents.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const tx = {
+    socialCommand: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    socialMessage: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+    socialOutboxEvent: {
+      create: vi.fn(),
+    },
+  };
+  return {
+    ensureActiveLeagueSeason: vi.fn(),
+    transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    tx,
+  };
+});
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    $transaction: mocks.transaction,
+  },
+}));
+
+vi.mock('./socialAccess', () => ({
+  ensureActiveLeagueSeason: mocks.ensureActiveLeagueSeason,
+}));
+
+vi.mock('./socialDto', () => ({
+  socialMessageInclude: {},
+  toSocialMessage: vi.fn((record) => ({
+    id: record.id,
+    leagueId: record.leagueId,
+    seasonId: record.seasonId,
+    type: 'system',
+    content: record.content,
+    author: null,
+    createdAt: record.createdAt.toISOString(),
+    moderationStatus: 'active',
+    isOwn: false,
+  })),
+}));
+
+import { publishLeagueSystemMessage } from './socialSystemEvents';
+
+describe('league social system activity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.ensureActiveLeagueSeason.mockResolvedValue('season-1');
+    mocks.tx.socialCommand.findUnique.mockResolvedValue(null);
+    mocks.tx.socialCommand.create.mockResolvedValue({ id: 'command-1' });
+    mocks.tx.socialMessage.create.mockResolvedValue({
+      id: 'message-1',
+      leagueId: 'league-1',
+      seasonId: 'season-1',
+      content: 'Jordan Example was drafted.',
+      createdAt: new Date('2026-07-19T10:00:00.000Z'),
+    });
+    mocks.tx.socialOutboxEvent.create.mockResolvedValue({ sequence: 12 });
+    mocks.tx.socialCommand.update.mockResolvedValue({});
+  });
+
+  it('persists automated events as system messages routed only through Activity', async () => {
+    await publishLeagueSystemMessage({
+      leagueId: 'league-1',
+      eventType: 'PLAYER_DRAFTED',
+      relatedEntityId: 'pick-1',
+      content: 'Jordan Example was drafted.',
+    });
+
+    expect(mocks.tx.socialCommand.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        actorUserId: '__system__',
+        idempotencyKey: 'system:PLAYER_DRAFTED:pick-1',
+      }),
+    });
+    expect(mocks.tx.socialCommand.create.mock.calls[0][0].data).not.toHaveProperty('actorMemberId');
+    expect(mocks.tx.socialOutboxEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        channel: 'ACTIVITY',
+        eventType: 'social:activity',
+        aggregateType: 'activity',
+        actorUserId: null,
+        payloadJson: expect.stringContaining('"type":"system"'),
+      }),
+    });
+  });
+});

--- a/src/server/leagues/social/socialSystemEvents.ts
+++ b/src/server/leagues/social/socialSystemEvents.ts
@@ -1,0 +1,131 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+
+import { prisma } from '@/lib/prisma';
+import type { SocialMessage, SocialRealtimeEnvelope } from '@/types/social';
+
+import { ensureActiveLeagueSeason } from './socialAccess';
+import { socialMessageInclude, toSocialMessage } from './socialDto';
+import { SocialError } from './socialErrors';
+import { SOCIAL_MESSAGE_MAX_LENGTH } from './socialValidation';
+
+export async function publishLeagueSystemMessage({
+  leagueId,
+  eventType,
+  relatedEntityId,
+  content,
+}: {
+  leagueId: string;
+  eventType: string;
+  relatedEntityId: string;
+  content: string;
+}): Promise<SocialMessage> {
+  const normalizedContent = content.trim();
+  if (!normalizedContent || normalizedContent.length > SOCIAL_MESSAGE_MAX_LENGTH) {
+    throw new SocialError('VALIDATION', 'System message content is invalid');
+  }
+  const seasonId = await ensureActiveLeagueSeason(leagueId);
+  const commandKey = `system:${eventType}:${relatedEntityId}`.slice(0, 128);
+
+  return prisma.$transaction(async (tx) => {
+    const existingCommand = await tx.socialCommand.findUnique({
+      where: {
+        leagueId_actorUserId_idempotencyKey: {
+          leagueId,
+          actorUserId: '__system__',
+          idempotencyKey: commandKey,
+        },
+      },
+      select: { resultId: true },
+    });
+    if (existingCommand?.resultId) {
+      const existingMessage = await tx.socialMessage.findFirst({
+        where: { id: existingCommand.resultId, leagueId, seasonId },
+        include: socialMessageInclude,
+      });
+      if (existingMessage) return toSocialMessage(existingMessage, '');
+    }
+
+    const league = await tx.league.findUnique({
+      where: { id: leagueId },
+      select: {
+        ownerId: true,
+        members: {
+          where: { isActive: true, status: 'ACTIVE' },
+          orderBy: { joinedAt: 'asc' },
+          take: 1,
+          select: { id: true },
+        },
+      },
+    });
+    const actorMemberId = league?.members[0]?.id;
+    if (!actorMemberId) {
+      throw new SocialError('CONFLICT', 'League has no active member for system event retention');
+    }
+
+    const command = await tx.socialCommand.create({
+      data: {
+        leagueId,
+        seasonId,
+        actorUserId: '__system__',
+        actorMemberId,
+        idempotencyKey: commandKey,
+        commandType: 'PUBLISH_SYSTEM_MESSAGE',
+        requestHash: createHash('sha256')
+          .update(`${eventType}:${relatedEntityId}:${normalizedContent}`)
+          .digest('hex'),
+      },
+    });
+    const record = await tx.socialMessage.create({
+      data: {
+        leagueId,
+        seasonId,
+        type: 'SYSTEM',
+        content: normalizedContent,
+        relatedEntityType: eventType,
+        relatedEntityId,
+      },
+      include: socialMessageInclude,
+    });
+    const message = toSocialMessage(record, '');
+    const outbox = await tx.socialOutboxEvent.create({
+      data: {
+        leagueId,
+        seasonId,
+        channel: 'CHAT',
+        actorUserId: null,
+        eventType: 'social:message',
+        aggregateType: 'message',
+        aggregateId: record.id,
+        payloadJson: '{}',
+      },
+      select: { id: true, sequence: true, createdAt: true },
+    });
+    const envelope: SocialRealtimeEnvelope = {
+      id: outbox.id,
+      sequence: outbox.sequence,
+      leagueId,
+      seasonId,
+      channel: 'chat',
+      event: 'social:message',
+      payload: message,
+      occurredAt: outbox.createdAt.toISOString(),
+    };
+    await Promise.all([
+      tx.socialOutboxEvent.update({
+        where: { sequence: outbox.sequence },
+        data: { payloadJson: JSON.stringify(envelope) },
+      }),
+      tx.socialCommand.update({
+        where: { id: command.id },
+        data: {
+          resultType: 'message',
+          resultId: record.id,
+          responseJson: JSON.stringify(message),
+        },
+      }),
+    ]);
+    return message;
+  });
+}

--- a/src/server/leagues/social/socialSystemEvents.ts
+++ b/src/server/leagues/social/socialSystemEvents.ts
@@ -3,7 +3,7 @@ import 'server-only';
 import { createHash } from 'node:crypto';
 
 import { prisma } from '@/lib/prisma';
-import type { SocialMessage, SocialRealtimeEnvelope } from '@/types/social';
+import type { SocialMessage } from '@/types/social';
 
 import { ensureActiveLeagueSeason } from './socialAccess';
 import { socialMessageInclude, toSocialMessage } from './socialDto';
@@ -47,29 +47,11 @@ export async function publishLeagueSystemMessage({
       if (existingMessage) return toSocialMessage(existingMessage, '');
     }
 
-    const league = await tx.league.findUnique({
-      where: { id: leagueId },
-      select: {
-        ownerId: true,
-        members: {
-          where: { isActive: true, status: 'ACTIVE' },
-          orderBy: { joinedAt: 'asc' },
-          take: 1,
-          select: { id: true },
-        },
-      },
-    });
-    const actorMemberId = league?.members[0]?.id;
-    if (!actorMemberId) {
-      throw new SocialError('CONFLICT', 'League has no active member for system event retention');
-    }
-
     const command = await tx.socialCommand.create({
       data: {
         leagueId,
         seasonId,
         actorUserId: '__system__',
-        actorMemberId,
         idempotencyKey: commandKey,
         commandType: 'PUBLISH_SYSTEM_MESSAGE',
         requestHash: createHash('sha256')
@@ -89,43 +71,26 @@ export async function publishLeagueSystemMessage({
       include: socialMessageInclude,
     });
     const message = toSocialMessage(record, '');
-    const outbox = await tx.socialOutboxEvent.create({
+    await tx.socialOutboxEvent.create({
       data: {
         leagueId,
         seasonId,
-        channel: 'CHAT',
+        channel: 'ACTIVITY',
         actorUserId: null,
-        eventType: 'social:message',
-        aggregateType: 'message',
+        eventType: 'social:activity',
+        aggregateType: 'activity',
         aggregateId: record.id,
-        payloadJson: '{}',
+        payloadJson: JSON.stringify(message),
       },
-      select: { id: true, sequence: true, createdAt: true },
     });
-    const envelope: SocialRealtimeEnvelope = {
-      id: outbox.id,
-      sequence: outbox.sequence,
-      leagueId,
-      seasonId,
-      channel: 'chat',
-      event: 'social:message',
-      payload: message,
-      occurredAt: outbox.createdAt.toISOString(),
-    };
-    await Promise.all([
-      tx.socialOutboxEvent.update({
-        where: { sequence: outbox.sequence },
-        data: { payloadJson: JSON.stringify(envelope) },
-      }),
-      tx.socialCommand.update({
-        where: { id: command.id },
-        data: {
-          resultType: 'message',
-          resultId: record.id,
-          responseJson: JSON.stringify(message),
-        },
-      }),
-    ]);
+    await tx.socialCommand.update({
+      where: { id: command.id },
+      data: {
+        resultType: 'message',
+        resultId: record.id,
+        responseJson: JSON.stringify(message),
+      },
+    });
     return message;
   });
 }

--- a/src/server/leagues/social/socialSystemEvents.ts
+++ b/src/server/leagues/social/socialSystemEvents.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 import { createHash } from 'node:crypto';
 
 import { prisma } from '@/lib/prisma';

--- a/src/server/leagues/social/socialValidation.ts
+++ b/src/server/leagues/social/socialValidation.ts
@@ -23,8 +23,31 @@ const nonEmptyText = (maxLength: number) =>
     .refine((value) => value.trim().length > 0, 'Content cannot be empty')
     .transform((value) => value.trim());
 
+const socialContextMetadataSchema = z
+  .record(
+    z
+      .string()
+      .trim()
+      .min(1)
+      .max(40)
+      .regex(/^[A-Za-z0-9_-]+$/),
+    z.string().trim().min(1).max(200)
+  )
+  .refine((value) => Object.keys(value).length <= 6, 'Context metadata is limited to 6 fields');
+
+export const socialDiscussionContextSchema = z
+  .object({
+    type: z.enum(['player', 'trade', 'activity']),
+    id: z.string().trim().min(1).max(128),
+    title: nonEmptyText(150),
+    subtitle: nonEmptyText(300).optional(),
+    metadata: socialContextMetadataSchema.optional(),
+  })
+  .strict();
+
 export const createMessageSchema = z.object({
   content: nonEmptyText(SOCIAL_MESSAGE_MAX_LENGTH),
+  context: socialDiscussionContextSchema.optional(),
   idempotencyKey: idempotencyKeySchema,
 });
 
@@ -57,7 +80,7 @@ export const editReplySchema = z.object({
 });
 
 export const markReadSchema = z.object({
-  channel: z.enum(['chat', 'board']),
+  channel: z.enum(['chat', 'board', 'activity']),
   sequence: z.number().int().nonnegative().optional(),
 });
 

--- a/src/server/leagues/social/socialValidation.ts
+++ b/src/server/leagues/social/socialValidation.ts
@@ -23,6 +23,23 @@ const nonEmptyText = (maxLength: number) =>
     .refine((value) => value.trim().length > 0, 'Content cannot be empty')
     .transform((value) => value.trim());
 
+const socialMessageText = z
+  .string()
+  .max(SOCIAL_MESSAGE_MAX_LENGTH)
+  .transform((value) => value.trim());
+
+export const socialGifSchema = z
+  .object({
+    provider: z.literal('giphy'),
+    id: z
+      .string()
+      .trim()
+      .min(1)
+      .max(128)
+      .regex(/^[A-Za-z0-9]+$/),
+  })
+  .strict();
+
 const socialContextMetadataSchema = z
   .record(
     z
@@ -45,11 +62,23 @@ export const socialDiscussionContextSchema = z
   })
   .strict();
 
-export const createMessageSchema = z.object({
-  content: nonEmptyText(SOCIAL_MESSAGE_MAX_LENGTH),
-  context: socialDiscussionContextSchema.optional(),
-  idempotencyKey: idempotencyKeySchema,
-});
+export const createMessageSchema = z
+  .object({
+    content: socialMessageText,
+    context: socialDiscussionContextSchema.optional(),
+    gif: socialGifSchema.optional(),
+    idempotencyKey: idempotencyKeySchema,
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (!value.content && !value.gif) {
+      context.addIssue({
+        code: 'custom',
+        path: ['content'],
+        message: 'A message or GIF is required',
+      });
+    }
+  });
 
 export const editMessageSchema = z.object({
   content: nonEmptyText(SOCIAL_MESSAGE_MAX_LENGTH),

--- a/src/server/leagues/social/socialValidation.ts
+++ b/src/server/leagues/social/socialValidation.ts
@@ -1,0 +1,147 @@
+import { z } from 'zod';
+
+import type { SocialReportReason } from '@/types/social';
+
+export const SOCIAL_MESSAGE_MAX_LENGTH = 1_000;
+export const SOCIAL_POST_TITLE_MAX_LENGTH = 150;
+export const SOCIAL_POST_BODY_MAX_LENGTH = 10_000;
+export const SOCIAL_REPLY_MAX_LENGTH = 10_000;
+export const SOCIAL_PAGE_MAX_SIZE = 100;
+export const SOCIAL_PAGE_DEFAULT_SIZE = 40;
+
+const idempotencyKeySchema = z
+  .string()
+  .trim()
+  .min(8)
+  .max(128)
+  .regex(/^[A-Za-z0-9._:-]+$/);
+
+const nonEmptyText = (maxLength: number) =>
+  z
+    .string()
+    .max(maxLength)
+    .refine((value) => value.trim().length > 0, 'Content cannot be empty')
+    .transform((value) => value.trim());
+
+export const createMessageSchema = z.object({
+  content: nonEmptyText(SOCIAL_MESSAGE_MAX_LENGTH),
+  idempotencyKey: idempotencyKeySchema,
+});
+
+export const editMessageSchema = z.object({
+  content: nonEmptyText(SOCIAL_MESSAGE_MAX_LENGTH),
+});
+
+export const createPostSchema = z.object({
+  categoryId: z.string().trim().min(1).max(128),
+  title: nonEmptyText(SOCIAL_POST_TITLE_MAX_LENGTH),
+  body: nonEmptyText(SOCIAL_POST_BODY_MAX_LENGTH),
+  isAnnouncement: z.boolean().optional().default(false),
+  idempotencyKey: idempotencyKeySchema,
+});
+
+export const editPostSchema = z.object({
+  title: nonEmptyText(SOCIAL_POST_TITLE_MAX_LENGTH).optional(),
+  body: nonEmptyText(SOCIAL_POST_BODY_MAX_LENGTH).optional(),
+  isPinned: z.boolean().optional(),
+  isLocked: z.boolean().optional(),
+});
+
+export const createReplySchema = z.object({
+  body: nonEmptyText(SOCIAL_REPLY_MAX_LENGTH),
+  idempotencyKey: idempotencyKeySchema,
+});
+
+export const editReplySchema = z.object({
+  body: nonEmptyText(SOCIAL_REPLY_MAX_LENGTH),
+});
+
+export const markReadSchema = z.object({
+  channel: z.enum(['chat', 'board']),
+  sequence: z.number().int().nonnegative().optional(),
+});
+
+export const reportContentSchema = z.object({
+  contentType: z.enum(['message', 'post', 'reply']),
+  contentId: z.string().trim().min(1).max(128),
+  reason: z.enum(['harassment', 'hate', 'spam', 'threats', 'unsafe-link', 'other']),
+  details: z.string().trim().max(2_000).optional(),
+});
+
+export const socialPreferencesSchema = z.object({
+  chatInApp: z.boolean(),
+  boardPosts: z.boolean(),
+  ownPostReplies: z.boolean(),
+  announcements: z.boolean(),
+  tradeDiscussions: z.boolean(),
+  mentions: z.boolean(),
+  systemActivityInApp: z.boolean(),
+});
+
+export const moderationActionSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('remove'),
+    contentType: z.enum(['message', 'post', 'reply']),
+    contentId: z.string().trim().min(1).max(128),
+    reason: z.string().trim().min(1).max(2_000),
+  }),
+  z.object({
+    action: z.literal('restore'),
+    contentType: z.enum(['message', 'post', 'reply']),
+    contentId: z.string().trim().min(1).max(128),
+    reason: z.string().trim().min(1).max(2_000),
+  }),
+  z.object({
+    action: z.literal('mute'),
+    userId: z.string().trim().min(1).max(128),
+    until: z.iso.datetime(),
+    reason: z.string().trim().min(1).max(2_000),
+  }),
+  z.object({
+    action: z.literal('unmute'),
+    userId: z.string().trim().min(1).max(128),
+    reason: z.string().trim().min(1).max(2_000),
+  }),
+]);
+
+export interface SocialPageCursor {
+  createdAt: string;
+  id: string;
+}
+
+export function encodeSocialCursor(cursor: SocialPageCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+export function decodeSocialCursor(value: string | null): SocialPageCursor | null {
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as Record<
+      string,
+      unknown
+    >;
+    if (
+      typeof parsed.createdAt !== 'string' ||
+      Number.isNaN(new Date(parsed.createdAt).getTime()) ||
+      typeof parsed.id !== 'string' ||
+      !parsed.id
+    ) {
+      return null;
+    }
+    return { createdAt: parsed.createdAt, id: parsed.id };
+  } catch {
+    return null;
+  }
+}
+
+export function parseSocialPageSize(value: string | null): number {
+  if (!value) return SOCIAL_PAGE_DEFAULT_SIZE;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return SOCIAL_PAGE_DEFAULT_SIZE;
+  return Math.min(parsed, SOCIAL_PAGE_MAX_SIZE);
+}
+
+export function isSocialReportReason(value: string): value is SocialReportReason {
+  return ['harassment', 'hate', 'spam', 'threats', 'unsafe-link', 'other'].includes(value);
+}

--- a/src/server/socketioServer.ts
+++ b/src/server/socketioServer.ts
@@ -28,6 +28,11 @@ import { draftRepository } from '@/server/draft/repository/DraftRepository';
 import { draftApplicationService } from '@/server/draft/services/DraftApplicationService';
 import { draftRealtimeDispatcher } from '@/server/draft/services/DraftRealtimeDispatcher';
 import { draftRealtimePublisher } from '@/server/draft/services/DraftRealtimePublisher';
+import { flushSocialOutboxBatch } from '@/server/leagues/social/socialPublisher';
+import {
+  attachLeagueSocialSocketHandlers,
+  startLeagueSocialRealtime,
+} from '@/server/leagues/social/socialSocket';
 import { draftRoomStore } from '@/server/roomStore';
 
 // Validate configuration before starting
@@ -167,7 +172,9 @@ async function getDeltasSince(draftId: string, since: number): Promise<DraftDelt
 }
 
 async function runAutoPickForExpiredTimer(draftId: string): Promise<void> {
-  const draft = await draftRepository.transaction((tx) => draftRepository.getDraftAggregate(tx, draftId));
+  const draft = await draftRepository.transaction((tx) =>
+    draftRepository.getDraftAggregate(tx, draftId)
+  );
   if (!draft) {
     logger.warn('Skipping timer auto-pick for missing draft', { draftId });
     return;
@@ -194,7 +201,10 @@ async function runAutoPickForExpiredTimer(draftId: string): Promise<void> {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (message.startsWith('conflict:')) {
-      logger.info('Skipping stale timer auto-pick after draft state changed', { draftId, error: message });
+      logger.info('Skipping stale timer auto-pick after draft state changed', {
+        draftId,
+        error: message,
+      });
       return;
     }
     logger.error('Failed to auto-pick after timer expiry', { draftId, error: message });
@@ -492,6 +502,8 @@ io.use((socket, next) => {
   void authenticateSocketConnection(socket, next);
 });
 
+attachLeagueSocialSocketHandlers(io);
+
 draftRealtimeDispatcher.attachSocketServer(io);
 
 void (async () => {
@@ -508,6 +520,25 @@ void (async () => {
     logger.error('❌ Failed to start draft realtime dispatcher', { error: (e as Error).message });
   }
 })();
+
+const socialRealtimeReady = startLeagueSocialRealtime(io);
+const drainSocialOutbox = async (): Promise<void> => {
+  try {
+    await socialRealtimeReady;
+    await flushSocialOutboxBatch(io);
+  } catch (error) {
+    logger.error('Failed to drain league social outbox', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+void drainSocialOutbox();
+setInterval(
+  () => {
+    void drainSocialOutbox();
+  },
+  Number(process.env.SOCIAL_OUTBOX_DRAIN_INTERVAL_MS || 1_000)
+);
 
 // Handle draft connections with enhanced error handling
 io.on('connection', (socket) => {

--- a/src/services/realtime/pubsub.ts
+++ b/src/services/realtime/pubsub.ts
@@ -102,6 +102,7 @@ export class DraftPubSub {
       }
 
       const handler = (_pattern: unknown, _channel: unknown, message: unknown) => {
+        if (_pattern !== `${prefix}:*`) return;
         if (typeof message !== 'string') {
           logger.warn('Received non-string message from Redis', { messageType: typeof message });
           return;

--- a/src/types/leagues.ts
+++ b/src/types/leagues.ts
@@ -1,6 +1,7 @@
 import type { FantasyCategoryKey } from './fantasyCategories';
 import type { DraftOperationalReadiness } from './draftReadiness';
 import type { Timestamp } from 'firebase-admin/firestore';
+import type { SocialNotificationPreferences } from './social';
 
 // Core League Types
 export type LeagueType = 'public' | 'private';
@@ -82,6 +83,7 @@ export interface LeagueMemberNotificationSettings {
   waiverPush: boolean;
   draftReminder: boolean;
   scoringAlerts: boolean;
+  social?: SocialNotificationPreferences;
 }
 
 // API/UI shape for league members (client-side), dates as ISO strings

--- a/src/types/social.ts
+++ b/src/types/social.ts
@@ -26,6 +26,11 @@ export interface SocialDiscussionContext {
   metadata?: Record<string, string>;
 }
 
+export interface SocialGif {
+  provider: 'giphy';
+  id: string;
+}
+
 export interface SocialMessage {
   id: string;
   leagueId: string;
@@ -33,6 +38,7 @@ export interface SocialMessage {
   type: SocialMessageType;
   content: string;
   context?: SocialDiscussionContext;
+  gif?: SocialGif;
   author: SocialAuthor | null;
   relatedEntityId?: string;
   createdAt: string;
@@ -139,6 +145,7 @@ export const DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES: SocialNotificationPreferen
 export interface CreateSocialMessageInput {
   content: string;
   context?: SocialDiscussionContext;
+  gif?: SocialGif;
   idempotencyKey: string;
 }
 

--- a/src/types/social.ts
+++ b/src/types/social.ts
@@ -1,5 +1,5 @@
 export type SocialMessageType = 'member' | 'system';
-export type SocialChannel = 'chat' | 'board';
+export type SocialChannel = 'chat' | 'board' | 'activity';
 export type SocialModerationStatus = 'active' | 'removed';
 export type SocialReportReason =
   | 'harassment'
@@ -18,12 +18,21 @@ export interface SocialAuthor {
   avatarUrl?: string;
 }
 
+export interface SocialDiscussionContext {
+  type: 'player' | 'trade' | 'activity';
+  id: string;
+  title: string;
+  subtitle?: string;
+  metadata?: Record<string, string>;
+}
+
 export interface SocialMessage {
   id: string;
   leagueId: string;
   seasonId: string;
   type: SocialMessageType;
   content: string;
+  context?: SocialDiscussionContext;
   author: SocialAuthor | null;
   relatedEntityId?: string;
   createdAt: string;
@@ -91,10 +100,12 @@ export interface LeagueSocialSummary {
   unread: {
     chat: number;
     board: number;
+    activity: number;
   };
   latestSequence: {
     chat: number;
     board: number;
+    activity: number;
   };
   preferences: SocialNotificationPreferences;
   categories: SocialBoardCategory[];
@@ -127,6 +138,7 @@ export const DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES: SocialNotificationPreferen
 
 export interface CreateSocialMessageInput {
   content: string;
+  context?: SocialDiscussionContext;
   idempotencyKey: string;
 }
 
@@ -151,6 +163,7 @@ export interface SocialRealtimeEnvelope {
   channel: SocialChannel;
   event:
     | 'social:message'
+    | 'social:activity'
     | 'social:post'
     | 'social:reply'
     | 'social:moderation'

--- a/src/types/social.ts
+++ b/src/types/social.ts
@@ -1,0 +1,160 @@
+export type SocialMessageType = 'member' | 'system';
+export type SocialChannel = 'chat' | 'board';
+export type SocialModerationStatus = 'active' | 'removed';
+export type SocialReportReason =
+  | 'harassment'
+  | 'hate'
+  | 'spam'
+  | 'threats'
+  | 'unsafe-link'
+  | 'other';
+
+export interface SocialAuthor {
+  userId: string;
+  memberId?: string;
+  teamId?: string;
+  displayName: string;
+  teamName: string;
+  avatarUrl?: string;
+}
+
+export interface SocialMessage {
+  id: string;
+  leagueId: string;
+  seasonId: string;
+  type: SocialMessageType;
+  content: string;
+  author: SocialAuthor | null;
+  relatedEntityId?: string;
+  createdAt: string;
+  editedAt?: string;
+  deletedAt?: string;
+  moderationStatus: SocialModerationStatus;
+  isOwn: boolean;
+}
+
+export interface SocialBoardCategory {
+  id: string;
+  key: string;
+  name: string;
+  position: number;
+}
+
+export interface SocialPost {
+  id: string;
+  leagueId: string;
+  seasonId: string;
+  category: SocialBoardCategory;
+  author: SocialAuthor | null;
+  title: string;
+  body: string;
+  isPinned: boolean;
+  isLocked: boolean;
+  isAnnouncement: boolean;
+  replyCount: number;
+  latestActivityAt: string;
+  createdAt: string;
+  updatedAt: string;
+  editedAt?: string;
+  deletedAt?: string;
+  moderationStatus: SocialModerationStatus;
+  isOwn: boolean;
+}
+
+export interface SocialReply {
+  id: string;
+  postId: string;
+  leagueId: string;
+  seasonId: string;
+  author: SocialAuthor | null;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+  editedAt?: string;
+  deletedAt?: string;
+  moderationStatus: SocialModerationStatus;
+  isOwn: boolean;
+}
+
+export interface SocialCursorPage<T> {
+  items: T[];
+  nextCursor: string | null;
+}
+
+export interface LeagueSocialSummary {
+  leagueId: string;
+  seasonId: string;
+  canManage: boolean;
+  canPublish: boolean;
+  standardsAccepted: boolean;
+  mutedUntil: string | null;
+  unread: {
+    chat: number;
+    board: number;
+  };
+  latestSequence: {
+    chat: number;
+    board: number;
+  };
+  preferences: SocialNotificationPreferences;
+  categories: SocialBoardCategory[];
+}
+
+export interface SocialPostThread {
+  post: SocialPost;
+  replies: SocialCursorPage<SocialReply>;
+}
+
+export interface SocialNotificationPreferences {
+  chatInApp: boolean;
+  boardPosts: boolean;
+  ownPostReplies: boolean;
+  announcements: boolean;
+  tradeDiscussions: boolean;
+  mentions: boolean;
+  systemActivityInApp: boolean;
+}
+
+export const DEFAULT_SOCIAL_NOTIFICATION_PREFERENCES: SocialNotificationPreferences = {
+  chatInApp: true,
+  boardPosts: false,
+  ownPostReplies: true,
+  announcements: true,
+  tradeDiscussions: false,
+  mentions: true,
+  systemActivityInApp: true,
+};
+
+export interface CreateSocialMessageInput {
+  content: string;
+  idempotencyKey: string;
+}
+
+export interface CreateSocialPostInput {
+  categoryId: string;
+  title: string;
+  body: string;
+  isAnnouncement?: boolean;
+  idempotencyKey: string;
+}
+
+export interface CreateSocialReplyInput {
+  body: string;
+  idempotencyKey: string;
+}
+
+export interface SocialRealtimeEnvelope {
+  id: string;
+  sequence: number;
+  leagueId: string;
+  seasonId: string;
+  channel: SocialChannel;
+  event:
+    | 'social:message'
+    | 'social:post'
+    | 'social:reply'
+    | 'social:moderation'
+    | 'social:read-state';
+  payload: SocialMessage | SocialPost | SocialReply | Record<string, unknown>;
+  occurredAt: string;
+}

--- a/tests/unit/DraftRealtimePublisher.test.ts
+++ b/tests/unit/DraftRealtimePublisher.test.ts
@@ -5,6 +5,7 @@ const {
   draftRealtimeDispatcher,
   draftProjectionService,
   revalidateTags,
+  publishLeagueSystemMessage,
 } = vi.hoisted(() => ({
   draftRepository: {
     transaction: vi.fn(),
@@ -23,6 +24,7 @@ const {
     buildAuthoritativeDraftState: vi.fn(),
   },
   revalidateTags: vi.fn(),
+  publishLeagueSystemMessage: vi.fn(),
 }));
 
 vi.mock('@/lib/cache', () => ({
@@ -56,6 +58,10 @@ vi.mock('@/server/draft/services/DraftProjectionService', () => ({
   draftProjectionService,
 }));
 
+vi.mock('@/server/leagues/social/socialSystemEvents', () => ({
+  publishLeagueSystemMessage,
+}));
+
 import { DraftRealtimePublisher } from '@/server/draft/services/DraftRealtimePublisher';
 
 describe('DraftRealtimePublisher', () => {
@@ -63,6 +69,7 @@ describe('DraftRealtimePublisher', () => {
     vi.clearAllMocks();
     draftRepository.transaction.mockImplementation((work) => work({}));
     revalidateTags.mockResolvedValue(undefined);
+    publishLeagueSystemMessage.mockResolvedValue({});
   });
 
   it('drains the events claimed by batch flush instead of re-querying unlocked draft events', async () => {
@@ -113,7 +120,47 @@ describe('DraftRealtimePublisher', () => {
       'draft-2',
       'draft:completed'
     );
-    expect(draftRepository.markDraftEventsPublished).toHaveBeenCalledWith({}, ['event-1', 'event-2']);
+    expect(draftRepository.markDraftEventsPublished).toHaveBeenCalledWith({}, [
+      'event-1',
+      'event-2',
+    ]);
     expect(draftRepository.markDraftEventsFailed).not.toHaveBeenCalled();
+  });
+
+  it('keeps a draft event retryable until its social activity is durably created', async () => {
+    const event = {
+      id: 'event-pick',
+      draftId: 'draft-1',
+      leagueId: 'league-1',
+      event: 'draft:pick-made',
+      payload: {
+        id: 'pick-1',
+        member: { displayName: 'Alex' },
+        player: { name: 'Taylor' },
+      },
+      publishState: false,
+      attempts: 0,
+      lastError: null,
+      lockedAt: null,
+      lockedBy: null,
+      publishedAt: null,
+      createdAt: new Date('2026-06-05T00:00:00.000Z'),
+    } as any;
+    draftRepository.listPendingDraftEventsBatch.mockResolvedValue([event]);
+    draftRepository.claimDraftEvents.mockResolvedValue(1);
+    draftRepository.listClaimedDraftEvents.mockResolvedValue([event]);
+    publishLeagueSystemMessage.mockRejectedValueOnce(new Error('social write unavailable'));
+
+    const publisher = new DraftRealtimePublisher();
+    await expect(publisher.flushPendingDraftEventsBatch(50)).rejects.toThrow(
+      'social write unavailable'
+    );
+
+    expect(draftRepository.markDraftEventsPublished).not.toHaveBeenCalled();
+    expect(draftRepository.markDraftEventsFailed).toHaveBeenCalledWith(
+      {},
+      ['event-pick'],
+      'social write unavailable'
+    );
   });
 });

--- a/tests/unit/LeagueTabs.roster.test.tsx
+++ b/tests/unit/LeagueTabs.roster.test.tsx
@@ -35,7 +35,7 @@ vi.mock('@/components/MyTeamPanel', () => ({
 }));
 
 vi.mock('@/lib/authenticatedFetch', () => ({
-  authenticatedFetch: vi.fn(),
+  authenticatedFetch: vi.fn().mockResolvedValue({ ok: false }),
 }));
 
 const league: League = {

--- a/tests/unit/LeagueTabs.waivers.test.tsx
+++ b/tests/unit/LeagueTabs.waivers.test.tsx
@@ -30,7 +30,7 @@ vi.mock('@/components/waivers/LeagueWaiversContainer', () => ({
 }));
 
 vi.mock('@/lib/authenticatedFetch', () => ({
-  authenticatedFetch: vi.fn(),
+  authenticatedFetch: vi.fn().mockResolvedValue({ ok: false }),
 }));
 
 const league: League = {

--- a/tests/unit/UnifiedDraftRoom.liveShell.test.tsx
+++ b/tests/unit/UnifiedDraftRoom.liveShell.test.tsx
@@ -15,6 +15,8 @@ type DraftRoomPlayerFixture = {
 const playerGridSpy = vi.hoisted(() => vi.fn());
 const draftLeftRailSpy = vi.hoisted(() => vi.fn());
 const pickFeedSpy = vi.hoisted(() => vi.fn());
+const openLeagueSocialSpy = vi.hoisted(() => vi.fn());
+const setLeagueContextSpy = vi.hoisted(() => vi.fn());
 
 const draftContext = vi.hoisted<{
   status: 'SCHEDULED' | 'LIVE' | 'PAUSED' | 'COMPLETED';
@@ -54,6 +56,13 @@ vi.mock('@/components/ui', () => ({
   useConfirmation: () => ({
     confirm: vi.fn(),
     ConfirmationModal: null,
+  }),
+}));
+
+vi.mock('@/components/league/social', () => ({
+  useLeagueSocialWidget: () => ({
+    open: openLeagueSocialSpy,
+    setLeagueContext: setLeagueContextSpy,
   }),
 }));
 
@@ -230,6 +239,8 @@ describe('UnifiedDraftRoom live shell composition', () => {
     playerGridSpy.mockClear();
     draftLeftRailSpy.mockClear();
     pickFeedSpy.mockClear();
+    openLeagueSocialSpy.mockClear();
+    setLeagueContextSpy.mockClear();
     draftContext.status = 'LIVE';
     draftContext.availablePlayers = [
       {
@@ -258,6 +269,12 @@ describe('UnifiedDraftRoom live shell composition', () => {
     expect(screen.getByRole('complementary', { name: 'Pick feed' })).toBeInTheDocument();
     expect(screen.getByText('Draft queue panel')).toBeInTheDocument();
     expect(screen.getByText('Watchlist panel')).toBeInTheDocument();
+    expect(setLeagueContextSpy).toHaveBeenCalledWith(
+      'league-1',
+      'Test AFL Champions League - LIVE'
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'League chat' }));
+    expect(openLeagueSocialSpy).toHaveBeenCalledWith({ view: 'chat' });
     expect(screen.queryByText('Draft analytics panel')).not.toBeInTheDocument();
     expect(screen.queryByRole('tablist', { name: 'Draft room sections' })).not.toBeInTheDocument();
 

--- a/tests/unit/draftCreateAuthorization.test.ts
+++ b/tests/unit/draftCreateAuthorization.test.ts
@@ -85,7 +85,7 @@ describe('draft create authorization architecture', () => {
     );
   });
 
-  it('falls back to legacy membership when a Prisma league has no matching manager access', async () => {
+  it('does not fall back to legacy membership when Prisma has no active member', async () => {
     vi.mocked(prisma.league.findUnique).mockResolvedValue({
       ownerId: 'prisma-owner',
       members: [],
@@ -99,22 +99,17 @@ describe('draft create authorization architecture', () => {
 
     const access = await getLeagueMembershipAccess('league-1', 'user-1');
 
-    expect(getLeagueMembership).toHaveBeenCalledWith('league-1', 'user-1');
+    expect(getLeagueMembership).not.toHaveBeenCalled();
     expect(access).toEqual({
       leagueId: 'league-1',
       userId: 'user-1',
-      memberId: 'legacy-member',
-      role: 'commissioner',
-      isMember: true,
-      canManage: true,
+      isMember: false,
+      canManage: false,
     });
   });
 
   it('falls back to Firestore league ownership when Prisma access is missing', async () => {
-    vi.mocked(prisma.league.findUnique).mockResolvedValue({
-      ownerId: 'prisma-owner',
-      members: [],
-    } as never);
+    vi.mocked(prisma.league.findUnique).mockResolvedValue(null);
     vi.mocked(getLeagueMembership).mockResolvedValue({
       isMember: false,
       source: 'none',
@@ -139,10 +134,18 @@ describe('draft create authorization architecture', () => {
     });
   });
 
-  it('lets Firestore ownership elevate a stale non-manager Prisma member row', async () => {
+  it('does not let Firestore ownership override an active Prisma member role', async () => {
     vi.mocked(prisma.league.findUnique).mockResolvedValue({
       ownerId: 'prisma-owner',
-      members: [{ id: 'prisma-member', role: 'MEMBER' }],
+      members: [
+        {
+          id: 'prisma-member',
+          role: 'MEMBER',
+          isActive: true,
+          status: 'ACTIVE',
+          isCoCommissioner: false,
+        },
+      ],
     } as never);
     vi.mocked(getLeagueMembership).mockResolvedValue({
       isMember: false,
@@ -165,8 +168,9 @@ describe('draft create authorization architecture', () => {
       memberId: 'prisma-member',
       role: 'MEMBER',
       isMember: true,
-      canManage: true,
+      canManage: false,
     });
+    expect(adminDb.collection).not.toHaveBeenCalled();
   });
 
   it('returns 401 before parsing or draft side effects when the request is unauthenticated', async () => {

--- a/tests/unit/draftPageSocketProvider.test.tsx
+++ b/tests/unit/draftPageSocketProvider.test.tsx
@@ -32,14 +32,6 @@ vi.mock('@/components/ui/ErrorBoundary', () => ({
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-vi.mock('@/providers/SocketProvider', () => ({
-  SocketProvider: ({ uid, children }: { uid: string; children: React.ReactNode }) => (
-    <div data-testid="socket-provider" data-uid={uid}>
-      {children}
-    </div>
-  ),
-}));
-
 vi.mock('@/contexts/DraftContext', () => ({
   DraftProvider: ({
     draftId,
@@ -62,14 +54,11 @@ vi.mock('@/components/draft/UnifiedDraftRoom', () => ({
   ),
 }));
 
-describe('DraftPage socket composition', () => {
-  it('wraps the authenticated draft room with the SocketProvider', () => {
+describe('DraftPage provider composition', () => {
+  it('uses the app-level socket while preserving the draft provider and room', () => {
     render(<DraftPage />);
 
-    expect(screen.getByTestId('socket-provider')).toHaveAttribute(
-      'data-uid',
-      'statly-dev-tester'
-    );
+    expect(screen.queryByTestId('socket-provider')).not.toBeInTheDocument();
     expect(screen.getByTestId('draft-provider')).toHaveAttribute('data-draft-id', 'draft-1');
     expect(screen.getByTestId('draft-room')).toHaveAttribute('data-user-id', 'statly-dev-tester');
   });

--- a/tests/unit/leagueDetailReadModel.test.ts
+++ b/tests/unit/leagueDetailReadModel.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  leagueFindUnique: vi.fn(),
+  waiverPriorityFindMany: vi.fn(),
+  getLeagueDraftOperationalReadiness: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    league: { findUnique: mocks.leagueFindUnique },
+    waiverPriority: { findMany: mocks.waiverPriorityFindMany },
+  },
+}));
+vi.mock('@/lib/firebaseAdmin', () => ({
+  adminDb: {
+    collection: vi.fn(),
+  },
+}));
+vi.mock('@/lib/leagueMembership', () => ({
+  getLeagueMembership: vi.fn(),
+  isLeagueManagerRole: vi.fn(),
+  listActiveLeagueMembers: vi.fn(),
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+vi.mock('@/server/draft/services/DraftReadinessService', () => ({
+  getLeagueDraftOperationalReadiness: mocks.getLeagueDraftOperationalReadiness,
+}));
+
+import { loadAuthorizedLeagueDetail } from '@/server/leagues/leagueDetail';
+
+describe('league detail Prisma member projection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.waiverPriorityFindMany.mockResolvedValue([]);
+    mocks.getLeagueDraftOperationalReadiness.mockResolvedValue({ isReady: true });
+  });
+
+  it('excludes retained inactive members from teams and league capacity', async () => {
+    mocks.leagueFindUnique.mockResolvedValue({
+      id: 'test-league-id',
+      name: 'Test League',
+      inviteCode: 'TEST123',
+      ownerId: 'owner-user',
+      categoriesJson: null,
+      createdAt: new Date('2026-07-21T00:00:00.000Z'),
+      settings: { maxTeams: 2 },
+      drafts: [],
+      members: [
+        {
+          id: 'active-member',
+          leagueId: 'test-league-id',
+          userId: 'owner-user',
+          teamName: 'Active Team',
+          teamLogoUrl: null,
+          teamLogoPositionX: null,
+          teamLogoPositionY: null,
+          teamLogoZoom: null,
+          joinedAt: new Date('2026-07-01T00:00:00.000Z'),
+          isActive: true,
+          status: 'ACTIVE',
+        },
+        {
+          id: 'removed-member',
+          leagueId: 'test-league-id',
+          userId: 'former-user',
+          teamName: 'Former Team',
+          teamLogoUrl: null,
+          teamLogoPositionX: null,
+          teamLogoPositionY: null,
+          teamLogoZoom: null,
+          joinedAt: new Date('2026-07-02T00:00:00.000Z'),
+          isActive: false,
+          status: 'REMOVED',
+        },
+      ],
+    } as never);
+
+    const result = await loadAuthorizedLeagueDetail('test-league-id', null);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.members.map((member) => member.id)).toEqual(['active-member']);
+    expect(result.league).toMatchObject({
+      currentTeams: 1,
+      maxTeams: 2,
+    });
+  });
+});

--- a/tests/unit/prismaLeagueBridge.test.ts
+++ b/tests/unit/prismaLeagueBridge.test.ts
@@ -267,7 +267,7 @@ describe('prismaLeagueBridge', () => {
     });
   });
 
-  it('does not delete a Prisma member that already has draft dependencies', async () => {
+  it('deactivates a removed Prisma member while retaining draft history', async () => {
     const tx = buildTx({
       league: {
         findUnique: vi.fn(async () => ({ id: 'league-1', ownerId: 'owner-user' })),
@@ -275,6 +275,7 @@ describe('prismaLeagueBridge', () => {
       leagueMember: {
         findFirst: vi.fn(async () => ({ id: 'member-2', userId: 'member-user' })),
         delete: vi.fn(),
+        update: vi.fn(),
       },
       draftOrder: { count: vi.fn(async () => 1) },
       pick: { count: vi.fn(async () => 0) },
@@ -294,9 +295,17 @@ describe('prismaLeagueBridge', () => {
     );
 
     expect(result).toEqual({
-      synced: false,
-      reason: 'member-has-draft-dependencies',
+      synced: true,
+      action: 'deactivated',
     });
     expect(tx.leagueMember.delete).not.toHaveBeenCalled();
+    expect(tx.leagueMember.update).toHaveBeenCalledWith({
+      where: { id: 'member-2' },
+      data: {
+        isActive: false,
+        status: 'REMOVED',
+        leftAt: expect.any(Date),
+      },
+    });
   });
 });

--- a/tests/unit/socialActivityMigration.test.ts
+++ b/tests/unit/socialActivityMigration.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const migrationSql = readFileSync(
+  join(
+    process.cwd(),
+    'prisma',
+    'migrations',
+    '20260719120000_separate_league_social_activity',
+    'migration.sql'
+  ),
+  'utf8'
+);
+
+describe('league social Activity migration', () => {
+  it('adds structured message context and reclassifies only system-message outbox rows', () => {
+    expect(migrationSql).toContain('ALTER TABLE "SocialMessage" ADD COLUMN "contextJson" TEXT;');
+    expect(migrationSql).toContain('"channel" = \'ACTIVITY\'');
+    expect(migrationSql).toContain('"eventType" = \'social:activity\'');
+    expect(migrationSql).toContain('WHERE "type" = \'SYSTEM\'');
+  });
+
+  it('preserves chat read progress for Activity and removes arbitrary member ownership', () => {
+    expect(migrationSql).toContain('INSERT OR IGNORE INTO "SocialReadState"');
+    expect(migrationSql).toContain('\'activity:\' || "id"');
+    expect(migrationSql).toContain('WHERE "channel" = \'CHAT\'');
+    expect(migrationSql).toContain('"actorMemberId" TEXT,');
+    expect(migrationSql).toContain('ON DELETE SET NULL');
+  });
+});

--- a/tests/unit/socialGiphyMigration.test.ts
+++ b/tests/unit/socialGiphyMigration.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const migrationSql = readFileSync(
+  join(
+    process.cwd(),
+    'prisma',
+    'migrations',
+    '20260720100000_add_giphy_to_social_messages',
+    'migration.sql'
+  ),
+  'utf8'
+);
+
+describe('league social GIPHY migration', () => {
+  it('stores only the durable GIPHY identity on chat messages', () => {
+    expect(migrationSql).toContain('ALTER TABLE "SocialMessage" ADD COLUMN "giphyId" TEXT;');
+    expect(migrationSql).not.toMatch(/url|media|asset/i);
+  });
+});

--- a/tests/unit/socialStandaloneImports.test.ts
+++ b/tests/unit/socialStandaloneImports.test.ts
@@ -1,0 +1,32 @@
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const repositoryRoot = process.cwd();
+const tsxCli = require.resolve('tsx/cli');
+
+describe('League Social standalone server imports', () => {
+  it('loads socket and worker social dependencies outside Next.js', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        tsxCli,
+        '-r',
+        'dotenv/config',
+        '-e',
+        "Promise.all([import('./src/server/leagues/social/socialPublisher.ts'), import('./src/server/leagues/social/socialSystemEvents.ts')])",
+      ],
+      {
+        cwd: repositoryRoot,
+        encoding: 'utf8',
+        env: { ...process.env, NODE_ENV: 'test' },
+        timeout: 15_000,
+      }
+    );
+
+    expect(result.signal, result.stderr).toBeNull();
+    expect(result.status, result.stderr).toBe(0);
+  });
+});

--- a/tests/unit/socialStandaloneImports.test.ts
+++ b/tests/unit/socialStandaloneImports.test.ts
@@ -21,7 +21,11 @@ describe('League Social standalone server imports', () => {
       {
         cwd: repositoryRoot,
         encoding: 'utf8',
-        env: { ...process.env, NODE_ENV: 'test' },
+        env: {
+          ...process.env,
+          NODE_ENV: 'test',
+          GOOGLE_CLOUD_PROJECT: process.env.GOOGLE_CLOUD_PROJECT ?? 'statly-test',
+        },
         timeout: 15_000,
       }
     );

--- a/tests/unit/socialValidation.test.ts
+++ b/tests/unit/socialValidation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createMessageSchema,
+  createPostSchema,
+  decodeSocialCursor,
+  encodeSocialCursor,
+  markReadSchema,
+  socialPreferencesSchema,
+} from '@/server/leagues/social/socialValidation';
+
+describe('league social validation', () => {
+  it('rejects empty and over-limit chat messages', () => {
+    expect(
+      createMessageSchema.safeParse({ content: '   ', idempotencyKey: 'message:12345678' }).success
+    ).toBe(false);
+    expect(
+      createMessageSchema.safeParse({
+        content: 'x'.repeat(1_001),
+        idempotencyKey: 'message:12345678',
+      }).success
+    ).toBe(false);
+  });
+
+  it('accepts the documented chat and board limits', () => {
+    expect(
+      createMessageSchema.safeParse({
+        content: 'x'.repeat(1_000),
+        idempotencyKey: 'message:12345678',
+      }).success
+    ).toBe(true);
+    expect(
+      createPostSchema.safeParse({
+        categoryId: 'general',
+        title: 'x'.repeat(150),
+        body: 'x'.repeat(10_000),
+        idempotencyKey: 'post:12345678',
+      }).success
+    ).toBe(true);
+  });
+
+  it('round-trips stable pagination cursors and rejects malformed cursors', () => {
+    const cursor = {
+      createdAt: '2026-07-19T12:00:00.000Z',
+      id: 'message-1',
+    };
+    expect(decodeSocialCursor(encodeSocialCursor(cursor))).toEqual(cursor);
+    expect(decodeSocialCursor('not-a-cursor')).toBeNull();
+  });
+
+  it('allows read-state updates to derive the latest sequence server-side', () => {
+    expect(markReadSchema.parse({ channel: 'chat' })).toEqual({ channel: 'chat' });
+    expect(markReadSchema.safeParse({ channel: 'chat', sequence: -1 }).success).toBe(false);
+  });
+
+  it('requires a complete social notification preference contract', () => {
+    expect(
+      socialPreferencesSchema.safeParse({
+        chatInApp: true,
+        boardPosts: false,
+        ownPostReplies: true,
+        announcements: true,
+        tradeDiscussions: false,
+        mentions: true,
+        systemActivityInApp: true,
+      }).success
+    ).toBe(true);
+    expect(socialPreferencesSchema.safeParse({ chatInApp: true }).success).toBe(false);
+  });
+});

--- a/tests/unit/socialValidation.test.ts
+++ b/tests/unit/socialValidation.test.ts
@@ -39,6 +39,35 @@ describe('league social validation', () => {
     ).toBe(true);
   });
 
+  it('accepts strict GIPHY attachments and allows GIF-only chat messages', () => {
+    expect(
+      createMessageSchema.parse({
+        content: '   ',
+        gif: { provider: 'giphy', id: 'xT9IgG50Fb7Mi0prBC' },
+        idempotencyKey: 'message:giphy-1',
+      })
+    ).toEqual({
+      content: '',
+      gif: { provider: 'giphy', id: 'xT9IgG50Fb7Mi0prBC' },
+      idempotencyKey: 'message:giphy-1',
+    });
+
+    expect(
+      createMessageSchema.safeParse({
+        content: '',
+        gif: { provider: 'tenor', id: 'gif-1' },
+        idempotencyKey: 'message:giphy-2',
+      }).success
+    ).toBe(false);
+    expect(
+      createMessageSchema.safeParse({
+        content: '',
+        gif: { provider: 'giphy', id: 'gif1', url: 'https://media.giphy.com/example.gif' },
+        idempotencyKey: 'message:giphy-3',
+      }).success
+    ).toBe(false);
+  });
+
   it('accepts narrow structured discussion context and rejects unbounded metadata or markup fields', () => {
     expect(
       createMessageSchema.safeParse({

--- a/tests/unit/socialValidation.test.ts
+++ b/tests/unit/socialValidation.test.ts
@@ -39,6 +39,53 @@ describe('league social validation', () => {
     ).toBe(true);
   });
 
+  it('accepts narrow structured discussion context and rejects unbounded metadata or markup fields', () => {
+    expect(
+      createMessageSchema.safeParse({
+        content: 'What do we think?',
+        context: {
+          type: 'player',
+          id: 'player-1',
+          title: 'Jordan Example',
+          subtitle: 'MID · Melbourne',
+          metadata: {
+            status: 'Available',
+            round: '12',
+          },
+        },
+        idempotencyKey: 'message:context-1',
+      }).success
+    ).toBe(true);
+
+    expect(
+      createMessageSchema.safeParse({
+        content: 'Unsafe extra field',
+        context: {
+          type: 'trade',
+          id: 'trade-1',
+          title: 'Trade proposal',
+          html: '<strong>unsafe</strong>',
+        },
+        idempotencyKey: 'message:context-2',
+      }).success
+    ).toBe(false);
+
+    expect(
+      createMessageSchema.safeParse({
+        content: 'Too much metadata',
+        context: {
+          type: 'activity',
+          id: 'activity-1',
+          title: 'Draft result',
+          metadata: Object.fromEntries(
+            Array.from({ length: 7 }, (_, index) => [`field_${index}`, String(index)])
+          ),
+        },
+        idempotencyKey: 'message:context-3',
+      }).success
+    ).toBe(false);
+  });
+
   it('round-trips stable pagination cursors and rejects malformed cursors', () => {
     const cursor = {
       createdAt: '2026-07-19T12:00:00.000Z',
@@ -50,6 +97,7 @@ describe('league social validation', () => {
 
   it('allows read-state updates to derive the latest sequence server-side', () => {
     expect(markReadSchema.parse({ channel: 'chat' })).toEqual({ channel: 'chat' });
+    expect(markReadSchema.parse({ channel: 'activity' })).toEqual({ channel: 'activity' });
     expect(markReadSchema.safeParse({ channel: 'chat', sequence: -1 }).success).toBe(false);
   });
 


### PR DESCRIPTION
## What changed

- Added persistent league-and-season scoped chat, message board, activity, preferences, moderation, reporting, and unread state.
- Added authenticated Socket.IO rooms, Redis-backed cross-instance delivery, durable outbox processing, and draft-to-social activity events.
- Added the League Social widget and dedicated social routes with responsive, keyboard-accessible navigation.
- Added GIPHY search and message rendering with the chat-specific web SDK key.
- Added a semantic League Social colour system and a hardened shared composer with draft preservation.

## Why

League communication previously depended on a limited chat surface without a durable season boundary, persistent discussions, moderation workflows, or reliable cross-session delivery. This implements League Social as a first-class league capability while preserving existing draft, league, and authentication flows.

## Architectural decisions

- The database is the source of truth for social content, membership authorization, unread state, commands, and outbox events.
- Every social record is scoped by both `leagueId` and `seasonId`.
- API routes remain transport adapters over shared server-side command/query modules.
- Realtime joins and broadcasts re-check active membership; removed members are denied and evicted from league rooms.
- Durable outbox events are claimed and published with retry handling, while Redis provides cross-instance fan-out.
- Shared backend modules used by Next.js, Socket.IO, and the draft worker avoid Next-only runtime guards; a standalone-process regression protects this boundary.
- GIPHY search is composed inside the message form without nested forms or accidental composer submission.

## Database and deployment

Apply these migrations before enabling the feature:

- `20260719090000_add_league_social_domain`
- `20260719120000_separate_league_social_activity`
- `20260720100000_add_giphy_to_social_messages`

Configure the chat-specific GIPHY web SDK key and ensure the Socket.IO service, draft worker, Redis, and database migration step are running in the deployment environment.

## Verification completed

- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm test` — 333 tests passed across 56 files
- Standalone social server imports and draft publisher regression — 3 tests passed
- Full migration chain applied successfully to a disposable SQLite database
- `npm run build`
- Full local stack: web, Socket.IO, Redis social subscriber, and draft worker all healthy
- Signed-in browser verification of chat, board/activity keyboard navigation, GIPHY search composition, and absence of nested forms
- Authorization tests cover inactive-member denial and league/season isolation

## Visual review

The League Social drawer, dedicated page, composer, colour system, GIF picker, and launcher were reviewed in the authenticated local application. No production data or credentials are included in this PR.

## Known limitations / follow-up

- The repository retains its existing advisory lint-warning baseline; this PR introduces no lint errors.
- The legacy unauthenticated socket smoke script logs connection retries while exiting successfully, so authenticated realtime behavior is verified by dedicated tests and the healthy full-stack runtime instead.
