### PR TITLE
Fix local stack and realtime state transport

### DIFF
--- a/Scripts/dev/full-local-stack.sh
+++ b/Scripts/dev/full-local-stack.sh
@@ -79,7 +79,7 @@ elif port_is_open "127.0.0.1" "8080" || port_is_open "127.0.0.1" "9099"; then
   echo "local stack: only one Firebase emulator port is available; stop stale Firebase processes and retry" >&2
   exit 1
 else
-  npx firebase emulators:start --only auth,firestore --project "$STATLY_LOCAL_PROJECT_ID" &
+  npm run dev:firebase -- --project "$STATLY_LOCAL_PROJECT_ID" &
   FIREBASE_PID="$!"
 fi
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev:full": "concurrently \"npm run dev\" \"npm run socket\"",
     "dev:with-worker": "concurrently \"npm run dev\" \"npm run draft-worker:dev\"",
     "dev:full:all": "bash Scripts/dev/full-local-stack.sh",
-    "dev:firebase": "npx firebase emulators:start --only auth,firestore --project statly-4cbed",
+    "dev:firebase": "npx --yes --package=firebase-tools@15.24.0 firebase emulators:start --only auth,firestore",
     "dev:seed:local": "tsx Scripts/dev/seed-local-stack.ts",
     "dev:smoke:local": "tsx Scripts/dev/smoke-local-stack.ts",
     "dev:full:local": "bash Scripts/dev/full-local-stack.sh",

--- a/src/server/draft/services/DraftRealtimeDispatcher.ts
+++ b/src/server/draft/services/DraftRealtimeDispatcher.ts
@@ -4,6 +4,10 @@ import {
   type DraftRealtimeEnvelope,
   type DraftRealtimeEventType,
 } from '@/services/realtime/pubsub';
+import {
+  toDraftRealtimeStatePayload,
+  type DraftRealtimeStatePayload,
+} from '@/services/realtime/draftStateWire';
 import type { LiveDraftState } from '@/services/liveDraftEngine';
 
 import type { DraftPickEventPayload } from '../domain/draftTypes';
@@ -78,8 +82,9 @@ export class DraftRealtimeDispatcher {
   }
 
   async publishState(state: LiveDraftState): Promise<void> {
-    this.dispatchToLocal(state.draftId, 'draft:state', state);
-    await draftPubSub.publish(state.draftId, 'draft:state', state);
+    const payload = toDraftRealtimeStatePayload(state);
+    this.dispatchToLocal(state.draftId, 'draft:state', payload);
+    await draftPubSub.publish(state.draftId, 'draft:state', payload);
   }
 
   async publishDraftEvent(
@@ -149,7 +154,7 @@ export class DraftRealtimeDispatcher {
 
     switch (event) {
       case 'draft:state': {
-        const state = payload as LiveDraftState;
+        const state = payload as DraftRealtimeStatePayload;
         this.emitToDraftRooms(draftId, 'draft:state', payload);
         this.emitToDraftRooms(draftId, 'draft:update', payload);
         this.emitCompatDelta(draftId, {
@@ -165,7 +170,7 @@ export class DraftRealtimeDispatcher {
                   : state.currentPick.round % 2 === 1
                     ? 'FORWARD'
                     : 'REVERSE',
-              pickDeadlineAt: state.currentPick.expiresAt.toISOString(),
+              pickDeadlineAt: state.currentPick.expiresAt,
             },
             liveState: {
               currentPick: state.currentPick.pickNumber,

--- a/src/services/realtime/draftStateWire.ts
+++ b/src/services/realtime/draftStateWire.ts
@@ -1,0 +1,89 @@
+import type { LiveDraftState } from '@/services/liveDraftEngine';
+import { z } from 'zod';
+
+const IsoTimestampSchema = z.iso.datetime();
+
+export const DraftRealtimeStatePayloadSchema = z.object({
+  leagueId: z.string(),
+  draftId: z.string(),
+  status: z.enum(['SCHEDULED', 'LOBBY', 'COUNTDOWN', 'LIVE', 'PAUSED', 'COMPLETED']),
+  currentPick: z.object({
+    userId: z.string(),
+    memberId: z.string(),
+    pickNumber: z.number(),
+    round: z.number(),
+    slot: z.number(),
+    expiresAt: IsoTimestampSchema,
+    startedAt: IsoTimestampSchema,
+  }),
+  picks: z.array(
+    z.object({
+      playerId: z.string(),
+      userId: z.string(),
+      memberId: z.string(),
+      pickNumber: z.number(),
+      round: z.number(),
+      slot: z.number(),
+      auto: z.boolean(),
+      timestamp: IsoTimestampSchema,
+    })
+  ),
+  participants: z.array(
+    z.object({
+      userId: z.string(),
+      memberId: z.string(),
+      displayName: z.string(),
+      draftOrder: z.number(),
+      isOnline: z.boolean(),
+      queue: z.array(z.string()),
+      autoPickEnabled: z.boolean(),
+      lastActivity: IsoTimestampSchema,
+    })
+  ),
+  timerSettings: z.object({
+    durationSeconds: z.number(),
+    autopickAfterExpiry: z.boolean(),
+    pausedAt: IsoTimestampSchema.optional(),
+    pausedTimeRemaining: z.number().optional(),
+  }),
+  draftSettings: z.object({
+    totalRounds: z.number(),
+    totalTeams: z.number(),
+    draftType: z.enum(['SNAKE', 'LINEAR']),
+    pickTimeLimit: z.number(),
+  }),
+  paused: z.boolean(),
+  createdAt: IsoTimestampSchema,
+  updatedAt: IsoTimestampSchema,
+  lastActivity: IsoTimestampSchema,
+});
+
+export type DraftRealtimeStatePayload = z.infer<typeof DraftRealtimeStatePayloadSchema>;
+
+export function toDraftRealtimeStatePayload(state: LiveDraftState): DraftRealtimeStatePayload {
+  return DraftRealtimeStatePayloadSchema.parse({
+    ...state,
+    currentPick: {
+      ...state.currentPick,
+      expiresAt: state.currentPick.expiresAt.toISOString(),
+      startedAt: state.currentPick.startedAt.toISOString(),
+    },
+    picks: state.picks.map((pick) => ({
+      ...pick,
+      timestamp: pick.timestamp.toISOString(),
+    })),
+    participants: state.participants.map((participant) => ({
+      ...participant,
+      lastActivity: participant.lastActivity.toISOString(),
+    })),
+    timerSettings: {
+      ...state.timerSettings,
+      ...(state.timerSettings.pausedAt
+        ? { pausedAt: state.timerSettings.pausedAt.toISOString() }
+        : {}),
+    },
+    createdAt: state.createdAt.toISOString(),
+    updatedAt: state.updatedAt.toISOString(),
+    lastActivity: state.lastActivity.toISOString(),
+  });
+}

--- a/src/services/realtime/pubsub.ts
+++ b/src/services/realtime/pubsub.ts
@@ -1,5 +1,6 @@
 import { getPublisherClient, getSubscriberClient } from '@/server/realtime/scalableConnection';
 import { logger } from '@/lib/logger';
+import { DraftRealtimeStatePayloadSchema } from '@/services/realtime/draftStateWire';
 import type { Redis as IORedisClient, Cluster as IORedisCluster } from 'ioredis';
 import { z } from 'zod';
 
@@ -39,7 +40,7 @@ const EnvelopeSchema = z.object({
   ts: z.number(),
 });
 
-function parseAndValidateEnvelope(raw: string): DraftRealtimeEnvelope | null {
+export function parseAndValidateEnvelope(raw: string): DraftRealtimeEnvelope | null {
   try {
     const json = JSON.parse(raw);
     const res = EnvelopeSchema.safeParse(json);
@@ -50,7 +51,27 @@ function parseAndValidateEnvelope(raw: string): DraftRealtimeEnvelope | null {
       });
       return null;
     }
-    return res.data as DraftRealtimeEnvelope;
+
+    if (res.data.event === 'draft:state') {
+      const stateResult = DraftRealtimeStatePayloadSchema.safeParse(res.data.payload);
+      if (!stateResult.success) {
+        logger.warn('Invalid draft realtime state payload received', {
+          issues: stateResult.error.issues.map((issue) => ({
+            path: issue.path,
+            code: issue.code,
+            message: issue.message,
+          })),
+        });
+        return null;
+      }
+
+      return {
+        ...res.data,
+        payload: stateResult.data,
+      };
+    }
+
+    return res.data;
   } catch (e) {
     logger.warn('Failed to parse JSON for realtime envelope', {
       error: e instanceof Error ? e.message : String(e),

--- a/src/services/realtime/pubsub.ts
+++ b/src/services/realtime/pubsub.ts
@@ -65,6 +65,14 @@ export function parseAndValidateEnvelope(raw: string): DraftRealtimeEnvelope | n
         return null;
       }
 
+      if (stateResult.data.draftId !== res.data.draftId) {
+        logger.warn('Draft realtime state envelope draftId mismatch', {
+          envelopeDraftId: res.data.draftId,
+          payloadDraftId: stateResult.data.draftId,
+        });
+        return null;
+      }
+
       return {
         ...res.data,
         payload: stateResult.data,

--- a/tests/unit/draftRealtimeDispatcher.productionReadiness.test.ts
+++ b/tests/unit/draftRealtimeDispatcher.productionReadiness.test.ts
@@ -1,6 +1,70 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import type { LiveDraftState } from '@/services/liveDraftEngine';
+import { DraftRealtimeDispatcher } from '@/server/draft/services/DraftRealtimeDispatcher';
+import { DraftRealtimeStatePayloadSchema } from '@/services/realtime/draftStateWire';
+import { draftPubSub, parseAndValidateEnvelope } from '@/services/realtime/pubsub';
+import { describe, expect, it, vi } from 'vitest';
+
+function buildLiveDraftState(): LiveDraftState {
+  const startedAt = new Date('2026-07-28T12:00:00.000Z');
+  const expiresAt = new Date('2026-07-28T12:01:30.000Z');
+
+  return {
+    leagueId: 'league-1',
+    draftId: 'draft-1',
+    status: 'LIVE',
+    currentPick: {
+      userId: 'user-1',
+      memberId: 'member-1',
+      pickNumber: 1,
+      round: 1,
+      slot: 1,
+      expiresAt,
+      startedAt,
+    },
+    picks: [
+      {
+        playerId: 'player-1',
+        userId: 'user-2',
+        memberId: 'member-2',
+        pickNumber: 0,
+        round: 0,
+        slot: 0,
+        auto: false,
+        timestamp: startedAt,
+      },
+    ],
+    participants: [
+      {
+        userId: 'user-1',
+        memberId: 'member-1',
+        displayName: 'Member One',
+        draftOrder: 1,
+        isOnline: true,
+        queue: ['player-2'],
+        autoPickEnabled: false,
+        lastActivity: startedAt,
+      },
+    ],
+    timerSettings: {
+      durationSeconds: 90,
+      autopickAfterExpiry: true,
+      pausedAt: startedAt,
+      pausedTimeRemaining: 45,
+    },
+    draftSettings: {
+      totalRounds: 22,
+      totalTeams: 12,
+      draftType: 'SNAKE',
+      pickTimeLimit: 90,
+    },
+    paused: false,
+    createdAt: startedAt,
+    updatedAt: startedAt,
+    lastActivity: startedAt,
+  };
+}
 
 describe('draft realtime dispatcher production readiness', () => {
   it('does not warn for expected worker-side local emit skips', () => {
@@ -20,7 +84,72 @@ describe('draft realtime dispatcher production readiness', () => {
       'utf8'
     );
 
-    expect(source).toContain('pickDeadlineAt: state.currentPick.expiresAt.toISOString()');
+    expect(source).toContain('pickDeadlineAt: state.currentPick.expiresAt');
+    expect(source).not.toContain('state.currentPick.expiresAt.toISOString()');
+  });
+
+  it('uses one validated ISO timestamp payload for local and Redis state fanout', async () => {
+    const publishSpy = vi.spyOn(draftPubSub, 'publish').mockResolvedValue();
+    const emit = vi.fn();
+    const to = vi.fn(() => ({ emit }));
+    const dispatcher = new DraftRealtimeDispatcher();
+    dispatcher.attachSocketServer({ local: { to } } as never);
+
+    await dispatcher.publishState(buildLiveDraftState());
+
+    const publishedPayload = publishSpy.mock.calls[0]?.[2];
+    const wirePayload = DraftRealtimeStatePayloadSchema.parse(publishedPayload);
+    const jsonPayload = JSON.parse(JSON.stringify(wirePayload));
+    const parsedEnvelope = parseAndValidateEnvelope(
+      JSON.stringify({
+        v: 1,
+        event: 'draft:state',
+        draftId: 'draft-1',
+        payload: jsonPayload,
+        instanceId: 'another-instance',
+        ts: Date.now(),
+      })
+    );
+
+    expect(wirePayload.currentPick.expiresAt).toBe('2026-07-28T12:01:30.000Z');
+    expect(wirePayload.currentPick.startedAt).toBe('2026-07-28T12:00:00.000Z');
+    expect(wirePayload.picks[0]?.timestamp).toBe('2026-07-28T12:00:00.000Z');
+    expect(wirePayload.participants[0]?.lastActivity).toBe('2026-07-28T12:00:00.000Z');
+    expect(wirePayload.timerSettings.pausedAt).toBe('2026-07-28T12:00:00.000Z');
+    expect(parsedEnvelope?.payload).toEqual(jsonPayload);
+    expect(emit).toHaveBeenCalledWith('draft:state', wirePayload);
+    expect(emit).toHaveBeenCalledWith(
+      'draft:delta',
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          draft: expect.objectContaining({
+            pickDeadlineAt: '2026-07-28T12:01:30.000Z',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('rejects draft state envelopes with invalid wire timestamps', () => {
+    const payload = DraftRealtimeStatePayloadSchema.parse(
+      JSON.parse(JSON.stringify(buildLiveDraftState()))
+    );
+
+    expect(
+      parseAndValidateEnvelope(
+        JSON.stringify({
+          v: 1,
+          event: 'draft:state',
+          draftId: 'draft-1',
+          payload: {
+            ...payload,
+            currentPick: { ...payload.currentPick, expiresAt: 'not-a-timestamp' },
+          },
+          instanceId: 'another-instance',
+          ts: Date.now(),
+        })
+      )
+    ).toBeNull();
   });
 
   it('surfaces next pick metadata on pick deltas so the client clock advances', () => {

--- a/tests/unit/draftRealtimeDispatcher.productionReadiness.test.ts
+++ b/tests/unit/draftRealtimeDispatcher.productionReadiness.test.ts
@@ -152,6 +152,25 @@ describe('draft realtime dispatcher production readiness', () => {
     ).toBeNull();
   });
 
+  it('rejects draft state envelopes that route a payload to another draft', () => {
+    const payload = DraftRealtimeStatePayloadSchema.parse(
+      JSON.parse(JSON.stringify(buildLiveDraftState()))
+    );
+
+    expect(
+      parseAndValidateEnvelope(
+        JSON.stringify({
+          v: 1,
+          event: 'draft:state',
+          draftId: 'draft-2',
+          payload,
+          instanceId: 'another-instance',
+          ts: Date.now(),
+        })
+      )
+    ).toBeNull();
+  });
+
   it('surfaces next pick metadata on pick deltas so the client clock advances', () => {
     const source = readFileSync(
       join(process.cwd(), 'src/server/draft/services/DraftRealtimeDispatcher.ts'),

--- a/tests/unit/localFullStackArchitecture.test.ts
+++ b/tests/unit/localFullStackArchitecture.test.ts
@@ -25,10 +25,17 @@ describe('local full stack development architecture', () => {
   });
 
   it('exposes one canonical local full-stack command plus seed and smoke commands', () => {
-    const packageJson = JSON.parse(read('package.json')) as { scripts?: Record<string, string> };
+    const packageJson = JSON.parse(read('package.json')) as {
+      scripts?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
     const scripts = packageJson.scripts ?? {};
 
-    expect(scripts['dev:firebase']).toContain('emulators:start --only auth,firestore');
+    expect(packageJson.devDependencies?.['firebase-tools']).toBeUndefined();
+    expect(scripts['dev:firebase']).toBe(
+      'npx --yes --package=firebase-tools@15.24.0 firebase emulators:start --only auth,firestore'
+    );
+    expect(scripts['dev:firebase']).not.toContain('npx firebase');
     expect(scripts['dev:seed:local']).toBe('tsx Scripts/dev/seed-local-stack.ts');
     expect(scripts['dev:smoke:local']).toBe('tsx Scripts/dev/smoke-local-stack.ts');
     expect(scripts['dev:full:local']).toBe('bash Scripts/dev/full-local-stack.sh');
@@ -51,7 +58,8 @@ describe('local full stack development architecture', () => {
     expect(source).not.toContain(deprecatedEmulatorKeyLiteral);
     expect(source).toContain('port_is_open()');
     expect(source).toContain('reusing existing Firebase emulators');
-    expect(source).toContain('npx firebase emulators:start --only auth,firestore');
+    expect(source).toContain('npm run dev:firebase -- --project "$STATLY_LOCAL_PROJECT_ID"');
+    expect(source).not.toContain('npx firebase');
     expect(source).toContain('npm run prisma:generate');
     expect(source).toContain('npx prisma migrate deploy');
     expect(source).toContain('npm run dev:seed:local');


### PR DESCRIPTION
## Summary

- make the canonical local full-stack command resolve the pinned Firebase CLI instead of the Firebase SDK package
- serialize draft state to one validated ISO-timestamp wire contract before local and Redis fanout
- reject malformed cross-instance draft state and cover the JSON round trip behaviorally

## Root cause

Fresh clones ran `npx firebase`, which resolved the installed Firebase SDK package rather than the emulator CLI. Draft state was also emitted locally as `Date` objects but serialized through Redis as strings, while the compatibility delta still called `.toISOString()` after cross-instance delivery.

## Impact

`npm run dev:full:local` now starts the Firebase emulators from a fresh clone, and local/cross-instance draft state use the same transport-safe timestamp shape.

## Verification

- `npm run typecheck`
- `npm run typecheck:tests`
- touched-file ESLint with zero warnings
- Prettier checks and `bash -n Scripts/dev/full-local-stack.sh`
- targeted unit suites: 16/16 tests
- complete unit suite: 208 files, 856/856 tests
- fresh disposable clone: `npm ci`, `npm run dev:full:local`, and `npm run dev:smoke:local`
- logical council Decision 2: COMMIT

## Scope

Dependency upgrades, credential rotation/history cleanup, race hardening, legacy realtime retirement, and baseline formatting remain separate follow-up work.

## Summary by Sourcery

Align local full-stack Firebase emulator startup with a pinned CLI and standardize draft realtime state transport to a validated ISO-timestamp wire payload across local and Redis fanout.

Enhancements:
- Introduce a dedicated draft realtime state wire schema and converter to serialize LiveDraftState timestamps as ISO strings for transport.
- Validate incoming draft:state envelopes against the wire schema and drop malformed timestamp payloads while logging structured issues.
- Update DraftRealtimeDispatcher to emit draft state and compatibility deltas from the wire payload instead of raw LiveDraftState.
- Refine local full-stack architecture tests to enforce the new Firebase emulator command and script wiring.

Build:
- Change dev:firebase script to run the Firebase emulator via a pinned firebase-tools@15.24.0 CLI using npx and ensure full-local-stack uses this script instead of calling npx firebase directly.

Tests:
- Extend draft realtime dispatcher production readiness tests to cover ISO-timestamp serialization, JSON round trips, and rejection of invalid draft state payloads.
- Tighten local full stack development tests to ensure the canonical dev:firebase script uses the pinned firebase-tools CLI and the shell script delegates to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved draft realtime updates by standardizing state data and timestamp handling across local and published events.
  * Added validation to reject malformed draft state messages, improving reliability of live draft updates.

* **Development Experience**
  * Updated local Firebase emulator startup to use a pinned tool version and the configured local project.
  * Strengthened checks for local full-stack setup and realtime draft event behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->