### PR TITLE
Fix canonical player identity and league-scoped ownership

### DIFF
--- a/Scripts/player-identity-consolidation.ts
+++ b/Scripts/player-identity-consolidation.ts
@@ -11,10 +11,12 @@ import {
   PlayerIdentityConsolidationBlockedError,
 } from '@/server/players/playerIdentityConsolidation';
 import {
+  assertPlayerIdentitySourceFingerprint,
   createPlayerIdentitySourceFingerprint,
   parsePlayerIdentityCliArgs,
   validateDisposablePlayerIdentityDatabase,
   validateProductionPlayerIdentityDatabase,
+  validatePlayerIdentityFirestoreProject,
   validateReviewedPlayerIdentityManifest,
   type ReviewedPlayerIdentityManifest,
 } from '@/server/players/playerIdentityConsolidationCli';
@@ -94,6 +96,14 @@ async function projectWaiverAvailability(prisma: PrismaClient) {
   return results;
 }
 
+async function validateWaiverProjectionTarget(): Promise<void> {
+  const { adminDb } = await import('@/lib/firebaseAdmin');
+  validatePlayerIdentityFirestoreProject({
+    expectedProjectId: process.env.STATLY_PLAYER_IDENTITY_FIRESTORE_PROJECT ?? '',
+    actualProjectId: (adminDb as unknown as { projectId?: string }).projectId,
+  });
+}
+
 async function main() {
   const args = parsePlayerIdentityCliArgs(process.argv.slice(2));
   const databaseUrl = args.production
@@ -110,6 +120,9 @@ async function main() {
   const prisma = new PrismaClient({ datasources: { db: { url: databaseUrl } } });
 
   try {
+    if (args.projectWaivers || (args.production && args.apply)) {
+      await validateWaiverProjectionTarget();
+    }
     if (args.projectWaivers) {
       process.stdout.write(
         `${JSON.stringify({ status: 'projected', leagues: await projectWaiverAvailability(prisma) }, null, 2)}\n`
@@ -126,12 +139,7 @@ async function main() {
       orderBy: { id: 'asc' },
       select: { id: true, name: true, club: true, position: true },
     });
-    const currentFingerprint = createPlayerIdentitySourceFingerprint(currentPlayers);
-    if (currentFingerprint !== manifest.sourceFingerprint) {
-      throw new Error(
-        'Player identity data changed after manifest proposal; generate and review a new manifest'
-      );
-    }
+    assertPlayerIdentitySourceFingerprint(manifest.sourceFingerprint, currentPlayers);
     const plan = await planPlayerIdentityConsolidation(prisma, manifest.mappings);
 
     if (!args.apply) {
@@ -146,7 +154,9 @@ async function main() {
       throw new Error('Refusing to apply an identity manifest until reviewed is true');
     }
 
-    const appliedPlan = await consolidatePlayerIdentities(prisma, manifest.mappings);
+    const appliedPlan = await consolidatePlayerIdentities(prisma, manifest.mappings, {
+      expectedSourceFingerprint: manifest.sourceFingerprint,
+    });
     const waiverProjectionResults = args.production ? await projectWaiverAvailability(prisma) : [];
     process.stdout.write(
       `${JSON.stringify(

--- a/Scripts/player-identity-consolidation.ts
+++ b/Scripts/player-identity-consolidation.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env tsx
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { PrismaClient } from '@prisma/client';
+
+import { buildCanonicalPlayerId } from '@/lib/playerIdentity';
+import {
+  consolidatePlayerIdentities,
+  PlayerIdentityConsolidationBlockedError,
+} from '@/server/players/playerIdentityConsolidation';
+import {
+  planPlayerIdentityConsolidation,
+  type PlayerAliasMapping,
+} from '@/server/players/playerIdentityConsolidationPlanner';
+
+type ReviewedManifest = {
+  reviewed: boolean;
+  mappings: PlayerAliasMapping[];
+};
+
+function parseArgs(argv: readonly string[]) {
+  const apply = argv.includes('--apply');
+  const propose = argv.includes('--propose');
+  const manifestIndex = argv.indexOf('--manifest');
+  const manifestPath = manifestIndex >= 0 ? argv[manifestIndex + 1] : undefined;
+
+  if (propose && (apply || manifestPath)) {
+    throw new Error('--propose cannot be combined with --apply or --manifest');
+  }
+  if (!propose && !manifestPath) {
+    throw new Error('Use --propose or provide --manifest <reviewed-manifest.json>');
+  }
+
+  return { apply, propose, manifestPath };
+}
+
+function validateDisposableDatabase(): string {
+  const databaseUrl = (process.env.DATABASE_URL ?? '').trim();
+  const expectedPath = (process.env.STATLY_VERIFY_DB ?? '').trim();
+
+  if (!databaseUrl || !expectedPath) {
+    throw new Error('DATABASE_URL and STATLY_VERIFY_DB are required');
+  }
+
+  const parsedUrl = new URL(databaseUrl);
+  const databasePath = decodeURIComponent(parsedUrl.pathname);
+  if (
+    parsedUrl.protocol !== 'file:' ||
+    databasePath !== expectedPath ||
+    !expectedPath.startsWith('/tmp/statly-verify-player-') ||
+    !expectedPath.endsWith('.db')
+  ) {
+    throw new Error(
+      'Identity consolidation is restricted to matching file:/tmp/statly-verify-player-*.db URLs'
+    );
+  }
+
+  return databaseUrl;
+}
+
+async function readManifest(manifestPath: string): Promise<ReviewedManifest> {
+  const absolutePath = path.resolve(manifestPath);
+  const manifest = JSON.parse(await fs.readFile(absolutePath, 'utf8')) as ReviewedManifest;
+  if (!Array.isArray(manifest.mappings)) {
+    throw new Error('Manifest mappings must be an array');
+  }
+  return manifest;
+}
+
+async function proposeManifest(prisma: PrismaClient) {
+  const players = await prisma.player.findMany({
+    orderBy: { id: 'asc' },
+    select: { id: true, name: true, club: true, position: true },
+  });
+  const groups = new Map<string, typeof players>();
+
+  for (const player of players) {
+    const key = `${buildCanonicalPlayerId(player.name)}|${buildCanonicalPlayerId(player.club)}`;
+    groups.set(key, [...(groups.get(key) ?? []), player]);
+  }
+
+  const candidates = [...groups.entries()]
+    .filter(([, aliases]) => aliases.length > 1)
+    .map(([evidenceKey, aliases]) => {
+      const ranked = [...aliases].sort((left, right) => {
+        const expectedId = buildCanonicalPlayerId(left.name);
+        const canonicalDifference =
+          Number(right.id === expectedId) - Number(left.id === expectedId);
+        if (canonicalDifference !== 0) return canonicalDifference;
+        const positionDifference = Number(Boolean(right.position)) - Number(Boolean(left.position));
+        if (positionDifference !== 0) return positionDifference;
+        return left.id.localeCompare(right.id);
+      });
+      const canonicalPlayerId = ranked[0].id;
+      return {
+        evidenceKey,
+        name: ranked[0].name,
+        club: ranked[0].club,
+        canonicalPlayerId,
+        playerIds: ranked.map((player) => player.id),
+        mappings: ranked.slice(1).map((player) => ({
+          aliasId: player.id,
+          canonicalPlayerId,
+        })),
+      };
+    });
+
+  return {
+    reviewed: false,
+    warning:
+      'Name and club are candidate evidence only. Review every group; do not apply this proposal directly.',
+    candidateGroups: candidates,
+    mappings: candidates.flatMap((candidate) => candidate.mappings),
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const databaseUrl = validateDisposableDatabase();
+  const prisma = new PrismaClient({ datasources: { db: { url: databaseUrl } } });
+
+  try {
+    if (args.propose) {
+      process.stdout.write(`${JSON.stringify(await proposeManifest(prisma), null, 2)}\n`);
+      return;
+    }
+
+    const manifest = await readManifest(args.manifestPath!);
+    const plan = await planPlayerIdentityConsolidation(prisma, manifest.mappings);
+
+    if (!args.apply) {
+      process.stdout.write(
+        `${JSON.stringify({ manifestReviewed: manifest.reviewed, plan }, null, 2)}\n`
+      );
+      if (plan.status === 'blocked') process.exitCode = 1;
+      return;
+    }
+
+    if (!manifest.reviewed) {
+      throw new Error('Refusing to apply an identity manifest until reviewed is true');
+    }
+
+    const appliedPlan = await consolidatePlayerIdentities(prisma, manifest.mappings);
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          status: 'applied',
+          appliedMappings: appliedPlan.mappings.length,
+          preservedOwnershipBoundary: 'leagueId + canonicalPlayerId',
+        },
+        null,
+        2
+      )}\n`
+    );
+  } catch (error) {
+    if (error instanceof PlayerIdentityConsolidationBlockedError) {
+      process.stderr.write(`${JSON.stringify(error.plan, null, 2)}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    throw error;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error('[player-identity-consolidation] Failed', error);
+  process.exit(1);
+});

--- a/Scripts/player-identity-consolidation.ts
+++ b/Scripts/player-identity-consolidation.ts
@@ -11,62 +11,20 @@ import {
   PlayerIdentityConsolidationBlockedError,
 } from '@/server/players/playerIdentityConsolidation';
 import {
-  planPlayerIdentityConsolidation,
-  type PlayerAliasMapping,
-} from '@/server/players/playerIdentityConsolidationPlanner';
+  createPlayerIdentitySourceFingerprint,
+  parsePlayerIdentityCliArgs,
+  validateDisposablePlayerIdentityDatabase,
+  validateProductionPlayerIdentityDatabase,
+  validateReviewedPlayerIdentityManifest,
+  type ReviewedPlayerIdentityManifest,
+} from '@/server/players/playerIdentityConsolidationCli';
+import { planPlayerIdentityConsolidation } from '@/server/players/playerIdentityConsolidationPlanner';
 
-type ReviewedManifest = {
-  reviewed: boolean;
-  mappings: PlayerAliasMapping[];
-};
-
-function parseArgs(argv: readonly string[]) {
-  const apply = argv.includes('--apply');
-  const propose = argv.includes('--propose');
-  const manifestIndex = argv.indexOf('--manifest');
-  const manifestPath = manifestIndex >= 0 ? argv[manifestIndex + 1] : undefined;
-
-  if (propose && (apply || manifestPath)) {
-    throw new Error('--propose cannot be combined with --apply or --manifest');
-  }
-  if (!propose && !manifestPath) {
-    throw new Error('Use --propose or provide --manifest <reviewed-manifest.json>');
-  }
-
-  return { apply, propose, manifestPath };
-}
-
-function validateDisposableDatabase(): string {
-  const databaseUrl = (process.env.DATABASE_URL ?? '').trim();
-  const expectedPath = (process.env.STATLY_VERIFY_DB ?? '').trim();
-
-  if (!databaseUrl || !expectedPath) {
-    throw new Error('DATABASE_URL and STATLY_VERIFY_DB are required');
-  }
-
-  const parsedUrl = new URL(databaseUrl);
-  const databasePath = decodeURIComponent(parsedUrl.pathname);
-  if (
-    parsedUrl.protocol !== 'file:' ||
-    databasePath !== expectedPath ||
-    !expectedPath.startsWith('/tmp/statly-verify-player-') ||
-    !expectedPath.endsWith('.db')
-  ) {
-    throw new Error(
-      'Identity consolidation is restricted to matching file:/tmp/statly-verify-player-*.db URLs'
-    );
-  }
-
-  return databaseUrl;
-}
-
-async function readManifest(manifestPath: string): Promise<ReviewedManifest> {
+async function readManifest(manifestPath: string): Promise<ReviewedPlayerIdentityManifest> {
   const absolutePath = path.resolve(manifestPath);
-  const manifest = JSON.parse(await fs.readFile(absolutePath, 'utf8')) as ReviewedManifest;
-  if (!Array.isArray(manifest.mappings)) {
-    throw new Error('Manifest mappings must be an array');
-  }
-  return manifest;
+  return validateReviewedPlayerIdentityManifest(
+    JSON.parse(await fs.readFile(absolutePath, 'utf8')) as unknown
+  );
 }
 
 async function proposeManifest(prisma: PrismaClient) {
@@ -108,7 +66,11 @@ async function proposeManifest(prisma: PrismaClient) {
     });
 
   return {
+    schemaVersion: 1,
     reviewed: false,
+    reviewedBy: '',
+    reviewedAt: '',
+    sourceFingerprint: createPlayerIdentitySourceFingerprint(players),
     warning:
       'Name and club are candidate evidence only. Review every group; do not apply this proposal directly.',
     candidateGroups: candidates,
@@ -116,18 +78,60 @@ async function proposeManifest(prisma: PrismaClient) {
   };
 }
 
+async function projectWaiverAvailability(prisma: PrismaClient) {
+  const { WaiverAvailabilityProjectionService } = await import(
+    '@/server/waivers/WaiverAvailabilityProjectionService'
+  );
+  const projector = new WaiverAvailabilityProjectionService(prisma);
+  const leagues = await prisma.league.findMany({ select: { id: true }, orderBy: { id: 'asc' } });
+  const results = [];
+  for (const league of leagues) {
+    results.push({
+      leagueId: league.id,
+      ...(await projector.projectLeague({ leagueId: league.id })),
+    });
+  }
+  return results;
+}
+
 async function main() {
-  const args = parseArgs(process.argv.slice(2));
-  const databaseUrl = validateDisposableDatabase();
+  const args = parsePlayerIdentityCliArgs(process.argv.slice(2));
+  const databaseUrl = args.production
+    ? validateProductionPlayerIdentityDatabase({
+        databaseUrl: process.env.DATABASE_URL ?? '',
+        expectedPath: process.env.STATLY_PLAYER_IDENTITY_PRODUCTION_DB ?? '',
+        backupPath: process.env.STATLY_PLAYER_IDENTITY_BACKUP,
+        requireBackup: args.apply,
+      })
+    : validateDisposablePlayerIdentityDatabase({
+        databaseUrl: process.env.DATABASE_URL ?? '',
+        expectedPath: process.env.STATLY_VERIFY_DB ?? '',
+      });
   const prisma = new PrismaClient({ datasources: { db: { url: databaseUrl } } });
 
   try {
+    if (args.projectWaivers) {
+      process.stdout.write(
+        `${JSON.stringify({ status: 'projected', leagues: await projectWaiverAvailability(prisma) }, null, 2)}\n`
+      );
+      return;
+    }
     if (args.propose) {
       process.stdout.write(`${JSON.stringify(await proposeManifest(prisma), null, 2)}\n`);
       return;
     }
 
     const manifest = await readManifest(args.manifestPath!);
+    const currentPlayers = await prisma.player.findMany({
+      orderBy: { id: 'asc' },
+      select: { id: true, name: true, club: true, position: true },
+    });
+    const currentFingerprint = createPlayerIdentitySourceFingerprint(currentPlayers);
+    if (currentFingerprint !== manifest.sourceFingerprint) {
+      throw new Error(
+        'Player identity data changed after manifest proposal; generate and review a new manifest'
+      );
+    }
     const plan = await planPlayerIdentityConsolidation(prisma, manifest.mappings);
 
     if (!args.apply) {
@@ -138,17 +142,19 @@ async function main() {
       return;
     }
 
-    if (!manifest.reviewed) {
+    if (manifest.reviewed !== true) {
       throw new Error('Refusing to apply an identity manifest until reviewed is true');
     }
 
     const appliedPlan = await consolidatePlayerIdentities(prisma, manifest.mappings);
+    const waiverProjectionResults = args.production ? await projectWaiverAvailability(prisma) : [];
     process.stdout.write(
       `${JSON.stringify(
         {
           status: 'applied',
           appliedMappings: appliedPlan.mappings.length,
           preservedOwnershipBoundary: 'leagueId + canonicalPlayerId',
+          projectedLeagues: waiverProjectionResults.length,
         },
         null,
         2

--- a/docs/codex/player-identity-consolidation-runbook.md
+++ b/docs/codex/player-identity-consolidation-runbook.md
@@ -1,0 +1,70 @@
+# Canonical player identity consolidation
+
+This migration removes duplicate `Player` rows while preserving ownership independently in every
+league. It is deliberately a reviewed data operation: name and club matches are candidate evidence,
+not proof that two records represent the same person.
+
+## Rollout order
+
+1. Deploy the additive `PlayerExternalIdentity` schema and application compatibility code.
+2. Put roster, draft, waiver, lineup, and trade mutations into maintenance mode.
+3. Create a SQLite backup outside the repository and verify that it opens successfully.
+4. Generate a proposal from the production database.
+5. Review every mapping. Set `reviewed` to `true`, and fill in `reviewedBy` and `reviewedAt` without
+   changing `sourceFingerprint`.
+6. Run the planner. Any blocker must be resolved by correcting the manifest or underlying data; do
+   not bypass blockers.
+7. Apply the same reviewed manifest while writes remain paused.
+8. Confirm the apply output reports every league projected, then re-enable writes.
+
+The planner blocks same-league ownership conflicts across both normalized and legacy roster data,
+pending actions that still reference aliases, malformed legacy rosters, and unsafe relational
+collisions. Ownership in different leagues is expected and remains separate.
+
+## Commands
+
+Set `DATABASE_URL` and `STATLY_PLAYER_IDENTITY_PRODUCTION_DB` to the same absolute production SQLite
+file. The command rejects the repository's `prisma/dev.db`, URL options, symlinks, and mismatched
+paths.
+
+Generate the proposal:
+
+```sh
+npm run player-identity:consolidate -- --production --propose > player-identity-manifest.json
+```
+
+Review the plan without changing data:
+
+```sh
+npm run player-identity:consolidate -- --production --manifest player-identity-manifest.json
+```
+
+For apply, also set `STATLY_PLAYER_IDENTITY_BACKUP` to the separate, verified backup file:
+
+```sh
+npm run player-identity:consolidate -- --production --manifest player-identity-manifest.json --apply
+```
+
+Apply aborts if the player dataset fingerprint changed after proposal. Generate and review a new
+manifest instead of editing the fingerprint.
+
+Production apply also rebuilds every league's Firestore waiver projection. If that projection fails
+after the relational transaction commits, rerun it independently before re-enabling writes:
+
+```sh
+npm run player-identity:consolidate -- --production --project-waivers
+```
+
+## Verification
+
+- The command reports every reviewed mapping as applied.
+- No retired alias remains in mutable player foreign keys.
+- A player can have at most one normalized owner per league; ownership in other leagues is unchanged.
+- Draft, queue, roster, waiver, lineup, trade, and player-detail requests accept a retired alias but
+  persist or return the canonical ID.
+- Waiver lists show one row per canonical player and exclude every player owned in that league.
+- Historical trade snapshots, completed actions, and social records are not rewritten.
+
+If relational apply succeeds but a Firestore projection fails, keep the backup and use the standalone
+projection command before declaring the rollout complete. Do not restore only Firestore or only
+SQLite.

--- a/docs/codex/player-identity-consolidation-runbook.md
+++ b/docs/codex/player-identity-consolidation-runbook.md
@@ -39,7 +39,10 @@ Review the plan without changing data:
 npm run player-identity:consolidate -- --production --manifest player-identity-manifest.json
 ```
 
-For apply, also set `STATLY_PLAYER_IDENTITY_BACKUP` to the separate, verified backup file:
+For apply, also set `STATLY_PLAYER_IDENTITY_BACKUP` to the separate, verified backup file and set
+`STATLY_PLAYER_IDENTITY_FIRESTORE_PROJECT` to the exact Firebase project ID paired with this
+production database. The command checks the resolved Firestore client before changing relational
+data or projecting waivers:
 
 ```sh
 npm run player-identity:consolidate -- --production --manifest player-identity-manifest.json --apply
@@ -68,3 +71,17 @@ npm run player-identity:consolidate -- --production --project-waivers
 If relational apply succeeds but a Firestore projection fails, keep the backup and use the standalone
 projection command before declaring the rollout complete. Do not restore only Firestore or only
 SQLite.
+
+## Rollback
+
+1. Keep maintenance mode enabled and stop all roster, draft, waiver, lineup, and trade writes.
+2. Restore the verified SQLite backup as the complete relational source of truth.
+3. Run the standalone `--production --project-waivers` command with
+   `STATLY_PLAYER_IDENTITY_FIRESTORE_PROJECT` still pinned to the paired Firebase project. This
+   rebuilds Firestore from the restored relational state.
+4. Verify the restored player rows, league-scoped ownership, waiver availability, and Firestore
+   ownership documents together.
+5. Re-enable writes only after both stores agree.
+
+Never restore SQLite or Firestore independently; the waiver projection must be regenerated after a
+relational rollback.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "player-data:temp-db-runner": "tsx Scripts/player-data-convergence-temp-db-runner.ts",
     "player-data:temp-db-apply-simulation": "tsx Scripts/player-data-convergence-temp-db-apply-simulation.ts",
     "player-data:runner": "tsx Scripts/player-data-convergence-runner.ts",
+    "player-identity:consolidate": "tsx Scripts/player-identity-consolidation.ts",
     "db:check": "tsx Scripts/check-database.ts",
     "firestore:smoke": "tsx Scripts/firestore-smoke.ts",
     "test:unit": "vitest run --config vitest.config.unit.ts",

--- a/prisma/migrations/20260724190000_add_player_external_identity/migration.sql
+++ b/prisma/migrations/20260724190000_add_player_external_identity/migration.sql
@@ -1,0 +1,35 @@
+CREATE TABLE "PlayerExternalIdentity" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "playerId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "externalId" TEXT NOT NULL,
+    "verifiedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "PlayerExternalIdentity_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "Player" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+INSERT INTO "PlayerExternalIdentity" (
+    "id",
+    "playerId",
+    "provider",
+    "externalId",
+    "verifiedAt",
+    "createdAt",
+    "updatedAt"
+)
+SELECT
+    'statly-legacy:' || "id",
+    "id",
+    'statly-legacy',
+    "id",
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+FROM "Player";
+
+CREATE UNIQUE INDEX "PlayerExternalIdentity_provider_externalId_key"
+ON "PlayerExternalIdentity"("provider", "externalId");
+
+CREATE INDEX "PlayerExternalIdentity_playerId_idx"
+ON "PlayerExternalIdentity"("playerId");

--- a/prisma/migrations/20260724190000_add_player_external_identity/migration.sql
+++ b/prisma/migrations/20260724190000_add_player_external_identity/migration.sql
@@ -5,7 +5,7 @@ CREATE TABLE "PlayerExternalIdentity" (
     "externalId" TEXT NOT NULL,
     "verifiedAt" DATETIME,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
     CONSTRAINT "PlayerExternalIdentity_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "Player" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -433,21 +433,37 @@ model DraftOrder {
 }
 
 model Player {
-  id            String               @id
-  name          String
-  club          String
-  position      String
-  active        Boolean              @default(true)
-  picks         Pick[]
-  rosterPlayers LeagueRosterPlayer[]
-  lineupPlayers LeagueLineupPlayer[]
-  tradePlayers  LeagueTradePlayer[]
+  id                 String                   @id @default(cuid())
+  name               String
+  club               String
+  position           String
+  active             Boolean                  @default(true)
+  externalIdentities PlayerExternalIdentity[]
+  picks              Pick[]
+  rosterPlayers      LeagueRosterPlayer[]
+  lineupPlayers      LeagueLineupPlayer[]
+  tradePlayers       LeagueTradePlayer[]
 
   // Lobby relations
   watchlists     DraftWatchlist[]
   preDraftQueues PreDraftQueue[]
 
   @@index([name])
+}
+
+model PlayerExternalIdentity {
+  id         String    @id @default(cuid())
+  playerId   String
+  provider   String
+  externalId String
+  verifiedAt DateTime?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+
+  player Player @relation(fields: [playerId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, externalId])
+  @@index([playerId])
 }
 
 model Pick {

--- a/prisma/seed-clean.ts
+++ b/prisma/seed-clean.ts
@@ -1,6 +1,11 @@
 import { PrismaClient } from '@prisma/client';
 import fs from 'fs/promises';
 import { getPlayerPosition } from '../src/lib/playerPositionMapping';
+import { buildCanonicalPlayerId } from '../src/lib/playerIdentity';
+import {
+  PLAYER_STATS_2025_PROVIDER,
+  upsertCanonicalPlayer,
+} from '../src/server/players/playerIdentityService';
 
 const prisma = new PrismaClient();
 
@@ -10,10 +15,7 @@ async function main() {
   const raw = await fs.readFile('player_stats_2025.json', 'utf8');
   const data = JSON.parse(raw);
 
-  const playersMap = new Map<
-    string,
-    { id: string; name: string; club: string; position: string }
-  >();
+  const playersMap = new Map<string, { name: string; club: string; position: string }>();
 
   for (const entry of data) {
     const playerName = entry.Player?.trim();
@@ -22,20 +24,11 @@ async function main() {
       continue; // Skip empty names or already processed players
     }
 
-    // Generate a clean, unique ID based on player name
-    const playerId = playerName
-      .toLowerCase()
-      .replace(/[^a-z0-9\s]/g, '') // Remove special chars but keep spaces
-      .replace(/\s+/g, '_') // Replace spaces with underscores
-      .replace(/_+/g, '_') // Replace multiple underscores with single
-      .replace(/^_|_$/g, ''); // Remove leading/trailing underscores
-
     // Extract position from the data or use smart position mapping
     const position = entry.Position || getPlayerPosition(playerName);
     const club = entry.Team || 'UNK';
 
     playersMap.set(playerName, {
-      id: playerId,
       name: playerName,
       club: club,
       position: position,
@@ -59,15 +52,17 @@ async function main() {
   for (let i = 0; i < players.length; i += batchSize) {
     const batch = players.slice(i, i + batchSize);
 
-    await prisma.player.createMany({
-      data: batch.map((player) => ({
-        id: player.id,
+    for (const player of batch) {
+      await upsertCanonicalPlayer(prisma, {
+        provider: PLAYER_STATS_2025_PROVIDER,
+        externalId: buildCanonicalPlayerId(`${player.name}|${player.club}`),
         name: player.name,
         club: player.club,
         position: player.position,
         active: true,
-      })),
-    });
+        allowExactAttributeMatch: true,
+      });
+    }
 
     console.log(
       `✅ Seeded batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(players.length / batchSize)}`

--- a/prisma/seed-clean.ts
+++ b/prisma/seed-clean.ts
@@ -4,6 +4,7 @@ import { getPlayerPosition } from '../src/lib/playerPositionMapping';
 import { buildCanonicalPlayerId } from '../src/lib/playerIdentity';
 import {
   PLAYER_STATS_2025_PROVIDER,
+  STATLY_LEGACY_PLAYER_PROVIDER,
   upsertCanonicalPlayer,
 } from '../src/server/players/playerIdentityService';
 
@@ -47,26 +48,30 @@ async function main() {
 
   console.log('📥 Seeding players...');
 
-  // Batch insert for better performance
-  const batchSize = 100;
-  for (let i = 0; i < players.length; i += batchSize) {
-    const batch = players.slice(i, i + batchSize);
+  const progressInterval = 100;
+  for (const [index, player] of players.entries()) {
+    const canonicalPlayer = await upsertCanonicalPlayer(prisma, {
+      provider: PLAYER_STATS_2025_PROVIDER,
+      externalId: buildCanonicalPlayerId(`${player.name}|${player.club}`),
+      name: player.name,
+      club: player.club,
+      position: player.position,
+      active: true,
+      allowExactAttributeMatch: true,
+    });
+    await upsertCanonicalPlayer(prisma, {
+      provider: STATLY_LEGACY_PLAYER_PROVIDER,
+      externalId: buildCanonicalPlayerId(player.name),
+      canonicalPlayerId: canonicalPlayer.id,
+      name: player.name,
+      club: player.club,
+      position: player.position,
+      active: true,
+    });
 
-    for (const player of batch) {
-      await upsertCanonicalPlayer(prisma, {
-        provider: PLAYER_STATS_2025_PROVIDER,
-        externalId: buildCanonicalPlayerId(`${player.name}|${player.club}`),
-        name: player.name,
-        club: player.club,
-        position: player.position,
-        active: true,
-        allowExactAttributeMatch: true,
-      });
+    if ((index + 1) % progressInterval === 0 || index === players.length - 1) {
+      console.log(`✅ Seeded ${index + 1}/${players.length} players`);
     }
-
-    console.log(
-      `✅ Seeded batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(players.length / batchSize)}`
-    );
   }
 
   console.log('🎉 Seeding completed successfully!');

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,10 @@
 import { PrismaClient } from '@prisma/client';
 import fs from 'fs/promises';
+import { buildCanonicalPlayerId } from '../src/lib/playerIdentity';
+import {
+  PLAYER_STATS_2025_PROVIDER,
+  upsertCanonicalPlayer,
+} from '../src/server/players/playerIdentityService';
 
 const prisma = new PrismaClient();
 
@@ -7,21 +12,14 @@ async function main() {
   const raw = await fs.readFile('player_stats_2025.json', 'utf8');
   const data = JSON.parse(raw);
 
-  const playersMap = new Map<
-    string,
-    { id: string; name: string; club: string; position: string }
-  >();
+  const playersMap = new Map<string, { name: string; club: string; position: string }>();
 
   for (const entry of data) {
     if (!playersMap.has(entry.Player)) {
-      // Generate a unique ID based on player name
-      const playerId = entry.Player.toLowerCase().replace(/[^a-z0-9]/g, '_');
-
       // Extract position from the data or default to a general position
       const position = entry.Position || 'UTIL'; // Fallback position
 
       playersMap.set(entry.Player, {
-        id: playerId,
         name: entry.Player,
         club: entry.Team || 'UNK', // Use 'UNK' if team is missing
         position: position,
@@ -33,23 +31,17 @@ async function main() {
 
   console.log(`Seeding ${players.length} players...`);
 
-  // Use upsert to handle potential duplicates
+  // Resolve the source identity before writing so re-seeding cannot create a
+  // second Player row with a different ID convention.
   for (const player of players) {
-    await prisma.player.upsert({
-      where: { id: player.id },
-      update: {
-        name: player.name,
-        club: player.club,
-        position: player.position,
-        active: true,
-      },
-      create: {
-        id: player.id,
-        name: player.name,
-        club: player.club,
-        position: player.position,
-        active: true,
-      },
+    await upsertCanonicalPlayer(prisma, {
+      provider: PLAYER_STATS_2025_PROVIDER,
+      externalId: buildCanonicalPlayerId(`${player.name}|${player.club}`),
+      name: player.name,
+      club: player.club,
+      position: player.position,
+      active: true,
+      allowExactAttributeMatch: true,
     });
   }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 import { buildCanonicalPlayerId } from '../src/lib/playerIdentity';
 import {
   PLAYER_STATS_2025_PROVIDER,
+  STATLY_LEGACY_PLAYER_PROVIDER,
   upsertCanonicalPlayer,
 } from '../src/server/players/playerIdentityService';
 
@@ -34,7 +35,7 @@ async function main() {
   // Resolve the source identity before writing so re-seeding cannot create a
   // second Player row with a different ID convention.
   for (const player of players) {
-    await upsertCanonicalPlayer(prisma, {
+    const canonicalPlayer = await upsertCanonicalPlayer(prisma, {
       provider: PLAYER_STATS_2025_PROVIDER,
       externalId: buildCanonicalPlayerId(`${player.name}|${player.club}`),
       name: player.name,
@@ -42,6 +43,15 @@ async function main() {
       position: player.position,
       active: true,
       allowExactAttributeMatch: true,
+    });
+    await upsertCanonicalPlayer(prisma, {
+      provider: STATLY_LEGACY_PLAYER_PROVIDER,
+      externalId: buildCanonicalPlayerId(player.name),
+      canonicalPlayerId: canonicalPlayer.id,
+      name: player.name,
+      club: player.club,
+      position: player.position,
+      active: true,
     });
   }
 

--- a/src/app/api/drafts/[id]/queue/route.ts
+++ b/src/app/api/drafts/[id]/queue/route.ts
@@ -12,16 +12,16 @@ import {
 } from '@/server/players/playerIdentityService';
 
 const QueuePostSchema = z.object({
-  playerId: z.string().min(1),
+  playerId: z.string().trim().min(1),
   rank: z.coerce.number().int().positive().optional(),
 });
 
 const QueueDeleteQuerySchema = z.object({
-  playerId: z.string().min(1),
+  playerId: z.string().trim().min(1),
 });
 
 const QueuePutSchema = z.object({
-  queue: z.array(z.string().min(1)).default([]),
+  queue: z.array(z.string().trim().min(1)).default([]),
 });
 
 const queueEntrySelect = {

--- a/src/app/api/drafts/[id]/queue/route.ts
+++ b/src/app/api/drafts/[id]/queue/route.ts
@@ -6,6 +6,10 @@ import { logger } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedUserId } from '@/lib/serverAuth';
 import { getDraftMembershipAccess } from '@/server/leagues/membership';
+import {
+  resolveCanonicalPlayerId,
+  resolveCanonicalPlayerIds,
+} from '@/server/players/playerIdentityService';
 
 const QueuePostSchema = z.object({
   playerId: z.string().min(1),
@@ -73,7 +77,10 @@ export async function POST(
       });
     }
 
-    const { playerId } = parsed.data;
+    const playerId = await resolveCanonicalPlayerId(parsed.data.playerId);
+    if (!playerId) {
+      return commonErrors.badRequest('Player not found or not available');
+    }
     const memberId = access.memberId;
 
     const alreadyPicked = await prisma.pick.findFirst({
@@ -110,11 +117,12 @@ export async function POST(
 
       const rank =
         parsed.data.rank ??
-        ((await tx.preDraftQueue.aggregate({
-          where: { draftId, memberId },
-          _max: { rank: true },
-        }))._max.rank ?? 0) +
-          1;
+        ((
+          await tx.preDraftQueue.aggregate({
+            where: { draftId, memberId },
+            _max: { rank: true },
+          })
+        )._max.rank ?? 0) + 1;
 
       return tx.preDraftQueue.upsert({
         where: {
@@ -177,7 +185,10 @@ export async function DELETE(
     }
 
     const { memberId } = access;
-    const { playerId } = parsed.data;
+    const playerId = await resolveCanonicalPlayerId(parsed.data.playerId);
+    if (!playerId) {
+      return commonErrors.notFound('Player not in queue');
+    }
     const deleted = await prisma.preDraftQueue.deleteMany({
       where: { draftId, memberId, playerId },
     });
@@ -275,7 +286,11 @@ export async function PUT(
     }
 
     const memberId = access.memberId;
-    const inputIds = Array.from(new Set(parsed.data.queue.map(String)));
+    const requestedIds = Array.from(new Set(parsed.data.queue.map(String)));
+    const resolvedIds = await resolveCanonicalPlayerIds(requestedIds);
+    const inputIds = Array.from(
+      new Set(requestedIds.map((playerId) => resolvedIds.get(playerId) ?? playerId))
+    );
 
     const { created, failedIds } = await prisma.$transaction(async (tx) => {
       const [activePlayers, alreadyPicked] = await Promise.all([

--- a/src/app/api/leagues/[id]/actions/[userId]/route.ts
+++ b/src/app/api/leagues/[id]/actions/[userId]/route.ts
@@ -96,6 +96,9 @@ export async function POST(
     if (!actionType || !details) {
       return errorResponse('Action type and details are required', 400);
     }
+    if (typeof details !== 'object' || Array.isArray(details)) {
+      return errorResponse('Action details must be an object', 400);
+    }
     const canonicalDetails = await resolveTeamActionPlayerIds(details);
 
     await ensureRosterTables();
@@ -190,10 +193,10 @@ export async function POST(
   }
 }
 
-async function resolveTeamActionPlayerIds(details: unknown): Promise<Record<string, unknown>> {
-  if (!details || typeof details !== 'object' || Array.isArray(details)) return {};
-
-  const canonicalDetails = { ...(details as Record<string, unknown>) };
+async function resolveTeamActionPlayerIds(
+  details: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const canonicalDetails = { ...details };
   for (const key of ['playerId', 'dropPlayerId'] as const) {
     const requestedPlayerId = canonicalDetails[key];
     if (typeof requestedPlayerId !== 'string') continue;

--- a/src/app/api/leagues/[id]/actions/[userId]/route.ts
+++ b/src/app/api/leagues/[id]/actions/[userId]/route.ts
@@ -7,7 +7,7 @@ import { prisma } from '@/lib/prisma';
 import { ensureRosterTables } from '@/lib/ensureLobbyColumns';
 import { getAuthenticatedUserId } from '@/lib/serverAuth';
 import { verifyLeagueMembership } from '@/lib/leagueMembership';
-import { resolveCanonicalPlayerId } from '@/server/players/playerIdentityService';
+import { resolveCanonicalPlayerIds } from '@/server/players/playerIdentityService';
 import { WaiverAvailabilityProjectionService } from '@/server/waivers/WaiverAvailabilityProjectionService';
 
 // GET /api/leagues/[id]/actions/[userId] - Get user's team actions
@@ -197,11 +197,35 @@ async function resolveTeamActionPlayerIds(
   details: Record<string, unknown>
 ): Promise<Record<string, unknown>> {
   const canonicalDetails = { ...details };
-  for (const key of ['playerId', 'dropPlayerId'] as const) {
+  const scalarKeys = ['playerId', 'dropPlayerId'] as const;
+  const arrayKeys = ['offeredPlayers', 'requestedPlayers'] as const;
+  const requestedPlayerIds = [
+    ...scalarKeys.flatMap((key) =>
+      typeof canonicalDetails[key] === 'string' ? [canonicalDetails[key] as string] : []
+    ),
+    ...arrayKeys.flatMap((key) =>
+      Array.isArray(canonicalDetails[key])
+        ? (canonicalDetails[key] as unknown[]).filter(
+            (playerId): playerId is string => typeof playerId === 'string'
+          )
+        : []
+    ),
+  ];
+  const resolvedPlayerIds = await resolveCanonicalPlayerIds(requestedPlayerIds);
+  const canonicalPlayerId = (playerId: string) =>
+    resolvedPlayerIds.get(playerId.trim()) ?? playerId;
+
+  for (const key of scalarKeys) {
     const requestedPlayerId = canonicalDetails[key];
     if (typeof requestedPlayerId !== 'string') continue;
-    const canonicalPlayerId = await resolveCanonicalPlayerId(requestedPlayerId);
-    if (canonicalPlayerId) canonicalDetails[key] = canonicalPlayerId;
+    canonicalDetails[key] = canonicalPlayerId(requestedPlayerId);
+  }
+  for (const key of arrayKeys) {
+    const requestedPlayerIdsForKey = canonicalDetails[key];
+    if (!Array.isArray(requestedPlayerIdsForKey)) continue;
+    canonicalDetails[key] = requestedPlayerIdsForKey.map((playerId) =>
+      typeof playerId === 'string' ? canonicalPlayerId(playerId) : playerId
+    );
   }
   return canonicalDetails;
 }

--- a/src/app/api/leagues/[id]/actions/[userId]/route.ts
+++ b/src/app/api/leagues/[id]/actions/[userId]/route.ts
@@ -7,6 +7,7 @@ import { prisma } from '@/lib/prisma';
 import { ensureRosterTables } from '@/lib/ensureLobbyColumns';
 import { getAuthenticatedUserId } from '@/lib/serverAuth';
 import { verifyLeagueMembership } from '@/lib/leagueMembership';
+import { resolveCanonicalPlayerId } from '@/server/players/playerIdentityService';
 import { WaiverAvailabilityProjectionService } from '@/server/waivers/WaiverAvailabilityProjectionService';
 
 // GET /api/leagues/[id]/actions/[userId] - Get user's team actions
@@ -95,6 +96,7 @@ export async function POST(
     if (!actionType || !details) {
       return errorResponse('Action type and details are required', 400);
     }
+    const canonicalDetails = await resolveTeamActionPlayerIds(details);
 
     await ensureRosterTables();
 
@@ -113,7 +115,7 @@ export async function POST(
     // Validate action based on type
     const validationResult = await validateTeamAction(
       actionType,
-      details,
+      canonicalDetails,
       leagueId,
       member.id,
       targetMemberId
@@ -140,7 +142,7 @@ export async function POST(
     const actionId = `action_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
     await prisma.$executeRaw`
       INSERT INTO TeamAction (id, leagueId, memberId, actionType, details, targetMemberId, processingAt, createdAt, updatedAt)
-      VALUES (${actionId}, ${leagueId}, ${member.id}, ${actionType}, ${JSON.stringify(details)}, ${targetMemberId}, ${processingAt}, datetime('now'), datetime('now'))
+      VALUES (${actionId}, ${leagueId}, ${member.id}, ${actionType}, ${JSON.stringify(canonicalDetails)}, ${targetMemberId}, ${processingAt}, datetime('now'), datetime('now'))
     `;
 
     const action = {
@@ -148,7 +150,7 @@ export async function POST(
       leagueId,
       memberId: member.id,
       actionType,
-      details: JSON.stringify(details),
+      details: JSON.stringify(canonicalDetails),
       targetMemberId,
       processingAt,
       createdAt: new Date(),
@@ -186,6 +188,19 @@ export async function POST(
     });
     return errorResponse('Failed to create team action', 500);
   }
+}
+
+async function resolveTeamActionPlayerIds(details: unknown): Promise<Record<string, unknown>> {
+  if (!details || typeof details !== 'object' || Array.isArray(details)) return {};
+
+  const canonicalDetails = { ...(details as Record<string, unknown>) };
+  for (const key of ['playerId', 'dropPlayerId'] as const) {
+    const requestedPlayerId = canonicalDetails[key];
+    if (typeof requestedPlayerId !== 'string') continue;
+    const canonicalPlayerId = await resolveCanonicalPlayerId(requestedPlayerId);
+    if (canonicalPlayerId) canonicalDetails[key] = canonicalPlayerId;
+  }
+  return canonicalDetails;
 }
 
 async function authorizeTeamActionRequest(

--- a/src/app/api/leagues/[id]/roster/add/route.ts
+++ b/src/app/api/leagues/[id]/roster/add/route.ts
@@ -9,6 +9,7 @@ import { tags } from '@/lib/cacheTags';
 import { logger } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedUserId } from '@/lib/serverAuth';
+import { resolveCanonicalPlayerId } from '@/server/players/playerIdentityService';
 import { WaiverAvailabilityProjectionService } from '@/server/waivers/WaiverAvailabilityProjectionService';
 
 function parsePlayerIds(value: unknown): string[] {
@@ -30,8 +31,11 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     if (!userId) return errorResponse('Unauthorized', 401);
 
     const body = (await request.json().catch(() => ({}))) as { playerId?: unknown };
-    const playerId = typeof body.playerId === 'string' ? body.playerId.trim() : '';
-    if (!leagueId || !playerId) return errorResponse('League ID and player ID are required', 400);
+    const requestedPlayerId = typeof body.playerId === 'string' ? body.playerId.trim() : '';
+    if (!leagueId || !requestedPlayerId)
+      return errorResponse('League ID and player ID are required', 400);
+    const playerId = await resolveCanonicalPlayerId(requestedPlayerId);
+    if (!playerId) return errorResponse('Player not found', 404);
 
     const [member, player, existingOwnership, activeWaiverHold] = await prisma.$transaction([
       prisma.leagueMember.findFirst({ where: { leagueId, userId }, select: { id: true } }),

--- a/src/app/api/leagues/[id]/roster/add/route.ts
+++ b/src/app/api/leagues/[id]/roster/add/route.ts
@@ -3,8 +3,9 @@ export const dynamic = 'force-dynamic';
 
 import type { NextRequest } from 'next/server';
 import { revalidateTag } from 'next/cache';
+import { NextResponse } from 'next/server';
 
-import { errorResponse, successResponse } from '@/lib/apiResponse';
+import { createErrorResponse, errorResponse, successResponse } from '@/lib/apiResponse';
 import { tags } from '@/lib/cacheTags';
 import { logger } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
@@ -35,7 +36,11 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     if (!leagueId || !requestedPlayerId)
       return errorResponse('League ID and player ID are required', 400);
     const playerId = await resolveCanonicalPlayerId(requestedPlayerId);
-    if (!playerId) return errorResponse('Player not found', 404);
+    if (!playerId) {
+      return NextResponse.json(createErrorResponse('Player not found', 'NOT_FOUND'), {
+        status: 404,
+      });
+    }
 
     const [member, player, existingOwnership, activeWaiverHold] = await prisma.$transaction([
       prisma.leagueMember.findFirst({ where: { leagueId, userId }, select: { id: true } }),
@@ -57,7 +62,11 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     ]);
 
     if (!member) return errorResponse('User is not a member of this league', 404);
-    if (!player) return errorResponse('Player not found', 404);
+    if (!player) {
+      return NextResponse.json(createErrorResponse('Player not found', 'NOT_FOUND'), {
+        status: 404,
+      });
+    }
     if (existingOwnership) return errorResponse('Player already owned in this league', 409);
     if (activeWaiverHold) return errorResponse('Player is on waivers', 409);
 

--- a/src/app/api/leagues/[id]/waivers/route.ts
+++ b/src/app/api/leagues/[id]/waivers/route.ts
@@ -18,7 +18,10 @@ import {
   type FantasyCategoryKey,
   type PlayerStats,
 } from '@/types/fantasyCategories';
-import { resolveCanonicalPlayerId } from '@/server/players/playerIdentityService';
+import {
+  resolveCanonicalPlayerId,
+  resolveCanonicalPlayerIds,
+} from '@/server/players/playerIdentityService';
 import { normalizeAvailableWaiverPlayers } from '@/server/waivers/waiverPlayerIdentity';
 
 export const runtime = 'nodejs';
@@ -338,7 +341,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         }),
       ]);
 
-    const claims = claimsSnap.docs
+    const rawClaims = claimsSnap.docs
       .map((doc) => {
         const data = doc.data() as WaiverClaimDoc;
         const createdAt = toIso(data.createdAt);
@@ -360,7 +363,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       .filter((claim) => claim.playerId)
       .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
 
-    const activity = activitySnap.docs.map((doc) => {
+    const rawActivity = activitySnap.docs.map((doc) => {
       const data = doc.data() as ActivityDoc;
 
       return {
@@ -378,6 +381,24 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         timestamp: toIso(data.timestamp),
       };
     });
+
+    const responsePlayerIds = [
+      ...rawClaims.flatMap((claim) => [claim.playerId, claim.dropPlayerId].filter(Boolean)),
+      ...rawActivity.flatMap((item) => [item.playerId, item.dropPlayerId].filter(Boolean)),
+    ] as string[];
+    const canonicalPlayerIds = await resolveCanonicalPlayerIds(responsePlayerIds);
+    const canonicalizePlayerId = (playerId: string) =>
+      canonicalPlayerIds.get(playerId.trim()) ?? playerId;
+    const claims = rawClaims.map((claim) => ({
+      ...claim,
+      playerId: canonicalizePlayerId(claim.playerId),
+      ...(claim.dropPlayerId ? { dropPlayerId: canonicalizePlayerId(claim.dropPlayerId) } : {}),
+    }));
+    const activity = rawActivity.map((item) => ({
+      ...item,
+      ...(item.playerId ? { playerId: canonicalizePlayerId(item.playerId) } : {}),
+      ...(item.dropPlayerId ? { dropPlayerId: canonicalizePlayerId(item.dropPlayerId) } : {}),
+    }));
 
     const playerIdsForIndex = new Set<string>();
     for (const player of availablePlayersResult.items) playerIdsForIndex.add(player.id);

--- a/src/app/api/leagues/[id]/waivers/route.ts
+++ b/src/app/api/leagues/[id]/waivers/route.ts
@@ -18,6 +18,7 @@ import {
   type FantasyCategoryKey,
   type PlayerStats,
 } from '@/types/fantasyCategories';
+import { resolveCanonicalPlayerId } from '@/server/players/playerIdentityService';
 import { normalizeAvailableWaiverPlayers } from '@/server/waivers/waiverPlayerIdentity';
 
 export const runtime = 'nodejs';
@@ -203,9 +204,12 @@ async function loadAvailablePlayers(input: {
     select: { details: true },
   });
   const ownedPlayerIds = ownerships.map((ownership) => ownership.playerId);
-  const heldPlayerIds = waiverHolds
+  const heldExternalPlayerIds = waiverHolds
     .map((hold) => parseActionDetails(hold.details).playerId)
     .filter((playerId): playerId is string => typeof playerId === 'string' && Boolean(playerId));
+  const heldPlayerIds = (
+    await Promise.all(heldExternalPlayerIds.map((playerId) => resolveCanonicalPlayerId(playerId)))
+  ).filter((playerId): playerId is string => Boolean(playerId));
   const unavailablePlayerIds = new Set([...ownedPlayerIds, ...heldPlayerIds]);
   const playerSelect = { id: true, name: true, club: true, position: true } as const;
   const activePlayers = await prisma.player.findMany({
@@ -213,6 +217,8 @@ async function loadAvailablePlayers(input: {
     orderBy: { id: 'asc' },
     select: playerSelect,
   });
+  // Keep the name/club grouping only as a transition guard for databases that
+  // have not completed the reviewed identity consolidation yet.
   const normalizedPlayers = normalizeAvailableWaiverPlayers(activePlayers, unavailablePlayerIds);
   const firstPlayerAfterCursor = input.cursor
     ? normalizedPlayers.findIndex((player) => player.id > input.cursor!)

--- a/src/app/api/leagues/[id]/waivers/submit/route.ts
+++ b/src/app/api/leagues/[id]/waivers/submit/route.ts
@@ -55,8 +55,10 @@ export const POST = withMetrics(
         where: { active: true },
         select: { id: true, name: true, club: true, position: true },
       });
-      const transitionalAliasIds = findWaiverPlayerAliasIds(activePlayers, requestedPlayerId);
       const resolvedPlayerId = await resolveCanonicalPlayerId(requestedPlayerId);
+      const transitionalAliasIds = resolvedPlayerId
+        ? findWaiverPlayerAliasIds(activePlayers, resolvedPlayerId)
+        : [];
       const canonicalPlayerId =
         resolvedPlayerId && resolvedPlayerId !== requestedPlayerId
           ? resolvedPlayerId

--- a/src/app/api/leagues/[id]/waivers/submit/route.ts
+++ b/src/app/api/leagues/[id]/waivers/submit/route.ts
@@ -13,6 +13,7 @@ import {
   WaiverClaimStoreError,
   type WaiverSettings as ProcessingWaiverSettings,
 } from '@/server/waivers/WaiverProcessingService';
+import { resolveCanonicalPlayerId } from '@/server/players/playerIdentityService';
 import { findWaiverPlayerAliasIds } from '@/server/waivers/waiverPlayerIdentity';
 
 export const runtime = 'nodejs';
@@ -54,10 +55,18 @@ export const POST = withMetrics(
         where: { active: true },
         select: { id: true, name: true, club: true, position: true },
       });
-      const playerAliasIds = findWaiverPlayerAliasIds(activePlayers, requestedPlayerId);
-      if (playerAliasIds.length === 0) {
+      const transitionalAliasIds = findWaiverPlayerAliasIds(activePlayers, requestedPlayerId);
+      const resolvedPlayerId = await resolveCanonicalPlayerId(requestedPlayerId);
+      const canonicalPlayerId =
+        resolvedPlayerId && resolvedPlayerId !== requestedPlayerId
+          ? resolvedPlayerId
+          : transitionalAliasIds[0];
+      if (!canonicalPlayerId || transitionalAliasIds.length === 0) {
         return NextResponse.json({ error: 'Player not found' }, { status: 404 });
       }
+      const playerAliasIds = [
+        ...new Set([requestedPlayerId, canonicalPlayerId, ...transitionalAliasIds]),
+      ];
 
       const prismaOwnership = await prisma.leagueRosterPlayer.findFirst({
         where: { leagueId, playerId: { in: playerAliasIds } },
@@ -128,10 +137,15 @@ export const POST = withMetrics(
         leagueId,
         userId,
         teamId: String(teamId),
-        playerId: requestedPlayerId,
+        playerId: canonicalPlayerId,
         priority: Number(priority) || 1,
         waiverSettings: (ws ?? {}) as ProcessingWaiverSettings,
-        ...(dropPlayerId ? { dropPlayerId: String(dropPlayerId) } : {}),
+        ...(dropPlayerId
+          ? {
+              dropPlayerId:
+                (await resolveCanonicalPlayerId(String(dropPlayerId))) ?? String(dropPlayerId),
+            }
+          : {}),
         ...(typeof validatedBid === 'number' ? { bidAmount: validatedBid } : {}),
       });
       const claimId = submittedClaim.id;
@@ -140,7 +154,7 @@ export const POST = withMetrics(
         leagueId,
         userId,
         teamId,
-        playerId: requestedPlayerId,
+        playerId: canonicalPlayerId,
         claimId,
       });
       try {

--- a/src/app/api/leagues/[id]/waivers/submit/route.ts
+++ b/src/app/api/leagues/[id]/waivers/submit/route.ts
@@ -59,10 +59,7 @@ export const POST = withMetrics(
       const transitionalAliasIds = resolvedPlayerId
         ? findWaiverPlayerAliasIds(activePlayers, resolvedPlayerId)
         : [];
-      const canonicalPlayerId =
-        resolvedPlayerId && resolvedPlayerId !== requestedPlayerId
-          ? resolvedPlayerId
-          : transitionalAliasIds[0];
+      const canonicalPlayerId = resolvedPlayerId;
       if (!canonicalPlayerId || transitionalAliasIds.length === 0) {
         return NextResponse.json({ error: 'Player not found' }, { status: 404 });
       }

--- a/src/app/api/players/[id]/route.ts
+++ b/src/app/api/players/[id]/route.ts
@@ -11,6 +11,7 @@ import { logger } from '@/lib/logger';
 import { buildCanonicalPlayerId } from '@/lib/playerIdentity';
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedUserId } from '@/lib/serverAuth';
+import { resolveCanonicalPlayerId } from '@/server/players/playerIdentityService';
 import type { Player } from '@/types/players';
 
 type PlayerStatSnapshot = {
@@ -145,7 +146,10 @@ export async function GET(request: NextRequest, context: { params: Promise<{ id:
     const nameCandidate = decodedId.replace(/[_-]+/g, ' ');
     let fallbackPlayer: Player | null = null;
 
-    let player = await prisma.player.findUnique({ where: { id: decodedId } });
+    const canonicalPlayerId = await resolveCanonicalPlayerId(decodedId);
+    let player = canonicalPlayerId
+      ? await prisma.player.findUnique({ where: { id: canonicalPlayerId } })
+      : null;
     if (!player) {
       fallbackPlayer = await getPlayer(decodedId);
     }

--- a/src/lib/ensureLobbyColumns.ts
+++ b/src/lib/ensureLobbyColumns.ts
@@ -144,7 +144,12 @@ export async function ensureRosterTables(): Promise<boolean> {
           "id" TEXT NOT NULL,
           "leagueId" TEXT NOT NULL,
           "memberId" TEXT NOT NULL,
+          "draftId" TEXT,
+          "pickId" TEXT,
           "playerId" TEXT NOT NULL,
+          "slot" TEXT,
+          "acquiredBy" TEXT NOT NULL DEFAULT 'DRAFT',
+          "acquiredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
           "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
           "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
           CONSTRAINT "LeagueRosterPlayer_pkey" PRIMARY KEY ("id")
@@ -256,12 +261,53 @@ export async function ensureRosterTables(): Promise<boolean> {
       }
     }
 
+    const rosterPlayerColumns = (await prisma.$queryRaw`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = current_schema()
+        AND table_name = 'LeagueRosterPlayer'
+    `) as Array<{ column_name: string }>;
+    const existingRosterPlayerColumns = new Set(
+      rosterPlayerColumns.map((column) => column.column_name)
+    );
+    const missingRosterPlayerColumns = [
+      { name: 'draftId', sql: 'ALTER TABLE "LeagueRosterPlayer" ADD COLUMN "draftId" TEXT' },
+      { name: 'pickId', sql: 'ALTER TABLE "LeagueRosterPlayer" ADD COLUMN "pickId" TEXT' },
+      { name: 'slot', sql: 'ALTER TABLE "LeagueRosterPlayer" ADD COLUMN "slot" TEXT' },
+      {
+        name: 'acquiredBy',
+        sql: `ALTER TABLE "LeagueRosterPlayer" ADD COLUMN "acquiredBy" TEXT NOT NULL DEFAULT 'DRAFT'`,
+      },
+      {
+        name: 'acquiredAt',
+        sql: 'ALTER TABLE "LeagueRosterPlayer" ADD COLUMN "acquiredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP',
+      },
+    ].filter((column) => !existingRosterPlayerColumns.has(column.name));
+
+    for (const column of missingRosterPlayerColumns) {
+      try {
+        await prisma.$executeRawUnsafe(column.sql);
+        logger.info(`Added LeagueRosterPlayer.${column.name}`);
+      } catch (error) {
+        logger.warn(`Failed to add LeagueRosterPlayer.${column.name}`, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
     // Ownership is scoped to a league, not a member. Keep this outside the
     // creation branch so databases made by the older fallback are corrected.
-    await prisma.$executeRaw`
-      CREATE UNIQUE INDEX IF NOT EXISTS "LeagueRosterPlayer_leagueId_playerId_key"
-      ON "LeagueRosterPlayer"("leagueId", "playerId")
-    `;
+    try {
+      await prisma.$executeRaw`
+        CREATE UNIQUE INDEX IF NOT EXISTS "LeagueRosterPlayer_leagueId_playerId_key"
+        ON "LeagueRosterPlayer"("leagueId", "playerId")
+      `;
+    } catch (error) {
+      logger.error('Failed to enforce unique league player ownership', {
+        error: error instanceof Error ? error.message : String(error),
+        hint: 'Resolve duplicate (leagueId, playerId) rows in LeagueRosterPlayer before retrying.',
+      });
+    }
 
     // Add captain system columns to LeagueSettings if they don't exist
     try {

--- a/src/lib/ensureLobbyColumns.ts
+++ b/src/lib/ensureLobbyColumns.ts
@@ -150,11 +150,6 @@ export async function ensureRosterTables(): Promise<boolean> {
           CONSTRAINT "LeagueRosterPlayer_pkey" PRIMARY KEY ("id")
         )
       `;
-      await prisma.$executeRaw`
-        CREATE UNIQUE INDEX IF NOT EXISTS "LeagueRosterPlayer_unique" 
-        ON "LeagueRosterPlayer"("leagueId", "memberId", "playerId")
-      `;
-
       // Add foreign key constraints with proper namespace checking
       try {
         const constraintExists = await prisma.$queryRaw`
@@ -260,6 +255,13 @@ export async function ensureRosterTables(): Promise<boolean> {
         }
       }
     }
+
+    // Ownership is scoped to a league, not a member. Keep this outside the
+    // creation branch so databases made by the older fallback are corrected.
+    await prisma.$executeRaw`
+      CREATE UNIQUE INDEX IF NOT EXISTS "LeagueRosterPlayer_leagueId_playerId_key"
+      ON "LeagueRosterPlayer"("leagueId", "playerId")
+    `;
 
     // Add captain system columns to LeagueSettings if they don't exist
     try {

--- a/src/server/draft/api/handlePickCommand.ts
+++ b/src/server/draft/api/handlePickCommand.ts
@@ -7,6 +7,7 @@ import { logger } from '@/lib/logger';
 import { getAuthenticatedUserId } from '@/lib/serverAuth';
 import { draftApplicationService } from '@/server/draft/services/DraftApplicationService';
 import { draftRealtimePublisher } from '@/server/draft/services/DraftRealtimePublisher';
+import { resolveCanonicalPlayerId } from '@/server/players/playerIdentityService';
 
 export async function handlePickCommand(
   request: NextRequest,
@@ -63,11 +64,15 @@ export async function handlePickCommand(
         ? request.headers.get('x-dev-user-id') || undefined
         : undefined;
     const effectiveUserId = devOverrideUserId || userId;
+    const canonicalPlayerId = await resolveCanonicalPlayerId(parsed.data.playerId);
+    if (!canonicalPlayerId) {
+      return commonErrors.notFound('Player not found');
+    }
 
     const result = await draftApplicationService.makePick({
       draftId,
       actorUserId: effectiveUserId,
-      playerId: parsed.data.playerId,
+      playerId: canonicalPlayerId,
     });
 
     const eventPick = result.data.eventPick ?? null;

--- a/src/server/leagues/lineupService.test.ts
+++ b/src/server/leagues/lineupService.test.ts
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => {
       update: vi.fn(),
       updateMany: vi.fn(),
     },
+    player: { findMany: vi.fn() },
+    playerExternalIdentity: { findMany: vi.fn() },
     $transaction: vi.fn(),
   };
   return { getRoundMatchesResult: vi.fn(), prisma };
@@ -60,6 +62,8 @@ function rosterPlayer(playerId = 'player-1', club = 'GWS') {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.prisma.player.findMany.mockResolvedValue([{ id: 'player-1' }]);
+  mocks.prisma.playerExternalIdentity.findMany.mockResolvedValue([]);
   mocks.prisma.$transaction.mockImplementation(async (work: (tx: typeof mocks.prisma) => unknown) =>
     work(mocks.prisma)
   );
@@ -226,6 +230,43 @@ describe('authoritative lineup timing', () => {
     ).resolves.toEqual({
       ok: false,
       error: 'Official AFL match timing is temporarily unavailable.',
+    });
+  });
+
+  it('resolves a retired player alias before saving a lineup', async () => {
+    const thursdaySettings = {
+      ...settings,
+      competitionRulesJson: JSON.stringify({ lockPolicy: 'THURSDAY_7PM_AEST' }),
+    };
+    mocks.prisma.playerExternalIdentity.findMany.mockResolvedValue([
+      { externalId: 'retired-player-1', playerId: 'player-1' },
+    ]);
+    mocks.prisma.league.findUnique.mockResolvedValue({ settings: thursdaySettings });
+    mocks.prisma.leagueRosterPlayer.findMany.mockResolvedValue([rosterPlayer()]);
+    mocks.prisma.leagueCompetitionRound.findUnique.mockResolvedValue({
+      ...scheduledRound,
+      startsAt: new Date('2027-07-18T09:00:00.000Z'),
+    });
+    mocks.prisma.leagueLineup.findUnique.mockResolvedValue(null);
+    mocks.prisma.leagueLineup.upsert.mockResolvedValue({ id: 'lineup-1' });
+
+    const result = await saveMemberLineup({
+      leagueId: 'league-1',
+      memberId: 'member-1',
+      round: 1,
+      players: [{ playerId: 'retired-player-1', slot: 'MID', slotIndex: 1 }],
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(mocks.prisma.leagueLineupPlayer.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          lineupId: 'lineup-1',
+          playerId: 'player-1',
+          slot: 'MID',
+          slotIndex: 1,
+        },
+      ],
     });
   });
 });

--- a/src/server/leagues/lineupService.ts
+++ b/src/server/leagues/lineupService.ts
@@ -3,6 +3,7 @@ import type { Prisma } from '@prisma/client';
 import { getRoundMatchesResult } from '@/lib/etlIntegration';
 import { prisma } from '@/lib/prisma';
 import { getTeamName } from '@/lib/teamLogos';
+import { resolveCanonicalPlayerIds } from '@/server/players/playerIdentityService';
 
 import { parseCompetitionRulesJson, type CompetitionRules } from './competitionRules';
 import { parseLineupSlotsJson } from './lineupSettings';
@@ -628,14 +629,29 @@ export async function saveMemberLineup({
     return { ok: false, code: 'INVALID_LINEUP', errors: ['Invalid round.'] };
   }
 
-  const submittedPlayers = normalizeSubmittedPlayers(players);
-  if (submittedPlayers.length !== players.length) {
+  const normalizedPlayers = normalizeSubmittedPlayers(players);
+  if (normalizedPlayers.length !== players.length) {
     return {
       ok: false,
       code: 'INVALID_LINEUP',
       errors: ['Lineup payload contains invalid player rows.'],
     };
   }
+
+  const playerIdsByRequestedId = await resolveCanonicalPlayerIds(
+    normalizedPlayers.map((player) => player.playerId)
+  );
+  if (normalizedPlayers.some((player) => !playerIdsByRequestedId.has(player.playerId))) {
+    return {
+      ok: false,
+      code: 'INVALID_LINEUP',
+      errors: ['Lineup contains a player who no longer exists.'],
+    };
+  }
+  const submittedPlayers = normalizedPlayers.map((player) => ({
+    ...player,
+    playerId: playerIdsByRequestedId.get(player.playerId)!,
+  }));
 
   const [league, initialRosterPlayers] = await Promise.all([
     prisma.league.findUnique({

--- a/src/server/leagues/lineupService.ts
+++ b/src/server/leagues/lineupService.ts
@@ -507,12 +507,13 @@ function normalizeSubmittedPlayers(players: readonly unknown[]): SubmittedLineup
           ? Number(source.slotIndex)
           : Number.NaN;
 
-    if (typeof source.playerId !== 'string' || !isLeagueLineupSlot(source.slot)) {
+    const playerId = typeof source.playerId === 'string' ? source.playerId.trim() : '';
+    if (!playerId || !isLeagueLineupSlot(source.slot)) {
       return [];
     }
 
     return {
-      playerId: source.playerId,
+      playerId,
       slot: source.slot,
       slotIndex,
     };

--- a/src/server/leagues/trades/tradeService.test.ts
+++ b/src/server/leagues/trades/tradeService.test.ts
@@ -18,6 +18,7 @@ const ids = {
   firstMember: 'trade-test-member-first',
   secondMember: 'trade-test-member-second',
   firstPlayer: 'trade-test-player-first',
+  firstPlayerAlias: 'trade-test-player-first-retired',
   secondPlayer: 'trade-test-player-second',
 } as const;
 
@@ -103,6 +104,19 @@ describe.sequential('league trade service transactions', () => {
     await expect(prisma.leagueTradeThread.count()).resolves.toBe(1);
     await expect(prisma.leagueTradeOffer.count()).resolves.toBe(1);
     await expect(prisma.leagueTradeCommand.count()).resolves.toBe(1);
+  });
+
+  it('resolves a retired player alias before validating trade ownership', async () => {
+    const created = await service.createLeagueTrade(
+      ids.league,
+      ids.firstUser,
+      createInput({ sendingPlayerIds: [ids.firstPlayerAlias] }),
+      now
+    );
+
+    await expect(
+      prisma.leagueTradePlayer.findFirstOrThrow({ where: { offerId: created.offerId } })
+    ).resolves.toMatchObject({ playerId: ids.firstPlayer });
   });
 
   it('persists immutable player identity snapshots with an offer', async () => {
@@ -751,6 +765,13 @@ async function seedLeague(): Promise<void> {
       { id: ids.firstPlayer, name: 'First Player', club: 'AAA', position: 'MID' },
       { id: ids.secondPlayer, name: 'Second Player', club: 'BBB', position: 'FWD' },
     ],
+  });
+  await prisma.playerExternalIdentity.create({
+    data: {
+      provider: 'statly-legacy',
+      externalId: ids.firstPlayerAlias,
+      playerId: ids.firstPlayer,
+    },
   });
   await prisma.leagueRosterPlayer.createMany({
     data: [

--- a/src/server/leagues/trades/tradeService.ts
+++ b/src/server/leagues/trades/tradeService.ts
@@ -5,6 +5,7 @@ import { createHash } from 'node:crypto';
 import { Prisma, type TradeReviewMode } from '@prisma/client';
 
 import { prisma } from '@/lib/prisma';
+import { resolveCanonicalPlayerIds } from '@/server/players/playerIdentityService';
 import {
   evaluateRosterExchangeCapacity,
   getLeagueRosterCapacity,
@@ -70,9 +71,14 @@ export async function createLeagueTrade(
   if (!parsed.success) {
     throw new TradeServiceError('INVALID_INPUT', 'Trade proposal is invalid.');
   }
-  const selection = validateTradePlayerSelection(
+  const canonicalSelection = await resolveTradePlayerSelection(
     parsed.data.sendingPlayerIds,
     parsed.data.receivingPlayerIds
+  );
+  const canonicalInput: CreateTradeInput = { ...parsed.data, ...canonicalSelection };
+  const selection = validateTradePlayerSelection(
+    canonicalInput.sendingPlayerIds,
+    canonicalInput.receivingPlayerIds
   );
   if (!selection.ok) throw new TradeServiceError('INVALID_INPUT', selection.error);
 
@@ -81,10 +87,10 @@ export async function createLeagueTrade(
 
   return executeIdempotentTradeCommand(
     access,
-    parsed.data.idempotencyKey,
+    canonicalInput.idempotencyKey,
     'CREATE_TRADE',
-    parsed.data,
-    async (tx) => createTradeInTransaction(tx, access, parsed.data, now)
+    canonicalInput,
+    async (tx) => createTradeInTransaction(tx, access, canonicalInput, now)
   );
 }
 
@@ -99,15 +105,41 @@ export async function executeLeagueTradeAction(
   if (!parsed.success) {
     throw new TradeServiceError('INVALID_INPUT', 'Trade action is invalid.');
   }
+  let canonicalInput: TradeActionInput = parsed.data;
+  if (parsed.data.action === 'counter') {
+    canonicalInput = {
+      ...parsed.data,
+      ...(await resolveTradePlayerSelection(
+        parsed.data.sendingPlayerIds,
+        parsed.data.receivingPlayerIds
+      )),
+    };
+  }
   const access = await requireTradeAccess(leagueId, userId);
 
   return executeIdempotentTradeCommand(
     access,
-    parsed.data.idempotencyKey,
-    `TRADE_${parsed.data.action.toUpperCase()}`,
-    { threadId, ...parsed.data },
-    async (tx) => executeActionInTransaction(tx, access, threadId, parsed.data, now)
+    canonicalInput.idempotencyKey,
+    `TRADE_${canonicalInput.action.toUpperCase()}`,
+    { threadId, ...canonicalInput },
+    async (tx) => executeActionInTransaction(tx, access, threadId, canonicalInput, now)
   );
+}
+
+async function resolveTradePlayerSelection(
+  sendingPlayerIds: readonly string[],
+  receivingPlayerIds: readonly string[]
+): Promise<{ sendingPlayerIds: string[]; receivingPlayerIds: string[] }> {
+  const requestedPlayerIds = [...sendingPlayerIds, ...receivingPlayerIds];
+  const resolvedPlayerIds = await resolveCanonicalPlayerIds(requestedPlayerIds);
+  if (requestedPlayerIds.some((playerId) => !resolvedPlayerIds.has(playerId))) {
+    throw new TradeServiceError('INVALID_INPUT', 'One or more selected players no longer exist.');
+  }
+
+  return {
+    sendingPlayerIds: sendingPlayerIds.map((playerId) => resolvedPlayerIds.get(playerId)!),
+    receivingPlayerIds: receivingPlayerIds.map((playerId) => resolvedPlayerIds.get(playerId)!),
+  };
 }
 
 export async function processDueLeagueTrades(now = new Date(), limit = 50): Promise<number> {

--- a/src/server/players/playerIdentityConsolidation.ts
+++ b/src/server/players/playerIdentityConsolidation.ts
@@ -1,5 +1,7 @@
 import type { Prisma, PrismaClient } from '@prisma/client';
 
+import { assertPlayerIdentitySourceFingerprint } from './playerIdentityConsolidationCli';
+import { containsPlayerIdentityReference } from './playerIdentityJsonReferences';
 import {
   planPlayerIdentityConsolidation,
   type PlayerAliasMapping,
@@ -14,6 +16,12 @@ export class PlayerIdentityConsolidationBlockedError extends Error {
 }
 
 type AliasMap = ReadonlyMap<string, string>;
+
+export type PlayerIdentityConsolidationOptions = {
+  expectedSourceFingerprint?: string;
+  maxWaitMs?: number;
+  timeoutMs?: number;
+};
 
 function replacePlayerIds(value: unknown, aliases: AliasMap): unknown {
   if (typeof value === 'string') {
@@ -35,7 +43,7 @@ function replacePlayerIds(value: unknown, aliases: AliasMap): unknown {
 
 function rewriteJson(value: string | null, aliases: AliasMap): string | null {
   if (!value) return value;
-  if (![...aliases.keys()].some((aliasId) => value.includes(aliasId))) return value;
+  if (!containsPlayerIdentityReference(value, new Set(aliases.keys()))) return value;
 
   try {
     return JSON.stringify(replacePlayerIds(JSON.parse(value), aliases));
@@ -45,7 +53,7 @@ function rewriteJson(value: string | null, aliases: AliasMap): string | null {
 }
 
 function rewriteJsonIdArray(value: string | null, aliases: AliasMap): string | null {
-  if (!value || ![...aliases.keys()].some((aliasId) => value.includes(aliasId))) return value;
+  if (!value || !containsPlayerIdentityReference(value, new Set(aliases.keys()))) return value;
   const rewritten = rewriteJson(value, aliases);
   if (!rewritten) return rewritten;
   const parsed = JSON.parse(rewritten) as unknown;
@@ -251,28 +259,43 @@ async function applyMapping(
 
 export async function consolidatePlayerIdentities(
   client: PrismaClient,
-  mappings: readonly PlayerAliasMapping[]
+  mappings: readonly PlayerAliasMapping[],
+  options: PlayerIdentityConsolidationOptions = {}
 ): Promise<PlayerIdentityConsolidationPlan> {
-  return client.$transaction(async (tx) => {
-    const plan = await planPlayerIdentityConsolidation(tx, mappings);
-    if (plan.status === 'blocked') {
-      throw new PlayerIdentityConsolidationBlockedError(plan);
+  return client.$transaction(
+    async (tx) => {
+      if (options.expectedSourceFingerprint) {
+        const players = await tx.player.findMany({
+          orderBy: { id: 'asc' },
+          select: { id: true, name: true, club: true, position: true },
+        });
+        assertPlayerIdentitySourceFingerprint(options.expectedSourceFingerprint, players);
+      }
+
+      const plan = await planPlayerIdentityConsolidation(tx, mappings);
+      if (plan.status === 'blocked') {
+        throw new PlayerIdentityConsolidationBlockedError(plan);
+      }
+
+      const aliasMap = new Map(
+        plan.mappings.map((mapping) => [mapping.aliasId, mapping.canonicalPlayerId])
+      );
+      for (const mapping of plan.mappings) {
+        await applyMapping(tx, mapping);
+      }
+
+      await rewriteLegacyRosterDocuments(tx, aliasMap);
+
+      for (const mapping of plan.mappings) {
+        await assertNoRelationalReferences(tx, mapping.aliasId);
+        await tx.player.delete({ where: { id: mapping.aliasId } });
+      }
+
+      return plan;
+    },
+    {
+      maxWait: options.maxWaitMs ?? 10_000,
+      timeout: options.timeoutMs ?? 300_000,
     }
-
-    const aliasMap = new Map(
-      plan.mappings.map((mapping) => [mapping.aliasId, mapping.canonicalPlayerId])
-    );
-    for (const mapping of plan.mappings) {
-      await applyMapping(tx, mapping);
-    }
-
-    await rewriteLegacyRosterDocuments(tx, aliasMap);
-
-    for (const mapping of plan.mappings) {
-      await assertNoRelationalReferences(tx, mapping.aliasId);
-      await tx.player.delete({ where: { id: mapping.aliasId } });
-    }
-
-    return plan;
-  });
+  );
 }

--- a/src/server/players/playerIdentityConsolidation.ts
+++ b/src/server/players/playerIdentityConsolidation.ts
@@ -181,22 +181,27 @@ async function mergeRosterOwnership(
 async function rewriteLegacyRosterDocuments(tx: Prisma.TransactionClient, aliases: AliasMap) {
   const rows = await tx.leagueRoster.findMany();
   for (const row of rows) {
-    const playerIds = rewriteJsonIdArray(row.playerIds, aliases)!;
-    const captainId = row.captainId ? (aliases.get(row.captainId) ?? row.captainId) : null;
-    const viceCaptainId = row.viceCaptainId
-      ? (aliases.get(row.viceCaptainId) ?? row.viceCaptainId)
-      : null;
-    const benchOrder = rewriteJsonIdArray(row.benchOrder, aliases);
-    if (
-      playerIds !== row.playerIds ||
-      captainId !== row.captainId ||
-      viceCaptainId !== row.viceCaptainId ||
-      benchOrder !== row.benchOrder
-    ) {
-      await tx.leagueRoster.update({
-        where: { id: row.id },
-        data: { playerIds, captainId, viceCaptainId, benchOrder },
-      });
+    try {
+      const playerIds = rewriteJsonIdArray(row.playerIds, aliases)!;
+      const captainId = row.captainId ? (aliases.get(row.captainId) ?? row.captainId) : null;
+      const viceCaptainId = row.viceCaptainId
+        ? (aliases.get(row.viceCaptainId) ?? row.viceCaptainId)
+        : null;
+      const benchOrder = rewriteJsonIdArray(row.benchOrder, aliases);
+      if (
+        playerIds !== row.playerIds ||
+        captainId !== row.captainId ||
+        viceCaptainId !== row.viceCaptainId ||
+        benchOrder !== row.benchOrder
+      ) {
+        await tx.leagueRoster.update({
+          where: { id: row.id },
+          data: { playerIds, captainId, viceCaptainId, benchOrder },
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to rewrite legacy roster ${row.id}: ${message}`, { cause: error });
     }
   }
 }

--- a/src/server/players/playerIdentityConsolidation.ts
+++ b/src/server/players/playerIdentityConsolidation.ts
@@ -45,6 +45,7 @@ function rewriteJson(value: string | null, aliases: AliasMap): string | null {
 }
 
 function rewriteJsonIdArray(value: string | null, aliases: AliasMap): string | null {
+  if (!value || ![...aliases.keys()].some((aliasId) => value.includes(aliasId))) return value;
   const rewritten = rewriteJson(value, aliases);
   if (!rewritten) return rewritten;
   const parsed = JSON.parse(rewritten) as unknown;
@@ -214,6 +215,9 @@ async function assertNoRelationalReferences(tx: Prisma.TransactionClient, aliasI
     tx.queueItem.count({ where: { playerId: aliasId } }),
     tx.leagueRosterPlayer.count({ where: { playerId: aliasId } }),
     tx.leagueLineupPlayer.count({ where: { playerId: aliasId } }),
+    tx.leagueLineupAutosub.count({
+      where: { OR: [{ outgoingPlayerId: aliasId }, { replacementPlayerId: aliasId }] },
+    }),
     tx.leagueTradePlayer.count({ where: { playerId: aliasId } }),
   ]);
   if (counts.some((count) => count > 0)) {

--- a/src/server/players/playerIdentityConsolidation.ts
+++ b/src/server/players/playerIdentityConsolidation.ts
@@ -1,0 +1,338 @@
+import type { Prisma, PrismaClient } from '@prisma/client';
+
+import {
+  planPlayerIdentityConsolidation,
+  type PlayerAliasMapping,
+  type PlayerIdentityConsolidationPlan,
+} from './playerIdentityConsolidationPlanner';
+
+export class PlayerIdentityConsolidationBlockedError extends Error {
+  constructor(readonly plan: PlayerIdentityConsolidationPlan) {
+    super(`Player identity consolidation is blocked by ${plan.blockers.length} conflict(s)`);
+    this.name = 'PlayerIdentityConsolidationBlockedError';
+  }
+}
+
+type AliasMap = ReadonlyMap<string, string>;
+
+function replacePlayerIds(value: unknown, aliases: AliasMap): unknown {
+  if (typeof value === 'string') {
+    return aliases.get(value) ?? value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => replacePlayerIds(entry, aliases));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, replacePlayerIds(entry, aliases)])
+    );
+  }
+
+  return value;
+}
+
+function rewriteJson(value: string | null, aliases: AliasMap): string | null {
+  if (!value) return value;
+  if (![...aliases.keys()].some((aliasId) => value.includes(aliasId))) return value;
+
+  try {
+    return JSON.stringify(replacePlayerIds(JSON.parse(value), aliases));
+  } catch {
+    throw new Error('Player alias appears in a value that is not valid JSON');
+  }
+}
+
+function rewriteJsonIdArray(value: string | null, aliases: AliasMap): string | null {
+  const rewritten = rewriteJson(value, aliases);
+  if (!rewritten) return rewritten;
+  const parsed = JSON.parse(rewritten) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error('Expected a JSON player ID array during identity consolidation');
+  }
+  return JSON.stringify([...new Set(parsed.map((entry) => String(entry)))]);
+}
+
+async function mergeWatchlists(
+  tx: Prisma.TransactionClient,
+  aliasId: string,
+  canonicalPlayerId: string
+) {
+  const rows = await tx.draftWatchlist.findMany({ where: { playerId: aliasId } });
+  for (const row of rows) {
+    const existing = await tx.draftWatchlist.findUnique({
+      where: {
+        draftId_memberId_playerId: {
+          draftId: row.draftId,
+          memberId: row.memberId,
+          playerId: canonicalPlayerId,
+        },
+      },
+    });
+    if (existing) {
+      await tx.draftWatchlist.update({
+        where: { id: existing.id },
+        data: {
+          priority: Math.min(existing.priority, row.priority),
+          notes: existing.notes ?? row.notes,
+        },
+      });
+      await tx.draftWatchlist.delete({ where: { id: row.id } });
+    } else {
+      await tx.draftWatchlist.update({
+        where: { id: row.id },
+        data: { playerId: canonicalPlayerId },
+      });
+    }
+  }
+}
+
+async function mergePreDraftQueues(
+  tx: Prisma.TransactionClient,
+  aliasId: string,
+  canonicalPlayerId: string
+) {
+  const rows = await tx.preDraftQueue.findMany({ where: { playerId: aliasId } });
+  for (const row of rows) {
+    const existing = await tx.preDraftQueue.findUnique({
+      where: {
+        draftId_memberId_playerId: {
+          draftId: row.draftId,
+          memberId: row.memberId,
+          playerId: canonicalPlayerId,
+        },
+      },
+    });
+    if (existing) {
+      await tx.preDraftQueue.update({
+        where: { id: existing.id },
+        data: { rank: Math.min(existing.rank, row.rank), notes: existing.notes ?? row.notes },
+      });
+      await tx.preDraftQueue.delete({ where: { id: row.id } });
+    } else {
+      await tx.preDraftQueue.update({
+        where: { id: row.id },
+        data: { playerId: canonicalPlayerId },
+      });
+    }
+  }
+}
+
+async function mergeLegacyQueues(
+  tx: Prisma.TransactionClient,
+  aliasId: string,
+  canonicalPlayerId: string
+) {
+  const rows = await tx.queueItem.findMany({ where: { playerId: aliasId } });
+  for (const row of rows) {
+    const existing = await tx.queueItem.findUnique({
+      where: { memberId_playerId: { memberId: row.memberId, playerId: canonicalPlayerId } },
+    });
+    if (existing) {
+      await tx.queueItem.delete({ where: { id: row.id } });
+    } else {
+      await tx.queueItem.update({ where: { id: row.id }, data: { playerId: canonicalPlayerId } });
+    }
+  }
+}
+
+async function mergeRosterOwnership(
+  tx: Prisma.TransactionClient,
+  aliasId: string,
+  canonicalPlayerId: string
+) {
+  const rows = await tx.leagueRosterPlayer.findMany({ where: { playerId: aliasId } });
+  for (const row of rows) {
+    const existing = await tx.leagueRosterPlayer.findUnique({
+      where: { leagueId_playerId: { leagueId: row.leagueId, playerId: canonicalPlayerId } },
+    });
+    if (!existing) {
+      await tx.leagueRosterPlayer.update({
+        where: { id: row.id },
+        data: { playerId: canonicalPlayerId },
+      });
+      continue;
+    }
+
+    if (existing.memberId !== row.memberId) {
+      throw new Error(`Ownership changed after preflight for league ${row.leagueId}`);
+    }
+
+    if (row.acquiredAt < existing.acquiredAt) {
+      await tx.leagueRosterPlayer.update({
+        where: { id: existing.id },
+        data: {
+          draftId: row.draftId,
+          pickId: row.pickId,
+          slot: existing.slot ?? row.slot,
+          acquiredBy: row.acquiredBy,
+          acquiredAt: row.acquiredAt,
+        },
+      });
+    }
+    await tx.leagueRosterPlayer.delete({ where: { id: row.id } });
+  }
+}
+
+async function rewriteLegacyRosterDocuments(tx: Prisma.TransactionClient, aliases: AliasMap) {
+  const rows = await tx.leagueRoster.findMany();
+  for (const row of rows) {
+    const playerIds = rewriteJsonIdArray(row.playerIds, aliases)!;
+    const captainId = row.captainId ? (aliases.get(row.captainId) ?? row.captainId) : null;
+    const viceCaptainId = row.viceCaptainId
+      ? (aliases.get(row.viceCaptainId) ?? row.viceCaptainId)
+      : null;
+    const benchOrder = rewriteJsonIdArray(row.benchOrder, aliases);
+    if (
+      playerIds !== row.playerIds ||
+      captainId !== row.captainId ||
+      viceCaptainId !== row.viceCaptainId ||
+      benchOrder !== row.benchOrder
+    ) {
+      await tx.leagueRoster.update({
+        where: { id: row.id },
+        data: { playerIds, captainId, viceCaptainId, benchOrder },
+      });
+    }
+  }
+}
+
+async function rewriteGenericJsonDocuments(tx: Prisma.TransactionClient, aliases: AliasMap) {
+  const lobbyActivities = await tx.lobbyActivity.findMany({ where: { details: { not: null } } });
+  for (const row of lobbyActivities) {
+    const details = rewriteJson(row.details, aliases);
+    if (details !== row.details)
+      await tx.lobbyActivity.update({ where: { id: row.id }, data: { details } });
+  }
+
+  const draftEvents = await tx.draftEvent.findMany({ where: { payload: { not: null } } });
+  for (const row of draftEvents) {
+    const payload = rewriteJson(row.payload, aliases);
+    if (payload !== row.payload)
+      await tx.draftEvent.update({ where: { id: row.id }, data: { payload } });
+  }
+
+  const competitionAudits = await tx.leagueCompetitionAudit.findMany();
+  for (const row of competitionAudits) {
+    const payloadJson = rewriteJson(row.payloadJson, aliases)!;
+    if (payloadJson !== row.payloadJson) {
+      await tx.leagueCompetitionAudit.update({ where: { id: row.id }, data: { payloadJson } });
+    }
+  }
+
+  const teamActions = await tx.teamAction.findMany();
+  for (const row of teamActions) {
+    const details = rewriteJson(row.details, aliases)!;
+    if (details !== row.details)
+      await tx.teamAction.update({ where: { id: row.id }, data: { details } });
+  }
+
+  const tradeEvents = await tx.leagueTradeEvent.findMany({ where: { payloadJson: { not: null } } });
+  for (const row of tradeEvents) {
+    const payloadJson = rewriteJson(row.payloadJson, aliases);
+    if (payloadJson !== row.payloadJson) {
+      await tx.leagueTradeEvent.update({ where: { id: row.id }, data: { payloadJson } });
+    }
+  }
+
+  const tradeCommands = await tx.leagueTradeCommand.findMany({
+    where: { responseJson: { not: null } },
+  });
+  for (const row of tradeCommands) {
+    const responseJson = rewriteJson(row.responseJson, aliases);
+    if (responseJson !== row.responseJson) {
+      await tx.leagueTradeCommand.update({ where: { id: row.id }, data: { responseJson } });
+    }
+  }
+
+  const outboxEvents = await tx.leagueTradeOutboxEvent.findMany();
+  for (const row of outboxEvents) {
+    const payloadJson = rewriteJson(row.payloadJson, aliases)!;
+    if (payloadJson !== row.payloadJson) {
+      await tx.leagueTradeOutboxEvent.update({
+        where: { sequence: row.sequence },
+        data: { payloadJson },
+      });
+    }
+  }
+}
+
+async function assertNoRelationalReferences(tx: Prisma.TransactionClient, aliasId: string) {
+  const counts = await Promise.all([
+    tx.pick.count({ where: { playerId: aliasId } }),
+    tx.draftWatchlist.count({ where: { playerId: aliasId } }),
+    tx.preDraftQueue.count({ where: { playerId: aliasId } }),
+    tx.queueItem.count({ where: { playerId: aliasId } }),
+    tx.leagueRosterPlayer.count({ where: { playerId: aliasId } }),
+    tx.leagueLineupPlayer.count({ where: { playerId: aliasId } }),
+    tx.leagueTradePlayer.count({ where: { playerId: aliasId } }),
+    tx.leagueLineupAutosub.count({
+      where: { OR: [{ outgoingPlayerId: aliasId }, { replacementPlayerId: aliasId }] },
+    }),
+  ]);
+  if (counts.some((count) => count > 0)) {
+    throw new Error(`Relational references remain for player alias ${aliasId}`);
+  }
+}
+
+async function applyMapping(
+  tx: Prisma.TransactionClient,
+  mapping: PlayerAliasMapping
+): Promise<void> {
+  const { aliasId, canonicalPlayerId } = mapping;
+  await tx.pick.updateMany({ where: { playerId: aliasId }, data: { playerId: canonicalPlayerId } });
+  await mergeWatchlists(tx, aliasId, canonicalPlayerId);
+  await mergePreDraftQueues(tx, aliasId, canonicalPlayerId);
+  await mergeLegacyQueues(tx, aliasId, canonicalPlayerId);
+  await mergeRosterOwnership(tx, aliasId, canonicalPlayerId);
+  await tx.leagueLineupPlayer.updateMany({
+    where: { playerId: aliasId },
+    data: { playerId: canonicalPlayerId },
+  });
+  await tx.leagueTradePlayer.updateMany({
+    where: { playerId: aliasId },
+    data: { playerId: canonicalPlayerId },
+  });
+  await tx.leagueLineupAutosub.updateMany({
+    where: { outgoingPlayerId: aliasId },
+    data: { outgoingPlayerId: canonicalPlayerId },
+  });
+  await tx.leagueLineupAutosub.updateMany({
+    where: { replacementPlayerId: aliasId },
+    data: { replacementPlayerId: canonicalPlayerId },
+  });
+  await tx.playerExternalIdentity.updateMany({
+    where: { playerId: aliasId },
+    data: { playerId: canonicalPlayerId },
+  });
+}
+
+export async function consolidatePlayerIdentities(
+  client: PrismaClient,
+  mappings: readonly PlayerAliasMapping[]
+): Promise<PlayerIdentityConsolidationPlan> {
+  return client.$transaction(async (tx) => {
+    const plan = await planPlayerIdentityConsolidation(tx, mappings);
+    if (plan.status === 'blocked') {
+      throw new PlayerIdentityConsolidationBlockedError(plan);
+    }
+
+    const aliasMap = new Map(
+      plan.mappings.map((mapping) => [mapping.aliasId, mapping.canonicalPlayerId])
+    );
+    for (const mapping of plan.mappings) {
+      await applyMapping(tx, mapping);
+    }
+
+    await rewriteLegacyRosterDocuments(tx, aliasMap);
+    await rewriteGenericJsonDocuments(tx, aliasMap);
+
+    for (const mapping of plan.mappings) {
+      await assertNoRelationalReferences(tx, mapping.aliasId);
+      await tx.player.delete({ where: { id: mapping.aliasId } });
+    }
+
+    return plan;
+  });
+}

--- a/src/server/players/playerIdentityConsolidation.ts
+++ b/src/server/players/playerIdentityConsolidation.ts
@@ -131,6 +131,9 @@ async function mergeLegacyQueues(
     });
     if (existing) {
       await tx.queueItem.delete({ where: { id: row.id } });
+      if (row.rank < existing.rank) {
+        await tx.queueItem.update({ where: { id: existing.id }, data: { rank: row.rank } });
+      }
     } else {
       await tx.queueItem.update({ where: { id: row.id }, data: { playerId: canonicalPlayerId } });
     }
@@ -198,66 +201,6 @@ async function rewriteLegacyRosterDocuments(tx: Prisma.TransactionClient, aliase
   }
 }
 
-async function rewriteGenericJsonDocuments(tx: Prisma.TransactionClient, aliases: AliasMap) {
-  const lobbyActivities = await tx.lobbyActivity.findMany({ where: { details: { not: null } } });
-  for (const row of lobbyActivities) {
-    const details = rewriteJson(row.details, aliases);
-    if (details !== row.details)
-      await tx.lobbyActivity.update({ where: { id: row.id }, data: { details } });
-  }
-
-  const draftEvents = await tx.draftEvent.findMany({ where: { payload: { not: null } } });
-  for (const row of draftEvents) {
-    const payload = rewriteJson(row.payload, aliases);
-    if (payload !== row.payload)
-      await tx.draftEvent.update({ where: { id: row.id }, data: { payload } });
-  }
-
-  const competitionAudits = await tx.leagueCompetitionAudit.findMany();
-  for (const row of competitionAudits) {
-    const payloadJson = rewriteJson(row.payloadJson, aliases)!;
-    if (payloadJson !== row.payloadJson) {
-      await tx.leagueCompetitionAudit.update({ where: { id: row.id }, data: { payloadJson } });
-    }
-  }
-
-  const teamActions = await tx.teamAction.findMany();
-  for (const row of teamActions) {
-    const details = rewriteJson(row.details, aliases)!;
-    if (details !== row.details)
-      await tx.teamAction.update({ where: { id: row.id }, data: { details } });
-  }
-
-  const tradeEvents = await tx.leagueTradeEvent.findMany({ where: { payloadJson: { not: null } } });
-  for (const row of tradeEvents) {
-    const payloadJson = rewriteJson(row.payloadJson, aliases);
-    if (payloadJson !== row.payloadJson) {
-      await tx.leagueTradeEvent.update({ where: { id: row.id }, data: { payloadJson } });
-    }
-  }
-
-  const tradeCommands = await tx.leagueTradeCommand.findMany({
-    where: { responseJson: { not: null } },
-  });
-  for (const row of tradeCommands) {
-    const responseJson = rewriteJson(row.responseJson, aliases);
-    if (responseJson !== row.responseJson) {
-      await tx.leagueTradeCommand.update({ where: { id: row.id }, data: { responseJson } });
-    }
-  }
-
-  const outboxEvents = await tx.leagueTradeOutboxEvent.findMany();
-  for (const row of outboxEvents) {
-    const payloadJson = rewriteJson(row.payloadJson, aliases)!;
-    if (payloadJson !== row.payloadJson) {
-      await tx.leagueTradeOutboxEvent.update({
-        where: { sequence: row.sequence },
-        data: { payloadJson },
-      });
-    }
-  }
-}
-
 async function assertNoRelationalReferences(tx: Prisma.TransactionClient, aliasId: string) {
   const counts = await Promise.all([
     tx.pick.count({ where: { playerId: aliasId } }),
@@ -267,9 +210,6 @@ async function assertNoRelationalReferences(tx: Prisma.TransactionClient, aliasI
     tx.leagueRosterPlayer.count({ where: { playerId: aliasId } }),
     tx.leagueLineupPlayer.count({ where: { playerId: aliasId } }),
     tx.leagueTradePlayer.count({ where: { playerId: aliasId } }),
-    tx.leagueLineupAutosub.count({
-      where: { OR: [{ outgoingPlayerId: aliasId }, { replacementPlayerId: aliasId }] },
-    }),
   ]);
   if (counts.some((count) => count > 0)) {
     throw new Error(`Relational references remain for player alias ${aliasId}`);
@@ -293,14 +233,6 @@ async function applyMapping(
   await tx.leagueTradePlayer.updateMany({
     where: { playerId: aliasId },
     data: { playerId: canonicalPlayerId },
-  });
-  await tx.leagueLineupAutosub.updateMany({
-    where: { outgoingPlayerId: aliasId },
-    data: { outgoingPlayerId: canonicalPlayerId },
-  });
-  await tx.leagueLineupAutosub.updateMany({
-    where: { replacementPlayerId: aliasId },
-    data: { replacementPlayerId: canonicalPlayerId },
   });
   await tx.playerExternalIdentity.updateMany({
     where: { playerId: aliasId },
@@ -326,7 +258,6 @@ export async function consolidatePlayerIdentities(
     }
 
     await rewriteLegacyRosterDocuments(tx, aliasMap);
-    await rewriteGenericJsonDocuments(tx, aliasMap);
 
     for (const mapping of plan.mappings) {
       await assertNoRelationalReferences(tx, mapping.aliasId);

--- a/src/server/players/playerIdentityConsolidationCli.ts
+++ b/src/server/players/playerIdentityConsolidationCli.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { lstatSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import type { PlayerAliasMapping } from './playerIdentityConsolidationPlanner';
@@ -36,8 +37,11 @@ export function parsePlayerIdentityCliArgs(argv: readonly string[]): PlayerIdent
   const manifestIndex = argv.indexOf('--manifest');
   const manifestPath = manifestIndex >= 0 ? argv[manifestIndex + 1] : undefined;
 
+  if (manifestIndex >= 0 && (!manifestPath || manifestPath.startsWith('--'))) {
+    throw new Error('--manifest requires a file path');
+  }
   if (propose && (apply || manifestPath || projectWaivers)) {
-    throw new Error('--propose cannot be combined with --apply or --manifest');
+    throw new Error('--propose cannot be combined with --apply, --manifest, or --project-waivers');
   }
   if (projectWaivers && (apply || propose || manifestPath)) {
     throw new Error('--project-waivers must be run as a standalone mode');
@@ -51,10 +55,6 @@ export function parsePlayerIdentityCliArgs(argv: readonly string[]): PlayerIdent
   if (!propose && !projectWaivers && !manifestPath) {
     throw new Error('Use --propose or provide --manifest <reviewed-manifest.json>');
   }
-  if (manifestIndex >= 0 && (!manifestPath || manifestPath.startsWith('--'))) {
-    throw new Error('--manifest requires a file path');
-  }
-
   return {
     apply,
     projectWaivers,
@@ -142,8 +142,45 @@ export function createPlayerIdentitySourceFingerprint(
       club: player.club,
       position: player.position,
     }))
-    .sort((left, right) => left.id.localeCompare(right.id));
+    .sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));
   return createHash('sha256').update(JSON.stringify(normalizedRows)).digest('hex');
+}
+
+export function assertPlayerIdentitySourceFingerprint(
+  expectedFingerprint: string,
+  players: readonly PlayerIdentitySourceRow[]
+): void {
+  if (createPlayerIdentitySourceFingerprint(players) !== expectedFingerprint) {
+    throw new Error(
+      'Player identity data changed after manifest proposal; generate and review a new manifest'
+    );
+  }
+}
+
+export function validatePlayerIdentityFirestoreProject(input: {
+  expectedProjectId: string;
+  actualProjectId: string | undefined;
+}): string {
+  const expectedProjectId = input.expectedProjectId.trim();
+  const actualProjectId = input.actualProjectId?.trim();
+  if (!expectedProjectId) {
+    throw new Error('STATLY_PLAYER_IDENTITY_FIRESTORE_PROJECT is required for projection');
+  }
+  if (!actualProjectId || actualProjectId !== expectedProjectId) {
+    throw new Error(
+      `Firestore project mismatch: expected ${expectedProjectId}, resolved ${actualProjectId || 'unknown'}`
+    );
+  }
+  return actualProjectId;
+}
+
+function safeRealpath(filePath: string): string | null {
+  try {
+    return realpathSync(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
 }
 
 export function validateDisposablePlayerIdentityDatabase(input: {
@@ -164,25 +201,32 @@ export function validateDisposablePlayerIdentityDatabase(input: {
 
   const databasePath = path.normalize(decodeURIComponent(parsedUrl.pathname));
   const normalizedExpectedPath = path.normalize(expectedPath);
+  const verificationDirectory = path.normalize(tmpdir());
   if (
     databasePath !== normalizedExpectedPath ||
-    !/^\/tmp\/statly-verify-player-[^/]+\.db$/.test(normalizedExpectedPath)
+    path.dirname(normalizedExpectedPath) !== verificationDirectory ||
+    !/^statly-verify-player-[^/]+\.db$/.test(path.basename(normalizedExpectedPath))
   ) {
     throw new Error(
-      'Identity consolidation is restricted to matching /tmp/statly-verify-player-*.db files'
+      `Identity consolidation is restricted to matching ${verificationDirectory}/statly-verify-player-*.db files`
     );
   }
 
-  const stat = lstatSync(normalizedExpectedPath);
+  let stat;
+  try {
+    stat = lstatSync(normalizedExpectedPath);
+  } catch {
+    throw new Error('Identity verification database must exist and be readable');
+  }
   if (!stat.isFile() || stat.isSymbolicLink()) {
     throw new Error('Identity verification database must be a regular non-symlink file');
   }
 
   const realDatabasePath = realpathSync(normalizedExpectedPath);
-  const protectedDatabasePath = realpathSync(
+  const protectedDatabasePath = safeRealpath(
     path.resolve(input.repositoryRoot ?? process.cwd(), 'prisma/dev.db')
   );
-  if (realDatabasePath === protectedDatabasePath) {
+  if (protectedDatabasePath && realDatabasePath === protectedDatabasePath) {
     throw new Error('Refusing to use protected prisma/dev.db');
   }
 
@@ -213,16 +257,21 @@ export function validateProductionPlayerIdentityDatabase(input: {
     throw new Error('DATABASE_URL must exactly match STATLY_PLAYER_IDENTITY_PRODUCTION_DB');
   }
 
-  const stat = lstatSync(normalizedExpectedPath);
+  let stat;
+  try {
+    stat = lstatSync(normalizedExpectedPath);
+  } catch {
+    throw new Error('Production identity database must exist and be readable');
+  }
   if (!stat.isFile() || stat.isSymbolicLink()) {
     throw new Error('Production identity database must be a regular non-symlink file');
   }
 
   const realDatabasePath = realpathSync(normalizedExpectedPath);
-  const protectedDatabasePath = realpathSync(
+  const protectedDatabasePath = safeRealpath(
     path.resolve(input.repositoryRoot ?? process.cwd(), 'prisma/dev.db')
   );
-  if (realDatabasePath === protectedDatabasePath) {
+  if (protectedDatabasePath && realDatabasePath === protectedDatabasePath) {
     throw new Error('Refusing to use protected prisma/dev.db');
   }
 
@@ -231,12 +280,23 @@ export function validateProductionPlayerIdentityDatabase(input: {
     if (!backupPath) {
       throw new Error('STATLY_PLAYER_IDENTITY_BACKUP is required for production apply');
     }
-    const backupStat = lstatSync(backupPath);
+    let backupStat;
+    try {
+      backupStat = lstatSync(backupPath);
+    } catch {
+      throw new Error('Production backup must exist and be readable');
+    }
     if (!backupStat.isFile() || backupStat.isSymbolicLink()) {
       throw new Error('Production backup must be a regular non-symlink file');
     }
+    if (backupStat.size === 0) {
+      throw new Error('Production backup must not be empty');
+    }
     if (realpathSync(backupPath) === realDatabasePath) {
       throw new Error('Production backup must be a separate file');
+    }
+    if (backupStat.mtimeMs < stat.mtimeMs) {
+      throw new Error('Production backup is older than the database; create a fresh backup');
     }
   }
 

--- a/src/server/players/playerIdentityConsolidationCli.ts
+++ b/src/server/players/playerIdentityConsolidationCli.ts
@@ -1,0 +1,244 @@
+import { createHash } from 'node:crypto';
+import { lstatSync, realpathSync } from 'node:fs';
+import path from 'node:path';
+
+import type { PlayerAliasMapping } from './playerIdentityConsolidationPlanner';
+
+export type PlayerIdentityCliArgs = {
+  apply: boolean;
+  projectWaivers: boolean;
+  propose: boolean;
+  production: boolean;
+  manifestPath?: string;
+};
+
+export type ReviewedPlayerIdentityManifest = {
+  schemaVersion: 1;
+  reviewed: boolean;
+  sourceFingerprint: string;
+  reviewedAt?: string;
+  reviewedBy?: string;
+  mappings: PlayerAliasMapping[];
+};
+
+export type PlayerIdentitySourceRow = {
+  id: string;
+  name: string;
+  club: string;
+  position: string | null;
+};
+
+export function parsePlayerIdentityCliArgs(argv: readonly string[]): PlayerIdentityCliArgs {
+  const apply = argv.includes('--apply');
+  const projectWaivers = argv.includes('--project-waivers');
+  const propose = argv.includes('--propose');
+  const production = argv.includes('--production');
+  const manifestIndex = argv.indexOf('--manifest');
+  const manifestPath = manifestIndex >= 0 ? argv[manifestIndex + 1] : undefined;
+
+  if (propose && (apply || manifestPath || projectWaivers)) {
+    throw new Error('--propose cannot be combined with --apply or --manifest');
+  }
+  if (projectWaivers && (apply || propose || manifestPath)) {
+    throw new Error('--project-waivers must be run as a standalone mode');
+  }
+  if (projectWaivers && !production) {
+    throw new Error('--project-waivers requires --production');
+  }
+  if (production && !propose && !apply && !projectWaivers && !manifestPath) {
+    throw new Error('--production requires a consolidation mode');
+  }
+  if (!propose && !projectWaivers && !manifestPath) {
+    throw new Error('Use --propose or provide --manifest <reviewed-manifest.json>');
+  }
+  if (manifestIndex >= 0 && (!manifestPath || manifestPath.startsWith('--'))) {
+    throw new Error('--manifest requires a file path');
+  }
+
+  return {
+    apply,
+    projectWaivers,
+    propose,
+    production,
+    ...(manifestPath ? { manifestPath } : {}),
+  };
+}
+
+export function validateReviewedPlayerIdentityManifest(
+  value: unknown
+): ReviewedPlayerIdentityManifest {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Identity manifest must be a JSON object');
+  }
+
+  const manifest = value as Record<string, unknown>;
+  if (manifest.schemaVersion !== 1) {
+    throw new Error('Identity manifest schemaVersion must be 1');
+  }
+  if (typeof manifest.reviewed !== 'boolean') {
+    throw new Error('Identity manifest reviewed must be a boolean');
+  }
+  if (
+    typeof manifest.sourceFingerprint !== 'string' ||
+    !/^[a-f0-9]{64}$/.test(manifest.sourceFingerprint)
+  ) {
+    throw new Error('Identity manifest sourceFingerprint must be a SHA-256 hex digest');
+  }
+  if (manifest.reviewed === true) {
+    if (typeof manifest.reviewedBy !== 'string' || !manifest.reviewedBy.trim()) {
+      throw new Error('Reviewed identity manifests require reviewedBy');
+    }
+    if (
+      typeof manifest.reviewedAt !== 'string' ||
+      !manifest.reviewedAt.trim() ||
+      Number.isNaN(Date.parse(manifest.reviewedAt))
+    ) {
+      throw new Error('Reviewed identity manifests require a valid reviewedAt timestamp');
+    }
+  }
+  if (!Array.isArray(manifest.mappings)) {
+    throw new Error('Identity manifest mappings must be an array');
+  }
+
+  const mappings = manifest.mappings.map((mapping, index) => {
+    if (!mapping || typeof mapping !== 'object') {
+      throw new Error(`Identity mapping ${index} must be an object`);
+    }
+    const row = mapping as Record<string, unknown>;
+    if (
+      typeof row.aliasId !== 'string' ||
+      !row.aliasId.trim() ||
+      typeof row.canonicalPlayerId !== 'string' ||
+      !row.canonicalPlayerId.trim()
+    ) {
+      throw new Error(`Identity mapping ${index} requires aliasId and canonicalPlayerId`);
+    }
+    if (row.aliasId.trim() === row.canonicalPlayerId.trim()) {
+      throw new Error(`Identity mapping ${index} cannot map a player to itself`);
+    }
+    return {
+      aliasId: row.aliasId.trim(),
+      canonicalPlayerId: row.canonicalPlayerId.trim(),
+    };
+  });
+
+  return {
+    schemaVersion: 1,
+    reviewed: manifest.reviewed,
+    sourceFingerprint: manifest.sourceFingerprint,
+    ...(typeof manifest.reviewedAt === 'string' ? { reviewedAt: manifest.reviewedAt } : {}),
+    ...(typeof manifest.reviewedBy === 'string' ? { reviewedBy: manifest.reviewedBy.trim() } : {}),
+    mappings,
+  };
+}
+
+export function createPlayerIdentitySourceFingerprint(
+  players: readonly PlayerIdentitySourceRow[]
+): string {
+  const normalizedRows = [...players]
+    .map((player) => ({
+      id: player.id,
+      name: player.name,
+      club: player.club,
+      position: player.position,
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  return createHash('sha256').update(JSON.stringify(normalizedRows)).digest('hex');
+}
+
+export function validateDisposablePlayerIdentityDatabase(input: {
+  databaseUrl: string;
+  expectedPath: string;
+  repositoryRoot?: string;
+}): string {
+  const databaseUrl = input.databaseUrl.trim();
+  const expectedPath = input.expectedPath.trim();
+  if (!databaseUrl || !expectedPath) {
+    throw new Error('DATABASE_URL and STATLY_VERIFY_DB are required');
+  }
+
+  const parsedUrl = new URL(databaseUrl);
+  if (parsedUrl.protocol !== 'file:' || parsedUrl.host || parsedUrl.search || parsedUrl.hash) {
+    throw new Error('Identity consolidation requires a plain local file: URL');
+  }
+
+  const databasePath = path.normalize(decodeURIComponent(parsedUrl.pathname));
+  const normalizedExpectedPath = path.normalize(expectedPath);
+  if (
+    databasePath !== normalizedExpectedPath ||
+    !/^\/tmp\/statly-verify-player-[^/]+\.db$/.test(normalizedExpectedPath)
+  ) {
+    throw new Error(
+      'Identity consolidation is restricted to matching /tmp/statly-verify-player-*.db files'
+    );
+  }
+
+  const stat = lstatSync(normalizedExpectedPath);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error('Identity verification database must be a regular non-symlink file');
+  }
+
+  const realDatabasePath = realpathSync(normalizedExpectedPath);
+  const protectedDatabasePath = realpathSync(
+    path.resolve(input.repositoryRoot ?? process.cwd(), 'prisma/dev.db')
+  );
+  if (realDatabasePath === protectedDatabasePath) {
+    throw new Error('Refusing to use protected prisma/dev.db');
+  }
+
+  return databaseUrl;
+}
+
+export function validateProductionPlayerIdentityDatabase(input: {
+  databaseUrl: string;
+  expectedPath: string;
+  backupPath?: string;
+  requireBackup: boolean;
+  repositoryRoot?: string;
+}): string {
+  const databaseUrl = input.databaseUrl.trim();
+  const expectedPath = input.expectedPath.trim();
+  if (!databaseUrl || !expectedPath) {
+    throw new Error('DATABASE_URL and STATLY_PLAYER_IDENTITY_PRODUCTION_DB are required');
+  }
+
+  const parsedUrl = new URL(databaseUrl);
+  if (parsedUrl.protocol !== 'file:' || parsedUrl.host || parsedUrl.search || parsedUrl.hash) {
+    throw new Error('Production identity consolidation requires a plain local file: URL');
+  }
+
+  const databasePath = path.normalize(decodeURIComponent(parsedUrl.pathname));
+  const normalizedExpectedPath = path.normalize(expectedPath);
+  if (databasePath !== normalizedExpectedPath) {
+    throw new Error('DATABASE_URL must exactly match STATLY_PLAYER_IDENTITY_PRODUCTION_DB');
+  }
+
+  const stat = lstatSync(normalizedExpectedPath);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error('Production identity database must be a regular non-symlink file');
+  }
+
+  const realDatabasePath = realpathSync(normalizedExpectedPath);
+  const protectedDatabasePath = realpathSync(
+    path.resolve(input.repositoryRoot ?? process.cwd(), 'prisma/dev.db')
+  );
+  if (realDatabasePath === protectedDatabasePath) {
+    throw new Error('Refusing to use protected prisma/dev.db');
+  }
+
+  if (input.requireBackup) {
+    const backupPath = input.backupPath?.trim();
+    if (!backupPath) {
+      throw new Error('STATLY_PLAYER_IDENTITY_BACKUP is required for production apply');
+    }
+    const backupStat = lstatSync(backupPath);
+    if (!backupStat.isFile() || backupStat.isSymbolicLink()) {
+      throw new Error('Production backup must be a regular non-symlink file');
+    }
+    if (realpathSync(backupPath) === realDatabasePath) {
+      throw new Error('Production backup must be a separate file');
+    }
+  }
+
+  return databaseUrl;
+}

--- a/src/server/players/playerIdentityConsolidationPlanner.ts
+++ b/src/server/players/playerIdentityConsolidationPlanner.ts
@@ -1,0 +1,386 @@
+import type { Prisma } from '@prisma/client';
+
+export type PlayerAliasMapping = {
+  aliasId: string;
+  canonicalPlayerId: string;
+};
+
+export type PlayerIdentityBlockerCode =
+  | 'INVALID_MAPPING'
+  | 'MISSING_PLAYER'
+  | 'CANONICAL_IS_ALIAS'
+  | 'DRAFT_PICK_COLLISION'
+  | 'LEAGUE_OWNERSHIP_CONFLICT'
+  | 'LINEUP_COLLISION'
+  | 'TRADE_COLLISION'
+  | 'CAPTAIN_COLLISION'
+  | 'AUTOSUB_COLLISION';
+
+export type PlayerIdentityBlocker = {
+  code: PlayerIdentityBlockerCode;
+  canonicalPlayerId: string;
+  scopeId?: string;
+  aliasIds: string[];
+  message: string;
+};
+
+export type PlayerIdentityConsolidationPlan = {
+  status: 'ready' | 'blocked';
+  mappings: PlayerAliasMapping[];
+  blockers: PlayerIdentityBlocker[];
+  references: {
+    picks: number;
+    watchlists: number;
+    preDraftQueues: number;
+    queueItems: number;
+    rosterPlayers: number;
+    legacyRosters: number;
+    lineupPlayers: number;
+    autosubs: number;
+    tradePlayers: number;
+    jsonDocuments: number;
+  };
+  safeSameMemberRosterMerges: number;
+};
+
+type PlannerClient = Pick<
+  Prisma.TransactionClient,
+  | 'player'
+  | 'playerExternalIdentity'
+  | 'pick'
+  | 'draftWatchlist'
+  | 'preDraftQueue'
+  | 'queueItem'
+  | 'leagueRosterPlayer'
+  | 'leagueRoster'
+  | 'leagueLineupPlayer'
+  | 'leagueLineupAutosub'
+  | 'leagueTradePlayer'
+  | 'lobbyActivity'
+  | 'draftEvent'
+  | 'leagueCompetitionAudit'
+  | 'teamAction'
+  | 'leagueTradeEvent'
+  | 'leagueTradeCommand'
+  | 'leagueTradeOutboxEvent'
+>;
+
+function normalizeMappings(input: readonly PlayerAliasMapping[]): PlayerAliasMapping[] {
+  const byAlias = new Map<string, string>();
+
+  for (const mapping of input) {
+    const aliasId = mapping.aliasId.trim();
+    const canonicalPlayerId = mapping.canonicalPlayerId.trim();
+    const existingTarget = byAlias.get(aliasId);
+
+    if (!aliasId || !canonicalPlayerId || aliasId === canonicalPlayerId) {
+      throw new Error(
+        `Invalid player alias mapping: ${mapping.aliasId} -> ${mapping.canonicalPlayerId}`
+      );
+    }
+
+    if (existingTarget && existingTarget !== canonicalPlayerId) {
+      throw new Error(`Player alias ${aliasId} maps to multiple canonical players`);
+    }
+
+    byAlias.set(aliasId, canonicalPlayerId);
+  }
+
+  return [...byAlias.entries()]
+    .map(([aliasId, canonicalPlayerId]) => ({ aliasId, canonicalPlayerId }))
+    .sort((left, right) => left.aliasId.localeCompare(right.aliasId));
+}
+
+function projectedPlayerId(playerId: string, aliases: ReadonlyMap<string, string>): string {
+  return aliases.get(playerId) ?? playerId;
+}
+
+function groupBy<T>(rows: readonly T[], keyFor: (row: T) => string): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const row of rows) {
+    const key = keyFor(row);
+    groups.set(key, [...(groups.get(key) ?? []), row]);
+  }
+  return groups;
+}
+
+function containsAnyAlias(value: string | null, aliasIds: ReadonlySet<string>): boolean {
+  if (!value) return false;
+  return [...aliasIds].some((aliasId) => value.includes(aliasId));
+}
+
+export async function planPlayerIdentityConsolidation(
+  client: PlannerClient,
+  inputMappings: readonly PlayerAliasMapping[]
+): Promise<PlayerIdentityConsolidationPlan> {
+  let mappings: PlayerAliasMapping[];
+  const blockers: PlayerIdentityBlocker[] = [];
+
+  try {
+    mappings = normalizeMappings(inputMappings);
+  } catch (error) {
+    return {
+      status: 'blocked',
+      mappings: [],
+      blockers: [
+        {
+          code: 'INVALID_MAPPING',
+          canonicalPlayerId: '',
+          aliasIds: [],
+          message: error instanceof Error ? error.message : String(error),
+        },
+      ],
+      references: {
+        picks: 0,
+        watchlists: 0,
+        preDraftQueues: 0,
+        queueItems: 0,
+        rosterPlayers: 0,
+        legacyRosters: 0,
+        lineupPlayers: 0,
+        autosubs: 0,
+        tradePlayers: 0,
+        jsonDocuments: 0,
+      },
+      safeSameMemberRosterMerges: 0,
+    };
+  }
+
+  const requestedMappings = mappings;
+  const requestedAliasIds = new Set(requestedMappings.map((mapping) => mapping.aliasId));
+  const requestedCanonicalIds = new Set(
+    requestedMappings.map((mapping) => mapping.canonicalPlayerId)
+  );
+
+  for (const canonicalPlayerId of requestedCanonicalIds) {
+    if (requestedAliasIds.has(canonicalPlayerId)) {
+      blockers.push({
+        code: 'CANONICAL_IS_ALIAS',
+        canonicalPlayerId,
+        aliasIds: [canonicalPlayerId],
+        message: `Canonical player ${canonicalPlayerId} is also listed as an alias; flatten the manifest first.`,
+      });
+    }
+  }
+
+  const allPlayerIds = [...new Set([...requestedAliasIds, ...requestedCanonicalIds])];
+  const existingPlayers = await client.player.findMany({
+    where: { id: { in: allPlayerIds } },
+    select: { id: true },
+  });
+  const existingPlayerIds = new Set(existingPlayers.map((player) => player.id));
+  const retiredAliasIdentities = await client.playerExternalIdentity.findMany({
+    where: { provider: 'statly-legacy', externalId: { in: [...requestedAliasIds] } },
+    select: { externalId: true, playerId: true },
+  });
+  const retiredAliasTargets = new Map(
+    retiredAliasIdentities.map((identity) => [identity.externalId, identity.playerId])
+  );
+
+  mappings = requestedMappings.filter((mapping) => {
+    const aliasExists = existingPlayerIds.has(mapping.aliasId);
+    const canonicalExists = existingPlayerIds.has(mapping.canonicalPlayerId);
+    const alreadyApplied =
+      !aliasExists &&
+      canonicalExists &&
+      retiredAliasTargets.get(mapping.aliasId) === mapping.canonicalPlayerId;
+
+    if (!canonicalExists || (!aliasExists && !alreadyApplied)) {
+      const missingIds = [mapping.aliasId, mapping.canonicalPlayerId].filter(
+        (playerId) => !existingPlayerIds.has(playerId)
+      );
+      blockers.push({
+        code: 'MISSING_PLAYER',
+        canonicalPlayerId: mapping.canonicalPlayerId,
+        aliasIds: [mapping.aliasId],
+        message: `Mapping references missing Player rows: ${missingIds.join(', ')}`,
+      });
+    }
+    return aliasExists && canonicalExists;
+  });
+
+  const aliasMap = new Map(mappings.map((mapping) => [mapping.aliasId, mapping.canonicalPlayerId]));
+  const aliasIds = new Set(aliasMap.keys());
+  const canonicalIds = new Set(aliasMap.values());
+
+  const referencedPlayerIds = [...new Set([...aliasIds, ...canonicalIds])];
+  const [
+    picks,
+    watchlists,
+    preDraftQueues,
+    queueItems,
+    rosterPlayers,
+    legacyRosters,
+    lineupPlayers,
+    autosubs,
+    tradePlayers,
+    lobbyActivities,
+    draftEvents,
+    competitionAudits,
+    teamActions,
+    tradeEvents,
+    tradeCommands,
+    tradeOutboxEvents,
+  ] = await Promise.all([
+    client.pick.findMany({ where: { playerId: { in: referencedPlayerIds } } }),
+    client.draftWatchlist.findMany({ where: { playerId: { in: referencedPlayerIds } } }),
+    client.preDraftQueue.findMany({ where: { playerId: { in: referencedPlayerIds } } }),
+    client.queueItem.findMany({ where: { playerId: { in: referencedPlayerIds } } }),
+    client.leagueRosterPlayer.findMany({ where: { playerId: { in: referencedPlayerIds } } }),
+    client.leagueRoster.findMany(),
+    client.leagueLineupPlayer.findMany({ where: { playerId: { in: referencedPlayerIds } } }),
+    client.leagueLineupAutosub.findMany({
+      where: {
+        OR: [
+          { outgoingPlayerId: { in: referencedPlayerIds } },
+          { replacementPlayerId: { in: referencedPlayerIds } },
+        ],
+      },
+    }),
+    client.leagueTradePlayer.findMany({ where: { playerId: { in: referencedPlayerIds } } }),
+    client.lobbyActivity.findMany({ where: { details: { not: null } }, select: { details: true } }),
+    client.draftEvent.findMany({ where: { payload: { not: null } }, select: { payload: true } }),
+    client.leagueCompetitionAudit.findMany({ select: { payloadJson: true } }),
+    client.teamAction.findMany({ select: { details: true } }),
+    client.leagueTradeEvent.findMany({
+      where: { payloadJson: { not: null } },
+      select: { payloadJson: true },
+    }),
+    client.leagueTradeCommand.findMany({
+      where: { responseJson: { not: null } },
+      select: { responseJson: true },
+    }),
+    client.leagueTradeOutboxEvent.findMany({ select: { payloadJson: true } }),
+  ]);
+
+  for (const [key, rows] of groupBy(
+    picks,
+    (row) => `${row.draftId}\u0000${projectedPlayerId(row.playerId, aliasMap)}`
+  )) {
+    if (rows.length < 2) continue;
+    const [draftId, canonicalPlayerId] = key.split('\u0000');
+    blockers.push({
+      code: 'DRAFT_PICK_COLLISION',
+      canonicalPlayerId,
+      scopeId: draftId,
+      aliasIds: rows.map((row) => row.playerId),
+      message: `Draft ${draftId} contains more than one pick for canonical player ${canonicalPlayerId}.`,
+    });
+  }
+
+  let safeSameMemberRosterMerges = 0;
+  for (const [key, rows] of groupBy(
+    rosterPlayers,
+    (row) => `${row.leagueId}\u0000${projectedPlayerId(row.playerId, aliasMap)}`
+  )) {
+    if (rows.length < 2) continue;
+    const [leagueId, canonicalPlayerId] = key.split('\u0000');
+    const memberIds = new Set(rows.map((row) => row.memberId));
+    if (memberIds.size === 1) {
+      safeSameMemberRosterMerges += rows.length - 1;
+      continue;
+    }
+    blockers.push({
+      code: 'LEAGUE_OWNERSHIP_CONFLICT',
+      canonicalPlayerId,
+      scopeId: leagueId,
+      aliasIds: rows.map((row) => row.playerId),
+      message: `League ${leagueId} has different members owning aliases of ${canonicalPlayerId}.`,
+    });
+  }
+
+  for (const [key, rows] of groupBy(
+    lineupPlayers,
+    (row) => `${row.lineupId}\u0000${projectedPlayerId(row.playerId, aliasMap)}`
+  )) {
+    if (rows.length < 2) continue;
+    const [lineupId, canonicalPlayerId] = key.split('\u0000');
+    blockers.push({
+      code: 'LINEUP_COLLISION',
+      canonicalPlayerId,
+      scopeId: lineupId,
+      aliasIds: rows.map((row) => row.playerId),
+      message: `Lineup ${lineupId} contains multiple aliases of ${canonicalPlayerId}.`,
+    });
+  }
+
+  for (const [key, rows] of groupBy(
+    tradePlayers,
+    (row) => `${row.offerId}\u0000${projectedPlayerId(row.playerId, aliasMap)}`
+  )) {
+    if (rows.length < 2) continue;
+    const [offerId, canonicalPlayerId] = key.split('\u0000');
+    blockers.push({
+      code: 'TRADE_COLLISION',
+      canonicalPlayerId,
+      scopeId: offerId,
+      aliasIds: rows.map((row) => row.playerId),
+      message: `Trade offer ${offerId} contains multiple aliases of ${canonicalPlayerId}.`,
+    });
+  }
+
+  for (const roster of legacyRosters) {
+    const captainId = roster.captainId ? projectedPlayerId(roster.captainId, aliasMap) : null;
+    const viceCaptainId = roster.viceCaptainId
+      ? projectedPlayerId(roster.viceCaptainId, aliasMap)
+      : null;
+    if (captainId && captainId === viceCaptainId) {
+      blockers.push({
+        code: 'CAPTAIN_COLLISION',
+        canonicalPlayerId: captainId,
+        scopeId: roster.id,
+        aliasIds: [roster.captainId!, roster.viceCaptainId!],
+        message: `Roster ${roster.id} would assign ${captainId} as both captain and vice-captain.`,
+      });
+    }
+  }
+
+  for (const autosub of autosubs) {
+    const outgoing = projectedPlayerId(autosub.outgoingPlayerId, aliasMap);
+    const replacement = projectedPlayerId(autosub.replacementPlayerId, aliasMap);
+    if (outgoing === replacement) {
+      blockers.push({
+        code: 'AUTOSUB_COLLISION',
+        canonicalPlayerId: outgoing,
+        scopeId: autosub.id,
+        aliasIds: [autosub.outgoingPlayerId, autosub.replacementPlayerId],
+        message: `Autosub ${autosub.id} would replace a player with the same canonical player.`,
+      });
+    }
+  }
+
+  const jsonDocuments = [
+    ...lobbyActivities.map((row) => row.details),
+    ...draftEvents.map((row) => row.payload),
+    ...competitionAudits.map((row) => row.payloadJson),
+    ...teamActions.map((row) => row.details),
+    ...tradeEvents.map((row) => row.payloadJson),
+    ...tradeCommands.map((row) => row.responseJson),
+    ...tradeOutboxEvents.map((row) => row.payloadJson),
+  ].filter((value) => containsAnyAlias(value, aliasIds)).length;
+
+  return {
+    status: blockers.length > 0 ? 'blocked' : 'ready',
+    mappings,
+    blockers,
+    references: {
+      picks: picks.filter((row) => aliasIds.has(row.playerId)).length,
+      watchlists: watchlists.filter((row) => aliasIds.has(row.playerId)).length,
+      preDraftQueues: preDraftQueues.filter((row) => aliasIds.has(row.playerId)).length,
+      queueItems: queueItems.filter((row) => aliasIds.has(row.playerId)).length,
+      rosterPlayers: rosterPlayers.filter((row) => aliasIds.has(row.playerId)).length,
+      legacyRosters: legacyRosters.filter((row) =>
+        [row.playerIds, row.captainId, row.viceCaptainId, row.benchOrder].some((value) =>
+          containsAnyAlias(value, aliasIds)
+        )
+      ).length,
+      lineupPlayers: lineupPlayers.filter((row) => aliasIds.has(row.playerId)).length,
+      autosubs: autosubs.filter(
+        (row) => aliasIds.has(row.outgoingPlayerId) || aliasIds.has(row.replacementPlayerId)
+      ).length,
+      tradePlayers: tradePlayers.filter((row) => aliasIds.has(row.playerId)).length,
+      jsonDocuments,
+    },
+    safeSameMemberRosterMerges,
+  };
+}

--- a/src/server/players/playerIdentityConsolidationPlanner.ts
+++ b/src/server/players/playerIdentityConsolidationPlanner.ts
@@ -11,6 +11,9 @@ export type PlayerIdentityBlockerCode =
   | 'CANONICAL_IS_ALIAS'
   | 'DRAFT_PICK_COLLISION'
   | 'LEAGUE_OWNERSHIP_CONFLICT'
+  | 'LEGACY_OWNERSHIP_CONFLICT'
+  | 'INVALID_LEGACY_ROSTER'
+  | 'PENDING_ACTION_REFERENCE'
   | 'LINEUP_COLLISION'
   | 'TRADE_COLLISION'
   | 'CAPTAIN_COLLISION'
@@ -241,7 +244,9 @@ export async function planPlayerIdentityConsolidation(
     client.lobbyActivity.findMany({ where: { details: { not: null } }, select: { details: true } }),
     client.draftEvent.findMany({ where: { payload: { not: null } }, select: { payload: true } }),
     client.leagueCompetitionAudit.findMany({ select: { payloadJson: true } }),
-    client.teamAction.findMany({ select: { details: true } }),
+    client.teamAction.findMany({
+      select: { id: true, leagueId: true, status: true, details: true },
+    }),
     client.leagueTradeEvent.findMany({
       where: { payloadJson: { not: null } },
       select: { payloadJson: true },
@@ -286,6 +291,67 @@ export async function planPlayerIdentityConsolidation(
       scopeId: leagueId,
       aliasIds: rows.map((row) => row.playerId),
       message: `League ${leagueId} has different members owning aliases of ${canonicalPlayerId}.`,
+    });
+  }
+
+  const ownershipEvidence = rosterPlayers.map((row) => ({
+    leagueId: row.leagueId,
+    memberId: row.memberId,
+    playerId: row.playerId,
+    sourceId: row.id,
+  }));
+  for (const roster of legacyRosters) {
+    let playerIds: string[];
+    try {
+      const parsed = JSON.parse(roster.playerIds) as unknown;
+      if (!Array.isArray(parsed) || parsed.some((playerId) => typeof playerId !== 'string')) {
+        throw new Error('not a string array');
+      }
+      playerIds = parsed;
+    } catch {
+      if (containsAnyAlias(roster.playerIds, aliasIds)) {
+        blockers.push({
+          code: 'INVALID_LEGACY_ROSTER',
+          canonicalPlayerId: '',
+          scopeId: roster.id,
+          aliasIds: [...aliasIds].filter((aliasId) => roster.playerIds.includes(aliasId)),
+          message: `Legacy roster ${roster.id} contains player aliases in invalid JSON.`,
+        });
+      }
+      continue;
+    }
+
+    for (const playerId of playerIds) {
+      if (!referencedPlayerIds.includes(playerId)) continue;
+      ownershipEvidence.push({
+        leagueId: roster.leagueId,
+        memberId: roster.memberId,
+        playerId,
+        sourceId: roster.id,
+      });
+    }
+  }
+
+  for (const [key, rows] of groupBy(
+    ownershipEvidence,
+    (row) => `${row.leagueId}\u0000${projectedPlayerId(row.playerId, aliasMap)}`
+  )) {
+    const memberIds = new Set(rows.map((row) => row.memberId));
+    if (memberIds.size < 2) continue;
+    const [leagueId, canonicalPlayerId] = key.split('\u0000');
+    const alreadyBlocked = blockers.some(
+      (blocker) =>
+        blocker.code === 'LEAGUE_OWNERSHIP_CONFLICT' &&
+        blocker.scopeId === leagueId &&
+        blocker.canonicalPlayerId === canonicalPlayerId
+    );
+    if (alreadyBlocked) continue;
+    blockers.push({
+      code: 'LEGACY_OWNERSHIP_CONFLICT',
+      canonicalPlayerId,
+      scopeId: leagueId,
+      aliasIds: [...new Set(rows.map((row) => row.playerId))],
+      message: `League ${leagueId} has conflicting normalized or legacy owners for ${canonicalPlayerId}.`,
     });
   }
 
@@ -347,6 +413,17 @@ export async function planPlayerIdentityConsolidation(
         message: `Autosub ${autosub.id} would replace a player with the same canonical player.`,
       });
     }
+  }
+
+  for (const action of teamActions) {
+    if (action.status !== 'PENDING' || !containsAnyAlias(action.details, aliasIds)) continue;
+    blockers.push({
+      code: 'PENDING_ACTION_REFERENCE',
+      canonicalPlayerId: '',
+      scopeId: action.id,
+      aliasIds: [...aliasIds].filter((aliasId) => action.details.includes(aliasId)),
+      message: `Pending team action ${action.id} in league ${action.leagueId} must be resolved before consolidation.`,
+    });
   }
 
   const jsonDocuments = [

--- a/src/server/players/playerIdentityConsolidationPlanner.ts
+++ b/src/server/players/playerIdentityConsolidationPlanner.ts
@@ -17,6 +17,7 @@ export type PlayerIdentityBlockerCode =
   | 'LINEUP_COLLISION'
   | 'TRADE_COLLISION'
   | 'CAPTAIN_COLLISION'
+  | 'AUTOSUB_REFERENCE'
   | 'AUTOSUB_COLLISION';
 
 export type PlayerIdentityBlocker = {
@@ -402,6 +403,11 @@ export async function planPlayerIdentityConsolidation(
   }
 
   for (const autosub of autosubs) {
+    const referencedAliasIds = [autosub.outgoingPlayerId, autosub.replacementPlayerId].filter(
+      (playerId) => aliasIds.has(playerId)
+    );
+    if (referencedAliasIds.length === 0) continue;
+
     const outgoing = projectedPlayerId(autosub.outgoingPlayerId, aliasMap);
     const replacement = projectedPlayerId(autosub.replacementPlayerId, aliasMap);
     if (outgoing === replacement) {
@@ -412,7 +418,17 @@ export async function planPlayerIdentityConsolidation(
         aliasIds: [autosub.outgoingPlayerId, autosub.replacementPlayerId],
         message: `Autosub ${autosub.id} would replace a player with the same canonical player.`,
       });
+      continue;
     }
+
+    blockers.push({
+      code: 'AUTOSUB_REFERENCE',
+      canonicalPlayerId:
+        aliasMap.get(autosub.outgoingPlayerId) ?? aliasMap.get(autosub.replacementPlayerId) ?? '',
+      scopeId: autosub.id,
+      aliasIds: referencedAliasIds,
+      message: `Historical autosub ${autosub.id} references a player alias and must remain immutable.`,
+    });
   }
 
   for (const action of teamActions) {

--- a/src/server/players/playerIdentityConsolidationPlanner.ts
+++ b/src/server/players/playerIdentityConsolidationPlanner.ts
@@ -1,5 +1,7 @@
 import type { Prisma } from '@prisma/client';
 
+import { containsPlayerIdentityReference } from './playerIdentityJsonReferences';
+
 export type PlayerAliasMapping = {
   aliasId: string;
   canonicalPlayerId: string;
@@ -109,8 +111,24 @@ function groupBy<T>(rows: readonly T[], keyFor: (row: T) => string): Map<string,
 }
 
 function containsAnyAlias(value: string | null, aliasIds: ReadonlySet<string>): boolean {
-  if (!value) return false;
-  return [...aliasIds].some((aliasId) => value.includes(aliasId));
+  return containsPlayerIdentityReference(value, aliasIds);
+}
+
+const PLANNER_BATCH_SIZE = 250;
+
+async function collectBatchedRows<T extends { id: string }>(
+  loadPage: (cursor: string | undefined) => Promise<T[]>
+): Promise<T[]> {
+  const rows: T[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const page = await loadPage(cursor);
+    rows.push(...page);
+    cursor = page.length === PLANNER_BATCH_SIZE ? page[page.length - 1]?.id : undefined;
+  } while (cursor);
+
+  return rows;
 }
 
 export async function planPlayerIdentityConsolidation(
@@ -208,6 +226,9 @@ export async function planPlayerIdentityConsolidation(
   const canonicalIds = new Set(aliasMap.values());
 
   const referencedPlayerIds = [...new Set([...aliasIds, ...canonicalIds])];
+  const aliasIdList = [...aliasIds];
+  const cursorPage = (cursor: string | undefined): { cursor?: { id: string }; skip?: number } =>
+    cursor ? { cursor: { id: cursor }, skip: 1 } : {};
   const [
     picks,
     watchlists,
@@ -231,7 +252,21 @@ export async function planPlayerIdentityConsolidation(
     client.preDraftQueue.findMany({ where: { playerId: { in: referencedPlayerIds } } }),
     client.queueItem.findMany({ where: { playerId: { in: referencedPlayerIds } } }),
     client.leagueRosterPlayer.findMany({ where: { playerId: { in: referencedPlayerIds } } }),
-    client.leagueRoster.findMany(),
+    collectBatchedRows((cursor) =>
+      client.leagueRoster.findMany({
+        where: {
+          OR: [
+            ...referencedPlayerIds.map((playerId) => ({ playerIds: { contains: playerId } })),
+            { captainId: { in: referencedPlayerIds } },
+            { viceCaptainId: { in: referencedPlayerIds } },
+            ...referencedPlayerIds.map((playerId) => ({ benchOrder: { contains: playerId } })),
+          ],
+        },
+        orderBy: { id: 'asc' },
+        take: PLANNER_BATCH_SIZE,
+        ...cursorPage(cursor),
+      })
+    ),
     client.leagueLineupPlayer.findMany({ where: { playerId: { in: referencedPlayerIds } } }),
     client.leagueLineupAutosub.findMany({
       where: {
@@ -242,28 +277,76 @@ export async function planPlayerIdentityConsolidation(
       },
     }),
     client.leagueTradePlayer.findMany({ where: { playerId: { in: referencedPlayerIds } } }),
-    client.lobbyActivity.findMany({ where: { details: { not: null } }, select: { details: true } }),
-    client.draftEvent.findMany({ where: { payload: { not: null } }, select: { payload: true } }),
-    client.leagueCompetitionAudit.findMany({ select: { payloadJson: true } }),
-    client.teamAction.findMany({
-      select: { id: true, leagueId: true, status: true, details: true },
-    }),
-    client.leagueTradeEvent.findMany({
-      where: { payloadJson: { not: null } },
-      select: { payloadJson: true },
-    }),
-    client.leagueTradeCommand.findMany({
-      where: { responseJson: { not: null } },
-      select: { responseJson: true },
-    }),
-    client.leagueTradeOutboxEvent.findMany({ select: { payloadJson: true } }),
+    collectBatchedRows((cursor) =>
+      client.lobbyActivity.findMany({
+        where: { OR: aliasIdList.map((aliasId) => ({ details: { contains: aliasId } })) },
+        select: { id: true, details: true },
+        orderBy: { id: 'asc' },
+        take: PLANNER_BATCH_SIZE,
+        ...cursorPage(cursor),
+      })
+    ),
+    collectBatchedRows((cursor) =>
+      client.draftEvent.findMany({
+        where: { OR: aliasIdList.map((aliasId) => ({ payload: { contains: aliasId } })) },
+        select: { id: true, payload: true },
+        orderBy: { id: 'asc' },
+        take: PLANNER_BATCH_SIZE,
+        ...cursorPage(cursor),
+      })
+    ),
+    collectBatchedRows((cursor) =>
+      client.leagueCompetitionAudit.findMany({
+        where: { OR: aliasIdList.map((aliasId) => ({ payloadJson: { contains: aliasId } })) },
+        select: { id: true, payloadJson: true },
+        orderBy: { id: 'asc' },
+        take: PLANNER_BATCH_SIZE,
+        ...cursorPage(cursor),
+      })
+    ),
+    collectBatchedRows((cursor) =>
+      client.teamAction.findMany({
+        where: { OR: aliasIdList.map((aliasId) => ({ details: { contains: aliasId } })) },
+        select: { id: true, leagueId: true, status: true, details: true },
+        orderBy: { id: 'asc' },
+        take: PLANNER_BATCH_SIZE,
+        ...cursorPage(cursor),
+      })
+    ),
+    collectBatchedRows((cursor) =>
+      client.leagueTradeEvent.findMany({
+        where: { OR: aliasIdList.map((aliasId) => ({ payloadJson: { contains: aliasId } })) },
+        select: { id: true, payloadJson: true },
+        orderBy: { id: 'asc' },
+        take: PLANNER_BATCH_SIZE,
+        ...cursorPage(cursor),
+      })
+    ),
+    collectBatchedRows((cursor) =>
+      client.leagueTradeCommand.findMany({
+        where: { OR: aliasIdList.map((aliasId) => ({ responseJson: { contains: aliasId } })) },
+        select: { id: true, responseJson: true },
+        orderBy: { id: 'asc' },
+        take: PLANNER_BATCH_SIZE,
+        ...cursorPage(cursor),
+      })
+    ),
+    collectBatchedRows((cursor) =>
+      client.leagueTradeOutboxEvent.findMany({
+        where: { OR: aliasIdList.map((aliasId) => ({ payloadJson: { contains: aliasId } })) },
+        select: { id: true, payloadJson: true },
+        orderBy: { id: 'asc' },
+        take: PLANNER_BATCH_SIZE,
+        ...cursorPage(cursor),
+      })
+    ),
   ]);
 
   for (const [key, rows] of groupBy(
     picks,
     (row) => `${row.draftId}\u0000${projectedPlayerId(row.playerId, aliasMap)}`
   )) {
-    if (rows.length < 2) continue;
+    if (rows.length < 2 || !rows.some((row) => aliasIds.has(row.playerId))) continue;
     const [draftId, canonicalPlayerId] = key.split('\u0000');
     blockers.push({
       code: 'DRAFT_PICK_COLLISION',
@@ -279,7 +362,7 @@ export async function planPlayerIdentityConsolidation(
     rosterPlayers,
     (row) => `${row.leagueId}\u0000${projectedPlayerId(row.playerId, aliasMap)}`
   )) {
-    if (rows.length < 2) continue;
+    if (rows.length < 2 || !rows.some((row) => aliasIds.has(row.playerId))) continue;
     const [leagueId, canonicalPlayerId] = key.split('\u0000');
     const memberIds = new Set(rows.map((row) => row.memberId));
     if (memberIds.size === 1) {
@@ -338,7 +421,7 @@ export async function planPlayerIdentityConsolidation(
     (row) => `${row.leagueId}\u0000${projectedPlayerId(row.playerId, aliasMap)}`
   )) {
     const memberIds = new Set(rows.map((row) => row.memberId));
-    if (memberIds.size < 2) continue;
+    if (memberIds.size < 2 || !rows.some((row) => aliasIds.has(row.playerId))) continue;
     const [leagueId, canonicalPlayerId] = key.split('\u0000');
     const alreadyBlocked = blockers.some(
       (blocker) =>
@@ -360,7 +443,7 @@ export async function planPlayerIdentityConsolidation(
     lineupPlayers,
     (row) => `${row.lineupId}\u0000${projectedPlayerId(row.playerId, aliasMap)}`
   )) {
-    if (rows.length < 2) continue;
+    if (rows.length < 2 || !rows.some((row) => aliasIds.has(row.playerId))) continue;
     const [lineupId, canonicalPlayerId] = key.split('\u0000');
     blockers.push({
       code: 'LINEUP_COLLISION',
@@ -375,7 +458,7 @@ export async function planPlayerIdentityConsolidation(
     tradePlayers,
     (row) => `${row.offerId}\u0000${projectedPlayerId(row.playerId, aliasMap)}`
   )) {
-    if (rows.length < 2) continue;
+    if (rows.length < 2 || !rows.some((row) => aliasIds.has(row.playerId))) continue;
     const [offerId, canonicalPlayerId] = key.split('\u0000');
     blockers.push({
       code: 'TRADE_COLLISION',
@@ -387,6 +470,13 @@ export async function planPlayerIdentityConsolidation(
   }
 
   for (const roster of legacyRosters) {
+    if (
+      ![roster.captainId, roster.viceCaptainId].some(
+        (playerId) => playerId && aliasIds.has(playerId)
+      )
+    ) {
+      continue;
+    }
     const captainId = roster.captainId ? projectedPlayerId(roster.captainId, aliasMap) : null;
     const viceCaptainId = roster.viceCaptainId
       ? projectedPlayerId(roster.viceCaptainId, aliasMap)

--- a/src/server/players/playerIdentityJsonReferences.ts
+++ b/src/server/players/playerIdentityJsonReferences.ts
@@ -1,0 +1,21 @@
+function containsStringLeaf(value: unknown, playerIds: ReadonlySet<string>): boolean {
+  if (typeof value === 'string') return playerIds.has(value);
+  if (Array.isArray(value)) return value.some((entry) => containsStringLeaf(entry, playerIds));
+  if (value && typeof value === 'object') {
+    return Object.values(value).some((entry) => containsStringLeaf(entry, playerIds));
+  }
+  return false;
+}
+
+export function containsPlayerIdentityReference(
+  serializedValue: string | null,
+  playerIds: ReadonlySet<string>
+): boolean {
+  if (!serializedValue || playerIds.size === 0) return false;
+
+  try {
+    return containsStringLeaf(JSON.parse(serializedValue) as unknown, playerIds);
+  } catch {
+    return [...playerIds].some((playerId) => serializedValue.includes(playerId));
+  }
+}

--- a/src/server/players/playerIdentityService.ts
+++ b/src/server/players/playerIdentityService.ts
@@ -1,0 +1,164 @@
+import type { Player, Prisma } from '@prisma/client';
+
+import { prisma } from '@/lib/prisma';
+
+export const STATLY_LEGACY_PLAYER_PROVIDER = 'statly-legacy';
+export const PLAYER_STATS_2025_PROVIDER = 'player-stats-2025';
+
+type PlayerIdentityReadClient = Pick<Prisma.TransactionClient, 'player'> &
+  Partial<Pick<Prisma.TransactionClient, 'playerExternalIdentity'>>;
+type PlayerIdentityWriteClient = Pick<
+  Prisma.TransactionClient,
+  'player' | 'playerExternalIdentity'
+>;
+
+export type CanonicalPlayerInput = {
+  provider: string;
+  externalId: string;
+  name: string;
+  club: string;
+  position: string;
+  active?: boolean;
+  canonicalPlayerId?: string;
+  allowExactAttributeMatch?: boolean;
+};
+
+export class AmbiguousPlayerIdentityError extends Error {
+  constructor(
+    readonly nameValue: string,
+    readonly clubValue: string,
+    readonly candidateIds: string[]
+  ) {
+    super(
+      `Player identity is ambiguous for ${nameValue} (${clubValue}): ${candidateIds.join(', ')}`
+    );
+    this.name = 'AmbiguousPlayerIdentityError';
+  }
+}
+
+function requiredIdentityPart(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${label} is required to resolve a player identity`);
+  }
+  return normalized;
+}
+
+function mutablePlayerData(input: CanonicalPlayerInput) {
+  return {
+    name: input.name.trim(),
+    club: input.club.trim(),
+    position: input.position.trim(),
+    active: input.active ?? true,
+  };
+}
+
+export async function resolveCanonicalPlayerId(
+  externalId: string,
+  provider = STATLY_LEGACY_PLAYER_PROVIDER,
+  client: PlayerIdentityReadClient = prisma
+): Promise<string | null> {
+  const normalizedProvider = requiredIdentityPart(provider, 'Player identity provider');
+  const normalizedExternalId = requiredIdentityPart(externalId, 'External player ID');
+  const identity = client.playerExternalIdentity
+    ? await client.playerExternalIdentity.findUnique({
+        where: {
+          provider_externalId: {
+            provider: normalizedProvider,
+            externalId: normalizedExternalId,
+          },
+        },
+        select: { playerId: true },
+      })
+    : null;
+
+  if (identity) {
+    return identity.playerId;
+  }
+
+  if (typeof client.player.findUnique !== 'function') {
+    return normalizedExternalId;
+  }
+
+  const directPlayer = await client.player.findUnique({
+    where: { id: normalizedExternalId },
+    select: { id: true },
+  });
+
+  return directPlayer?.id ?? null;
+}
+
+export async function upsertCanonicalPlayer(
+  client: PlayerIdentityWriteClient,
+  input: CanonicalPlayerInput
+): Promise<Player> {
+  const provider = requiredIdentityPart(input.provider, 'Player identity provider');
+  const externalId = requiredIdentityPart(input.externalId, 'External player ID');
+  const playerData = mutablePlayerData(input);
+
+  const existingIdentity = await client.playerExternalIdentity.findUnique({
+    where: { provider_externalId: { provider, externalId } },
+    select: { playerId: true },
+  });
+
+  if (existingIdentity) {
+    return client.player.update({
+      where: { id: existingIdentity.playerId },
+      data: playerData,
+    });
+  }
+
+  let canonicalPlayer: Player | null = null;
+
+  if (input.canonicalPlayerId) {
+    canonicalPlayer = await client.player.findUnique({
+      where: { id: input.canonicalPlayerId },
+    });
+
+    if (!canonicalPlayer) {
+      throw new Error(`Canonical player ${input.canonicalPlayerId} does not exist`);
+    }
+  } else if (input.allowExactAttributeMatch) {
+    const candidates = await client.player.findMany({
+      where: { name: playerData.name, club: playerData.club },
+      orderBy: { id: 'asc' },
+      take: 2,
+    });
+
+    if (candidates.length > 1) {
+      throw new AmbiguousPlayerIdentityError(
+        playerData.name,
+        playerData.club,
+        candidates.map((candidate) => candidate.id)
+      );
+    }
+
+    canonicalPlayer = candidates[0] ?? null;
+  }
+
+  if (canonicalPlayer) {
+    canonicalPlayer = await client.player.update({
+      where: { id: canonicalPlayer.id },
+      data: playerData,
+    });
+  } else {
+    canonicalPlayer = await client.player.create({ data: playerData });
+  }
+
+  await client.playerExternalIdentity.create({
+    data: {
+      playerId: canonicalPlayer.id,
+      provider,
+      externalId,
+      verifiedAt: new Date(),
+    },
+  });
+
+  return canonicalPlayer;
+}
+
+export async function upsertCanonicalPlayerInTransaction(
+  input: CanonicalPlayerInput
+): Promise<Player> {
+  return prisma.$transaction((tx) => upsertCanonicalPlayer(tx, input));
+}

--- a/src/server/players/playerIdentityService.ts
+++ b/src/server/players/playerIdentityService.ts
@@ -1,4 +1,4 @@
-import type { Player, Prisma } from '@prisma/client';
+import type { Player, Prisma, PrismaClient } from '@prisma/client';
 
 import { prisma } from '@/lib/prisma';
 
@@ -10,7 +10,9 @@ type PlayerIdentityReadClient = Pick<Prisma.TransactionClient, 'player'> &
 type PlayerIdentityWriteClient = Pick<
   Prisma.TransactionClient,
   'player' | 'playerExternalIdentity'
->;
+> & {
+  $transaction?: PrismaClient['$transaction'];
+};
 
 export type CanonicalPlayerInput = {
   provider: string;
@@ -58,8 +60,10 @@ export async function resolveCanonicalPlayerId(
   provider = STATLY_LEGACY_PLAYER_PROVIDER,
   client: PlayerIdentityReadClient = prisma
 ): Promise<string | null> {
+  const normalizedExternalId = externalId.trim();
+  if (!normalizedExternalId) return null;
+
   const normalizedProvider = requiredIdentityPart(provider, 'Player identity provider');
-  const normalizedExternalId = requiredIdentityPart(externalId, 'External player ID');
   const identity = client.playerExternalIdentity
     ? await client.playerExternalIdentity.findUnique({
         where: {
@@ -122,7 +126,7 @@ export async function resolveCanonicalPlayerIds(
   return resolved;
 }
 
-export async function upsertCanonicalPlayer(
+async function upsertCanonicalPlayerWithClient(
   client: PlayerIdentityWriteClient,
   input: CanonicalPlayerInput
 ): Promise<Player> {
@@ -205,8 +209,21 @@ export async function upsertCanonicalPlayer(
   return canonicalPlayer;
 }
 
+export async function upsertCanonicalPlayer(
+  client: PlayerIdentityWriteClient,
+  input: CanonicalPlayerInput
+): Promise<Player> {
+  if (typeof client.$transaction === 'function') {
+    return client.$transaction((tx: Prisma.TransactionClient) =>
+      upsertCanonicalPlayerWithClient(tx, input)
+    );
+  }
+
+  return upsertCanonicalPlayerWithClient(client, input);
+}
+
 export async function upsertCanonicalPlayerInTransaction(
   input: CanonicalPlayerInput
 ): Promise<Player> {
-  return prisma.$transaction((tx) => upsertCanonicalPlayer(tx, input));
+  return upsertCanonicalPlayer(prisma, input);
 }

--- a/src/server/players/playerIdentityService.ts
+++ b/src/server/players/playerIdentityService.ts
@@ -76,7 +76,7 @@ export async function resolveCanonicalPlayerId(
     return identity.playerId;
   }
 
-  if (typeof client.player.findUnique !== 'function') {
+  if (typeof client.player?.findUnique !== 'function') {
     return normalizedExternalId;
   }
 
@@ -86,6 +86,40 @@ export async function resolveCanonicalPlayerId(
   });
 
   return directPlayer?.id ?? null;
+}
+
+export async function resolveCanonicalPlayerIds(
+  externalIds: readonly string[],
+  provider = STATLY_LEGACY_PLAYER_PROVIDER,
+  client: PlayerIdentityReadClient = prisma
+): Promise<Map<string, string>> {
+  const uniqueExternalIds = [
+    ...new Set(externalIds.map((playerId) => playerId.trim()).filter(Boolean)),
+  ];
+  if (uniqueExternalIds.length === 0) return new Map();
+
+  const resolved = new Map<string, string>();
+  if (client.playerExternalIdentity) {
+    const identities = await client.playerExternalIdentity.findMany({
+      where: { provider, externalId: { in: uniqueExternalIds } },
+      select: { externalId: true, playerId: true },
+    });
+    for (const identity of identities) resolved.set(identity.externalId, identity.playerId);
+  }
+
+  const unresolvedIds = uniqueExternalIds.filter((playerId) => !resolved.has(playerId));
+  if (unresolvedIds.length === 0) return resolved;
+  if (typeof client.player?.findMany !== 'function') {
+    for (const playerId of unresolvedIds) resolved.set(playerId, playerId);
+    return resolved;
+  }
+
+  const directPlayers = await client.player.findMany({
+    where: { id: { in: unresolvedIds } },
+    select: { id: true },
+  });
+  for (const player of directPlayers) resolved.set(player.id, player.id);
+  return resolved;
 }
 
 export async function upsertCanonicalPlayer(
@@ -134,6 +168,20 @@ export async function upsertCanonicalPlayer(
     }
 
     canonicalPlayer = candidates[0] ?? null;
+    if (!canonicalPlayer) {
+      const sameNameCandidates = await client.player.findMany({
+        where: { name: playerData.name },
+        orderBy: { id: 'asc' },
+        take: 2,
+      });
+      if (sameNameCandidates.length > 0) {
+        throw new AmbiguousPlayerIdentityError(
+          playerData.name,
+          playerData.club,
+          sameNameCandidates.map((candidate) => candidate.id)
+        );
+      }
+    }
   }
 
   if (canonicalPlayer) {

--- a/src/server/waivers/WaiverAvailabilityProjectionService.ts
+++ b/src/server/waivers/WaiverAvailabilityProjectionService.ts
@@ -38,6 +38,16 @@ export class WaiverAvailabilityProjectionService {
     const allPlayers = await this.db.player.findMany({
       select: { id: true, name: true, club: true, position: true },
     });
+    const retiredExternalIds = this.db.playerExternalIdentity
+      ? (
+          await this.db.playerExternalIdentity.findMany({
+            where: { provider: 'statly-legacy' },
+            select: { externalId: true, playerId: true },
+          })
+        )
+          .filter((identity) => identity.externalId !== identity.playerId)
+          .map((identity) => identity.externalId)
+      : [];
     const playerGroups = groupWaiverPlayersByIdentity(allPlayers);
     const owned = new Map(ownerships.map((ownership) => [ownership.playerId, ownership.memberId]));
     const held = new Map<string, Date | null>();
@@ -77,6 +87,7 @@ export class WaiverAvailabilityProjectionService {
 
     let ownedCount = 0;
     let availableCount = 0;
+    const removedAliasIds = new Set<string>();
 
     for (const group of playerGroups) {
       const player = group.representative;
@@ -133,7 +144,14 @@ export class WaiverAvailabilityProjectionService {
         if (alias.id === player.id) continue;
         await remove(leagueRef.collection('availablePlayers').doc(alias.id));
         await remove(leagueRef.collection('playerOwnerships').doc(alias.id));
+        removedAliasIds.add(alias.id);
       }
+    }
+
+    for (const retiredExternalId of retiredExternalIds) {
+      if (removedAliasIds.has(retiredExternalId)) continue;
+      await remove(leagueRef.collection('availablePlayers').doc(retiredExternalId));
+      await remove(leagueRef.collection('playerOwnerships').doc(retiredExternalId));
     }
 
     if (writeCount > 0) {

--- a/src/server/waivers/WaiverAvailabilityProjectionService.ts
+++ b/src/server/waivers/WaiverAvailabilityProjectionService.ts
@@ -1,8 +1,12 @@
 import { adminDb } from '@/lib/firebaseAdmin';
 import { prisma } from '@/lib/prisma';
+import { resolveCanonicalPlayerId } from '@/server/players/playerIdentityService';
 import { groupWaiverPlayersByIdentity } from '@/server/waivers/waiverPlayerIdentity';
 
-type PrismaLike = Pick<typeof prisma, 'leagueRosterPlayer' | 'player' | 'teamAction'>;
+type PrismaLike = Pick<
+  typeof prisma,
+  'leagueRosterPlayer' | 'player' | 'playerExternalIdentity' | 'teamAction'
+>;
 type FirestoreLike = typeof adminDb;
 const FIRESTORE_BATCH_WRITE_LIMIT = 450;
 
@@ -40,7 +44,11 @@ export class WaiverAvailabilityProjectionService {
     for (const hold of waiverHolds) {
       const details = parseActionDetails(hold.details);
       const playerId = typeof details.playerId === 'string' ? details.playerId : null;
-      if (playerId) held.set(playerId, hold.processingAt ?? null);
+      if (playerId) {
+        const canonicalPlayerId =
+          (await resolveCanonicalPlayerId(playerId, undefined, this.db)) ?? playerId;
+        held.set(canonicalPlayerId, hold.processingAt ?? null);
+      }
     }
     const leagueRef = this.firestore.collection('leagues').doc(input.leagueId);
     let batch = this.firestore.batch();

--- a/src/server/waivers/WaiverProcessingService.ts
+++ b/src/server/waivers/WaiverProcessingService.ts
@@ -517,6 +517,9 @@ export class WaiverProcessingService {
       select: { id: true, name: true, club: true, position: true },
     });
     const resolvedPlayerId = await resolveCanonicalPlayerId(claim.playerId, undefined, tx);
+    if (!resolvedPlayerId) {
+      return { status: 'FAILED', reason: 'Player not found' };
+    }
     const playerGroup = groupWaiverPlayersByIdentity(activePlayers).find((group) =>
       group.aliases.some((player) => player.id === claim.playerId || player.id === resolvedPlayerId)
     );
@@ -531,10 +534,7 @@ export class WaiverProcessingService {
         ...playerGroup.aliases.map((player) => player.id),
       ]),
     ];
-    const canonicalPlayerId =
-      resolvedPlayerId && resolvedPlayerId !== claim.playerId
-        ? resolvedPlayerId
-        : playerGroup.representative.id;
+    const canonicalPlayerId = resolvedPlayerId;
     const existingOwnership = await tx.leagueRosterPlayer.findFirst({
       where: { leagueId, playerId: { in: playerAliasIds } },
       select: { playerId: true, memberId: true },

--- a/src/server/waivers/WaiverProcessingService.ts
+++ b/src/server/waivers/WaiverProcessingService.ts
@@ -126,7 +126,13 @@ type FirestoreLike = Pick<typeof adminDb, 'collection' | 'doc'>;
 type ProjectionLike = Pick<WaiverAvailabilityProjectionService, 'projectLeague'>;
 
 type CanonicalRosterPlan =
-  | { status: 'READY'; memberId: string; playerId: string; nextPlayerIds: string }
+  | {
+      status: 'READY';
+      memberId: string;
+      playerId: string;
+      dropPlayerId?: string;
+      nextPlayerIds: string;
+    }
   | { status: 'FAILED'; reason: string };
 
 function parsePlayerIds(raw?: string | null): string[] {
@@ -421,9 +427,9 @@ export class WaiverProcessingService {
         if (plan.status === 'FAILED') {
           return plan;
         }
-        if (claim.dropPlayerId) {
+        if (plan.dropPlayerId) {
           await tx.leagueRosterPlayer.deleteMany({
-            where: { leagueId, memberId: plan.memberId, playerId: claim.dropPlayerId },
+            where: { leagueId, memberId: plan.memberId, playerId: plan.dropPlayerId },
           });
           await tx.teamAction.create({
             data: {
@@ -432,7 +438,7 @@ export class WaiverProcessingService {
               actionType: 'DROP_PLAYER',
               status: 'PENDING',
               details: JSON.stringify({
-                playerId: claim.dropPlayerId,
+                playerId: plan.dropPlayerId,
                 source: 'drop-to-waivers',
                 waiverClaimId: claim.id,
               }),
@@ -577,6 +583,7 @@ export class WaiverProcessingService {
       status: 'READY',
       memberId,
       playerId: canonicalPlayerId,
+      ...(canonicalDropPlayerId ? { dropPlayerId: canonicalDropPlayerId } : {}),
       nextPlayerIds: stringifyPlayerIds(playerIds),
     };
   }

--- a/src/server/waivers/WaiverProcessingService.ts
+++ b/src/server/waivers/WaiverProcessingService.ts
@@ -5,6 +5,7 @@ import { FieldValue } from 'firebase-admin/firestore';
 import { adminDb } from '@/lib/firebaseAdmin';
 import { logger } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
+import { resolveCanonicalPlayerId } from '@/server/players/playerIdentityService';
 import { WaiverAvailabilityProjectionService } from '@/server/waivers/WaiverAvailabilityProjectionService';
 import { groupWaiverPlayersByIdentity } from '@/server/waivers/waiverPlayerIdentity';
 
@@ -509,15 +510,25 @@ export class WaiverProcessingService {
       where: { active: true },
       select: { id: true, name: true, club: true, position: true },
     });
+    const resolvedPlayerId = await resolveCanonicalPlayerId(claim.playerId, undefined, tx);
     const playerGroup = groupWaiverPlayersByIdentity(activePlayers).find((group) =>
-      group.aliases.some((player) => player.id === claim.playerId)
+      group.aliases.some((player) => player.id === claim.playerId || player.id === resolvedPlayerId)
     );
     if (!playerGroup) {
       return { status: 'FAILED', reason: 'Player not found' };
     }
 
-    const playerAliasIds = playerGroup.aliases.map((player) => player.id);
-    const canonicalPlayerId = playerGroup.representative.id;
+    const playerAliasIds = [
+      ...new Set([
+        claim.playerId,
+        ...(resolvedPlayerId ? [resolvedPlayerId] : []),
+        ...playerGroup.aliases.map((player) => player.id),
+      ]),
+    ];
+    const canonicalPlayerId =
+      resolvedPlayerId && resolvedPlayerId !== claim.playerId
+        ? resolvedPlayerId
+        : playerGroup.representative.id;
     const existingOwnership = await tx.leagueRosterPlayer.findFirst({
       where: { leagueId, playerId: { in: playerAliasIds } },
       select: { playerId: true, memberId: true },
@@ -532,10 +543,13 @@ export class WaiverProcessingService {
       where: { leagueId, memberId },
     });
     let nextRosterCount = currentRosterCount + 1;
+    const canonicalDropPlayerId = claim.dropPlayerId
+      ? ((await resolveCanonicalPlayerId(claim.dropPlayerId, undefined, tx)) ?? claim.dropPlayerId)
+      : undefined;
 
-    if (claim.dropPlayerId) {
+    if (canonicalDropPlayerId) {
       const dropOwnership = await tx.leagueRosterPlayer.findFirst({
-        where: { leagueId, memberId, playerId: claim.dropPlayerId },
+        where: { leagueId, memberId, playerId: canonicalDropPlayerId },
         select: { playerId: true },
       });
 
@@ -555,7 +569,7 @@ export class WaiverProcessingService {
       select: { playerIds: true },
     });
     const playerIds = parsePlayerIds(roster?.playerIds)
-      .filter((playerId) => playerId !== claim.dropPlayerId)
+      .filter((playerId) => playerId !== claim.dropPlayerId && playerId !== canonicalDropPlayerId)
       .filter((playerId) => !playerAliasIds.includes(playerId));
     playerIds.push(canonicalPlayerId);
 
@@ -1233,19 +1247,19 @@ export class FirestoreWaiverClaimStore implements ClaimStore {
       let query: FirebaseFirestore.Query = pendingCol.orderBy('__name__').limit(pageSize);
       if (cursor) query = query.startAfter(cursor);
 
-	      const snap = await query.get();
-	      if (snap.empty) break;
+      const snap = await query.get();
+      if (snap.empty) break;
 
-	      for (const document of snap.docs) {
-	        pending.push(toFirestoreWaiverClaim(document, leagueId));
-	      }
+      for (const document of snap.docs) {
+        pending.push(toFirestoreWaiverClaim(document, leagueId));
+      }
 
-	      if (snap.size < pageSize) break;
-	      cursor = snap.docs[snap.docs.length - 1] ?? null;
-	    }
+      if (snap.size < pageSize) break;
+      cursor = snap.docs[snap.docs.length - 1] ?? null;
+    }
 
-	    return applyWaiverPriorities(pending, await loadWaiverPriorityByUserId(leagueId));
-	  }
+    return applyWaiverPriorities(pending, await loadWaiverPriorityByUserId(leagueId));
+  }
 
   async markSuccessful(input: {
     leagueId: string;

--- a/tests/e2e/global.setup.ts
+++ b/tests/e2e/global.setup.ts
@@ -1,6 +1,7 @@
 import { DraftDirection, DraftStatus, DraftType, LeagueRole, PrismaClient } from '@prisma/client';
 
 import { DEVELOPMENT_AUTH_EMAIL, DEVELOPMENT_AUTH_USER_ID } from '../../src/lib/devAuth';
+import { upsertCanonicalPlayer } from '../../src/server/players/playerIdentityService';
 import { REAL_DATA_NINE_CATEGORY_PRESET } from '../../src/types/fantasyCategories';
 
 export const E2E_LEAGUE_ID = 'e2e-completed-league';
@@ -164,15 +165,19 @@ async function globalSetup() {
         ],
       });
 
-      await Promise.all(
-        E2E_PLAYERS.map((player) =>
-          tx.player.upsert({
-            where: { id: player.id },
-            update: { ...player, active: true },
-            create: { ...player, active: true },
-          })
-        )
-      );
+      const canonicalPlayerIds: string[] = [];
+      for (const player of E2E_PLAYERS) {
+        const canonicalPlayer = await upsertCanonicalPlayer(tx, {
+          provider: 'statly-e2e',
+          externalId: player.id,
+          name: player.name,
+          club: player.club,
+          position: player.position,
+          active: true,
+          allowExactAttributeMatch: true,
+        });
+        canonicalPlayerIds.push(canonicalPlayer.id);
+      }
 
       await tx.draft.create({
         data: {
@@ -206,7 +211,7 @@ async function globalSetup() {
           round: 1,
           slot: 1,
           memberId: E2E_HUMAN_MEMBER_ID,
-          playerId: E2E_PLAYERS[0].id,
+          playerId: canonicalPlayerIds[0],
         },
         {
           id: 'e2e-pick-2',
@@ -214,7 +219,7 @@ async function globalSetup() {
           round: 1,
           slot: 2,
           memberId: E2E_BOT_MEMBER_ID,
-          playerId: E2E_PLAYERS[1].id,
+          playerId: canonicalPlayerIds[1],
         },
         {
           id: 'e2e-pick-3',
@@ -222,7 +227,7 @@ async function globalSetup() {
           round: 2,
           slot: 2,
           memberId: E2E_BOT_MEMBER_ID,
-          playerId: E2E_PLAYERS[2].id,
+          playerId: canonicalPlayerIds[2],
         },
         {
           id: 'e2e-pick-4',
@@ -230,7 +235,7 @@ async function globalSetup() {
           round: 2,
           slot: 1,
           memberId: E2E_HUMAN_MEMBER_ID,
-          playerId: E2E_PLAYERS[3].id,
+          playerId: canonicalPlayerIds[3],
         },
       ];
 
@@ -248,7 +253,7 @@ async function globalSetup() {
           id: 'e2e-roster-human',
           leagueId: E2E_LEAGUE_ID,
           memberId: E2E_HUMAN_MEMBER_ID,
-          playerIds: JSON.stringify([E2E_PLAYERS[0].id, E2E_PLAYERS[3].id]),
+          playerIds: JSON.stringify([canonicalPlayerIds[0], canonicalPlayerIds[3]]),
         },
       });
 
@@ -260,7 +265,7 @@ async function globalSetup() {
             memberId: E2E_HUMAN_MEMBER_ID,
             draftId: E2E_DRAFT_ID,
             pickId: 'e2e-pick-1',
-            playerId: E2E_PLAYERS[0].id,
+            playerId: canonicalPlayerIds[0],
             slot: 'RUC',
             acquiredBy: 'DRAFT',
             acquiredAt: now,
@@ -271,7 +276,7 @@ async function globalSetup() {
             memberId: E2E_HUMAN_MEMBER_ID,
             draftId: E2E_DRAFT_ID,
             pickId: 'e2e-pick-4',
-            playerId: E2E_PLAYERS[3].id,
+            playerId: canonicalPlayerIds[3],
             slot: 'MID',
             acquiredBy: 'DRAFT',
             acquiredAt: now,
@@ -282,7 +287,7 @@ async function globalSetup() {
             memberId: E2E_BOT_MEMBER_ID,
             draftId: E2E_DRAFT_ID,
             pickId: 'e2e-pick-2',
-            playerId: E2E_PLAYERS[1].id,
+            playerId: canonicalPlayerIds[1],
             slot: 'MID',
             acquiredBy: 'DRAFT',
             acquiredAt: now,
@@ -293,7 +298,7 @@ async function globalSetup() {
             memberId: E2E_BOT_MEMBER_ID,
             draftId: E2E_DRAFT_ID,
             pickId: 'e2e-pick-3',
-            playerId: E2E_PLAYERS[2].id,
+            playerId: canonicalPlayerIds[2],
             slot: 'MID',
             acquiredBy: 'DRAFT',
             acquiredAt: now,

--- a/tests/e2e/helpers/fullDraftSoakFixture.ts
+++ b/tests/e2e/helpers/fullDraftSoakFixture.ts
@@ -138,14 +138,14 @@ async function upsertUsers(tx: TxClient) {
   );
 }
 
-async function upsertActivePlayerPool(tx: TxClient): Promise<string[]> {
+async function upsertActivePlayerPool(prisma: PrismaClient): Promise<string[]> {
   const players = await getPlayers();
   const activePlayers = players.slice(0, Math.max(FULL_DRAFT_SOAK.totalPicks + 64, 360));
   const candidateIds: string[] = [];
 
   for (const player of activePlayers) {
     const club = player.team ?? 'N/A';
-    const canonicalPlayer = await upsertCanonicalPlayer(tx, {
+    const canonicalPlayer = await upsertCanonicalPlayer(prisma, {
       provider: PLAYER_STATS_2025_PROVIDER,
       externalId: buildCanonicalPlayerId(`${player.name}|${club}`),
       name: player.name,
@@ -287,11 +287,11 @@ export async function seedFullDraftSoakFixture(): Promise<SoakFixture> {
   const prisma = new PrismaClient();
 
   try {
+    const candidateIds = await upsertActivePlayerPool(prisma);
     return await prisma.$transaction(
       async (tx) => {
         await deleteExistingFixture(tx);
         await upsertUsers(tx);
-        const candidateIds = await upsertActivePlayerPool(tx);
 
         const rankedPlayerIds = await rankActivePlayerIds(tx, candidateIds);
         if (rankedPlayerIds.length < FULL_DRAFT_SOAK.totalPicks) {

--- a/tests/e2e/helpers/fullDraftSoakFixture.ts
+++ b/tests/e2e/helpers/fullDraftSoakFixture.ts
@@ -15,6 +15,10 @@ import {
   buildDraftPlayerStatsLookup,
   calculateStatlyZScores,
 } from '../../../src/server/draft/readModels/draftPlayerReadModel';
+import {
+  PLAYER_STATS_2025_PROVIDER,
+  upsertCanonicalPlayer,
+} from '../../../src/server/players/playerIdentityService';
 import { REAL_DATA_NINE_CATEGORY_PRESET } from '../../../src/types/fantasyCategories';
 
 export const FULL_DRAFT_SOAK = {
@@ -136,37 +140,31 @@ async function upsertUsers(tx: TxClient) {
 
 async function upsertActivePlayerPool(tx: TxClient): Promise<string[]> {
   const players = await getPlayers();
-  const activePlayers = players
-    .slice(0, Math.max(FULL_DRAFT_SOAK.totalPicks + 64, 360))
-    .map((player) => ({ ...player, id: buildCanonicalPlayerId(player.name) }));
-  const candidateIds = [...new Set(activePlayers.map((player) => player.id))];
+  const activePlayers = players.slice(0, Math.max(FULL_DRAFT_SOAK.totalPicks + 64, 360));
+  const candidateIds: string[] = [];
 
-  if (candidateIds.length < FULL_DRAFT_SOAK.totalPicks) {
+  for (const player of activePlayers) {
+    const club = player.team ?? 'N/A';
+    const canonicalPlayer = await upsertCanonicalPlayer(tx, {
+      provider: PLAYER_STATS_2025_PROVIDER,
+      externalId: buildCanonicalPlayerId(`${player.name}|${club}`),
+      name: player.name,
+      club,
+      position: player.position ?? '',
+      active: true,
+      allowExactAttributeMatch: true,
+    });
+    candidateIds.push(canonicalPlayer.id);
+  }
+
+  const uniqueCandidateIds = [...new Set(candidateIds)];
+  if (uniqueCandidateIds.length < FULL_DRAFT_SOAK.totalPicks) {
     throw new Error(
-      `Full draft soak requires at least ${FULL_DRAFT_SOAK.totalPicks} canonical players, found ${candidateIds.length}`
+      `Full draft soak requires at least ${FULL_DRAFT_SOAK.totalPicks} canonical players, found ${uniqueCandidateIds.length}`
     );
   }
 
-  for (const player of activePlayers) {
-    await tx.player.upsert({
-      where: { id: player.id },
-      update: {
-        name: player.name,
-        club: player.team ?? 'N/A',
-        position: player.position ?? '',
-        active: true,
-      },
-      create: {
-        id: player.id,
-        name: player.name,
-        club: player.team ?? 'N/A',
-        position: player.position ?? '',
-        active: true,
-      },
-    });
-  }
-
-  return candidateIds;
+  return uniqueCandidateIds;
 }
 
 async function rankActivePlayerIds(tx: TxClient, candidateIds: string[]): Promise<string[]> {

--- a/tests/unit/WaiverProcessingService.test.ts
+++ b/tests/unit/WaiverProcessingService.test.ts
@@ -187,6 +187,41 @@ describe('WaiverProcessingService', () => {
     expect(projection.projectLeague).toHaveBeenCalledWith({ leagueId: 'league-1' });
   });
 
+  it('drops canonical ownership when a pending claim contains a retired alias', async () => {
+    const { db, tx } = createDbMock();
+    Object.assign(tx, {
+      playerExternalIdentity: {
+        findUnique: vi.fn(({ where }: { where: { provider_externalId: { externalId: string } } }) =>
+          Promise.resolve(
+            where.provider_externalId.externalId === 'retired-old-player'
+              ? { playerId: 'old-player' }
+              : null
+          )
+        ),
+      },
+    });
+    const claimStore = createClaimStoreMock();
+    const projection = { projectLeague: vi.fn().mockResolvedValue({ owned: 2, available: 10 }) };
+    const service = new WaiverProcessingService(db as never, claimStore, projection);
+
+    const result = await service.processClaims({
+      leagueId: 'league-1',
+      waiverSettings: { system: 'PRIORITY' },
+      claims: [claim({ dropPlayerId: 'retired-old-player' })],
+    });
+
+    expect(result.results).toEqual([{ id: 'claim-1', status: 'SUCCESSFUL' }]);
+    expect(tx.leagueRosterPlayer.deleteMany).toHaveBeenCalledWith({
+      where: { leagueId: 'league-1', memberId: 'member-1', playerId: 'old-player' },
+    });
+    expect(tx.teamAction.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        details: expect.stringContaining('"playerId":"old-player"'),
+      }),
+      select: { id: true },
+    });
+  });
+
   it('fails a claim before ownership transfer when the roster is full and no drop player is supplied', async () => {
     const { db, tx } = createDbMock();
     const claimStore = createClaimStoreMock();

--- a/tests/unit/draftCommandRoutes.test.ts
+++ b/tests/unit/draftCommandRoutes.test.ts
@@ -31,6 +31,7 @@ describe('draft command routes', () => {
     expect(pickRoute).not.toContain('prisma.$transaction');
     expect(pickCommand).toContain('draftApplicationService.makePick');
     expect(pickCommand).toContain('draftRealtimePublisher.publishCommandResult');
+    expect(pickCommand).toContain('resolveCanonicalPlayerId');
   });
 
   it('supports the client POST path used by DraftContext.makePick', () => {
@@ -68,7 +69,9 @@ describe('draft command routes', () => {
     expect(pickCommand).toContain('void draftRealtimePublisher.publishCommandResult(result)');
     expect(pickCommand).not.toContain('await draftRealtimePublisher.publishCommandResult(result)');
     expect(autoPickRoute).toContain('void draftRealtimePublisher.publishCommandResult(result)');
-    expect(autoPickRoute).not.toContain('await draftRealtimePublisher.publishCommandResult(result)');
+    expect(autoPickRoute).not.toContain(
+      'await draftRealtimePublisher.publishCommandResult(result)'
+    );
   });
 
   it('supports the authenticated client POST path used by DraftContext.startDraft', () => {

--- a/tests/unit/e2eFixtureSetup.test.ts
+++ b/tests/unit/e2eFixtureSetup.test.ts
@@ -12,13 +12,14 @@ describe('e2e fixture setup', () => {
     const source = read('tests/e2e/global.setup.ts');
 
     expect(source).not.toContain('player.deleteMany');
-    expect(source).toContain('tx.player.upsert');
+    expect(source).toContain('upsertCanonicalPlayer(tx');
   });
 
   it('uses canonical player ids and ranks only the full-draft fixture pool', () => {
     const source = read('tests/e2e/helpers/fullDraftSoakFixture.ts');
 
-    expect(source).toContain('buildCanonicalPlayerId(player.name)');
+    expect(source).toContain('buildCanonicalPlayerId(`${player.name}|${club}`)');
+    expect(source).toContain('provider: PLAYER_STATS_2025_PROVIDER');
     expect(source).toContain('const candidateIds = await upsertActivePlayerPool(tx)');
     expect(source).toContain('where: { active: true, id: { in: candidateIds } }');
     expect(source).not.toContain('where: { active: true },');

--- a/tests/unit/e2eFixtureSetup.test.ts
+++ b/tests/unit/e2eFixtureSetup.test.ts
@@ -20,7 +20,10 @@ describe('e2e fixture setup', () => {
 
     expect(source).toContain('buildCanonicalPlayerId(`${player.name}|${club}`)');
     expect(source).toContain('provider: PLAYER_STATS_2025_PROVIDER');
-    expect(source).toContain('const candidateIds = await upsertActivePlayerPool(tx)');
+    expect(source).toContain('const candidateIds = await upsertActivePlayerPool(prisma)');
+    expect(source.indexOf('upsertActivePlayerPool(prisma)')).toBeLessThan(
+      source.indexOf('prisma.$transaction')
+    );
     expect(source).toContain('where: { active: true, id: { in: candidateIds } }');
     expect(source).not.toContain('where: { active: true },');
   });

--- a/tests/unit/leagueFreeAgentAvailability.test.ts
+++ b/tests/unit/leagueFreeAgentAvailability.test.ts
@@ -30,7 +30,11 @@ const prismaMocks = vi.hoisted(() => ({
   },
   player: {
     findMany: vi.fn(),
+    findUnique: vi.fn(),
     count: vi.fn(),
+  },
+  playerExternalIdentity: {
+    findUnique: vi.fn(),
   },
   teamAction: {
     create: vi.fn(),
@@ -288,6 +292,10 @@ describe('league free-agent availability uses Prisma ownership as canonical', ()
     prismaMocks.player.findMany.mockResolvedValue([
       { id: 'free-player', name: 'Free Player', club: 'SYD', position: 'FWD' },
     ]);
+    prismaMocks.player.findUnique.mockImplementation(({ where }: { where: { id: string } }) =>
+      Promise.resolve(where.id ? { id: where.id } : null)
+    );
+    prismaMocks.playerExternalIdentity.findUnique.mockResolvedValue(null);
     prismaMocks.player.count.mockResolvedValue(1);
     prismaMocks.teamAction.create.mockResolvedValue({ id: 'claim-1' });
     prismaMocks.teamAction.update.mockResolvedValue({ id: 'claim-1' });
@@ -431,6 +439,39 @@ describe('league free-agent availability uses Prisma ownership as canonical', ()
           leagueId: 'league-1',
           memberId: 'member-1',
           actionType: 'WAIVER_CLAIM',
+        }),
+      })
+    );
+  });
+
+  it('submits a retired player alias against its canonical player', async () => {
+    prismaMocks.leagueRosterPlayer.findFirst.mockResolvedValue(null);
+    prismaMocks.player.findMany.mockResolvedValue([
+      { id: 'free-player', name: 'Free Player', club: 'SYD', position: 'FWD' },
+    ]);
+    prismaMocks.playerExternalIdentity.findUnique.mockResolvedValue({ playerId: 'free-player' });
+
+    const { POST } = await import('../../src/app/api/leagues/[id]/waivers/submit/route');
+    const response = await POST(
+      jsonRequest('/api/leagues/league-1/waivers/submit', {
+        teamId: 'member-1',
+        playerId: 'retired-free-player',
+      }),
+      { params: Promise.resolve({ id: 'league-1' }) }
+    );
+
+    expect(response.status).toBe(201);
+    expect(prismaMocks.leagueRosterPlayer.findFirst).toHaveBeenCalledWith({
+      where: {
+        leagueId: 'league-1',
+        playerId: { in: ['retired-free-player', 'free-player'] },
+      },
+      select: { playerId: true, memberId: true },
+    });
+    expect(prismaMocks.teamAction.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          details: expect.stringContaining('"playerId":"free-player"'),
         }),
       })
     );

--- a/tests/unit/leagueRosterAddAvailability.test.ts
+++ b/tests/unit/leagueRosterAddAvailability.test.ts
@@ -13,6 +13,9 @@ const prismaMocks = vi.hoisted(() => ({
   player: {
     findUnique: vi.fn(),
   },
+  playerExternalIdentity: {
+    findUnique: vi.fn(),
+  },
   leagueRoster: {
     upsert: vi.fn(),
     update: vi.fn(),
@@ -92,6 +95,7 @@ describe('league roster free-agent add eligibility', () => {
     authMocks.getAuthenticatedUserId.mockResolvedValue('user-1');
     prismaMocks.leagueMember.findFirst.mockResolvedValue({ id: 'member-1' });
     prismaMocks.player.findUnique.mockResolvedValue({ id: 'held-player' });
+    prismaMocks.playerExternalIdentity.findUnique.mockResolvedValue(null);
     prismaMocks.leagueRosterPlayer.findFirst.mockResolvedValue(null);
     prismaMocks.teamAction.findFirst.mockResolvedValue({
       id: 'drop-hold-1',
@@ -133,6 +137,24 @@ describe('league roster free-agent add eligibility', () => {
       },
       select: { id: true },
     });
+    expect(prismaMocks.leagueRosterPlayer.create).not.toHaveBeenCalled();
+  });
+
+  it('checks waiver holds using the canonical id for a retired alias', async () => {
+    prismaMocks.playerExternalIdentity.findUnique.mockResolvedValue({ playerId: 'held-player' });
+    const { POST } = await import('../../src/app/api/leagues/[id]/roster/add/route');
+
+    const response = await POST(
+      jsonRequest('/api/leagues/league-1/roster/add', { playerId: 'retired-held-player' }),
+      { params: Promise.resolve({ id: 'league-1' }) }
+    );
+
+    expect(response.status).toBe(409);
+    expect(prismaMocks.teamAction.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ details: { contains: '"playerId":"held-player"' } }),
+      })
+    );
     expect(prismaMocks.leagueRosterPlayer.create).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/playerIdentityConsolidationCli.test.ts
+++ b/tests/unit/playerIdentityConsolidationCli.test.ts
@@ -1,0 +1,138 @@
+import { symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createPlayerIdentitySourceFingerprint,
+  parsePlayerIdentityCliArgs,
+  validateDisposablePlayerIdentityDatabase,
+  validateProductionPlayerIdentityDatabase,
+  validateReviewedPlayerIdentityManifest,
+} from '../../src/server/players/playerIdentityConsolidationCli';
+
+const createdPaths: string[] = [];
+
+function tempDatabasePath(suffix: string): string {
+  return `/tmp/statly-verify-player-${process.pid}-${suffix}.db`;
+}
+
+afterEach(() => {
+  for (const filePath of createdPaths.splice(0)) {
+    try {
+      unlinkSync(filePath);
+    } catch {
+      // The test may deliberately fail before creating every path.
+    }
+  }
+});
+
+describe('player identity consolidation CLI safety', () => {
+  it('requires an explicit mode and a manifest path value', () => {
+    expect(() => parsePlayerIdentityCliArgs([])).toThrow('Use --propose');
+    expect(() => parsePlayerIdentityCliArgs(['--manifest', '--apply'])).toThrow(
+      '--manifest requires a file path'
+    );
+    expect(parsePlayerIdentityCliArgs(['--manifest', 'manifest.json', '--apply'])).toEqual({
+      apply: true,
+      projectWaivers: false,
+      propose: false,
+      production: false,
+      manifestPath: 'manifest.json',
+    });
+    expect(parsePlayerIdentityCliArgs(['--production', '--project-waivers'])).toEqual({
+      apply: false,
+      projectWaivers: true,
+      propose: false,
+      production: true,
+    });
+  });
+
+  it('rejects truthy non-boolean review flags and malformed mappings', () => {
+    expect(() =>
+      validateReviewedPlayerIdentityManifest({
+        schemaVersion: 1,
+        reviewed: 'false',
+        mappings: [],
+      })
+    ).toThrow('reviewed must be a boolean');
+    expect(() =>
+      validateReviewedPlayerIdentityManifest({
+        schemaVersion: 1,
+        reviewed: false,
+        sourceFingerprint: 'a'.repeat(64),
+        mappings: [{ aliasId: 'same', canonicalPlayerId: 'same' }],
+      })
+    ).toThrow('cannot map a player to itself');
+  });
+
+  it('binds reviewed manifests to a stable player data fingerprint', () => {
+    const players = [
+      { id: 'b', name: 'Second', club: 'BBB', position: null },
+      { id: 'a', name: 'First', club: 'AAA', position: 'MID' },
+    ];
+
+    expect(createPlayerIdentitySourceFingerprint(players)).toBe(
+      createPlayerIdentitySourceFingerprint([...players].reverse())
+    );
+    expect(
+      validateReviewedPlayerIdentityManifest({
+        schemaVersion: 1,
+        reviewed: true,
+        reviewedBy: 'operator@example.test',
+        reviewedAt: '2026-07-24T20:00:00.000Z',
+        sourceFingerprint: createPlayerIdentitySourceFingerprint(players),
+        mappings: [{ aliasId: 'b', canonicalPlayerId: 'a' }],
+      })
+    ).toMatchObject({ reviewed: true, reviewedBy: 'operator@example.test' });
+  });
+
+  it('accepts only a matching regular disposable database file', () => {
+    const databasePath = tempDatabasePath('valid');
+    createdPaths.push(databasePath);
+    writeFileSync(databasePath, 'sqlite fixture');
+
+    expect(
+      validateDisposablePlayerIdentityDatabase({
+        databaseUrl: `file:${databasePath}`,
+        expectedPath: databasePath,
+      })
+    ).toBe(`file:${databasePath}`);
+  });
+
+  it('rejects a disposable-looking symlink', () => {
+    const symlinkPath = tempDatabasePath('symlink');
+    createdPaths.push(symlinkPath);
+    symlinkSync('prisma/dev.db', symlinkPath);
+
+    expect(() =>
+      validateDisposablePlayerIdentityDatabase({
+        databaseUrl: `file:${symlinkPath}`,
+        expectedPath: symlinkPath,
+      })
+    ).toThrow('regular non-symlink file');
+  });
+
+  it('requires an explicitly matched production database and separate backup for apply', () => {
+    const databasePath = `/tmp/statly-production-player-${process.pid}.db`;
+    const backupPath = `/tmp/statly-production-player-${process.pid}.backup.db`;
+    createdPaths.push(databasePath, backupPath);
+    writeFileSync(databasePath, 'production sqlite fixture');
+    writeFileSync(backupPath, 'backup sqlite fixture');
+
+    expect(
+      validateProductionPlayerIdentityDatabase({
+        databaseUrl: `file:${databasePath}`,
+        expectedPath: databasePath,
+        backupPath,
+        requireBackup: true,
+      })
+    ).toBe(`file:${databasePath}`);
+    expect(() =>
+      validateProductionPlayerIdentityDatabase({
+        databaseUrl: `file:${databasePath}`,
+        expectedPath: databasePath,
+        requireBackup: true,
+      })
+    ).toThrow('BACKUP');
+  });
+});

--- a/tests/unit/playerIdentityConsolidationCli.test.ts
+++ b/tests/unit/playerIdentityConsolidationCli.test.ts
@@ -1,19 +1,23 @@
 import { symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+  assertPlayerIdentitySourceFingerprint,
   createPlayerIdentitySourceFingerprint,
   parsePlayerIdentityCliArgs,
   validateDisposablePlayerIdentityDatabase,
   validateProductionPlayerIdentityDatabase,
+  validatePlayerIdentityFirestoreProject,
   validateReviewedPlayerIdentityManifest,
 } from '../../src/server/players/playerIdentityConsolidationCli';
 
 const createdPaths: string[] = [];
 
 function tempDatabasePath(suffix: string): string {
-  return `/tmp/statly-verify-player-${process.pid}-${suffix}.db`;
+  return join(tmpdir(), `statly-verify-player-${process.pid}-${suffix}.db`);
 }
 
 afterEach(() => {
@@ -31,6 +35,9 @@ describe('player identity consolidation CLI safety', () => {
     expect(() => parsePlayerIdentityCliArgs([])).toThrow('Use --propose');
     expect(() => parsePlayerIdentityCliArgs(['--manifest', '--apply'])).toThrow(
       '--manifest requires a file path'
+    );
+    expect(() => parsePlayerIdentityCliArgs(['--propose', '--project-waivers'])).toThrow(
+      '--propose cannot be combined'
     );
     expect(parsePlayerIdentityCliArgs(['--manifest', 'manifest.json', '--apply'])).toEqual({
       apply: true,
@@ -74,6 +81,9 @@ describe('player identity consolidation CLI safety', () => {
     expect(createPlayerIdentitySourceFingerprint(players)).toBe(
       createPlayerIdentitySourceFingerprint([...players].reverse())
     );
+    expect(() => assertPlayerIdentitySourceFingerprint('0'.repeat(64), players)).toThrow(
+      'generate and review a new manifest'
+    );
     expect(
       validateReviewedPlayerIdentityManifest({
         schemaVersion: 1,
@@ -95,6 +105,7 @@ describe('player identity consolidation CLI safety', () => {
       validateDisposablePlayerIdentityDatabase({
         databaseUrl: `file:${databasePath}`,
         expectedPath: databasePath,
+        repositoryRoot: join(tmpdir(), 'statly-repository-without-dev-db'),
       })
     ).toBe(`file:${databasePath}`);
   });
@@ -113,8 +124,8 @@ describe('player identity consolidation CLI safety', () => {
   });
 
   it('requires an explicitly matched production database and separate backup for apply', () => {
-    const databasePath = `/tmp/statly-production-player-${process.pid}.db`;
-    const backupPath = `/tmp/statly-production-player-${process.pid}.backup.db`;
+    const databasePath = join(tmpdir(), `statly-production-player-${process.pid}.db`);
+    const backupPath = join(tmpdir(), `statly-production-player-${process.pid}.backup.db`);
     createdPaths.push(databasePath, backupPath);
     writeFileSync(databasePath, 'production sqlite fixture');
     writeFileSync(backupPath, 'backup sqlite fixture');
@@ -134,5 +145,34 @@ describe('player identity consolidation CLI safety', () => {
         requireBackup: true,
       })
     ).toThrow('BACKUP');
+  });
+
+  it('rejects empty backups and mismatched Firestore projects', () => {
+    const databasePath = join(tmpdir(), `statly-production-player-${process.pid}-guard.db`);
+    const backupPath = join(tmpdir(), `statly-production-player-${process.pid}-empty.db`);
+    createdPaths.push(databasePath, backupPath);
+    writeFileSync(databasePath, 'production sqlite fixture');
+    writeFileSync(backupPath, '');
+
+    expect(() =>
+      validateProductionPlayerIdentityDatabase({
+        databaseUrl: `file:${databasePath}`,
+        expectedPath: databasePath,
+        backupPath,
+        requireBackup: true,
+      })
+    ).toThrow('must not be empty');
+    expect(() =>
+      validatePlayerIdentityFirestoreProject({
+        expectedProjectId: 'statly-production',
+        actualProjectId: 'statly-staging',
+      })
+    ).toThrow('Firestore project mismatch');
+    expect(
+      validatePlayerIdentityFirestoreProject({
+        expectedProjectId: 'statly-production',
+        actualProjectId: 'statly-production',
+      })
+    ).toBe('statly-production');
   });
 });

--- a/tests/unit/playerIdentityJsonReferences.test.ts
+++ b/tests/unit/playerIdentityJsonReferences.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { containsPlayerIdentityReference } from '../../src/server/players/playerIdentityJsonReferences';
+
+describe('player identity JSON references', () => {
+  const aliases = new Set(['adam-treloar']);
+
+  it('matches exact string leaves without treating substrings as aliases', () => {
+    expect(
+      containsPlayerIdentityReference(JSON.stringify({ playerId: 'adam-treloar' }), aliases)
+    ).toBe(true);
+    expect(
+      containsPlayerIdentityReference(
+        JSON.stringify({ playerId: 'adam-treloar-western-bulldogs' }),
+        aliases
+      )
+    ).toBe(false);
+    expect(
+      containsPlayerIdentityReference(
+        JSON.stringify({ note: 'watch adam-treloar closely' }),
+        aliases
+      )
+    ).toBe(false);
+  });
+
+  it('falls back to a conservative substring scan for malformed legacy data', () => {
+    expect(containsPlayerIdentityReference('malformed:adam-treloar', aliases)).toBe(true);
+  });
+});

--- a/tests/unit/playerIdentityMigration.test.ts
+++ b/tests/unit/playerIdentityMigration.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../../src/server/players/playerIdentityConsolidation';
 import { planPlayerIdentityConsolidation } from '../../src/server/players/playerIdentityConsolidationPlanner';
 import {
+  AmbiguousPlayerIdentityError,
   resolveCanonicalPlayerId,
   upsertCanonicalPlayer,
 } from '../../src/server/players/playerIdentityService';
@@ -268,6 +269,23 @@ describe.sequential('canonical player identity migration', () => {
   it('backfills legacy IDs and preserves independent ownership in different leagues', async () => {
     await expect(prisma.playerExternalIdentity.count()).resolves.toBe(2);
 
+    await prisma.queueItem.createMany({
+      data: [
+        { id: 'canonical-queue', memberId: 'queue-member', playerId: canonicalPlayerId, rank: 2 },
+        { id: 'alias-queue', memberId: 'queue-member', playerId: aliasPlayerId, rank: 1 },
+      ],
+    });
+    await prisma.teamAction.create({
+      data: {
+        id: 'historical-alias-action',
+        leagueId: 'league-a',
+        memberId: 'member-a',
+        actionType: 'WAIVER_CLAIM',
+        status: 'PROCESSED',
+        details: JSON.stringify({ playerId: aliasPlayerId }),
+      },
+    });
+
     const mapping = [{ aliasId: aliasPlayerId, canonicalPlayerId }];
     const plan = await planPlayerIdentityConsolidation(prisma, mapping);
     expect(plan.status).toBe('ready');
@@ -295,6 +313,20 @@ describe.sequential('canonical player identity migration', () => {
         select: { playerId: true },
       })
     ).resolves.toEqual({ playerId: canonicalPlayerId });
+    await expect(
+      prisma.queueItem.findUnique({
+        where: {
+          memberId_playerId: { memberId: 'queue-member', playerId: canonicalPlayerId },
+        },
+        select: { rank: true },
+      })
+    ).resolves.toEqual({ rank: 1 });
+    await expect(
+      prisma.teamAction.findUnique({
+        where: { id: 'historical-alias-action' },
+        select: { details: true },
+      })
+    ).resolves.toEqual({ details: JSON.stringify({ playerId: aliasPlayerId }) });
     await expect(resolveCanonicalPlayerId(aliasPlayerId, undefined, prisma)).resolves.toBe(
       canonicalPlayerId
     );
@@ -311,6 +343,17 @@ describe.sequential('canonical player identity migration', () => {
     await expect(
       prisma.player.count({ where: { name: 'Jack Ginnivan', club: 'Hawthorn' } })
     ).resolves.toBe(1);
+    await expect(
+      upsertCanonicalPlayer(prisma, {
+        provider: 'future-weak-import',
+        externalId: 'fixture-jack-ginnivan-new-club',
+        name: 'Jack Ginnivan',
+        club: 'New Club',
+        position: 'FWD',
+        allowExactAttributeMatch: true,
+      })
+    ).rejects.toBeInstanceOf(AmbiguousPlayerIdentityError);
+    await expect(prisma.player.count({ where: { name: 'Jack Ginnivan' } })).resolves.toBe(1);
     await expect(
       prisma.$queryRawUnsafe<Array<Record<string, unknown>>>('PRAGMA foreign_key_check')
     ).resolves.toEqual([]);
@@ -433,6 +476,53 @@ describe.sequential('canonical player identity migration', () => {
     );
     await expect(prisma.pick.count({ where: { draftId: 'duplicate-player-draft' } })).resolves.toBe(
       2
+    );
+  });
+
+  it('blocks ownership conflicts that exist only in legacy roster JSON', async () => {
+    const canonicalId = 'legacy_conflict_player';
+    const aliasId = 'legacy-conflict-player-club';
+    await prisma.player.createMany({
+      data: [
+        { id: canonicalId, name: 'Legacy Conflict', club: 'Club', position: 'MID' },
+        { id: aliasId, name: 'Legacy Conflict', club: 'Club', position: 'MID' },
+      ],
+    });
+    await prisma.playerExternalIdentity.createMany({
+      data: [canonicalId, aliasId].map((playerId) => ({
+        playerId,
+        provider: 'statly-legacy',
+        externalId: playerId,
+      })),
+    });
+    await prisma.leagueRosterPlayer.create({
+      data: {
+        id: 'legacy-conflict-normalized',
+        leagueId: 'league-a',
+        memberId: 'member-a',
+        playerId: canonicalId,
+      },
+    });
+    await prisma.leagueRoster.create({
+      data: {
+        id: 'legacy-conflict-json',
+        leagueId: 'league-a',
+        memberId: 'member-c',
+        playerIds: JSON.stringify([aliasId]),
+      },
+    });
+
+    const plan = await planPlayerIdentityConsolidation(prisma, [
+      { aliasId, canonicalPlayerId: canonicalId },
+    ]);
+    expect(plan.status).toBe('blocked');
+    expect(plan.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'LEGACY_OWNERSHIP_CONFLICT',
+          scopeId: 'league-a',
+        }),
+      ])
     );
   });
 });

--- a/tests/unit/playerIdentityMigration.test.ts
+++ b/tests/unit/playerIdentityMigration.test.ts
@@ -1,5 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import {
+  accessSync,
+  constants as fsConstants,
   cpSync,
   mkdirSync,
   mkdtempSync,
@@ -9,7 +11,8 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { delimiter, join, resolve } from 'node:path';
 
 import type { PrismaClient } from '@prisma/client';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -18,6 +21,7 @@ import {
   consolidatePlayerIdentities,
   PlayerIdentityConsolidationBlockedError,
 } from '../../src/server/players/playerIdentityConsolidation';
+import { createPlayerIdentitySourceFingerprint } from '../../src/server/players/playerIdentityConsolidationCli';
 import { planPlayerIdentityConsolidation } from '../../src/server/players/playerIdentityConsolidationPlanner';
 import {
   AmbiguousPlayerIdentityError,
@@ -31,12 +35,14 @@ const conflictCanonicalId = 'same_player';
 const conflictAliasId = 'same-player-club';
 const now = new Date('2026-07-24T00:00:00.000Z');
 
-let databaseDirectory: string;
+const databaseDirectoryPrefix = join(tmpdir(), 'statly-verify-player-migration-');
+
+let databaseDirectory: string | undefined;
 let databasePath: string;
 let schemaPath: string;
 let prisma: PrismaClient;
-let protectedDatabaseBefore: Stats;
-let protectedDatabaseStatusBefore: string;
+let protectedDatabaseBefore: Stats | undefined;
+let protectedDatabaseStatusBefore: string | undefined;
 
 function runPrisma(args: string[]) {
   const prismaCli = resolve(process.cwd(), 'node_modules/.bin/prisma');
@@ -48,9 +54,32 @@ function runPrisma(args: string[]) {
 }
 
 function oldSchemaWithoutExternalIdentities(): string {
-  return readFileSync(resolve(process.cwd(), 'prisma/schema.prisma'), 'utf8')
-    .replace('  externalIdentities PlayerExternalIdentity[]\n', '')
-    .replace(/\nmodel PlayerExternalIdentity \{[\s\S]*?\n\}\n\nmodel Pick \{/, '\nmodel Pick {');
+  const source = readFileSync(resolve(process.cwd(), 'prisma/schema.prisma'), 'utf8');
+  const withoutRelation = source.replace('  externalIdentities PlayerExternalIdentity[]\n', '');
+  if (withoutRelation === source) {
+    throw new Error('Test schema setup could not remove Player.externalIdentities');
+  }
+  const withoutModel = withoutRelation.replace(
+    /\nmodel PlayerExternalIdentity \{[\s\S]*?\n\}\n\nmodel Pick \{/,
+    '\nmodel Pick {'
+  );
+  if (withoutModel === withoutRelation) {
+    throw new Error('Test schema setup could not remove PlayerExternalIdentity model');
+  }
+  return withoutModel;
+}
+
+function resolveExecutablePath(executable: string): string {
+  for (const directory of (process.env.PATH ?? '').split(delimiter).filter(Boolean)) {
+    const candidate = join(directory, executable);
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      return candidate;
+    } catch {
+      // Try the next PATH entry.
+    }
+  }
+  throw new Error(`${executable} is required to run the player identity migration test`);
 }
 
 async function seedTwoLeagueOwnerships() {
@@ -190,7 +219,7 @@ describe.sequential('canonical player identity migration', () => {
       { cwd: process.cwd(), encoding: 'utf8' }
     );
 
-    databaseDirectory = mkdtempSync('/tmp/statly-verify-player-migration-');
+    databaseDirectory = mkdtempSync(databaseDirectoryPrefix);
     databasePath = resolve(databaseDirectory, 'player-identity.db');
     schemaPath = resolve(databaseDirectory, 'schema.prisma');
     writeFileSync(schemaPath, oldSchemaWithoutExternalIdentities());
@@ -203,7 +232,10 @@ describe.sequential('canonical player identity migration', () => {
       schemaPath,
       '--script',
     ]);
-    execFileSync('/usr/bin/sqlite3', [databasePath], { input: schemaSql, stdio: 'pipe' });
+    execFileSync(resolveExecutablePath('sqlite3'), [databasePath], {
+      input: schemaSql,
+      stdio: 'pipe',
+    });
 
     const { PrismaClient } = await import('@prisma/client');
     prisma = new PrismaClient({ datasourceUrl: `file:${databasePath}` });
@@ -243,9 +275,11 @@ describe.sequential('canonical player identity migration', () => {
 
   afterAll(async () => {
     await prisma?.$disconnect();
-    if (databaseDirectory.startsWith('/tmp/statly-verify-player-migration-')) {
+    if (databaseDirectory?.startsWith(databaseDirectoryPrefix)) {
       rmSync(databaseDirectory, { recursive: true, force: true });
     }
+
+    if (!protectedDatabaseBefore) return;
 
     const protectedDatabaseAfter = statSync(resolve(process.cwd(), 'prisma/dev.db'));
     const protectedDatabaseStatusAfter = execFileSync(
@@ -268,6 +302,7 @@ describe.sequential('canonical player identity migration', () => {
 
   it('backfills legacy IDs and preserves independent ownership in different leagues', async () => {
     await expect(prisma.playerExternalIdentity.count()).resolves.toBe(2);
+    await expect(resolveCanonicalPlayerId(' ', undefined, prisma)).resolves.toBeNull();
 
     await prisma.queueItem.createMany({
       data: [
@@ -564,6 +599,40 @@ describe.sequential('canonical player identity migration', () => {
       benchOrder: 'also malformed',
     });
     await expect(prisma.player.findUnique({ where: { id: aliasId } })).resolves.toBeNull();
+  });
+
+  it('rechecks the reviewed player fingerprint inside the apply transaction', async () => {
+    const canonicalId = 'fingerprint_guard_canonical';
+    const aliasId = 'fingerprint-guard-alias';
+    await prisma.player.createMany({
+      data: [
+        { id: canonicalId, name: 'Fingerprint Guard', club: 'Club', position: 'FWD' },
+        { id: aliasId, name: 'Fingerprint Guard', club: 'Club', position: 'FWD' },
+      ],
+    });
+    await prisma.playerExternalIdentity.createMany({
+      data: [canonicalId, aliasId].map((playerId) => ({
+        playerId,
+        provider: 'statly-legacy',
+        externalId: playerId,
+      })),
+    });
+    const reviewedPlayers = await prisma.player.findMany({
+      orderBy: { id: 'asc' },
+      select: { id: true, name: true, club: true, position: true },
+    });
+    const reviewedFingerprint = createPlayerIdentitySourceFingerprint(reviewedPlayers);
+    await prisma.player.update({
+      where: { id: canonicalId },
+      data: { club: 'Changed After Review' },
+    });
+
+    await expect(
+      consolidatePlayerIdentities(prisma, [{ aliasId, canonicalPlayerId: canonicalId }], {
+        expectedSourceFingerprint: reviewedFingerprint,
+      })
+    ).rejects.toThrow('generate and review a new manifest');
+    await expect(prisma.player.findUnique({ where: { id: aliasId } })).resolves.not.toBeNull();
   });
 
   it('blocks alias retirement when immutable autosub history references it', async () => {

--- a/tests/unit/playerIdentityMigration.test.ts
+++ b/tests/unit/playerIdentityMigration.test.ts
@@ -1,0 +1,438 @@
+import { execFileSync } from 'node:child_process';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  type Stats,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { resolve } from 'node:path';
+
+import type { PrismaClient } from '@prisma/client';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  consolidatePlayerIdentities,
+  PlayerIdentityConsolidationBlockedError,
+} from '../../src/server/players/playerIdentityConsolidation';
+import { planPlayerIdentityConsolidation } from '../../src/server/players/playerIdentityConsolidationPlanner';
+import {
+  resolveCanonicalPlayerId,
+  upsertCanonicalPlayer,
+} from '../../src/server/players/playerIdentityService';
+
+const canonicalPlayerId = 'jack_ginnivan';
+const aliasPlayerId = 'jack-ginnivan-hawthorn';
+const conflictCanonicalId = 'same_player';
+const conflictAliasId = 'same-player-club';
+const now = new Date('2026-07-24T00:00:00.000Z');
+
+let databaseDirectory: string;
+let databasePath: string;
+let schemaPath: string;
+let prisma: PrismaClient;
+let protectedDatabaseBefore: Stats;
+let protectedDatabaseStatusBefore: string;
+
+function runPrisma(args: string[]) {
+  const prismaCli = resolve(process.cwd(), 'node_modules/.bin/prisma');
+  return execFileSync(prismaCli, args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: { ...process.env, DATABASE_URL: 'file:./player-identity.db' },
+  });
+}
+
+function oldSchemaWithoutExternalIdentities(): string {
+  return readFileSync(resolve(process.cwd(), 'prisma/schema.prisma'), 'utf8')
+    .replace('  externalIdentities PlayerExternalIdentity[]\n', '')
+    .replace(/\nmodel PlayerExternalIdentity \{[\s\S]*?\n\}\n\nmodel Pick \{/, '\nmodel Pick {');
+}
+
+async function seedTwoLeagueOwnerships() {
+  await prisma.user.createMany({
+    data: [
+      {
+        id: 'user-a',
+        email: 'player-identity-a@example.test',
+        passwordHash: 'test',
+        displayName: 'Manager A',
+      },
+      {
+        id: 'user-b',
+        email: 'player-identity-b@example.test',
+        passwordHash: 'test',
+        displayName: 'Manager B',
+      },
+      {
+        id: 'user-c',
+        email: 'player-identity-c@example.test',
+        passwordHash: 'test',
+        displayName: 'Manager C',
+      },
+    ],
+  });
+  await prisma.leagueSettings.createMany({
+    data: ['a', 'b'].map((suffix) => ({
+      id: `settings-${suffix}`,
+      rosterSize: 22,
+      benchSize: 4,
+      maxTeams: 12,
+      pickSeconds: 60,
+      draftType: 'SNAKE' as const,
+      startAt: now,
+    })),
+  });
+  await prisma.league.createMany({
+    data: [
+      {
+        id: 'league-a',
+        name: 'League A',
+        inviteCode: 'IDENTITY-A',
+        ownerId: 'user-a',
+        settingsId: 'settings-a',
+      },
+      {
+        id: 'league-b',
+        name: 'League B',
+        inviteCode: 'IDENTITY-B',
+        ownerId: 'user-b',
+        settingsId: 'settings-b',
+      },
+    ],
+  });
+  await prisma.leagueMember.createMany({
+    data: [
+      {
+        id: 'member-a',
+        leagueId: 'league-a',
+        userId: 'user-a',
+        role: 'OWNER',
+        teamName: 'Team A',
+      },
+      {
+        id: 'member-b',
+        leagueId: 'league-b',
+        userId: 'user-b',
+        role: 'OWNER',
+        teamName: 'Team B',
+      },
+      {
+        id: 'member-c',
+        leagueId: 'league-a',
+        userId: 'user-c',
+        role: 'MANAGER',
+        teamName: 'Team C',
+      },
+    ],
+  });
+  await prisma.player.createMany({
+    data: [
+      {
+        id: canonicalPlayerId,
+        name: 'Jack Ginnivan',
+        club: 'Hawthorn',
+        position: 'FWD',
+      },
+      {
+        id: aliasPlayerId,
+        name: 'Jack Ginnivan',
+        club: 'Hawthorn',
+        position: 'FWD',
+      },
+    ],
+  });
+  await prisma.leagueRosterPlayer.createMany({
+    data: [
+      {
+        id: 'ownership-a',
+        leagueId: 'league-a',
+        memberId: 'member-a',
+        playerId: aliasPlayerId,
+      },
+      {
+        id: 'ownership-b',
+        leagueId: 'league-b',
+        memberId: 'member-b',
+        playerId: canonicalPlayerId,
+      },
+    ],
+  });
+  await prisma.leagueRoster.createMany({
+    data: [
+      {
+        id: 'legacy-roster-a',
+        leagueId: 'league-a',
+        memberId: 'member-a',
+        playerIds: JSON.stringify([aliasPlayerId]),
+      },
+      {
+        id: 'legacy-roster-b',
+        leagueId: 'league-b',
+        memberId: 'member-b',
+        playerIds: JSON.stringify([canonicalPlayerId]),
+      },
+    ],
+  });
+}
+
+describe.sequential('canonical player identity migration', () => {
+  beforeAll(async () => {
+    const protectedDatabasePath = resolve(process.cwd(), 'prisma/dev.db');
+    protectedDatabaseBefore = statSync(protectedDatabasePath);
+    protectedDatabaseStatusBefore = execFileSync(
+      'git',
+      ['status', '--short', '--', 'prisma/dev.db'],
+      { cwd: process.cwd(), encoding: 'utf8' }
+    );
+
+    databaseDirectory = mkdtempSync('/tmp/statly-verify-player-migration-');
+    databasePath = resolve(databaseDirectory, 'player-identity.db');
+    schemaPath = resolve(databaseDirectory, 'schema.prisma');
+    writeFileSync(schemaPath, oldSchemaWithoutExternalIdentities());
+
+    const schemaSql = runPrisma([
+      'migrate',
+      'diff',
+      '--from-empty',
+      '--to-schema-datamodel',
+      schemaPath,
+      '--script',
+    ]);
+    execFileSync('/usr/bin/sqlite3', [databasePath], { input: schemaSql, stdio: 'pipe' });
+
+    const { PrismaClient } = await import('@prisma/client');
+    prisma = new PrismaClient({ datasourceUrl: `file:${databasePath}` });
+    await prisma.$connect();
+    await seedTwoLeagueOwnerships();
+
+    const migrationRoot = resolve(databaseDirectory, 'migrations');
+    const baselineDirectory = resolve(migrationRoot, '20260724180000_test_baseline');
+    const migrationDirectory = resolve(
+      migrationRoot,
+      '20260724190000_add_player_external_identity'
+    );
+    mkdirSync(baselineDirectory, { recursive: true });
+    mkdirSync(migrationDirectory, { recursive: true });
+    writeFileSync(resolve(baselineDirectory, 'migration.sql'), '-- Test-only schema baseline.\n');
+    cpSync(
+      resolve(process.cwd(), 'prisma/migrations/migration_lock.toml'),
+      resolve(migrationRoot, 'migration_lock.toml')
+    );
+    cpSync(
+      resolve(
+        process.cwd(),
+        'prisma/migrations/20260724190000_add_player_external_identity/migration.sql'
+      ),
+      resolve(migrationDirectory, 'migration.sql')
+    );
+    runPrisma([
+      'migrate',
+      'resolve',
+      '--applied',
+      '20260724180000_test_baseline',
+      '--schema',
+      schemaPath,
+    ]);
+    runPrisma(['migrate', 'deploy', '--schema', schemaPath]);
+  }, 60_000);
+
+  afterAll(async () => {
+    await prisma?.$disconnect();
+    if (databaseDirectory.startsWith('/tmp/statly-verify-player-migration-')) {
+      rmSync(databaseDirectory, { recursive: true, force: true });
+    }
+
+    const protectedDatabaseAfter = statSync(resolve(process.cwd(), 'prisma/dev.db'));
+    const protectedDatabaseStatusAfter = execFileSync(
+      'git',
+      ['status', '--short', '--', 'prisma/dev.db'],
+      { cwd: process.cwd(), encoding: 'utf8' }
+    );
+    expect({
+      size: protectedDatabaseAfter.size,
+      mtimeMs: protectedDatabaseAfter.mtimeMs,
+      ino: protectedDatabaseAfter.ino,
+      status: protectedDatabaseStatusAfter,
+    }).toEqual({
+      size: protectedDatabaseBefore.size,
+      mtimeMs: protectedDatabaseBefore.mtimeMs,
+      ino: protectedDatabaseBefore.ino,
+      status: protectedDatabaseStatusBefore,
+    });
+  });
+
+  it('backfills legacy IDs and preserves independent ownership in different leagues', async () => {
+    await expect(prisma.playerExternalIdentity.count()).resolves.toBe(2);
+
+    const mapping = [{ aliasId: aliasPlayerId, canonicalPlayerId }];
+    const plan = await planPlayerIdentityConsolidation(prisma, mapping);
+    expect(plan.status).toBe('ready');
+    expect(plan.references.rosterPlayers).toBe(1);
+
+    await consolidatePlayerIdentities(prisma, mapping);
+
+    await expect(
+      prisma.player.findMany({ orderBy: { id: 'asc' }, select: { id: true } })
+    ).resolves.toEqual([{ id: canonicalPlayerId }]);
+    await expect(
+      prisma.leagueRosterPlayer.findMany({
+        orderBy: { leagueId: 'asc' },
+        select: { leagueId: true, memberId: true, playerId: true },
+      })
+    ).resolves.toEqual([
+      { leagueId: 'league-a', memberId: 'member-a', playerId: canonicalPlayerId },
+      { leagueId: 'league-b', memberId: 'member-b', playerId: canonicalPlayerId },
+    ]);
+    await expect(
+      prisma.playerExternalIdentity.findUnique({
+        where: {
+          provider_externalId: { provider: 'statly-legacy', externalId: aliasPlayerId },
+        },
+        select: { playerId: true },
+      })
+    ).resolves.toEqual({ playerId: canonicalPlayerId });
+    await expect(resolveCanonicalPlayerId(aliasPlayerId, undefined, prisma)).resolves.toBe(
+      canonicalPlayerId
+    );
+
+    const importedPlayer = await upsertCanonicalPlayer(prisma, {
+      provider: 'fixture-import',
+      externalId: 'fixture-jack-ginnivan',
+      name: 'Jack Ginnivan',
+      club: 'Hawthorn',
+      position: 'FWD',
+      allowExactAttributeMatch: true,
+    });
+    expect(importedPlayer.id).toBe(canonicalPlayerId);
+    await expect(
+      prisma.player.count({ where: { name: 'Jack Ginnivan', club: 'Hawthorn' } })
+    ).resolves.toBe(1);
+    await expect(
+      prisma.$queryRawUnsafe<Array<Record<string, unknown>>>('PRAGMA foreign_key_check')
+    ).resolves.toEqual([]);
+
+    const repeatedPlan = await consolidatePlayerIdentities(prisma, mapping);
+    expect(repeatedPlan.mappings).toEqual([]);
+    expect(runPrisma(['migrate', 'deploy', '--schema', schemaPath])).toContain(
+      'No pending migrations to apply.'
+    );
+  });
+
+  it('blocks two different owners of aliases inside the same league', async () => {
+    await prisma.player.createMany({
+      data: [
+        { id: conflictCanonicalId, name: 'Same Player', club: 'Club', position: 'MID' },
+        { id: conflictAliasId, name: 'Same Player', club: 'Club', position: 'MID' },
+      ],
+    });
+    await prisma.playerExternalIdentity.createMany({
+      data: [conflictCanonicalId, conflictAliasId].map((playerId) => ({
+        playerId,
+        provider: 'statly-legacy',
+        externalId: playerId,
+      })),
+    });
+    await prisma.leagueRosterPlayer.createMany({
+      data: [
+        {
+          id: 'conflicting-owner-a',
+          leagueId: 'league-a',
+          memberId: 'member-a',
+          playerId: conflictCanonicalId,
+        },
+        {
+          id: 'conflicting-owner-c',
+          leagueId: 'league-a',
+          memberId: 'member-c',
+          playerId: conflictAliasId,
+        },
+      ],
+    });
+
+    const mapping = [{ aliasId: conflictAliasId, canonicalPlayerId: conflictCanonicalId }];
+    const plan = await planPlayerIdentityConsolidation(prisma, mapping);
+    expect(plan.status).toBe('blocked');
+    expect(plan.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'LEAGUE_OWNERSHIP_CONFLICT', scopeId: 'league-a' }),
+      ])
+    );
+    await expect(consolidatePlayerIdentities(prisma, mapping)).rejects.toBeInstanceOf(
+      PlayerIdentityConsolidationBlockedError
+    );
+    await expect(
+      prisma.player.count({ where: { id: { in: [conflictCanonicalId, conflictAliasId] } } })
+    ).resolves.toBe(2);
+  });
+
+  it('blocks duplicate draft history for two aliases of one player', async () => {
+    const canonicalId = 'draft_history_player';
+    const aliasId = 'draft-history-player-club';
+    await prisma.player.createMany({
+      data: [
+        { id: canonicalId, name: 'Draft History', club: 'Club', position: 'DEF' },
+        { id: aliasId, name: 'Draft History', club: 'Club', position: 'DEF' },
+      ],
+    });
+    await prisma.playerExternalIdentity.createMany({
+      data: [canonicalId, aliasId].map((playerId) => ({
+        playerId,
+        provider: 'statly-legacy',
+        externalId: playerId,
+      })),
+    });
+    await prisma.draft.create({
+      data: {
+        id: 'duplicate-player-draft',
+        leagueId: 'league-b',
+        status: 'COMPLETED',
+        currentPick: 2,
+        totalPicks: 2,
+      },
+    });
+    await prisma.pick.createMany({
+      data: [
+        {
+          id: 'duplicate-player-pick-1',
+          draftId: 'duplicate-player-draft',
+          overall: 1,
+          round: 1,
+          slot: 1,
+          memberId: 'member-b',
+          playerId: canonicalId,
+        },
+        {
+          id: 'duplicate-player-pick-2',
+          draftId: 'duplicate-player-draft',
+          overall: 2,
+          round: 1,
+          slot: 2,
+          memberId: 'member-b',
+          playerId: aliasId,
+        },
+      ],
+    });
+
+    const mapping = [{ aliasId, canonicalPlayerId: canonicalId }];
+    const plan = await planPlayerIdentityConsolidation(prisma, mapping);
+    expect(plan.status).toBe('blocked');
+    expect(plan.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'DRAFT_PICK_COLLISION',
+          scopeId: 'duplicate-player-draft',
+        }),
+      ])
+    );
+    await expect(consolidatePlayerIdentities(prisma, mapping)).rejects.toBeInstanceOf(
+      PlayerIdentityConsolidationBlockedError
+    );
+    await expect(prisma.pick.count({ where: { draftId: 'duplicate-player-draft' } })).resolves.toBe(
+      2
+    );
+  });
+});

--- a/tests/unit/playerIdentityMigration.test.ts
+++ b/tests/unit/playerIdentityMigration.test.ts
@@ -525,4 +525,102 @@ describe.sequential('canonical player identity migration', () => {
       ])
     );
   });
+
+  it('leaves unrelated malformed legacy roster JSON untouched', async () => {
+    const canonicalId = 'unrelated_roster_canonical';
+    const aliasId = 'unrelated-roster-alias';
+    await prisma.player.createMany({
+      data: [
+        { id: canonicalId, name: 'Unrelated Roster', club: 'Club', position: 'DEF' },
+        { id: aliasId, name: 'Unrelated Roster', club: 'Club', position: 'DEF' },
+      ],
+    });
+    await prisma.playerExternalIdentity.createMany({
+      data: [canonicalId, aliasId].map((playerId) => ({
+        playerId,
+        provider: 'statly-legacy',
+        externalId: playerId,
+      })),
+    });
+    await prisma.leagueRoster.update({
+      where: { leagueId_memberId: { leagueId: 'league-b', memberId: 'member-b' } },
+      data: { playerIds: 'unrelated malformed data', benchOrder: 'also malformed' },
+    });
+
+    const mapping = [{ aliasId, canonicalPlayerId: canonicalId }];
+    await expect(planPlayerIdentityConsolidation(prisma, mapping)).resolves.toMatchObject({
+      status: 'ready',
+    });
+    await expect(consolidatePlayerIdentities(prisma, mapping)).resolves.toMatchObject({
+      status: 'ready',
+    });
+    await expect(
+      prisma.leagueRoster.findUnique({
+        where: { leagueId_memberId: { leagueId: 'league-b', memberId: 'member-b' } },
+        select: { playerIds: true, benchOrder: true },
+      })
+    ).resolves.toEqual({
+      playerIds: 'unrelated malformed data',
+      benchOrder: 'also malformed',
+    });
+    await expect(prisma.player.findUnique({ where: { id: aliasId } })).resolves.toBeNull();
+  });
+
+  it('blocks alias retirement when immutable autosub history references it', async () => {
+    const canonicalId = 'autosub_history_canonical';
+    const aliasId = 'autosub-history-alias';
+    const replacementId = 'autosub-history-replacement';
+    await prisma.player.createMany({
+      data: [
+        { id: canonicalId, name: 'Autosub History', club: 'Club', position: 'MID' },
+        { id: aliasId, name: 'Autosub History', club: 'Club', position: 'MID' },
+        { id: replacementId, name: 'Autosub Replacement', club: 'Club', position: 'MID' },
+      ],
+    });
+    await prisma.playerExternalIdentity.createMany({
+      data: [canonicalId, aliasId, replacementId].map((playerId) => ({
+        playerId,
+        provider: 'statly-legacy',
+        externalId: playerId,
+      })),
+    });
+    await prisma.leagueLineup.create({
+      data: { id: 'autosub-history-lineup', leagueId: 'league-b', memberId: 'member-b', round: 1 },
+    });
+    await prisma.leagueLineupAutosub.create({
+      data: {
+        id: 'autosub-history-record',
+        lineupId: 'autosub-history-lineup',
+        outgoingPlayerId: aliasId,
+        replacementPlayerId: replacementId,
+        outgoingSlot: 'MID',
+        outgoingSlotIndex: 0,
+        interchangeSlotIndex: 0,
+        reason: 'DID_NOT_PLAY',
+      },
+    });
+
+    const mapping = [{ aliasId, canonicalPlayerId: canonicalId }];
+    const plan = await planPlayerIdentityConsolidation(prisma, mapping);
+    expect(plan.status).toBe('blocked');
+    expect(plan.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'AUTOSUB_REFERENCE',
+          scopeId: 'autosub-history-record',
+          aliasIds: [aliasId],
+        }),
+      ])
+    );
+    await expect(consolidatePlayerIdentities(prisma, mapping)).rejects.toBeInstanceOf(
+      PlayerIdentityConsolidationBlockedError
+    );
+    await expect(prisma.player.findUnique({ where: { id: aliasId } })).resolves.not.toBeNull();
+    await expect(
+      prisma.leagueLineupAutosub.findUnique({
+        where: { id: 'autosub-history-record' },
+        select: { outgoingPlayerId: true, replacementPlayerId: true },
+      })
+    ).resolves.toEqual({ outgoingPlayerId: aliasId, replacementPlayerId: replacementId });
+  });
 });

--- a/tests/unit/preDraftQueueAuthorization.test.ts
+++ b/tests/unit/preDraftQueueAuthorization.test.ts
@@ -26,6 +26,7 @@ describe('pre-draft queue authorization', () => {
     expect(source).toContain('preDraftQueue');
     expect(source).toContain('resolveCanonicalPlayerId');
     expect(source).toContain('resolveCanonicalPlayerIds');
+    expect(source).toContain('z.string().trim().min(1)');
     expect(source).not.toMatch(/\\bqueueItem\\b/i);
     expect(source).not.toContain('memberId: z.string().min(1)');
   });

--- a/tests/unit/preDraftQueueAuthorization.test.ts
+++ b/tests/unit/preDraftQueueAuthorization.test.ts
@@ -24,6 +24,8 @@ describe('pre-draft queue authorization', () => {
     expect(source).toContain('getDraftMembershipAccess');
     expect(source).toContain('access.memberId');
     expect(source).toContain('preDraftQueue');
+    expect(source).toContain('resolveCanonicalPlayerId');
+    expect(source).toContain('resolveCanonicalPlayerIds');
     expect(source).not.toMatch(/\\bqueueItem\\b/i);
     expect(source).not.toContain('memberId: z.string().min(1)');
   });

--- a/tests/unit/rosterOwnershipMigrationArchitecture.test.ts
+++ b/tests/unit/rosterOwnershipMigrationArchitecture.test.ts
@@ -27,6 +27,17 @@ describe('roster ownership migration architecture', () => {
     expect(structuredMigration).toBeDefined();
   });
 
+  it('enforces one canonical owner per player inside each league in both schema paths', () => {
+    const schema = readFileSync(join(root, 'prisma/schema.prisma'), 'utf8');
+    const runtimeFallback = readFileSync(join(root, 'src/lib/ensureLobbyColumns.ts'), 'utf8');
+
+    expect(schema).toContain('@@unique([leagueId, playerId])');
+    expect(runtimeFallback).toContain(
+      'CREATE UNIQUE INDEX IF NOT EXISTS "LeagueRosterPlayer_leagueId_playerId_key"'
+    );
+    expect(runtimeFallback).toContain('ON "LeagueRosterPlayer"("leagueId", "playerId")');
+  });
+
   it('uses the shared authenticated request helper for roster APIs', () => {
     const source = readFileSync(
       join(root, 'src/app/api/leagues/[id]/roster/[userId]/route.ts'),

--- a/tests/unit/rosterOwnershipMigrationArchitecture.test.ts
+++ b/tests/unit/rosterOwnershipMigrationArchitecture.test.ts
@@ -31,11 +31,17 @@ describe('roster ownership migration architecture', () => {
     const schema = readFileSync(join(root, 'prisma/schema.prisma'), 'utf8');
     const runtimeFallback = readFileSync(join(root, 'src/lib/ensureLobbyColumns.ts'), 'utf8');
 
-    expect(schema).toContain('@@unique([leagueId, playerId])');
+    const rosterPlayerModel = schema.match(/model LeagueRosterPlayer \{[\s\S]*?\n\}/)?.[0] ?? '';
+    expect(rosterPlayerModel).not.toBe('');
+    expect(rosterPlayerModel).toContain('@@unique([leagueId, playerId])');
     expect(runtimeFallback).toContain(
       'CREATE UNIQUE INDEX IF NOT EXISTS "LeagueRosterPlayer_leagueId_playerId_key"'
     );
     expect(runtimeFallback).toContain('ON "LeagueRosterPlayer"("leagueId", "playerId")');
+    for (const column of ['draftId', 'pickId', 'slot', 'acquiredBy', 'acquiredAt']) {
+      expect(runtimeFallback).toContain(`"${column}"`);
+    }
+    expect(runtimeFallback).toContain('Failed to enforce unique league player ownership');
   });
 
   it('uses the shared authenticated request helper for roster APIs', () => {

--- a/tests/unit/teamActionsRouteArchitecture.test.ts
+++ b/tests/unit/teamActionsRouteArchitecture.test.ts
@@ -110,6 +110,26 @@ describe('team actions route architecture', () => {
     expect(rosterMocks.ensureRosterTables).not.toHaveBeenCalled();
     expect(membershipMocks.verifyLeagueMembership).not.toHaveBeenCalled();
   });
+
+  it('rejects non-object action details without silently replacing the payload', async () => {
+    authMocks.getAuthenticatedUserId.mockResolvedValue('user-1');
+    membershipMocks.verifyLeagueMembership.mockResolvedValue({ isMember: true });
+
+    const { POST } = await import('../../src/app/api/leagues/[id]/actions/[userId]/route');
+    const response = await POST(
+      jsonRequest('/api/leagues/league-1/actions/user-1', {
+        actionType: 'OPTIMIZE_LINEUP',
+        details: 'unexpected-details',
+      }),
+      { params: Promise.resolve({ id: 'league-1', userId: 'user-1' }) }
+    );
+
+    expect(response!.status).toBe(400);
+    await expect(response!.json()).resolves.toMatchObject({
+      error: { message: 'Action details must be an object' },
+    });
+    expect(rosterMocks.ensureRosterTables).not.toHaveBeenCalled();
+  });
 });
 
 function jsonRequest(path: string, body: unknown): NextRequest {

--- a/tests/unit/teamActionsRouteArchitecture.test.ts
+++ b/tests/unit/teamActionsRouteArchitecture.test.ts
@@ -1,4 +1,6 @@
 import type { NextRequest } from 'next/server';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const authMocks = vi.hoisted(() => ({
@@ -129,6 +131,17 @@ describe('team actions route architecture', () => {
       error: { message: 'Action details must be an object' },
     });
     expect(rosterMocks.ensureRosterTables).not.toHaveBeenCalled();
+  });
+
+  it('canonicalizes scalar and trade-array player references before persistence', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/app/api/leagues/[id]/actions/[userId]/route.ts'),
+      'utf8'
+    );
+
+    expect(source).toContain("const scalarKeys = ['playerId', 'dropPlayerId']");
+    expect(source).toContain("const arrayKeys = ['offeredPlayers', 'requestedPlayers']");
+    expect(source).toContain('resolveCanonicalPlayerIds(requestedPlayerIds)');
   });
 });
 

--- a/tests/unit/waiverAvailabilityProjection.test.ts
+++ b/tests/unit/waiverAvailabilityProjection.test.ts
@@ -242,6 +242,52 @@ describe('WaiverAvailabilityProjectionService', () => {
     expect(result).toEqual({ owned: 1, available: 0 });
   });
 
+  it('removes retired alias documents after relational consolidation', async () => {
+    const { batches, firestore } = createFirestoreMock();
+    const db = {
+      leagueRosterPlayer: {
+        findMany: vi.fn().mockResolvedValue([{ playerId: 'jack_ginnivan', memberId: 'member-1' }]),
+      },
+      teamAction: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      player: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: 'jack_ginnivan',
+            name: 'Jack Ginnivan',
+            club: 'Hawthorn',
+            position: 'FWD',
+          },
+        ]),
+      },
+      playerExternalIdentity: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            externalId: 'jack_ginnivan',
+            playerId: 'jack_ginnivan',
+          },
+          {
+            externalId: 'jack-ginnivan-hawthorn',
+            playerId: 'jack_ginnivan',
+          },
+        ]),
+      },
+    };
+
+    const service = new WaiverAvailabilityProjectionService(db as never, firestore as never);
+    await service.projectLeague({ leagueId: 'league-1' });
+
+    expect(db.playerExternalIdentity.findMany).toHaveBeenCalledWith({
+      where: { provider: 'statly-legacy' },
+      select: { externalId: true, playerId: true },
+    });
+    const deletedIds = batches.flatMap((batch) =>
+      batch.delete.mock.calls.map(([ref]) => (ref as { id: string }).id)
+    );
+    expect(deletedIds).toEqual(expect.arrayContaining(['jack-ginnivan-hawthorn']));
+  });
+
   it('refreshes waiver availability after roster ownership projection', () => {
     const source = read('src/server/rosters/RosterProjectionService.ts');
 

--- a/tests/unit/waiverAvailabilityProjection.test.ts
+++ b/tests/unit/waiverAvailabilityProjection.test.ts
@@ -299,9 +299,12 @@ describe('WaiverAvailabilityProjectionService', () => {
   it('uses shared league membership helpers in waiver routes', () => {
     const submitSource = read('src/app/api/leagues/[id]/waivers/submit/route.ts');
     const processSource = read('src/app/api/leagues/[id]/waivers/process/route.ts');
+    const processingServiceSource = read('src/server/waivers/WaiverProcessingService.ts');
 
     expect(submitSource).toContain('getLeagueMembershipAccess');
     expect(submitSource).not.toContain('verifyLeagueMembership');
+    expect(submitSource).toContain('const canonicalPlayerId = resolvedPlayerId');
+    expect(processingServiceSource).toContain('const canonicalPlayerId = resolvedPlayerId');
 
     expect(processSource).toContain('canManageLeague');
     expect(processSource).not.toContain('getLeagueMembership');


### PR DESCRIPTION
## Summary
- add canonical external player identities and reviewed consolidation tooling
- resolve retired aliases at draft, queue, roster, waiver, lineup, trade, and player-detail boundaries
- preserve ownership independently per league and block conflicting same-league consolidation
- remove retired Firestore waiver documents while preserving immutable historical records
- add fingerprinted production gates, backup requirements, and a rollout runbook

## Verification
- npm run lint:ci
- npm run typecheck
- npm run typecheck:tests
- npm run test:unit (170 files, 673 tests)
- npm test -- src/server/leagues/lineupService.test.ts src/server/leagues/trades/tradeService.test.ts (56 tests)
- npm run test:int with a fresh migrated SQLite database
- npm run test:race (no race tests configured)
- npm run build
- disposable full-data planner: 361 candidate groups; correctly blocked 167 draft collisions, 155 same-league ownership conflicts, one lineup collision, and one pending-action reference

## Rollout safety
Production consolidation requires a reviewed manifest bound to the exact player-data fingerprint, an explicitly matched production database, a separate backup, and a clean preflight plan. The protected local database was not staged or committed.

## Summary by Sourcery

Introduce a canonical player identity layer with reviewed consolidation tooling, update league operations to resolve retired aliases to canonical players, and enforce league-scoped roster ownership.

New Features:
- Add player external identity schema and canonical player identity service with CLI and consolidation scripts.
- Allow application endpoints for drafts, waivers, rosters, lineups, trades, and player details to accept legacy player aliases while persisting canonical IDs.

Bug Fixes:
- Ensure waiver claim processing drops and records ownership against canonical players when claims reference retired aliases.
- Prevent duplicate or conflicting lineup, trade, and waiver states caused by multiple aliases of the same player.

Enhancements:
- Enforce a unique ownership constraint per player within each league across both Prisma schema and runtime fallback.
- Clean up Firestore waiver documents and projections for retired player aliases while keeping historical relational records intact.
- Strengthen tests and migration architecture around roster ownership, alias resolution, and end-to-end fixtures using canonical players.

Build:
- Add a player-identity consolidation script and supporting npm task for planning, validating, and applying identity migrations.

Documentation:
- Add a runbook documenting the safe rollout procedure for canonical player identity consolidation across production databases.

Tests:
- Add migration, consolidation, and alias-resolution test suites covering end-to-end identity consolidation, safety checks, and API behavior with retired aliases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added canonical player identity support with external identity mappings.
  * Added reviewed tooling to propose, validate, preview, and safely apply player identity consolidation.
  * Updated drafts, rosters, trades, lineups, waivers, and player lookups to recognize retired aliases.
  * Added migration and safeguards to preserve league ownership and prevent conflicting consolidations.

* **Documentation**
  * Added a rollout runbook with migration, verification, backup, and recovery guidance.

* **Bug Fixes**
  * Improved waiver projections by removing obsolete alias records.
  * Enforced one roster owner per league and player.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->