### PR TITLE
feat(leagues): improve overview accessibility

### DIFF
--- a/src/components/league/LeagueTabs.tsx
+++ b/src/components/league/LeagueTabs.tsx
@@ -514,7 +514,7 @@ export default function LeagueTabs({
                               {activeMembers.length}/{league.maxTeams} teams
                             </span>
                             <span className="inline-flex min-h-7 items-center rounded-full border border-white/35 bg-white/10 px-3 text-xs font-semibold text-white">
-                              {getDraftStatusLabel(draftReadiness?.status ?? league.status)}
+                              {getDraftStatusLabel(draftReadiness?.status)}
                             </span>
                           </div>
                           <p className="mt-2 text-sm text-white/75">

--- a/src/components/league/LeagueTabs.tsx
+++ b/src/components/league/LeagueTabs.tsx
@@ -118,6 +118,10 @@ function getLeagueTabFromSearch(
   return isLeagueTab(value) ? value : null;
 }
 
+function getDraftStatusLabel(status: string | null | undefined): string {
+  return `Draft ${(status ?? 'not started').replace(/_/g, ' ')}`;
+}
+
 export default function LeagueTabs({
   league,
   members,
@@ -444,14 +448,20 @@ export default function LeagueTabs({
     <div className="space-y-6">
       <div className="overflow-hidden rounded-[22px] border border-[color:var(--league-border)] bg-[color:var(--league-surface)] shadow-[0_18px_60px_-48px_rgba(23,34,48,0.38)]">
         <div className="border-b border-[color:var(--league-border)] bg-[color:var(--league-page)]/80">
-          <nav className="flex gap-1 overflow-x-auto px-3 py-3" aria-label="League sections">
+          <nav
+            className="flex max-w-full scroll-px-3 gap-1 overflow-x-auto overscroll-x-contain px-3 py-3 [scrollbar-width:thin]"
+            aria-label="League sections"
+          >
             {tabs.map((tab) => (
               <button
                 key={tab.id}
                 type="button"
                 onClick={() => handleTabChange(tab.id)}
+                onFocus={(event) =>
+                  event.currentTarget.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+                }
                 aria-current={activeTab === tab.id ? 'page' : undefined}
-                className={`inline-flex h-10 shrink-0 items-center justify-center rounded-full px-4 text-sm font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--league-primary)] ${
+                className={`scroll-mx-3 inline-flex h-10 shrink-0 items-center justify-center rounded-full px-4 text-sm font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--league-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--league-page)] ${
                   activeTab === tab.id
                     ? 'bg-[color:var(--league-primary)] text-[color:var(--league-primary-foreground)] shadow-sm'
                     : 'text-[color:var(--league-text-muted)] hover:bg-[color:var(--league-surface-muted)] hover:text-[color:var(--league-text)]'
@@ -460,7 +470,10 @@ export default function LeagueTabs({
                 <div className="flex items-center gap-2">
                   <span>{tab.name}</span>
                   {tab.badge && (
-                    <span className="rounded-full bg-[color:var(--league-danger-soft)] px-2 py-0.5 text-xs font-semibold text-[color:var(--league-danger)]">
+                    <span
+                      aria-label={`${tab.badge} unread`}
+                      className="rounded-full bg-[color:var(--league-danger-soft)] px-2 py-0.5 text-xs font-semibold text-[color:var(--league-danger)]"
+                    >
                       {tab.badge}
                     </span>
                   )}
@@ -481,22 +494,30 @@ export default function LeagueTabs({
             {activeTab === 'overview' && (
               <div className="space-y-6">
                 <div className="space-y-4">
-                  <section className="rounded-[22px] bg-[color:var(--league-primary)] p-5 text-[color:var(--league-primary-foreground)] shadow-[0_24px_70px_-48px_rgba(15,23,42,0.7)] sm:p-6">
+                  <section
+                    aria-labelledby="league-overview-heading"
+                    className="rounded-[22px] bg-[color:var(--league-primary)] p-5 text-[color:var(--league-primary-foreground)] shadow-[0_24px_70px_-48px_rgba(15,23,42,0.7)] sm:p-6"
+                  >
                     <div className="flex flex-col gap-6">
                       <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start">
                         <div>
-                          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-white/65">
-                            League overview
-                          </p>
-                          <h2 className="mt-3 text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+                          <p className="text-sm font-medium text-white/85">League overview</p>
+                          <h1
+                            id="league-overview-heading"
+                            className="mt-2 text-2xl font-semibold tracking-tight text-white sm:text-3xl"
+                          >
                             {league.name}
-                          </h2>
-                          <p className="mt-2 text-sm text-white/70">
-                            {league.type === 'private' ? 'Private' : 'Public'} ·{' '}
-                            {activeMembers.length}/{league.maxTeams} teams · Draft{' '}
-                            {draftReadiness?.status ?? league.status}
-                          </p>
-                          <p className="mt-1 text-sm text-white/55">
+                          </h1>
+                          <div className="mt-3 flex flex-wrap items-center gap-2 text-sm text-white/85">
+                            <span>
+                              {league.type === 'private' ? 'Private' : 'Public'} ·{' '}
+                              {activeMembers.length}/{league.maxTeams} teams
+                            </span>
+                            <span className="inline-flex min-h-7 items-center rounded-full border border-white/35 bg-white/10 px-3 text-xs font-semibold text-white">
+                              {getDraftStatusLabel(draftReadiness?.status ?? league.status)}
+                            </span>
+                          </div>
+                          <p className="mt-2 text-sm text-white/75">
                             {openTeamSlots === 0
                               ? 'League is full'
                               : `${openTeamSlots} team ${openTeamSlots === 1 ? 'slot' : 'slots'} open`}
@@ -505,52 +526,54 @@ export default function LeagueTabs({
 
                         <dl className="grid gap-5 sm:grid-cols-2 lg:min-w-[22rem]">
                           <div>
-                            <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/65">
-                              Your team
-                            </dt>
-                            <dd className="mt-2 text-lg font-semibold text-white">
-                              {currentMember?.teamName ?? 'Team not set'}
+                            <dt className="text-sm font-medium text-white/85">Your team</dt>
+                            <dd className="mt-2 flex flex-wrap items-center gap-2 text-lg font-semibold text-white">
+                              <span>{currentMember?.teamName ?? 'Team not set'}</span>
+                              {canAccessCompetitionRules && (
+                                <span className="inline-flex min-h-7 items-center rounded-full border border-white/35 bg-white/10 px-3 text-xs font-semibold text-white">
+                                  Commissioner
+                                </span>
+                              )}
                             </dd>
-                            <p className="mt-1 text-sm text-white/70">
-                              {currentMember?.role === 'owner' || currentMember?.role === 'manager'
-                                ? 'Commissioner access'
-                                : 'Member access'}
-                            </p>
                           </div>
                           <div>
-                            <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/65">
-                              Waiver position
-                            </dt>
-                            <dd className="mt-2 text-lg font-semibold text-white">
-                              {waiverPriorityLabel}
+                            <dt className="text-sm font-medium text-white/85">Waiver position</dt>
+                            <dd className="mt-2 text-white">
+                              <span className="block text-lg font-semibold">
+                                {waiverPriorityLabel}
+                              </span>
+                              <span className="mt-1 block text-sm capitalize text-white/80">
+                                {waiverPolicyLabel} order
+                              </span>
                             </dd>
-                            <p className="mt-1 text-sm capitalize text-white/70">
-                              {waiverPolicyLabel} order
-                            </p>
                           </div>
                         </dl>
                       </div>
 
                       <div className="border-t border-white/15 pt-5">
-                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/65">
-                          Scoring categories
-                        </p>
-                        <p className="mt-2 text-sm leading-6 text-white/80">
+                        <h2 className="text-sm font-semibold text-white/90">Scoring categories</h2>
+                        <p className="mt-2 text-sm leading-6 text-white/85">
                           {categoryLabels.join(' · ')}
                         </p>
                       </div>
                     </div>
                   </section>
 
-                  <section className="rounded-2xl border border-[color:var(--league-border)] bg-[color:var(--league-surface)] p-4">
+                  <section
+                    aria-labelledby="overview-teams-heading"
+                    className="rounded-2xl border border-[color:var(--league-border)] bg-[color:var(--league-surface)] p-4"
+                  >
                     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                       <div>
-                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--league-text-muted)]">
+                        <h2
+                          id="overview-teams-heading"
+                          className="text-lg font-semibold text-[color:var(--league-text)]"
+                        >
                           Teams
-                        </p>
-                        <h3 className="mt-1 text-lg font-semibold text-[color:var(--league-text)]">
+                        </h2>
+                        <p className="mt-1 text-sm text-[color:var(--league-text-muted)]">
                           {league.maxTeams}-team league
-                        </h3>
+                        </p>
                       </div>
                       <button
                         type="button"
@@ -561,66 +584,87 @@ export default function LeagueTabs({
                       </button>
                     </div>
 
-                    <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
-                      {overviewTeams.map((member) => (
-                        <div
-                          key={member.id}
-                          className="group flex min-h-32 flex-col items-center justify-center rounded-2xl border border-[color:var(--league-border)] bg-[color:var(--league-surface-muted)] px-3 py-3 text-center transition hover:-translate-y-0.5 hover:border-[color:var(--league-primary)] hover:bg-[color:var(--league-surface)] hover:shadow-md"
-                        >
-                          <div className="flex size-24 items-center justify-center overflow-hidden rounded-2xl border border-[color:var(--league-border)] bg-[color:var(--league-surface)] shadow-sm sm:size-28">
-                            {member.teamLogoUrl ? (
-                              <img
-                                src={member.teamLogoUrl}
-                                alt={`${member.teamName || 'Team'} symbol`}
-                                referrerPolicy="no-referrer"
-                                style={getTeamLogoImageStyle(member)}
-                                className="h-full w-full object-cover will-change-transform"
-                              />
-                            ) : (
-                              <span className="text-lg font-semibold text-[color:var(--league-text-muted)]">
-                                {getTeamInitials(member.teamName || 'Team')}
+                    <ul
+                      className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6"
+                      aria-label="League teams"
+                    >
+                      {overviewTeams.map((member) => {
+                        const isCurrentTeam = member.userId === currentUserId;
+
+                        return (
+                          <li
+                            key={member.id}
+                            className={`group flex min-h-32 flex-col items-center justify-center rounded-2xl border px-3 py-3 text-center transition hover:-translate-y-0.5 hover:border-[color:var(--league-primary)] hover:bg-[color:var(--league-surface)] hover:shadow-md ${
+                              isCurrentTeam
+                                ? 'border-[color:var(--league-primary)] bg-[color:var(--league-primary-soft)] ring-2 ring-[color:var(--league-primary)]/15'
+                                : 'border-[color:var(--league-border)] bg-[color:var(--league-surface-muted)]'
+                            }`}
+                          >
+                            <div className="flex size-24 items-center justify-center overflow-hidden rounded-2xl border border-[color:var(--league-border)] bg-[color:var(--league-surface)] shadow-sm sm:size-28">
+                              {member.teamLogoUrl ? (
+                                <img
+                                  src={member.teamLogoUrl}
+                                  alt={`${member.teamName || 'Team'} symbol`}
+                                  referrerPolicy="no-referrer"
+                                  style={getTeamLogoImageStyle(member)}
+                                  className="h-full w-full object-cover will-change-transform"
+                                />
+                              ) : (
+                                <span className="text-lg font-semibold text-[color:var(--league-text-muted)]">
+                                  {getTeamInitials(member.teamName || 'Team')}
+                                </span>
+                              )}
+                            </div>
+                            <p className="mt-3 text-sm font-semibold leading-5 text-[color:var(--league-text)]">
+                              {member.teamName || 'Unnamed team'}
+                            </p>
+                            {isCurrentTeam && (
+                              <span className="mt-2 inline-flex min-h-7 items-center rounded-full bg-[color:var(--league-primary)] px-3 text-xs font-semibold text-[color:var(--league-primary-foreground)]">
+                                Your team
                               </span>
                             )}
-                          </div>
-                          <p className="mt-3 text-sm font-semibold leading-5 text-[color:var(--league-text)]">
-                            {member.teamName || 'Unnamed team'}
-                          </p>
-                        </div>
-                      ))}
-                    </div>
+                          </li>
+                        );
+                      })}
+                    </ul>
                   </section>
                 </div>
 
-                <section className="grid gap-4 lg:grid-cols-2">
-                  <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_18px_55px_-48px_rgba(15,23,42,0.35)]">
+                <div className="grid gap-4 lg:grid-cols-2">
+                  <section
+                    aria-labelledby="overview-trades-heading"
+                    className="rounded-2xl border border-[color:var(--league-border)] bg-[color:var(--league-surface)] p-5 shadow-[0_18px_55px_-48px_rgba(15,23,42,0.35)]"
+                  >
                     <div className="flex items-start justify-between gap-4">
-                      <div>
-                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
-                          Trades
-                        </p>
-                        <h2 className="mt-1 text-lg font-semibold text-slate-950">Trade offers</h2>
-                      </div>
+                      <h2
+                        id="overview-trades-heading"
+                        className="text-lg font-semibold text-[color:var(--league-text)]"
+                      >
+                        Trade offers
+                      </h2>
                       <button
                         type="button"
                         onClick={() => router.push(`/leagues/${league.id}/trades`)}
-                        className="inline-flex h-10 items-center justify-center rounded-full border border-slate-300 bg-white px-4 text-sm font-semibold text-slate-900 transition hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--league-primary)]"
+                        className="inline-flex h-10 items-center justify-center rounded-full border border-[color:var(--league-border)] bg-[color:var(--league-surface)] px-4 text-sm font-semibold text-[color:var(--league-text)] transition hover:bg-[color:var(--league-surface-muted)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--league-primary)]"
                       >
                         Trade centre
                       </button>
                     </div>
                     <div className="mt-4 space-y-3">
                       {overviewTradesStatus === 'loading' ? (
-                        <p className="text-sm text-slate-600">Checking offers...</p>
+                        <p className="text-sm text-[color:var(--league-text-muted)]">
+                          Checking offers...
+                        </p>
                       ) : overviewTrades.length > 0 ? (
                         overviewTrades.map((trade) => (
                           <div
                             key={trade.tradeId}
-                            className="rounded-xl border border-slate-200 bg-slate-50 p-3"
+                            className="rounded-xl border border-[color:var(--league-border)] bg-[color:var(--league-surface-muted)] p-3"
                           >
-                            <p className="text-sm font-semibold text-slate-950">
+                            <p className="text-sm font-semibold text-[color:var(--league-text)]">
                               {trade.tradeName ?? `Trade ${trade.tradeId.slice(0, 8)}`}
                             </p>
-                            <p className="mt-1 text-xs text-slate-600">
+                            <p className="mt-1 text-xs text-[color:var(--league-text-muted)]">
                               {trade.playerNames.length > 0
                                 ? trade.playerNames.join(', ')
                                 : 'Player details available in trade centre'}
@@ -628,49 +672,54 @@ export default function LeagueTabs({
                           </div>
                         ))
                       ) : (
-                        <p className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-3 py-4 text-sm text-slate-600">
+                        <p className="rounded-xl border border-dashed border-[color:var(--league-border)] bg-[color:var(--league-surface-muted)] px-3 py-4 text-sm text-[color:var(--league-text-muted)]">
                           No pending trade offers.
                         </p>
                       )}
                     </div>
-                  </div>
+                  </section>
 
-                  <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-[0_18px_55px_-48px_rgba(15,23,42,0.35)]">
+                  <section
+                    aria-labelledby="overview-waivers-heading"
+                    className="rounded-2xl border border-[color:var(--league-border)] bg-[color:var(--league-surface)] p-5 shadow-[0_18px_55px_-48px_rgba(15,23,42,0.35)]"
+                  >
                     <div className="flex items-start justify-between gap-4">
-                      <div>
-                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
-                          Waivers
-                        </p>
-                        <h2 className="mt-1 text-lg font-semibold text-slate-950">
-                          Waiver position
-                        </h2>
-                      </div>
+                      <h2
+                        id="overview-waivers-heading"
+                        className="text-lg font-semibold text-[color:var(--league-text)]"
+                      >
+                        Waiver position
+                      </h2>
                       <button
                         type="button"
                         onClick={() => handleTabChange('waivers')}
-                        className="inline-flex h-10 items-center justify-center rounded-full border border-slate-300 bg-white px-4 text-sm font-semibold text-slate-900 transition hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--league-primary)]"
+                        className="inline-flex h-10 items-center justify-center rounded-full border border-[color:var(--league-border)] bg-[color:var(--league-surface)] px-4 text-sm font-semibold text-[color:var(--league-text)] transition hover:bg-[color:var(--league-surface-muted)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--league-primary)]"
                       >
                         Waivers
                       </button>
                     </div>
-                    <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4">
-                      <p className="text-2xl font-semibold text-slate-950">{waiverPriorityLabel}</p>
-                      <p className="mt-1 text-sm capitalize text-slate-600">
+                    <div className="mt-4 rounded-xl border border-[color:var(--league-border)] bg-[color:var(--league-surface-muted)] p-4">
+                      <p className="text-lg font-semibold text-[color:var(--league-text)]">
+                        {waiverPriorityIndex >= 0 ? waiverPriorityLabel : 'Waiver order pending'}
+                      </p>
+                      <p className="mt-1 text-sm capitalize text-[color:var(--league-text-muted)]">
                         {waiverPolicyLabel} waiver order
                       </p>
                       {overviewWaiversStatus === 'loading' ? (
-                        <p className="mt-3 text-sm text-slate-600">Checking waiver bids...</p>
+                        <p className="mt-3 text-sm text-[color:var(--league-text-muted)]">
+                          Checking waiver bids...
+                        </p>
                       ) : overviewWaiverClaims.length > 0 ? (
                         <div className="mt-4 space-y-2">
                           {overviewWaiverClaims.map((claim) => (
                             <div
                               key={claim.id}
-                              className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2"
+                              className="flex items-center justify-between gap-3 rounded-lg border border-[color:var(--league-border)] bg-[color:var(--league-surface)] px-3 py-2"
                             >
-                              <p className="min-w-0 truncate text-sm font-semibold text-slate-950">
+                              <p className="min-w-0 truncate text-sm font-semibold text-[color:var(--league-text)]">
                                 {claim.playerName}
                               </p>
-                              <p className="shrink-0 text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">
+                              <p className="shrink-0 text-xs font-semibold text-[color:var(--league-text-muted)]">
                                 {typeof claim.bidAmount === 'number'
                                   ? `$${claim.bidAmount}`
                                   : 'Claim'}
@@ -679,13 +728,15 @@ export default function LeagueTabs({
                           ))}
                         </div>
                       ) : (
-                        <p className="mt-3 text-sm text-slate-600">
-                          {waiverPriorityIndex >= 0 ? 'No pending waiver bids.' : 'Not set.'}
+                        <p className="mt-3 text-sm text-[color:var(--league-text-muted)]">
+                          {waiverPriorityIndex >= 0
+                            ? 'No pending waiver bids.'
+                            : 'Your position will appear when the order is set.'}
                         </p>
                       )}
                     </div>
-                  </div>
-                </section>
+                  </section>
+                </div>
               </div>
             )}
 

--- a/src/index.css
+++ b/src/index.css
@@ -121,7 +121,7 @@
   --league-surface-muted: #f5f0e8;
   --league-border: #d9d0c3;
   --league-text: #171611;
-  --league-text-muted: #6d665d;
+  --league-text-muted: #5f584f;
   --league-primary: var(--statly-navy);
   --league-primary-foreground: #fff;
   --league-primary-hover: #23445f;

--- a/tests/e2e/league-overview.accessibility.test.ts
+++ b/tests/e2e/league-overview.accessibility.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  authenticateAsDevelopmentUser,
+  collectRuntimeErrors,
+  expectNoAppErrorBoundary,
+} from './helpers/devAuth';
+import { E2E_LEAGUE_ID } from './global.setup';
+
+const leagueId = process.env.STATLY_E2E_LEAGUE_ID ?? E2E_LEAGUE_ID;
+
+for (const viewport of [
+  { width: 390, height: 844 },
+  { width: 768, height: 900 },
+]) {
+  test(`league overview navigation remains accessible at ${viewport.width}px`, async ({ page }) => {
+    const runtimeErrors = collectRuntimeErrors(page);
+    await page.setViewportSize(viewport);
+    await authenticateAsDevelopmentUser(page);
+
+    await page.goto(`/leagues/${leagueId}`);
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Test AFL Champions League' })
+    ).toBeVisible();
+    await expect(page.getByText('Draft completed', { exact: true })).toBeVisible();
+    await expect(page.getByText('Commissioner', { exact: true })).toBeVisible();
+
+    const teams = page.getByRole('list', { name: 'League teams' });
+    const currentTeam = teams.getByRole('listitem').filter({ hasText: 'Robbo Rockers' });
+    await expect(currentTeam.getByText('Your team', { exact: true })).toBeVisible();
+
+    const leagueNavigation = page.getByRole('navigation', { name: 'League sections' });
+    const navigationItems = leagueNavigation.getByRole('button');
+    const overview = leagueNavigation.getByRole('button', { name: 'Overview' });
+    const leagueSettings = leagueNavigation.getByRole('button', { name: 'League Settings' });
+
+    await expect(leagueNavigation).toBeVisible();
+    await expect(overview).toHaveAttribute('aria-current', 'page');
+    await expect
+      .poll(() => leagueNavigation.evaluate((element) => element.scrollWidth > element.clientWidth))
+      .toBe(true);
+
+    await overview.focus();
+    const itemCount = await navigationItems.count();
+    for (let index = 1; index < itemCount; index += 1) {
+      await page.keyboard.press('Tab');
+    }
+
+    await expect(leagueSettings).toBeFocused();
+    await expect
+      .poll(() =>
+        leagueNavigation.evaluate((element) => {
+          const activeElement = document.activeElement;
+          if (!(activeElement instanceof HTMLElement)) return false;
+
+          const navigationBox = element.getBoundingClientRect();
+          const activeBox = activeElement.getBoundingClientRect();
+          return (
+            element.contains(activeElement) &&
+            activeBox.left >= navigationBox.left &&
+            activeBox.right <= navigationBox.right
+          );
+        })
+      )
+      .toBe(true);
+
+    const focusBoxShadow = await leagueSettings.evaluate(
+      (element) => window.getComputedStyle(element).boxShadow
+    );
+    expect(focusBoxShadow).not.toBe('none');
+
+    await page.keyboard.press('Enter');
+
+    await expect(page).toHaveURL(new RegExp(`/leagues/${leagueId}\\?tab=league-settings$`));
+    await expect(leagueSettings).toHaveAttribute('aria-current', 'page');
+    await expect(page.getByRole('heading', { name: 'League Settings' })).toBeVisible();
+    await expectNoAppErrorBoundary(page);
+    expect(runtimeErrors).toEqual([]);
+  });
+}

--- a/tests/e2e/league-overview.accessibility.test.ts
+++ b/tests/e2e/league-overview.accessibility.test.ts
@@ -7,7 +7,7 @@ import {
 } from './helpers/devAuth';
 import { E2E_LEAGUE_ID } from './global.setup';
 
-const leagueId = process.env.STATLY_E2E_LEAGUE_ID ?? E2E_LEAGUE_ID;
+const leagueId = E2E_LEAGUE_ID;
 
 for (const viewport of [
   { width: 390, height: 844 },

--- a/tests/unit/LeagueTabs.overview.test.tsx
+++ b/tests/unit/LeagueTabs.overview.test.tsx
@@ -126,7 +126,7 @@ describe('LeagueTabs overview snapshot', () => {
     expect(screen.getByRole('heading', { level: 1, name: 'Snapshot League' })).toBeInTheDocument();
     expect(screen.getAllByText('Snapshot League').length).toBeGreaterThan(0);
     expect(screen.getByText(/3\/4 teams/)).toBeInTheDocument();
-    expect(screen.getByText('Draft completed')).toBeInTheDocument();
+    expect(screen.getByText('Draft not started')).toBeInTheDocument();
     expect(screen.getAllByText('Trade offers').length).toBeGreaterThan(0);
     expect(
       screen.getByText('Goals · Tackles · Inside 50s · Intercepts · Rebound 50s')

--- a/tests/unit/LeagueTabs.overview.test.tsx
+++ b/tests/unit/LeagueTabs.overview.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import LeagueTabs from '@/components/league/LeagueTabs';
@@ -123,8 +123,10 @@ describe('LeagueTabs overview snapshot', () => {
     render(<LeagueTabs league={league} members={members} currentUserId="user-2" />);
 
     expect(screen.getByText('League overview')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Snapshot League' })).toBeInTheDocument();
     expect(screen.getAllByText('Snapshot League').length).toBeGreaterThan(0);
     expect(screen.getByText(/3\/4 teams/)).toBeInTheDocument();
+    expect(screen.getByText('Draft completed')).toBeInTheDocument();
     expect(screen.getAllByText('Trade offers').length).toBeGreaterThan(0);
     expect(
       screen.getByText('Goals · Tackles · Inside 50s · Intercepts · Rebound 50s')
@@ -149,6 +151,11 @@ describe('LeagueTabs overview snapshot', () => {
     expect(screen.getByText('ST')).toBeInTheDocument();
     expect(screen.getByText('Third Team')).toBeInTheDocument();
     expect(screen.getByText('TT')).toBeInTheDocument();
+    const currentTeamCard = within(screen.getByRole('list', { name: 'League teams' }))
+      .getByText('Second Team')
+      .closest('li');
+    expect(currentTeamCard).not.toBeNull();
+    expect(within(currentTeamCard as HTMLElement).getByText('Your team')).toBeInTheDocument();
     expect(screen.queryByText('Offers needing review')).not.toBeInTheDocument();
     expect(screen.getByText('4-team league').closest('section')).toHaveClass(
       'bg-[color:var(--league-surface)]'
@@ -175,5 +182,75 @@ describe('LeagueTabs overview snapshot', () => {
       '/api/leagues/league-1/waivers?playersLimit=0&activityLimit=0',
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
+
+    const leagueNavigation = screen.getByRole('navigation', { name: 'League sections' });
+    expect(within(leagueNavigation).getByRole('button', { name: 'Overview' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  it('presents room-open, commissioner, and unassigned waiver states without raw or repeated copy', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ claims: [], playersIndex: {} }),
+      })
+    );
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ trades: [] }),
+    });
+
+    const roomOpenLeague: League = {
+      ...league,
+      waiverWire: {
+        ...league.waiverWire,
+        waiverOrder: [],
+      },
+      draftReadiness: {
+        leagueId: league.id,
+        draftId: 'draft-1',
+        status: 'room_open',
+        scheduledStartAt: null,
+        roomOpenedAt: '2026-07-21T10:00:00.000Z',
+        memberCount: members.length,
+        rosterSpots: 22,
+        totalPicks: 66,
+        playerPool: {
+          availableCount: 800,
+          hasPlayers: true,
+        },
+        lifecycle: {
+          shouldBeOpen: true,
+          canEnterRoom: true,
+          canStartClock: true,
+          isRunning: false,
+          isComplete: false,
+        },
+        blockers: [],
+      },
+    };
+
+    render(<LeagueTabs league={roomOpenLeague} members={members} currentUserId="user-1" />);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Snapshot League' })).toBeInTheDocument();
+    expect(screen.getByText('Draft room open')).toBeInTheDocument();
+    expect(screen.queryByText(/room_open/)).not.toBeInTheDocument();
+    expect(screen.getByText('Commissioner')).toBeInTheDocument();
+    expect(screen.queryByText('Commissioner access')).not.toBeInTheDocument();
+    expect(screen.queryByText('Member access')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Not set')).toHaveLength(1);
+    expect(screen.getByText('Waiver order pending')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Your position will appear when the order is set.')
+    ).toBeInTheDocument();
+
+    for (const name of ['Scoring categories', 'Teams', 'Trade offers', 'Waiver position']) {
+      expect(screen.getByRole('heading', { level: 2, name })).toBeInTheDocument();
+    }
+
+    expect(authenticatedFetchMock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- present draft readiness as a user-facing status badge, including `Draft room open`
- replace access copy with a concise `Commissioner` badge
- remove repeated empty waiver placeholders and explicitly identify the current user's team
- improve league-surface contrast, heading semantics, accessible names, focus visibility, and narrow-width navigation
- add focused unit and Chromium coverage at 390px and 768px

## Why

The league overview exposed internal status formatting, repeated empty-state copy, low-emphasis labels, and visual-only team identity. Its long navigation also needed real-browser proof that keyboard focus remains visible and reachable at narrow widths.

## Architecture and scope

- Kept display normalization and overview composition inside `LeagueTabs`, which owns this UI.
- Retained native button navigation with horizontal scrolling instead of introducing a disclosure menu or ARIA tab system.
- Updated the shared semantic `--league-text-muted` token rather than adding one-off cream-surface colors.
- No authentication, authorization, API, schema, migration, worker, Socket.IO, Firebase rules, or ETL behavior changed.

## Main files

- `src/components/league/LeagueTabs.tsx`
- `src/index.css`
- `tests/unit/LeagueTabs.overview.test.tsx`
- `tests/e2e/league-overview.accessibility.test.ts`

## Verification

- `npm exec -- prettier --check src/components/league/LeagueTabs.tsx src/index.css tests/unit/LeagueTabs.overview.test.tsx tests/e2e/league-overview.accessibility.test.ts` — passed
- `git diff --check origin/main...HEAD` — passed
- `npm run lint:ci` — passed
- `npm run typecheck` — passed
- `npm run typecheck:tests` — passed
- focused Vitest regression set — 5 files, 11 tests passed
- Playwright accessibility coverage — 2 cases passed at 390px and 768px using a disposable database
- independent change, verification, accessibility, and release reviews — no blocking findings

## Manual and accessibility coverage

- verified semantic `h1`/`h2` hierarchy and named league navigation
- verified visible `Your team`, `Commissioner`, and draft-status text
- verified horizontal overflow, full keyboard traversal, focus styling, focus-driven scroll visibility, Enter activation, URL state, and `aria-current`
- calculated muted-text contrast is at least 6.07:1 on the league cream surfaces; minimum changed navy secondary text is approximately 8.12:1

## Compatibility and limitations

- Automated browser coverage uses Chromium; Safari/WebKit, Firefox, Edge, touch gestures, and screen-reader software were not run locally.
- The browser fixture covers `Draft completed`; the exact `Draft room open` state is covered by the focused unit fixture.
- The semantic muted-text token applies across league surfaces; focused checks cover the overview boundary.
- No post-change screenshot is attached; responsive behavior is exercised by the Playwright regression.

## Deployment and migrations

- Next.js UI deployment only.
- No database migration or deployment sequencing is required.
- The repository's GitHub `deploy` job currently performs a production build but contains no hosting command; hosting-provider deployment must be verified separately after merge.

## Security

- No secrets, credentials, authentication, authorization, or protected data paths changed.
- The pre-existing local `prisma/dev.db` modification is excluded from this branch.

## Rollback

Revert the squash commit or redeploy the previous known-good frontend artifact. No database rollback is required.

## Summary by Sourcery

Improve the league overview page’s accessibility, semantics, and visual hierarchy while clarifying draft, commissioner, waiver, and team status presentation.

New Features:
- Display draft readiness as a dedicated status badge, including a user-facing "Draft room open" state.
- Highlight the current user’s team within the league teams grid and add a concise "Commissioner" badge where applicable.

Enhancements:
- Refine heading structure and landmarks on the league overview, including named sections and updated h1/h2 hierarchy.
- Improve keyboard and focus handling for the horizontal league navigation, ensuring focused items remain visible at narrow viewports.
- Align overview cards and navigation styling with shared league surface and text tokens, including updated muted text contrast.
- Present waiver position and policy states more clearly, avoiding raw status strings and repeated empty-state copy.

Tests:
- Expand unit coverage around league overview content and states, including room-open drafts, commissioner visibility, waiver pending messaging, and navigation aria-current.
- Add Playwright end-to-end accessibility tests to validate league overview navigation, focus behavior, and team identity at 390px and 768px viewports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the League Overview layout with clearer team, waiver, scoring, trade, and waiver information.
  * Added stronger highlighting for the current team and Commissioner status.
  * Improved tab navigation, keyboard focus behavior, and screen reader labels.
  * Added clearer draft and waiver status messaging.

* **Style**
  * Refined league text contrast and updated overview styling.

* **Tests**
  * Added accessibility and navigation coverage for the League Overview and Settings tabs.
  * Expanded checks for draft states, team labels, waiver messaging, and accessible headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->