### PR TITLE
Harden draft queue and room UX

### DIFF
--- a/prisma/migrations/20260801193000_add_pre_draft_queue_cleanup_index/migration.sql
+++ b/prisma/migrations/20260801193000_add_pre_draft_queue_cleanup_index/migration.sql
@@ -1,0 +1,3 @@
+-- Support draft-wide removal when a player is selected.
+CREATE INDEX "PreDraftQueue_draftId_playerId_idx"
+ON "PreDraftQueue"("draftId", "playerId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -416,6 +416,7 @@ model PreDraftQueue {
 
   @@unique([draftId, memberId, playerId])
   @@index([draftId, memberId])
+  @@index([draftId, playerId])
   @@index([rank])
 }
 

--- a/src/app/api/drafts/[id]/pre-queue/route.ts
+++ b/src/app/api/drafts/[id]/pre-queue/route.ts
@@ -1,9 +1,13 @@
 import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+
 import { successResponse, errorResponse, commonErrors } from '@/lib/apiResponse';
 import { logger } from '@/lib/logger';
 import { getAuthenticatedUserId } from '@/lib/serverAuth';
 import {
   DraftPrivateStateAccessError,
+  DraftPrivateStateConflictError,
+  DraftPrivateStateValidationError,
   draftPrivateStateService,
 } from '@/server/draft/services/DraftPrivateStateService';
 
@@ -11,13 +15,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-interface PreQueueRequest {
-  queue: Array<{
-    playerId: string;
-    rank: number;
-    notes?: string;
-  }>;
-}
+const PreQueueRequestSchema = z.object({
+  queue: z.array(
+    z.object({
+      playerId: z.string().trim().min(1),
+      rank: z.coerce.number().int().positive(),
+      notes: z.string().optional(),
+    })
+  ),
+});
 
 async function authenticate(request: NextRequest): Promise<string | Response> {
   const actorUserId = await getAuthenticatedUserId(request);
@@ -37,6 +43,12 @@ function privateResponse(data: unknown): Response {
 function privateStateErrorResponse(error: unknown, operation: string, draftId: string): Response {
   if (error instanceof DraftPrivateStateAccessError) {
     return commonErrors.forbidden(error.message);
+  }
+  if (error instanceof DraftPrivateStateValidationError) {
+    return commonErrors.badRequest(error.message);
+  }
+  if (error instanceof DraftPrivateStateConflictError) {
+    return errorResponse(error.message, 409, 'CONFLICT');
   }
 
   logger.error(`Failed to ${operation}`, {
@@ -82,25 +94,21 @@ export async function PUT(
       return actorUserId;
     }
 
-    const body = (await request.json().catch(() => null)) as PreQueueRequest | null;
-    if (!body || !Array.isArray(body.queue)) {
-      return errorResponse('Invalid queue format', 400);
+    const parsed = PreQueueRequestSchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
+      return commonErrors.unprocessableEntity('Invalid queue format', {
+        issues: parsed.error.flatten(),
+      });
     }
 
-    // Validate queue items
-    for (const item of body.queue) {
-      if (!item.playerId || typeof item.rank !== 'number') {
-        return errorResponse('Invalid queue item format', 400);
-      }
-    }
-
-    const updatedQueue = await draftPrivateStateService.replacePreDraftQueue({
+    const result = await draftPrivateStateService.replacePreDraftQueue({
       draftId,
       actorUserId,
-      queue: body.queue,
+      unresolvedPlayerPolicy: 'reject',
+      queue: parsed.data.queue,
     });
 
-    return privateResponse({ queue: updatedQueue });
+    return privateResponse(result);
   } catch (error) {
     return privateStateErrorResponse(error, 'update pre-draft queue', (await params).id);
   }

--- a/src/app/api/drafts/[id]/queue/route.ts
+++ b/src/app/api/drafts/[id]/queue/route.ts
@@ -1,15 +1,19 @@
 import type { NextRequest } from 'next/server';
 import { z } from 'zod';
 
-import { successResponse, errorResponse, commonErrors } from '@/lib/apiResponse';
+import { commonErrors, errorResponse, successResponse } from '@/lib/apiResponse';
 import { logger } from '@/lib/logger';
-import { prisma } from '@/lib/prisma';
 import { getAuthenticatedUserId } from '@/lib/serverAuth';
-import { getDraftMembershipAccess } from '@/server/leagues/membership';
 import {
-  resolveCanonicalPlayerId,
-  resolveCanonicalPlayerIds,
-} from '@/server/players/playerIdentityService';
+  DraftPrivateStateAccessError,
+  DraftPrivateStateConflictError,
+  DraftPrivateStateValidationError,
+  draftPrivateStateService,
+} from '@/server/draft/services/DraftPrivateStateService';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
 const QueuePostSchema = z.object({
   playerId: z.string().trim().min(1),
@@ -24,138 +28,72 @@ const QueuePutSchema = z.object({
   queue: z.array(z.string().trim().min(1)).default([]),
 });
 
-const queueEntrySelect = {
-  id: true,
-  draftId: true,
-  memberId: true,
-  playerId: true,
-  rank: true,
-  notes: true,
-} as const;
-
-async function resolveQueueMember(
-  request: NextRequest,
-  draftId: string
-): Promise<{ memberId: string; userId: string } | Response> {
-  const userId = await getAuthenticatedUserId(request);
-  if (!userId) {
-    return commonErrors.unauthorized();
+async function authenticate(request: NextRequest): Promise<string | Response> {
+  const actorUserId = await getAuthenticatedUserId(request);
+  if (!actorUserId) {
+    return commonErrors.unauthorized('Authentication required');
   }
 
-  const access = await getDraftMembershipAccess(draftId, userId);
-  if (!access.isMember || !access.memberId) {
-    return commonErrors.forbidden('Not a member of this draft');
-  }
-
-  return { memberId: access.memberId, userId };
+  return actorUserId;
 }
 
 function isInvalidDraftId(draftId: string): boolean {
   return typeof draftId !== 'string' || draftId.trim().length === 0;
 }
 
+function privateResponse(data: unknown, status = 200): Response {
+  const response = successResponse(data, status);
+  response.headers.set('Cache-Control', 'private, no-store');
+  return response;
+}
+
+function privateStateErrorResponse(error: unknown, operation: string, draftId: string): Response {
+  if (error instanceof DraftPrivateStateAccessError) {
+    return commonErrors.forbidden(error.message);
+  }
+  if (error instanceof DraftPrivateStateValidationError) {
+    return commonErrors.badRequest(error.message);
+  }
+  if (error instanceof DraftPrivateStateConflictError) {
+    return errorResponse(error.message, 409, 'CONFLICT');
+  }
+
+  logger.error(`Failed to ${operation}`, {
+    draftId,
+    error: error instanceof Error ? error.message : String(error),
+  });
+  return errorResponse(`Failed to ${operation}`, 500);
+}
+
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
+  const { id: draftId } = await params;
   try {
-    const { id: draftId } = await params;
     if (isInvalidDraftId(draftId)) {
-      return errorResponse('Missing or invalid draftId', 400);
+      return commonErrors.badRequest('Missing or invalid draftId');
     }
 
-    const access = await resolveQueueMember(request, draftId);
-    if (access instanceof Response) {
-      return access;
-    }
+    const actorUserId = await authenticate(request);
+    if (actorUserId instanceof Response) return actorUserId;
 
-    const json = await request.json().catch(() => null);
-    const parsed = QueuePostSchema.safeParse(json);
+    const parsed = QueuePostSchema.safeParse(await request.json().catch(() => null));
     if (!parsed.success) {
       return commonErrors.unprocessableEntity('Invalid request body', {
         issues: parsed.error.flatten(),
       });
     }
 
-    const playerId = await resolveCanonicalPlayerId(parsed.data.playerId);
-    if (!playerId) {
-      return commonErrors.badRequest('Player not found or not available');
-    }
-    const memberId = access.memberId;
-
-    const alreadyPicked = await prisma.pick.findFirst({
-      where: { draftId, playerId },
-      select: { id: true },
-    });
-    if (alreadyPicked) {
-      return commonErrors.badRequest('Player already picked');
-    }
-
-    const player = await prisma.player.findUnique({
-      where: { id: playerId },
-      select: { id: true, name: true, active: true },
-    });
-    if (!player?.active) {
-      return commonErrors.badRequest('Player not found or not available');
-    }
-
-    const entry = await prisma.$transaction(async (tx) => {
-      const existing = await tx.preDraftQueue.findUnique({
-        where: {
-          draftId_memberId_playerId: {
-            draftId,
-            memberId,
-            playerId,
-          },
-        },
-        select: queueEntrySelect,
-      });
-
-      if (existing && parsed.data.rank === undefined) {
-        return existing;
-      }
-
-      const rank =
-        parsed.data.rank ??
-        ((
-          await tx.preDraftQueue.aggregate({
-            where: { draftId, memberId },
-            _max: { rank: true },
-          })
-        )._max.rank ?? 0) + 1;
-
-      return tx.preDraftQueue.upsert({
-        where: {
-          draftId_memberId_playerId: {
-            draftId,
-            memberId,
-            playerId,
-          },
-        },
-        update: { rank },
-        create: { draftId, memberId, playerId, rank },
-        select: queueEntrySelect,
-      });
-    });
-
-    logger.info('Player added to queue', {
+    const entry = await draftPrivateStateService.addToPreDraftQueue({
       draftId,
-      memberId,
-      playerId,
-      playerName: player.name,
-      rank: entry.rank,
+      actorUserId,
+      ...parsed.data,
     });
 
-    return successResponse(entry, 201);
+    return privateResponse(entry, 201);
   } catch (error) {
-    logger.error('Failed to add player to queue', {
-      error: {
-        name: error instanceof Error ? error.name : 'Unknown',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-    });
-    return errorResponse('Failed to add player to queue', 500);
+    return privateStateErrorResponse(error, 'add player to queue', draftId);
   }
 }
 
@@ -163,16 +101,14 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
+  const { id: draftId } = await params;
   try {
-    const { id: draftId } = await params;
     if (isInvalidDraftId(draftId)) {
-      return errorResponse('Missing or invalid draftId', 400);
+      return commonErrors.badRequest('Missing or invalid draftId');
     }
 
-    const access = await resolveQueueMember(request, draftId);
-    if (access instanceof Response) {
-      return access;
-    }
+    const actorUserId = await authenticate(request);
+    if (actorUserId instanceof Response) return actorUserId;
 
     const url = new URL(request.url);
     const parsed = QueueDeleteQuerySchema.safeParse({
@@ -184,36 +120,18 @@ export async function DELETE(
       });
     }
 
-    const { memberId } = access;
-    const playerId = await resolveCanonicalPlayerId(parsed.data.playerId);
-    if (!playerId) {
-      return commonErrors.notFound('Player not in queue');
-    }
-    const deleted = await prisma.preDraftQueue.deleteMany({
-      where: { draftId, memberId, playerId },
-    });
-
-    if (deleted.count === 0) {
-      return commonErrors.notFound('Player not in queue');
-    }
-
-    logger.info('Player removed from queue', {
+    const removed = await draftPrivateStateService.removeFromPreDraftQueue({
       draftId,
-      memberId,
-      playerId,
+      actorUserId,
+      playerId: parsed.data.playerId,
     });
+    if (!removed) {
+      return commonErrors.notFound('Player not in queue');
+    }
 
-    return successResponse({ message: 'Player removed from queue' });
+    return privateResponse({ message: 'Player removed from queue' });
   } catch (error) {
-    logger.error('Failed to remove player from queue', {
-      error: {
-        name: error instanceof Error ? error.name : 'Unknown',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-    });
-
-    return errorResponse('Failed to remove player from queue', 500);
+    return privateStateErrorResponse(error, 'remove player from queue', draftId);
   }
 }
 
@@ -221,44 +139,19 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
+  const { id: draftId } = await params;
   try {
-    const { id: draftId } = await params;
     if (isInvalidDraftId(draftId)) {
-      return errorResponse('Missing or invalid draftId', 400);
+      return commonErrors.badRequest('Missing or invalid draftId');
     }
 
-    const access = await resolveQueueMember(request, draftId);
-    if (access instanceof Response) {
-      return access;
-    }
+    const actorUserId = await authenticate(request);
+    if (actorUserId instanceof Response) return actorUserId;
 
-    const queueEntries = await prisma.preDraftQueue.findMany({
-      where: { draftId, memberId: access.memberId },
-      orderBy: { rank: 'asc' },
-      include: {
-        player: {
-          select: { id: true, name: true, position: true, club: true, active: true },
-        },
-      },
-    });
-
-    logger.info('Queue retrieved', {
-      draftId,
-      memberId: access.memberId,
-      queueSize: queueEntries.length,
-    });
-
-    return successResponse(queueEntries);
+    const queue = await draftPrivateStateService.getPreDraftQueue({ draftId, actorUserId });
+    return privateResponse(queue);
   } catch (error) {
-    logger.error('Failed to get queue', {
-      error: {
-        name: error instanceof Error ? error.name : 'Unknown',
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-    });
-
-    return errorResponse('Failed to get queue', 500);
+    return privateStateErrorResponse(error, 'get queue', draftId);
   }
 }
 
@@ -266,99 +159,38 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
+  const { id: draftId } = await params;
   try {
-    const { id: draftId } = await params;
     if (isInvalidDraftId(draftId)) {
       return commonErrors.badRequest('Missing or invalid draftId');
     }
 
-    const access = await resolveQueueMember(request, draftId);
-    if (access instanceof Response) {
-      return access;
-    }
+    const actorUserId = await authenticate(request);
+    if (actorUserId instanceof Response) return actorUserId;
 
-    const raw = await request.json().catch(() => ({}));
-    const parsed = QueuePutSchema.safeParse(raw);
+    const parsed = QueuePutSchema.safeParse(await request.json().catch(() => null));
     if (!parsed.success) {
       return commonErrors.unprocessableEntity('Invalid request body', {
         issues: parsed.error.flatten(),
       });
     }
 
-    const memberId = access.memberId;
-    const requestedIds = Array.from(new Set(parsed.data.queue.map(String)));
-    const resolvedIds = await resolveCanonicalPlayerIds(requestedIds);
-    const inputIds = Array.from(
-      new Set(requestedIds.map((playerId) => resolvedIds.get(playerId) ?? playerId))
-    );
-
-    const { created, failedIds } = await prisma.$transaction(async (tx) => {
-      const [activePlayers, alreadyPicked] = await Promise.all([
-        tx.player.findMany({
-          where: { id: { in: inputIds }, active: true },
-          select: { id: true },
-        }),
-        tx.pick.findMany({
-          where: { draftId, playerId: { in: inputIds } },
-          select: { playerId: true },
-        }),
-      ]);
-
-      const activeIds = new Set(activePlayers.map((player) => player.id));
-      const pickedIds = new Set(alreadyPicked.map((pick) => pick.playerId));
-      const availableIds = new Set(
-        inputIds.filter((playerId) => activeIds.has(playerId) && !pickedIds.has(playerId))
-      );
-
-      await tx.preDraftQueue.deleteMany({ where: { draftId, memberId } });
-
-      const created: Array<{
-        id: string;
-        draftId: string;
-        memberId: string;
-        playerId: string;
-        rank: number;
-        notes: string | null;
-      }> = [];
-      const failedIds: string[] = [];
-
-      for (const playerId of inputIds) {
-        if (!availableIds.has(playerId)) {
-          failedIds.push(playerId);
-          continue;
-        }
-
-        const entry = await tx.preDraftQueue.create({
-          data: {
-            draftId,
-            memberId,
-            playerId,
-            rank: created.length + 1,
-          },
-          select: queueEntrySelect,
-        });
-        created.push(entry);
-      }
-
-      return { created, failedIds };
-    });
-
-    logger.info('Queue replaced', {
+    const result = await draftPrivateStateService.replacePreDraftQueue({
       draftId,
-      memberId,
-      size: created.length,
-      failed: failedIds.length,
+      actorUserId,
+      unresolvedPlayerPolicy: 'remove',
+      queue: parsed.data.queue.map((playerId, index) => ({
+        playerId,
+        rank: index + 1,
+      })),
     });
 
-    return successResponse({
-      memberId,
-      queue: created,
-      failedIds,
+    return privateResponse({
+      memberId: result.memberId,
+      queue: result.queue,
+      failedIds: result.removedPlayerIds,
     });
   } catch (error) {
-    logger.error('Failed to replace queue', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return errorResponse('Failed to update queue', 500);
+    return privateStateErrorResponse(error, 'update queue', draftId);
   }
 }

--- a/src/components/DraftWatchlist.tsx
+++ b/src/components/DraftWatchlist.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import { AlertCircle, Bookmark, Clock, ListPlus, Search, Trash2, Zap } from 'lucide-react';
 
 import type { DraftPlayer } from '@/types/draft';
+import { getStatlyZPresentation } from '@/lib/statlyZPresentation';
 import { cn } from '@/lib/utils';
 
 interface WatchlistItem {
@@ -32,13 +33,22 @@ interface WatchlistProps {
   pendingWatchlistPlayerIds?: string[];
   onRemoveFromWatchlist: (playerId: string) => void | Promise<void>;
   isLoading?: boolean;
+  isQueueMutationPending?: boolean;
 }
 
 type WatchlistRow = {
   item: WatchlistItem;
   player: Pick<DraftPlayer, 'id' | 'name' | 'position' | 'club'> &
     Partial<
-      Pick<DraftPlayer, 'avgPoints' | 'averagePoints' | 'adp' | 'injuryStatus' | 'isAvailable'>
+      Pick<
+        DraftPlayer,
+        | 'adp'
+        | 'injuryStatus'
+        | 'isAvailable'
+        | 'statlyZScore'
+        | 'statlyZBreakdown'
+        | 'statlyZMissingCategories'
+      >
     >;
   draftablePlayer: DraftPlayer | null;
   order: number;
@@ -82,7 +92,13 @@ function getInjuryLabel(player: WatchlistRow['player']): string | null {
 }
 
 function WatchlistPlayerMeta({ row }: { row: WatchlistRow }) {
-  const avgPoints = row.player.avgPoints ?? row.player.averagePoints;
+  const statlyZ = row.draftablePlayer
+    ? getStatlyZPresentation(row.player)
+    : {
+        state: 'no-data' as const,
+        value: '—',
+        accessibleLabel: 'Statly Z unavailable for this drafted or unavailable player',
+      };
 
   return (
     <div className="mt-1 flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
@@ -91,7 +107,14 @@ function WatchlistPlayerMeta({ row }: { row: WatchlistRow }) {
       </span>
       <span className="truncate">{row.player.club}</span>
       {typeof row.player.adp === 'number' && <span className="shrink-0">ADP {row.player.adp}</span>}
-      {typeof avgPoints === 'number' && <span className="shrink-0">{avgPoints.toFixed(1)} avg</span>}
+      <span className="shrink-0" aria-label={statlyZ.accessibleLabel}>
+        Statly Z {statlyZ.value}
+      </span>
+      {statlyZ.state === 'partial' && (
+        <span className="shrink-0 rounded-md border border-border bg-muted px-1.5 py-0.5 text-[0.625rem] font-medium uppercase">
+          Partial
+        </span>
+      )}
     </div>
   );
 }
@@ -124,6 +147,7 @@ interface WatchlistRowActionsProps {
   canActOnPlayer: boolean;
   canDraft: boolean;
   isLoading: boolean;
+  isQueueMutationPending: boolean;
   isWatchlistPending: boolean;
   onAddToQueue?: (player: DraftPlayer) => void | Promise<void>;
   onDraftPlayer: (player: DraftPlayer) => void | Promise<void>;
@@ -135,6 +159,7 @@ function WatchlistRowActions({
   canActOnPlayer,
   canDraft,
   isLoading,
+  isQueueMutationPending,
   isWatchlistPending,
   onAddToQueue,
   onDraftPlayer,
@@ -148,7 +173,7 @@ function WatchlistRowActions({
           onClick={() => {
             if (row.draftablePlayer) void onAddToQueue(row.draftablePlayer);
           }}
-          disabled={!canActOnPlayer || row.isQueued || isLoading}
+          disabled={!canActOnPlayer || row.isQueued || isQueueMutationPending}
           className="inline-flex h-8 items-center justify-center gap-1 rounded-md border border-primary/20 bg-primary/10 px-2 text-xs font-medium text-primary transition-colors hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
           aria-label={
             row.isQueued
@@ -197,6 +222,7 @@ interface WatchlistPlayerRowProps {
   row: WatchlistRow;
   canDraft: boolean;
   isLoading: boolean;
+  isQueueMutationPending: boolean;
   pendingWatchlistIds: ReadonlySet<string>;
   onAddToQueue?: (player: DraftPlayer) => void | Promise<void>;
   onDraftPlayer: (player: DraftPlayer) => void | Promise<void>;
@@ -207,6 +233,7 @@ function WatchlistPlayerRow({
   row,
   canDraft,
   isLoading,
+  isQueueMutationPending,
   pendingWatchlistIds,
   onAddToQueue,
   onDraftPlayer,
@@ -252,6 +279,7 @@ function WatchlistPlayerRow({
             canActOnPlayer={canActOnPlayer}
             canDraft={canDraft}
             isLoading={isLoading}
+            isQueueMutationPending={isQueueMutationPending}
             isWatchlistPending={isWatchlistPending}
             onAddToQueue={onAddToQueue}
             onDraftPlayer={onDraftPlayer}
@@ -275,6 +303,7 @@ export default function DraftWatchlist({
   pendingWatchlistPlayerIds = [],
   onRemoveFromWatchlist,
   isLoading = false,
+  isQueueMutationPending = false,
 }: WatchlistProps) {
   const [showAvailableOnly, setShowAvailableOnly] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -436,6 +465,7 @@ export default function DraftWatchlist({
                 row={row}
                 canDraft={canDraft}
                 isLoading={isLoading}
+                isQueueMutationPending={isQueueMutationPending}
                 pendingWatchlistIds={pendingWatchlistIds}
                 onAddToQueue={onAddToQueue}
                 onDraftPlayer={onDraftPlayer}

--- a/src/components/LivePickHeader.tsx
+++ b/src/components/LivePickHeader.tsx
@@ -111,12 +111,12 @@ export default function LivePickHeader({
         yourSlot,
         status: normalizedStatus as DraftRoomStatus,
         timePerPick,
+        draftType: draftData.draftType,
       }),
     [draftData, normalizedStatus, timePerPick, yourSlot]
   );
   const nextUserPick = sequence.nextUserPick;
   const picksUntilYourTurn = nextUserPick?.picksUntil ?? 0;
-  const estimatedTimeUntilYourTurn = nextUserPick?.estimatedSecondsUntil ?? 0;
 
   const getTimerState = useMemo(
     () => () => {
@@ -404,16 +404,9 @@ export default function LivePickHeader({
                 }`}
                 role="status"
                 aria-live="polite"
-                aria-label={`Your turn status: ${picksUntilYourTurn === 1 ? 'You are up next' : `${picksUntilYourTurn} picks until your turn`}`}
+                aria-label={`Your next pick is pick ${nextUserPick?.overall}`}
               >
-                {picksUntilYourTurn === 1
-                  ? "You're up next"
-                  : `${picksUntilYourTurn} pick${picksUntilYourTurn > 1 ? 's' : ''} until your turn`}
-                {estimatedTimeUntilYourTurn > 0 && (
-                  <span className="ml-1 opacity-75">
-                    / about {formatTime(estimatedTimeUntilYourTurn)}
-                  </span>
-                )}
+                Your next pick: Pick {nextUserPick?.overall}
               </div>
             )}
           </div>

--- a/src/components/PickFeed.tsx
+++ b/src/components/PickFeed.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useEffect } from 'react';
 
 import Image from 'next/image';
-import { Clock3, Sparkles, User, Star, ChevronRight } from 'lucide-react';
+import { Clock3, Sparkles, User, Star } from 'lucide-react';
 
 import { getTeamLogo } from '@/lib/teamLogos';
 import { cn } from '@/lib/utils';
@@ -93,7 +93,7 @@ export default function PickFeed({
     }
 
     if (isWatchlistPick(pick)) {
-      return 'border-accent bg-accent/40';
+      return 'border-[color:var(--draft-broadcast-watchlist-border)] bg-[color:var(--draft-broadcast-watchlist-hit)]';
     }
 
     return 'border-border bg-card hover:bg-accent/50';
@@ -203,12 +203,7 @@ export default function PickFeed({
         </div>
 
         <div className="mt-4 flex items-center justify-between rounded-lg border border-border bg-card px-3 py-2">
-          <div>
-            <div className="text-xs font-medium text-card-foreground">Live rail</div>
-            <div className="text-[11px] text-muted-foreground">
-              {autoScroll ? 'Auto-scroll on new picks' : 'Manual scroll mode'}
-            </div>
-          </div>
+          <span className="text-xs font-medium text-card-foreground">Auto-scroll on new picks</span>
           <button
             type="button"
             onClick={() => setAutoScroll((value) => !value)}
@@ -216,8 +211,9 @@ export default function PickFeed({
               'inline-flex h-7 w-12 items-center rounded-full px-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
               autoScroll ? 'bg-primary' : 'bg-muted'
             )}
-            aria-pressed={autoScroll}
-            aria-label="Toggle auto-scroll"
+            role="switch"
+            aria-checked={autoScroll}
+            aria-label="Auto-scroll on new picks"
           >
             <span
               className={cn(
@@ -249,6 +245,9 @@ export default function PickFeed({
             {filteredPicks.map((pick) => (
               <div
                 key={pick.id}
+                data-pick-state={
+                  isMyPick(pick) ? 'mine' : isWatchlistPick(pick) ? 'watchlist' : 'standard'
+                }
                 className={cn('rounded-lg border p-4 transition-colors', getPickCardClasses(pick))}
               >
                 <div className="flex items-start justify-between gap-3">
@@ -280,19 +279,21 @@ export default function PickFeed({
                         )}
                         {isMyPick(pick) && (
                           <span className="inline-flex items-center gap-1 rounded-full bg-primary px-2 py-0.5 text-[11px] font-medium text-primary-foreground">
-                            <User className="size-3" />
+                            <User className="size-3" aria-hidden="true" />
                             Mine
                           </span>
                         )}
                         {isWatchlistPick(pick) && !isMyPick(pick) && (
-                          <span className="inline-flex items-center gap-1 rounded-full border border-border bg-accent px-2 py-0.5 text-[11px] font-medium text-accent-foreground">
-                            <Star className="size-3" />
+                          <span className="inline-flex items-center gap-1 rounded-full border border-[color:var(--draft-broadcast-watchlist-border)] bg-[color:var(--draft-broadcast-watchlist-chip)] px-2 py-0.5 text-[11px] font-medium text-[color:var(--draft-broadcast-watchlist-chip-text)]">
+                            <Star className="size-3" aria-hidden="true" />
                             Watchlist
                           </span>
                         )}
                       </div>
                       <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-                        <span className="font-medium text-foreground">{getTeamName(pick.slot)}</span>
+                        <span className="font-medium text-foreground">
+                          {getTeamName(pick.slot)}
+                        </span>
                         <span>Round {pick.round}</span>
                         <span>{pick.player.club}</span>
                       </div>
@@ -310,15 +311,11 @@ export default function PickFeed({
                     </div>
                   </div>
                 </div>
-                <div className="mt-3 flex items-center justify-between rounded-lg bg-muted px-3 py-2 text-xs text-muted-foreground">
+                <div className="mt-3 rounded-lg bg-muted px-3 py-2 text-xs text-muted-foreground">
                   <span>
                     Slot {pick.slot}
                     <span className="mx-1.5 text-muted-foreground">/</span>
                     Pick {pick.overall}
-                  </span>
-                  <span className="inline-flex items-center gap-1 font-medium text-foreground">
-                    View context
-                    <ChevronRight className="size-3.5" />
                   </span>
                 </div>
               </div>

--- a/src/components/__tests__/LivePickHeader.test.tsx
+++ b/src/components/__tests__/LivePickHeader.test.tsx
@@ -8,6 +8,7 @@ const draftData = {
   totalPicks: 12,
   round: 1,
   direction: 'FORWARD',
+  draftType: 'SNAKE' as const,
   status: 'LIVE',
   pickDeadlineAt: new Date(Date.now() + 120_000).toISOString(),
   participants: [
@@ -56,6 +57,32 @@ describe('LivePickHeader', () => {
     expect(within(items[2]).getByText('Gamma')).toBeInTheDocument();
     expect(within(items[2]).getByText('Your next pick')).toBeInTheDocument();
     expect(within(draftOrder).queryAllByRole('button')).toHaveLength(0);
+    expect(screen.getByText('Your next pick: Pick 3')).toBeInTheDocument();
+  });
+
+  it('uses linear order for the compact next-pick notice and pick train', () => {
+    render(
+      <LivePickHeader
+        draftData={{
+          ...draftData,
+          currentPick: 4,
+          round: 2,
+          direction: 'FORWARD',
+          draftType: 'LINEAR',
+        }}
+        isYourTurn={false}
+        yourSlot={3}
+      />
+    );
+
+    const draftOrder = screen.getByRole('list', { name: 'Draft picks' });
+    const items = within(draftOrder).getAllByRole('listitem');
+
+    expect(screen.getByText('Your next pick: Pick 6')).toBeInTheDocument();
+    expect(within(items[0]).getByText('Gamma')).toBeInTheDocument();
+    expect(within(items[2]).getByText('Beta')).toBeInTheDocument();
+    expect(within(items[3]).getByText('Gamma')).toBeInTheDocument();
+    expect(within(items[3]).getByText('Your next pick')).toBeInTheDocument();
   });
 
   it('shows a syncing state instead of inventing a two-minute clock', () => {

--- a/src/components/draft/DraftLeftRail.tsx
+++ b/src/components/draft/DraftLeftRail.tsx
@@ -95,15 +95,19 @@ function RosterPanel({ rosterSlots }: { rosterSlots: DraftLeftRailRosterSlot[] }
           {rosterSlots.map((slot) => (
             <li
               key={slot.id}
-              className="rounded-md border border-border bg-background px-3 py-2 text-sm"
+              data-roster-state={slot.player ? 'filled' : 'empty'}
+              className={cn(
+                'rounded-md border border-border px-3 py-2 text-sm',
+                slot.player
+                  ? 'bg-[color:var(--draft-broadcast-roster-filled)]'
+                  : 'border-dashed bg-background'
+              )}
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
                   <p className="truncate font-medium text-foreground">{slot.label}</p>
                   {slot.position && (
-                    <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                      {slot.position}
-                    </p>
+                    <p className="mt-0.5 truncate text-xs text-muted-foreground">{slot.position}</p>
                   )}
                 </div>
                 {!slot.player && (

--- a/src/components/draft/DraftQueue.tsx
+++ b/src/components/draft/DraftQueue.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useCallback, useState } from 'react';
-import { AlertContainer, useAlert } from '@/components/ui/Alert';
 import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
 import { GripVertical, ListPlus, Pencil, Trash2, X } from 'lucide-react';
 import type { DraftPlayer } from '@/types/draft';
@@ -10,7 +9,7 @@ import { cn } from '@/lib/utils';
 interface DraftQueueProps {
   queue: string[];
   availablePlayers: DraftPlayer[];
-  onQueueUpdate: (queue: string[]) => void;
+  onQueueUpdate: (queue: string[]) => Promise<void>;
   isLoading: boolean;
   confirm?: (options: {
     title: string;
@@ -30,11 +29,30 @@ export default function DraftQueue({
   confirm,
 }: DraftQueueProps) {
   const [isEditing, setIsEditing] = useState(false);
-  const { success, error, alerts, removeAlert } = useAlert();
+  const [isMutationPending, setIsMutationPending] = useState(false);
+  const controlsDisabled = isLoading || isMutationPending;
 
-  const queuePlayers = queue
-    .map((id) => availablePlayers.find((p) => p.id === id))
-    .filter(Boolean) as DraftPlayer[];
+  const queueEntries = queue.map((playerId) => ({
+    playerId,
+    player: availablePlayers.find((player) => player.id === playerId),
+  }));
+
+  const commitQueue = useCallback(
+    async (nextQueue: string[]) => {
+      if (controlsDisabled) return;
+
+      setIsMutationPending(true);
+      try {
+        await onQueueUpdate(nextQueue);
+      } catch {
+        // The room-level mutation boundary owns recoverable feedback. Keep this local control
+        // resilient when a caller rejects so fire-and-forget queue actions never leak a promise.
+      } finally {
+        setIsMutationPending(false);
+      }
+    },
+    [controlsDisabled, onQueueUpdate]
+  );
 
   const handleDragEnd = useCallback(
     (result: any) => {
@@ -44,16 +62,16 @@ export default function DraftQueue({
       const [reorderedItem] = items.splice(result.source.index, 1);
       items.splice(result.destination.index, 0, reorderedItem);
 
-      onQueueUpdate(items);
+      void commitQueue(items);
     },
-    [queue, onQueueUpdate]
+    [commitQueue, queue]
   );
 
   const handleRemovePlayer = useCallback(
     (playerId: string) => {
-      onQueueUpdate(queue.filter((id) => id !== playerId));
+      void commitQueue(queue.filter((id) => id !== playerId));
     },
-    [queue, onQueueUpdate]
+    [commitQueue, queue]
   );
 
   const handleClearQueue = useCallback(() => {
@@ -65,33 +83,23 @@ export default function DraftQueue({
         confirmText: 'Clear',
         cancelText: 'Cancel',
         onConfirm: async () => {
-          try {
-            await Promise.resolve(onQueueUpdate([]));
-            success('Queue cleared');
-          } catch (e) {
-            error('Failed to clear queue', e instanceof Error ? e.message : String(e));
-          }
+          await commitQueue([]);
         },
       });
     } else if (
       window.confirm('Are you sure you want to clear your entire queue? This cannot be undone.')
     ) {
-      try {
-        onQueueUpdate([]);
-        success('Queue cleared');
-      } catch (e) {
-        error('Failed to clear queue', e instanceof Error ? e.message : String(e));
-      }
+      void commitQueue([]);
     }
-  }, [confirm, onQueueUpdate, success, error]);
+  }, [commitQueue, confirm]);
 
   const handleAddToQueue = useCallback(
     (player: DraftPlayer) => {
       if (queue.includes(player.id)) return;
 
-      onQueueUpdate([...queue, player.id]);
+      void commitQueue([...queue, player.id]);
     },
-    [queue, onQueueUpdate]
+    [commitQueue, queue]
   );
 
   const availableForQueue = availablePlayers.filter(
@@ -100,21 +108,20 @@ export default function DraftQueue({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">
-      <div role="status" aria-live="polite" aria-atomic="true">
-        <AlertContainer alerts={alerts} onRemove={removeAlert} position="top-right" />
-      </div>
-
       <section
         className="rounded-md border border-border bg-background p-3"
         aria-label="Draft queue"
+        aria-busy={controlsDisabled}
       >
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <h2 className="text-sm font-semibold text-foreground">Draft Queue</h2>
             <p className="mt-1 text-xs text-muted-foreground">
-              {queue.length === 0
-                ? 'Build your auto-pick priority list.'
-                : `${queue.length} queued`}
+              {controlsDisabled
+                ? 'Saving queue…'
+                : queueEntries.length === 0
+                  ? 'Build your auto-pick priority list.'
+                  : `${queueEntries.length} queued`}
             </p>
           </div>
 
@@ -122,7 +129,8 @@ export default function DraftQueue({
             <button
               type="button"
               onClick={() => setIsEditing(!isEditing)}
-              className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border bg-card text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              disabled={controlsDisabled}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border bg-card text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
               aria-label={isEditing ? 'Finish editing draft queue' : 'Edit draft queue'}
               title={isEditing ? 'Done' : 'Edit'}
             >
@@ -131,7 +139,7 @@ export default function DraftQueue({
             <button
               type="button"
               onClick={handleClearQueue}
-              disabled={queue.length === 0 || isLoading}
+              disabled={queueEntries.length === 0 || controlsDisabled}
               className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-destructive/30 bg-destructive/10 text-destructive transition-colors hover:bg-destructive/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
               aria-label="Clear draft queue"
               title="Clear"
@@ -141,7 +149,7 @@ export default function DraftQueue({
           </div>
         </div>
 
-        {queue.length === 0 ? (
+        {queueEntries.length === 0 ? (
           <div className="mt-3 rounded-md border border-dashed border-border bg-muted/30 px-3 py-5 text-center">
             <ListPlus className="mx-auto h-6 w-6 text-muted-foreground" aria-hidden="true" />
             <p className="mt-2 text-sm font-medium text-foreground">Your queue is empty</p>
@@ -159,12 +167,12 @@ export default function DraftQueue({
                   className="mt-3 flex max-h-72 flex-col gap-2 overflow-y-auto pr-1"
                   aria-label="Queued players"
                 >
-                  {queuePlayers.map((player, index) => (
+                  {queueEntries.map(({ playerId, player }, index) => (
                     <Draggable
-                      key={player.id}
-                      draggableId={player.id}
+                      key={playerId}
+                      draggableId={playerId}
                       index={index}
-                      isDragDisabled={!isEditing}
+                      isDragDisabled={!isEditing || controlsDisabled}
                     >
                       {(provided, snapshot) => (
                         <li
@@ -191,23 +199,32 @@ export default function DraftQueue({
 
                             <div className="min-w-0 flex-1">
                               <h3 className="truncate text-sm font-semibold text-foreground">
-                                {player.name}
+                                {player?.name ?? 'Queued player'}
                               </h3>
                               <div className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
-                                <span className="rounded-md bg-muted px-1.5 py-0.5 font-medium text-muted-foreground">
-                                  {player.position}
-                                </span>
-                                <span className="truncate">{player.club}</span>
-                                {player.adp && <span className="shrink-0">ADP {player.adp}</span>}
+                                {player ? (
+                                  <>
+                                    <span className="rounded-md bg-muted px-1.5 py-0.5 font-medium text-muted-foreground">
+                                      {player.position}
+                                    </span>
+                                    <span className="truncate">{player.club}</span>
+                                    {player.adp && (
+                                      <span className="shrink-0">ADP {player.adp}</span>
+                                    )}
+                                  </>
+                                ) : (
+                                  <span>Player details loading</span>
+                                )}
                               </div>
                             </div>
 
                             {isEditing && (
                               <button
                                 type="button"
-                                onClick={() => handleRemovePlayer(player.id)}
-                                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                                aria-label={`Remove ${player.name} from queue`}
+                                onClick={() => handleRemovePlayer(playerId)}
+                                disabled={controlsDisabled}
+                                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                                aria-label={`Remove ${player?.name ?? 'queued player'} from queue`}
                               >
                                 <X className="h-4 w-4" />
                               </button>
@@ -228,6 +245,7 @@ export default function DraftQueue({
       <section
         className="flex min-h-0 flex-1 flex-col rounded-md border border-border bg-background p-3"
         aria-label="Available players for queue"
+        aria-busy={controlsDisabled}
       >
         <div className="min-w-0">
           <h2 className="text-sm font-semibold text-foreground">Add to Queue</h2>
@@ -264,7 +282,7 @@ export default function DraftQueue({
                   <button
                     type="button"
                     onClick={() => handleAddToQueue(player)}
-                    disabled={isLoading}
+                    disabled={controlsDisabled}
                     className="inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-primary/20 bg-primary/10 px-2 text-xs font-medium text-primary transition-colors hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     Add

--- a/src/components/draft/PlayerGrid.tsx
+++ b/src/components/draft/PlayerGrid.tsx
@@ -5,18 +5,15 @@ import Image from 'next/image';
 
 import { CheckCircle2, Info, ListPlus, Star } from 'lucide-react';
 
+import Tooltip from '@/components/ui/Tooltip';
+import { getStatlyZPresentation, STATLY_Z_DESCRIPTION } from '@/lib/statlyZPresentation';
 import { cn } from '@/lib/utils';
 import { getTeamAbbreviation, getTeamLogo } from '@/lib/teamLogos';
 import { FANTASY_CATEGORIES, type FantasyCategoryKey } from '@/types/fantasyCategories';
 import type { DraftPlayer } from '@/types/draft';
 
 type PlayerGridSortKey =
-  | 'statlyZ'
-  | 'name'
-  | 'position'
-  | 'club'
-  | 'adp'
-  | `category:${FantasyCategoryKey}`;
+  'statlyZ' | 'name' | 'position' | 'club' | 'adp' | `category:${FantasyCategoryKey}`;
 
 interface PlayerGridProps {
   players: DraftPlayer[];
@@ -40,6 +37,7 @@ interface PlayerGridProps {
   statSeasons?: number[];
   onStatSeasonChange?: (season: number) => void;
   isLoading: boolean;
+  isQueueMutationPending?: boolean;
   emptyStateMessage?: string;
   className?: string;
 }
@@ -52,7 +50,6 @@ const FALLBACK_TABLE_VIEWPORT_HEIGHT = 680;
 const FALLBACK_VIRTUALIZED_ROW_HEIGHT = 112;
 const VIRTUALIZED_ROW_OVERSCAN = 6;
 const VIRTUALIZED_ROW_THRESHOLD = 120;
-const STATLY_Z_DESCRIPTION = "Combined Z score across this league's selected scoring categories.";
 const ACTION_BUTTON_BASE_CLASS =
   'inline-flex h-10 w-full justify-center items-center gap-1 rounded-md px-1.5 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
 const ACTION_BUTTON_DISABLED_CLASS =
@@ -200,13 +197,23 @@ function getInjuryLabel(status: DraftPlayer['injuryStatus']): string {
 }
 
 function PlayerStatlyZCell({ player }: { player: DraftPlayer }): React.JSX.Element {
-  const statlyZScore = typeof player.statlyZScore === 'number' ? player.statlyZScore : null;
+  const statlyZ = getStatlyZPresentation(player);
 
   return (
     <td className="border-l border-border/60 px-4 py-4 text-center align-middle">
-      <span className="inline-flex min-w-16 justify-center text-lg font-semibold leading-none text-foreground tabular-nums">
-        {statlyZScore !== null ? statlyZScore.toFixed(2) : 'Pending'}
-      </span>
+      <div className="inline-flex min-w-16 flex-col items-center justify-center gap-1">
+        <span
+          className="text-lg font-semibold leading-none text-foreground tabular-nums"
+          aria-label={statlyZ.accessibleLabel}
+        >
+          {statlyZ.value}
+        </span>
+        {statlyZ.state === 'partial' && (
+          <span className="rounded-md border border-border bg-muted px-1.5 py-0.5 text-[0.625rem] font-medium uppercase text-muted-foreground">
+            Partial
+          </span>
+        )}
+      </div>
     </td>
   );
 }
@@ -250,6 +257,7 @@ interface PlayerRowActionsProps {
   isWatched: boolean;
   isQueued: boolean;
   isLoading: boolean;
+  isQueueMutationPending: boolean;
   isWatchlistPending: boolean;
   selectionInFlight: boolean;
   canMakePick: boolean;
@@ -264,6 +272,7 @@ function PlayerRowActions({
   isWatched,
   isQueued,
   isLoading,
+  isQueueMutationPending,
   isWatchlistPending,
   selectionInFlight,
   canMakePick,
@@ -274,7 +283,7 @@ function PlayerRowActions({
 }: PlayerRowActionsProps): React.JSX.Element {
   const actionDisabled = isLoading || selectionInFlight;
   const watchlistDisabled = isWatchlistPending;
-  const queueDisabled = actionDisabled || isQueued;
+  const queueDisabled = isQueueMutationPending || isQueued;
   const selectDisabled = !canMakePick || actionDisabled;
 
   return (
@@ -334,6 +343,7 @@ interface PlayerTableRowProps {
   isQueued: boolean;
   isWatched: boolean;
   isLoading: boolean;
+  isQueueMutationPending: boolean;
   isWatchlistPending: boolean;
   selectionInFlight: boolean;
   canMakePick: boolean;
@@ -355,6 +365,7 @@ function PlayerTableRow({
   isQueued,
   isWatched,
   isLoading,
+  isQueueMutationPending,
   isWatchlistPending,
   selectionInFlight,
   canMakePick,
@@ -402,6 +413,7 @@ function PlayerTableRow({
         isWatched={isWatched}
         isQueued={isQueued}
         isLoading={isLoading}
+        isQueueMutationPending={isQueueMutationPending}
         isWatchlistPending={isWatchlistPending}
         selectionInFlight={selectionInFlight}
         canMakePick={canMakePick}
@@ -627,6 +639,7 @@ interface PlayerGridTableProps {
   watchedIds: ReadonlySet<string>;
   pendingWatchlistIds: ReadonlySet<string>;
   isLoading: boolean;
+  isQueueMutationPending: boolean;
   selectionInFlight: boolean;
   canMakePick: boolean;
   pendingSelectionId: string | null;
@@ -656,6 +669,7 @@ function PlayerGridTable({
   watchedIds,
   pendingWatchlistIds,
   isLoading,
+  isQueueMutationPending,
   selectionInFlight,
   canMakePick,
   pendingSelectionId,
@@ -715,16 +729,31 @@ function PlayerGridTable({
                 aria-sort={sortBy === 'statlyZ' ? 'descending' : 'none'}
                 className="border-l border-border/70 px-3 py-3 text-center font-semibold"
               >
-                <button
-                  type="button"
-                  onClick={() => onSortChange('statlyZ')}
-                  className="mx-auto inline-flex items-center justify-center gap-1 rounded-md px-2 py-1 text-xs font-semibold uppercase text-foreground transition-colors hover:bg-[color:var(--draft-broadcast-field)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                  aria-label="Sort by Statly Z"
-                  title={STATLY_Z_DESCRIPTION}
-                >
-                  <span>Statly Z</span>
-                  <Info className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
-                </button>
+                <div className="flex items-center justify-center gap-0.5">
+                  <button
+                    type="button"
+                    onClick={() => onSortChange('statlyZ')}
+                    className="inline-flex items-center justify-center rounded-md px-2 py-1 text-xs font-semibold uppercase text-foreground transition-colors hover:bg-[color:var(--draft-broadcast-field)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                    aria-label="Sort by Statly Z"
+                  >
+                    Statly Z
+                  </button>
+                  <Tooltip
+                    content={STATLY_Z_DESCRIPTION}
+                    placement="bottom"
+                    size="sm"
+                    delay={150}
+                    contentClassName="leading-5"
+                  >
+                    <button
+                      type="button"
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-[color:var(--draft-broadcast-field)] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                      aria-label="About Statly Z"
+                    >
+                      <Info className="h-3.5 w-3.5" aria-hidden="true" />
+                    </button>
+                  </Tooltip>
+                </div>
               </th>
               <th
                 scope={visibleCategories.length > 0 ? 'colgroup' : 'col'}
@@ -793,6 +822,7 @@ function PlayerGridTable({
                   isWatched={watchedIds.has(player.id)}
                   isWatchlistPending={pendingWatchlistIds.has(player.id)}
                   isLoading={isLoading}
+                  isQueueMutationPending={isQueueMutationPending}
                   selectionInFlight={selectionInFlight}
                   canMakePick={canMakePick}
                   pendingSelectionId={pendingSelectionId}
@@ -856,6 +886,7 @@ export default function PlayerGrid({
   statSeasons,
   onStatSeasonChange,
   isLoading,
+  isQueueMutationPending = false,
   emptyStateMessage,
   className,
 }: PlayerGridProps): React.JSX.Element {
@@ -1133,6 +1164,7 @@ export default function PlayerGrid({
         watchedIds={watchedIds}
         pendingWatchlistIds={pendingWatchlistIds}
         isLoading={isLoading}
+        isQueueMutationPending={isQueueMutationPending}
         selectionInFlight={selectionInFlight}
         canMakePick={canMakePick}
         pendingSelectionId={pendingSelectionId}

--- a/src/components/draft/UnifiedDraftRoom.tsx
+++ b/src/components/draft/UnifiedDraftRoom.tsx
@@ -35,6 +35,9 @@ interface UnifiedDraftRoomProps {
 type PlayerSortKey =
   'statlyZ' | 'name' | 'position' | 'club' | 'adp' | `category:${FantasyCategoryKey}`;
 
+type QueueMutationFeedback =
+  { kind: 'error'; message: string; retryQueue: string[] } | { kind: 'success'; message: string };
+
 function getPositiveInteger(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
 }
@@ -202,12 +205,18 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
   const [positionFilter, setPositionFilter] = useState<string>('ALL');
   const [sortBy, setSortBy] = useState<PlayerSortKey>('statlyZ');
   const [isPickFeedOpen, setIsPickFeedOpen] = useState(false);
+  const [isQueueMutationPending, setIsQueueMutationPending] = useState(false);
+  const [queueMutationFeedback, setQueueMutationFeedback] = useState<QueueMutationFeedback | null>(
+    null
+  );
+  const [queueAnnouncement, setQueueAnnouncement] = useState('');
 
   // Desktop FAB ref + modal focus mgmt refs
   const openFeedBtnRef = useRef<HTMLButtonElement | null>(null);
   const closeBtnRef = useRef<HTMLButtonElement | null>(null);
   const lastFocusedRef = useRef<HTMLElement | null>(null);
   const hasOpenedPickFeedRef = useRef(false);
+  const queueMutationInFlightRef = useRef(false);
 
   // Participants/picks/players are guaranteed arrays by DraftContext
   const participants = draft.participants as DraftParticipant[];
@@ -260,18 +269,47 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
     [draft]
   );
 
+  const commitQueue = useCallback(
+    async (queue: string[], options: { retry?: boolean } = {}): Promise<boolean> => {
+      if (queueMutationInFlightRef.current) return false;
+
+      queueMutationInFlightRef.current = true;
+      setIsQueueMutationPending(true);
+      setQueueAnnouncement('Saving queue…');
+      if (!options.retry) setQueueMutationFeedback(null);
+
+      try {
+        await draft.updateQueue(queue);
+        setQueueAnnouncement('Queue saved.');
+        setQueueMutationFeedback(
+          options.retry ? { kind: 'success', message: 'Queue saved.' } : null
+        );
+        return true;
+      } catch {
+        setQueueAnnouncement('');
+        setQueueMutationFeedback({
+          kind: 'error',
+          message:
+            'Your queue could not be saved. The draft is still live; review the current queue and retry.',
+          retryQueue: [...queue],
+        });
+        return false;
+      } finally {
+        queueMutationInFlightRef.current = false;
+        setIsQueueMutationPending(false);
+      }
+    },
+    [draft]
+  );
+
   const handleAddToQueue = useCallback(
-    async (player: DraftPlayer) => {
+    (player: DraftPlayer) => {
       const nextQueue = Array.isArray(me?.queue) ? me.queue : [];
       if (nextQueue.includes(player.id)) return;
 
-      try {
-        await draft.updateQueue([...nextQueue, player.id]);
-      } catch (error) {
-        console.error('Failed to add player to queue:', error);
-      }
+      void commitQueue([...nextQueue, player.id]);
     },
-    [draft, me?.queue]
+    [commitQueue, me?.queue]
   );
 
   const handleAddWatchlistPlayerToQueue = useCallback(
@@ -299,14 +337,15 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
   // Handle queue update
   const handleQueueUpdate = useCallback(
     async (queue: string[]) => {
-      try {
-        await draft.updateQueue(queue);
-      } catch (error) {
-        console.error('Failed to update queue:', error);
-      }
+      await commitQueue(queue);
     },
-    [draft]
+    [commitQueue]
   );
+
+  const handleRetryQueueUpdate = useCallback(async () => {
+    if (queueMutationFeedback?.kind !== 'error') return;
+    await commitQueue(queueMutationFeedback.retryQueue, { retry: true });
+  }, [commitQueue, queueMutationFeedback]);
 
   // Memoized feed props (perf + stability)
   const feedPicks = useMemo(() => toFeedPicks(picks), [picks]);
@@ -490,7 +529,7 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
       queue={me?.queue || []}
       availablePlayers={playersList}
       onQueueUpdate={handleQueueUpdate}
-      isLoading={draft.isSaving}
+      isLoading={isQueueMutationPending}
       confirm={confirm}
     />
   );
@@ -508,6 +547,7 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
       pendingWatchlistPlayerIds={draft.pendingWatchlistPlayerIds}
       onRemoveFromWatchlist={draft.removeFromWatchlist}
       isLoading={draft.isSaving}
+      isQueueMutationPending={isQueueMutationPending}
     />
   );
   const pickFeedProps = {
@@ -674,6 +714,63 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
             </section>
           )}
 
+          {!isCompletedDraft && queueMutationFeedback ? (
+            <div
+              className={`mt-4 flex flex-col gap-3 rounded-lg border px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between ${
+                queueMutationFeedback.kind === 'error'
+                  ? 'border-destructive/40 bg-destructive/10 text-foreground'
+                  : 'border-border bg-muted/30 text-foreground'
+              }`}
+            >
+              <p
+                role={
+                  queueMutationFeedback.kind === 'error' && !isQueueMutationPending
+                    ? 'alert'
+                    : 'status'
+                }
+                aria-live={
+                  queueMutationFeedback.kind === 'success' || isQueueMutationPending
+                    ? 'polite'
+                    : undefined
+                }
+                aria-atomic="true"
+              >
+                {queueMutationFeedback.kind === 'error' && isQueueMutationPending
+                  ? 'Retrying queue update…'
+                  : queueMutationFeedback.message}
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  if (isQueueMutationPending) return;
+                  if (queueMutationFeedback.kind === 'error') {
+                    void handleRetryQueueUpdate();
+                  } else {
+                    setQueueMutationFeedback(null);
+                    setQueueAnnouncement('');
+                  }
+                }}
+                aria-disabled={isQueueMutationPending}
+                className="inline-flex h-10 shrink-0 items-center justify-center rounded-md border border-border bg-background px-4 font-semibold text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-disabled:cursor-wait aria-disabled:opacity-60"
+              >
+                {queueMutationFeedback.kind === 'error' ? 'Retry queue update' : 'Dismiss'}
+              </button>
+            </div>
+          ) : !isCompletedDraft && isQueueMutationPending ? (
+            <div
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              className="mt-4 rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm font-medium text-foreground"
+            >
+              Saving queue…
+            </div>
+          ) : !isCompletedDraft && queueAnnouncement ? (
+            <p role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+              {queueAnnouncement}
+            </p>
+          ) : null}
+
           <section
             aria-label={isCompletedDraft ? 'Completed draft background' : undefined}
             className={isCompletedDraft ? 'opacity-45 pointer-events-none select-none' : undefined}
@@ -720,6 +817,7 @@ export default function UnifiedDraftRoom({ draftId, userId }: UnifiedDraftRoomPr
                     void draft.setStatSeason(season);
                   }}
                   isLoading={draft.isSaving}
+                  isQueueMutationPending={isQueueMutationPending}
                   emptyStateMessage={emptyPlayerMessage}
                 />
               </div>

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -25,13 +25,7 @@ export type TooltipTrigger = 'hover' | 'click' | 'focus' | 'manual';
 
 // Tooltip variants
 export type TooltipVariant =
-  | 'default'
-  | 'dark'
-  | 'light'
-  | 'info'
-  | 'success'
-  | 'warning'
-  | 'error';
+  'default' | 'dark' | 'light' | 'info' | 'success' | 'warning' | 'error';
 
 // Tooltip size
 export type TooltipSize = 'sm' | 'md' | 'lg';
@@ -59,9 +53,9 @@ interface TooltipProps {
 // Variant configurations
 const VARIANT_CONFIG = {
   default: {
-    background: 'bg-gray-900',
-    text: 'text-white',
-    border: 'border-gray-900',
+    background: 'bg-popover',
+    text: 'text-popover-foreground',
+    border: 'border-border',
   },
   dark: {
     background: 'bg-black',
@@ -386,15 +380,25 @@ export default function Tooltip({
     </AnimatePresence>
   );
 
+  const hasElementTrigger = React.isValidElement<{ 'aria-describedby'?: string }>(children);
+  const describedChildren = hasElementTrigger
+    ? React.cloneElement(children, {
+        'aria-describedby':
+          [children.props['aria-describedby'], isVisible ? tooltipId : undefined]
+            .filter(Boolean)
+            .join(' ') || undefined,
+      })
+    : children;
+
   return (
     <>
       <div
         ref={triggerRef}
         className={`inline-block ${className}`}
         {...eventHandlers}
-        aria-describedby={isVisible ? tooltipId : undefined}
+        aria-describedby={!hasElementTrigger && isVisible ? tooltipId : undefined}
       >
-        {children}
+        {describedChildren}
       </div>
 
       {portal && typeof window !== 'undefined'

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import type { ReactNode } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { createPortal } from 'react-dom';
 
 // Tooltip placement options
@@ -261,6 +261,16 @@ export default function Tooltip({
     }
   }, [interactive]);
 
+  // Escape is an immediate dismissal, even for interactive or delayed tooltips.
+  const dismissTooltip = React.useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = undefined;
+    }
+
+    setIsVisible(false);
+  }, []);
+
   // Update position when visible
   useEffect(() => {
     if (isVisible && triggerRef.current && tooltipRef.current) {
@@ -317,19 +327,18 @@ export default function Tooltip({
     return handlers;
   }, [trigger, isVisible, hideTooltip, showTooltip]);
 
-  // Close on escape key
+  // Listen for Escape for the lifetime of the trigger so a key press cannot race
+  // the effect that follows disclosure. This also cancels a pending delayed show.
   useEffect(() => {
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && isVisible) {
-        hideTooltip();
+      if (event.key === 'Escape') {
+        dismissTooltip();
       }
     };
 
-    if (isVisible) {
-      document.addEventListener('keydown', handleEscape);
-      return () => document.removeEventListener('keydown', handleEscape);
-    }
-  }, [isVisible, hideTooltip]);
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [dismissTooltip]);
 
   // Clean up timeout on unmount
   useEffect(() => {
@@ -340,45 +349,41 @@ export default function Tooltip({
     };
   }, []);
 
-  const tooltipContent = (
-    <AnimatePresence>
-      {isVisible && (
-        <motion.div
-          id={tooltipId}
-          ref={tooltipRef}
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          exit={{ opacity: 0, scale: 0.95 }}
-          transition={{ duration: 0.15, ease: 'easeOut' }}
-          className={`
+  // Unmount the semantic tooltip immediately on dismissal. Retaining it for an
+  // exit animation leaves assistive technology associated with stale content.
+  const tooltipContent = isVisible ? (
+    <motion.div
+      id={tooltipId}
+      ref={tooltipRef}
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.15, ease: 'easeOut' }}
+      className={`
             absolute z-50 rounded-lg shadow-lg border
             ${variantConfig.background} ${variantConfig.text} ${variantConfig.border}
             ${sizeConfig} ${maxWidth} ${contentClassName}
           `}
-          style={{
-            top: position.top,
-            left: position.left,
-            zIndex,
-          }}
-          onMouseEnter={
-            interactive
-              ? () => {
-                  if (timeoutRef.current) {
-                    clearTimeout(timeoutRef.current);
-                  }
-                }
-              : undefined
-          }
-          onMouseLeave={interactive ? hideTooltip : undefined}
-          role="tooltip"
-          aria-hidden={!isVisible}
-        >
-          {content}
-          {arrow && <TooltipArrow placement={placement} variant={variant} />}
-        </motion.div>
-      )}
-    </AnimatePresence>
-  );
+      style={{
+        top: position.top,
+        left: position.left,
+        zIndex,
+      }}
+      onMouseEnter={
+        interactive
+          ? () => {
+              if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+              }
+            }
+          : undefined
+      }
+      onMouseLeave={interactive ? hideTooltip : undefined}
+      role="tooltip"
+    >
+      {content}
+      {arrow && <TooltipArrow placement={placement} variant={variant} />}
+    </motion.div>
+  ) : null;
 
   const hasElementTrigger = React.isValidElement<{ 'aria-describedby'?: string }>(children);
   const describedChildren = hasElementTrigger

--- a/src/contexts/DraftContext.tsx
+++ b/src/contexts/DraftContext.tsx
@@ -12,7 +12,7 @@ import React, {
 
 import { useSocket } from '@/contexts/SocketContext';
 import { fetchApi } from '@/lib/api';
-import { getSlotForOverallPick } from '@/lib/draftRoomSequencing';
+import { getDraftPickCoordinate } from '@/lib/draftOrder';
 import {
   DraftClockPayloadSchema,
   DraftRoomSnapshotPayloadSchema,
@@ -385,6 +385,7 @@ function normalizeSnapshot(raw?: DraftSnapshot | null): {
   includesParticipantQueues: boolean;
   includesPicks: boolean;
   includesAvailablePlayers: boolean;
+  includesDraftType: boolean;
   ts?: number;
   revision?: number;
   throughSequence?: number;
@@ -403,6 +404,7 @@ function normalizeSnapshot(raw?: DraftSnapshot | null): {
       includesParticipantQueues: false,
       includesPicks: false,
       includesAvailablePlayers: false,
+      includesDraftType: false,
     };
   }
 
@@ -424,6 +426,7 @@ function normalizeSnapshot(raw?: DraftSnapshot | null): {
       totalPicks: snapshot.state.totalPicks,
       round: snapshot.state.round,
       direction: snapshot.state.direction,
+      draftType: snapshot.state.draftType,
       schedulingVersion: snapshot.revision,
       serverNow: snapshot.serverNow,
       clock,
@@ -453,6 +456,7 @@ function normalizeSnapshot(raw?: DraftSnapshot | null): {
       includesParticipantQueues: false,
       includesPicks: true,
       includesAvailablePlayers: false,
+      includesDraftType: snapshot.state.draftType !== undefined,
       ts: Date.parse(snapshot.serverNow),
       revision: snapshot.revision,
       throughSequence: snapshot.throughSequence,
@@ -467,6 +471,11 @@ function normalizeSnapshot(raw?: DraftSnapshot | null): {
   const includesParticipantQueues = participantQueueIncluded((legacyRaw as any).participants);
   const includesPicks = 'picks' in legacyRaw;
   const includesAvailablePlayers = 'availablePlayers' in legacyRaw;
+  const includesDraftType =
+    'draftType' in draftSource ||
+    (draftSource.settings &&
+      typeof draftSource.settings === 'object' &&
+      'draftType' in draftSource.settings);
 
   const picks = toArray<DraftPick>(legacyRaw.picks)
     .slice()
@@ -518,6 +527,7 @@ function normalizeSnapshot(raw?: DraftSnapshot | null): {
     includesParticipantQueues,
     includesPicks,
     includesAvailablePlayers,
+    includesDraftType: Boolean(includesDraftType),
     ts: legacyRaw.ts ?? (clockResult.success ? Date.parse(clockResult.data.serverNow) : undefined),
     revision: clockResult.success ? clockResult.data.revision : normalizedRevision,
     throughSequence:
@@ -527,9 +537,14 @@ function normalizeSnapshot(raw?: DraftSnapshot | null): {
   };
 }
 
-function computeCurrentSlotFromSnake(currentPick: number, teamCount: number): number | undefined {
-  const slot = getSlotForOverallPick(currentPick, teamCount);
-  return slot > 0 ? slot : undefined;
+function computeCurrentSlot(
+  currentPick: number,
+  teamCount: number,
+  draftType: DraftCore['settings']['draftType']
+): number | undefined {
+  if (!Number.isInteger(currentPick) || currentPick <= 0 || teamCount <= 0) return undefined;
+
+  return getDraftPickCoordinate(draftType, currentPick, teamCount).slot;
 }
 
 function normalizeCommandPick(raw: unknown, participants: DraftParticipant[]): DraftPick | null {
@@ -900,11 +915,22 @@ function applySnapshotState(state: DraftState, snapshot: NormalizedDraftSnapshot
 }
 
 function mergeSnapshotState(state: DraftState, snapshot: NormalizedDraftSnapshot): DraftState {
-  const draft = mergeSnapshotDraft(snapshot.draft, state.draft);
-  const participants = snapshot.includesParticipantQueues
+  const incomingDraft =
+    !snapshot.includesDraftType && snapshot.draft && state.draft
+      ? {
+          ...snapshot.draft,
+          settings: {
+            ...snapshot.draft.settings,
+            draftType: state.draft.settings.draftType,
+          },
+        }
+      : snapshot.draft;
+  const draft = mergeSnapshotDraft(incomingDraft, state.draft);
+  const snapshotParticipants = snapshot.includesParticipantQueues
     ? snapshot.participants
     : mergeParticipantQueues(snapshot.participants, state.participants);
   const picks = snapshot.includesPicks ? snapshot.picks : state.picks;
+  const participants = reconcileParticipantQueues(snapshotParticipants, picks);
   const availablePlayers = excludeDraftedAvailablePlayers(
     snapshot.includesAvailablePlayers ? snapshot.availablePlayers : state.availablePlayers,
     picks
@@ -947,6 +973,31 @@ function getDraftedPlayerIds(picks: DraftPick[]): Set<string> {
   return new Set(picks.map((pick) => String((pick as any).player?.id ?? (pick as any).playerId)));
 }
 
+export function reconcileQueueWithPicks(queue: unknown, picks: DraftPick[]): string[] {
+  const draftedPlayerIds = getDraftedPlayerIds(picks);
+  const seenPlayerIds = new Set<string>();
+  const reconciledQueue: string[] = [];
+
+  for (const value of toArray<unknown>(queue)) {
+    const playerId = String(value ?? '').trim();
+    if (!playerId || draftedPlayerIds.has(playerId) || seenPlayerIds.has(playerId)) continue;
+    seenPlayerIds.add(playerId);
+    reconciledQueue.push(playerId);
+  }
+
+  return reconciledQueue;
+}
+
+function reconcileParticipantQueues(
+  participants: DraftParticipant[],
+  picks: DraftPick[]
+): DraftParticipant[] {
+  return participants.map((participant) => ({
+    ...participant,
+    queue: reconcileQueueWithPicks(participant.queue, picks),
+  }));
+}
+
 function applyPersistedPicksState(state: DraftState, incomingPicks: DraftPick[]): DraftState {
   const picks = mergePersistedPicks(state.picks, incomingPicks);
   const draftedPlayerIds = getDraftedPlayerIds(picks);
@@ -954,6 +1005,7 @@ function applyPersistedPicksState(state: DraftState, incomingPicks: DraftPick[])
   return {
     ...state,
     picks,
+    participants: reconcileParticipantQueues(state.participants, picks),
     availablePlayers: state.availablePlayers.filter(
       (player) => !draftedPlayerIds.has(String(player.id))
     ),
@@ -1025,12 +1077,7 @@ function applyDelta(state: DraftState, delta: DraftDelta): DraftState {
       });
       const pid = String((pick as any).player?.id ?? (pick as any).playerId);
       const availablePlayers = next.availablePlayers.filter((p) => String(p.id) !== pid);
-      const participants = next.participants.map((participant) => ({
-        ...participant,
-        queue: Array.isArray(participant.queue)
-          ? participant.queue.filter((queuedId) => String(queuedId) !== pid)
-          : [],
-      }));
+      const participants = reconcileParticipantQueues(next.participants, picks);
       const nextCurrentPick =
         typeof payload.currentPick === 'number' && Number.isFinite(payload.currentPick)
           ? payload.currentPick
@@ -1137,7 +1184,7 @@ function applyDelta(state: DraftState, delta: DraftDelta): DraftState {
       const participants = next.participants.map((m) =>
         (memberId && String((m as any).id) === String(memberId)) ||
         (userId && String((m as any).userId) === String(userId))
-          ? { ...m, queue: Array.isArray(queue) ? queue : [] }
+          ? { ...m, queue: reconcileQueueWithPicks(queue, next.picks) }
           : m
       );
       return { ...next, participants };
@@ -1553,6 +1600,7 @@ export function DraftProvider({
   const initialHydrateStartedRef = useRef(Boolean(initialSnapshot));
   const availablePlayersHydratingRef = useRef(false);
   const persistedPickHydratingRef = useRef(false);
+  const queueMutationInFlightRef = useRef(false);
   const privateStateHydrationRef = useRef<{
     generation: number;
     controller: AbortController | null;
@@ -1562,9 +1610,9 @@ export function DraftProvider({
     const snap = normalizeSnapshot(initialSnapshot ?? null);
     return {
       draft: snap.draft,
-      participants: snap.participants,
+      participants: reconcileParticipantQueues(snap.participants, snap.picks),
       picks: snap.picks,
-      availablePlayers: snap.availablePlayers,
+      availablePlayers: excludeDraftedAvailablePlayers(snap.availablePlayers, snap.picks),
       draftReadiness: snap.draftReadiness,
       selectedCategories: snap.selectedCategories,
       statSeason: snap.statSeason,
@@ -2060,37 +2108,24 @@ export function DraftProvider({
   const updateQueue = useCallback(
     async (queue: string[]) => {
       if (!Array.isArray(queue)) {
-        dispatch({
-          type: 'SET_ERROR',
-          error: 'Queue must be an array',
-        });
-        return;
+        throw new Error('Queue must be an array');
       }
 
-      const availableIds = new Set(state.availablePlayers.map((p) => String(p.id)));
-      const invalidIds = queue.filter((id) => !availableIds.has(id));
-      if (invalidIds.length > 0) {
-        dispatch({
-          type: 'SET_ERROR',
-          error: `Invalid player IDs in queue: ${invalidIds.join(', ')}`,
-        });
-        return;
+      if (queueMutationInFlightRef.current) {
+        throw new Error('A queue update is already in progress');
       }
 
       const me = state.participants.find((p) => String((p as any).userId) === String(userId));
       const memberId = me ? String((me as any).id) : undefined;
       if (!memberId) {
-        dispatch({
-          type: 'SET_ERROR',
-          error: 'Unable to identify your draft membership',
-        });
-        return;
+        throw new Error('Unable to identify your draft membership');
       }
 
-      dispatch({ type: 'SET_SAVING', saving: true });
+      const desiredQueue = reconcileQueueWithPicks(queue, state.picks);
+      queueMutationInFlightRef.current = true;
       invalidatePrivateStateHydration();
       try {
-        const queuePayload = queue.map((playerId, index) => ({
+        const queuePayload = desiredQueue.map((playerId, index) => ({
           playerId,
           rank: index + 1,
         }));
@@ -2114,19 +2149,27 @@ export function DraftProvider({
           payload: { memberId, queue: persistedQueue },
           ts: Date.now(),
         };
+        // A reconnect may start private hydration while this PUT is pending. The confirmed
+        // mutation must invalidate that older read before its queue is committed locally.
+        invalidatePrivateStateHydration();
         dispatch({ type: 'APPLY_DELTAS', deltas: [delta] });
       } catch (err: any) {
         if (isMounted.current) {
-          dispatch({
-            type: 'SET_ERROR',
-            error: err?.message ?? 'Failed to update queue',
-          });
+          await hydratePrivateDraftState(memberId);
         }
+        throw err instanceof Error ? err : new Error('Failed to update queue');
       } finally {
-        if (isMounted.current) dispatch({ type: 'SET_SAVING', saving: false });
+        queueMutationInFlightRef.current = false;
       }
     },
-    [draftId, invalidatePrivateStateHydration, state.participants, userId, state.availablePlayers]
+    [
+      draftId,
+      hydratePrivateDraftState,
+      invalidatePrivateStateHydration,
+      state.participants,
+      state.picks,
+      userId,
+    ]
   );
 
   const addToWatchlist = useCallback(
@@ -2320,14 +2363,17 @@ export function DraftProvider({
     const currentPick = Number(
       (state.draft as any).currentPick ?? state.liveState?.currentPick ?? 0
     );
-    const currentSlot = computeCurrentSlotFromSnake(currentPick, teamCount);
-    const onClock = currentSlot && yourSlot && Number(currentSlot) === Number(yourSlot);
+    const persistedOnClockMemberId = state.liveState.onClockTeamId;
+    const currentSlot = computeCurrentSlot(currentPick, teamCount, state.draft.settings.draftType);
+    const onClock = persistedOnClockMemberId
+      ? String(persistedOnClockMemberId) === String(me?.id)
+      : Boolean(currentSlot && yourSlot && Number(currentSlot) === Number(yourSlot));
 
     const status = String((state.draft as any).status ?? '').toUpperCase();
     const live = status === 'LIVE' || status === 'IN_PROGRESS';
 
     return !!(live && onClock && !state.isSaving);
-  }, [state.draft, state.liveState, state.participants.length, yourSlot, state.isSaving]);
+  }, [state.draft, state.liveState, state.participants.length, me?.id, yourSlot, state.isSaving]);
 
   /* ------------------------------- Provide value ---------------------------- */
 

--- a/src/index.css
+++ b/src/index.css
@@ -146,6 +146,11 @@
   --draft-broadcast-table-row-hover: #1d2b3d;
   --draft-broadcast-field: rgba(255, 255, 255, 0.09);
   --draft-broadcast-field-strong: rgba(255, 255, 255, 0.16);
+  --draft-broadcast-roster-filled: var(--draft-broadcast-field-strong);
+  --draft-broadcast-watchlist-hit: rgb(222 232 250 / 20%);
+  --draft-broadcast-watchlist-border: rgb(222 232 250 / 72%);
+  --draft-broadcast-watchlist-chip: #dee8fa;
+  --draft-broadcast-watchlist-chip-text: #1a49a0;
   --draft-broadcast-border: #2c3a4d;
   --draft-broadcast-border-soft: rgba(148, 163, 184, 0.18);
   --draft-broadcast-text: #f4f7fb;

--- a/src/lib/draftOrder.test.ts
+++ b/src/lib/draftOrder.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { getDraftPickCoordinate, type DraftOrderType } from '@/lib/draftOrder';
+
+describe('getDraftPickCoordinate', () => {
+  it('reverses slot order on even snake rounds', () => {
+    expect(getDraftPickCoordinate('SNAKE', 6, 6)).toEqual({
+      round: 1,
+      slot: 6,
+      direction: 'FORWARD',
+    });
+    expect(getDraftPickCoordinate('SNAKE', 7, 6)).toEqual({
+      round: 2,
+      slot: 6,
+      direction: 'REVERSE',
+    });
+    expect(getDraftPickCoordinate('SNAKE', 12, 6)).toEqual({
+      round: 2,
+      slot: 1,
+      direction: 'REVERSE',
+    });
+  });
+
+  it('keeps slot order forward on every linear round', () => {
+    expect(getDraftPickCoordinate('LINEAR', 7, 6)).toEqual({
+      round: 2,
+      slot: 1,
+      direction: 'FORWARD',
+    });
+    expect(getDraftPickCoordinate('LINEAR', 12, 6)).toEqual({
+      round: 2,
+      slot: 6,
+      direction: 'FORWARD',
+    });
+  });
+
+  it('supports one-team drafts while preserving the configured order direction', () => {
+    expect(getDraftPickCoordinate('SNAKE', 2, 1)).toEqual({
+      round: 2,
+      slot: 1,
+      direction: 'REVERSE',
+    });
+    expect(getDraftPickCoordinate('LINEAR', 2, 1)).toEqual({
+      round: 2,
+      slot: 1,
+      direction: 'FORWARD',
+    });
+  });
+
+  it.each([
+    ['SNAKE', 0, 6],
+    ['SNAKE', 1.5, 6],
+    ['LINEAR', 1, 0],
+    ['LINEAR', 1, 2.5],
+  ] as const)('rejects invalid coordinates for %s pick %s with %s teams', (type, pick, teams) => {
+    expect(() => getDraftPickCoordinate(type, pick, teams)).toThrow();
+  });
+
+  it('rejects an unsupported runtime draft type', () => {
+    expect(() => getDraftPickCoordinate('AUCTION' as DraftOrderType, 1, 6)).toThrow(
+      'Unsupported draft order type: AUCTION'
+    );
+  });
+});

--- a/src/lib/draftOrder.ts
+++ b/src/lib/draftOrder.ts
@@ -1,0 +1,42 @@
+export type DraftOrderType = 'SNAKE' | 'LINEAR';
+export type DraftOrderDirection = 'FORWARD' | 'REVERSE';
+
+export type DraftPickCoordinate = {
+  round: number;
+  slot: number;
+  direction: DraftOrderDirection;
+};
+
+/**
+ * Returns the round, slot, and direction for an overall draft pick.
+ *
+ * This helper intentionally owns only order arithmetic. Callers remain responsible
+ * for validating that the calculated slot belongs to a persisted participant.
+ */
+export function getDraftPickCoordinate(
+  draftType: DraftOrderType,
+  overall: number,
+  teamCount: number
+): DraftPickCoordinate {
+  if (draftType !== 'SNAKE' && draftType !== 'LINEAR') {
+    throw new Error(`Unsupported draft order type: ${String(draftType)}`);
+  }
+
+  if (!Number.isInteger(teamCount) || teamCount <= 0) {
+    throw new Error('Draft has no participants');
+  }
+
+  if (!Number.isInteger(overall) || overall <= 0) {
+    throw new Error('Draft pick must be a positive integer');
+  }
+
+  const round = Math.ceil(overall / teamCount);
+  const pickIndex = (overall - 1) % teamCount;
+  const isReverse = draftType === 'SNAKE' && round % 2 === 0;
+
+  return {
+    round,
+    slot: isReverse ? teamCount - pickIndex : pickIndex + 1,
+    direction: isReverse ? 'REVERSE' : 'FORWARD',
+  };
+}

--- a/src/lib/draftRoomSequencing.ts
+++ b/src/lib/draftRoomSequencing.ts
@@ -1,4 +1,5 @@
 import type { DraftClockPayload } from '@/services/realtime/draftStateWire';
+import { getDraftPickCoordinate, type DraftOrderType } from '@/lib/draftOrder';
 
 export type DraftRoomStatus =
   'SCHEDULED' | 'LOBBY' | 'COUNTDOWN' | 'LIVE' | 'PAUSED' | 'COMPLETED' | 'CANCELLED' | string;
@@ -71,13 +72,21 @@ function toSlot(participant: DraftRoomParticipant): number {
   return Number(participant.slot ?? participant.draftOrder ?? 0);
 }
 
-export function getSlotForOverallPick(overall: number, teamCount: number): number {
-  if (overall <= 0 || teamCount <= 0) return 0;
+export function getSlotForOverallPick(
+  overall: number,
+  teamCount: number,
+  draftType: DraftOrderType = 'SNAKE'
+): number {
+  if (
+    !Number.isInteger(overall) ||
+    !Number.isInteger(teamCount) ||
+    overall <= 0 ||
+    teamCount <= 0
+  ) {
+    return 0;
+  }
 
-  const round = Math.ceil(overall / teamCount);
-  const pickIndex = (overall - 1) % teamCount;
-
-  return round % 2 === 1 ? pickIndex + 1 : teamCount - pickIndex;
+  return getDraftPickCoordinate(draftType, overall, teamCount).slot;
 }
 
 export function buildDraftRoomSequence(input: {
@@ -90,12 +99,14 @@ export function buildDraftRoomSequence(input: {
   timePerPick?: number;
   windowBefore?: number;
   windowAfter?: number;
+  draftType?: DraftOrderType;
 }): DraftRoomSequence {
   const teamCount = input.participants.length;
   const totalPicks = Math.max(0, Math.floor(input.totalPicks));
   const currentPick = Math.max(1, Math.floor(input.currentPick || 1));
   const timePerPick = Math.max(1, Math.floor(input.timePerPick ?? 120));
   const phase = input.status ?? 'LIVE';
+  const draftType = input.draftType ?? 'SNAKE';
   const participantsBySlot = new Map(
     input.participants.map((participant) => [toSlot(participant), participant])
   );
@@ -110,49 +121,55 @@ export function buildDraftRoomSequence(input: {
     pickWindow.add(overall);
   }
 
-  if (input.yourSlot && teamCount > 0 && !isComplete) {
+  const validYourSlot =
+    Number.isInteger(input.yourSlot) &&
+    Number(input.yourSlot) >= 1 &&
+    Number(input.yourSlot) <= teamCount
+      ? Number(input.yourSlot)
+      : null;
+
+  const buildSlot = (overall: number): DraftRoomSequenceSlot => {
+    const slot = getSlotForOverallPick(overall, teamCount, draftType);
+    const participant = participantsBySlot.get(slot);
+    const pick = picksByOverall.get(overall);
+    const status: DraftRoomSequenceSlot['status'] =
+      overall === safeCurrent && !isComplete
+        ? 'current'
+        : overall < safeCurrent || Boolean(pick)
+          ? 'completed'
+          : 'upcoming';
+    const member = participant?.member;
+
+    return {
+      overall,
+      round: teamCount > 0 ? Math.ceil(overall / teamCount) : 1,
+      slot,
+      status,
+      isUserPick: slot === validYourSlot,
+      displayName: member?.displayName ?? participant?.displayName ?? `Team ${slot}`,
+      teamName: member?.teamName ?? participant?.teamName,
+      picksUntil: Math.max(0, overall - safeCurrent),
+      estimatedSecondsUntil: Math.max(0, overall - safeCurrent) * timePerPick,
+      player: pick?.player,
+    };
+  };
+
+  const slots = [...pickWindow].sort((a, b) => a - b).map(buildSlot);
+  let nextUserPick: DraftRoomSequenceSlot | null = null;
+
+  if (validYourSlot !== null && !isComplete) {
     for (let overall = safeCurrent; overall <= totalPicks; overall += 1) {
-      if (getSlotForOverallPick(overall, teamCount) === input.yourSlot) {
-        pickWindow.add(overall);
+      if (getSlotForOverallPick(overall, teamCount, draftType) === validYourSlot) {
+        nextUserPick = slots.find((slot) => slot.overall === overall) ?? buildSlot(overall);
         break;
       }
     }
   }
 
-  const slots = [...pickWindow]
-    .sort((a, b) => a - b)
-    .map((overall) => {
-      const slot = getSlotForOverallPick(overall, teamCount);
-      const participant = participantsBySlot.get(slot);
-      const pick = picksByOverall.get(overall);
-      const status: DraftRoomSequenceSlot['status'] =
-        overall === safeCurrent && !isComplete
-          ? 'current'
-          : overall < safeCurrent || Boolean(pick)
-            ? 'completed'
-            : 'upcoming';
-      const member = participant?.member;
-
-      return {
-        overall,
-        round: teamCount > 0 ? Math.ceil(overall / teamCount) : 1,
-        slot,
-        status,
-        isUserPick: slot === input.yourSlot,
-        displayName: member?.displayName ?? participant?.displayName ?? `Team ${slot}`,
-        teamName: member?.teamName ?? participant?.teamName,
-        picksUntil: Math.max(0, overall - safeCurrent),
-        estimatedSecondsUntil: Math.max(0, overall - safeCurrent) * timePerPick,
-        player: pick?.player,
-      };
-    });
-
   return {
     phase,
     current: isComplete ? null : (slots.find((slot) => slot.status === 'current') ?? null),
-    nextUserPick: input.yourSlot
-      ? (slots.find((slot) => slot.isUserPick && slot.overall >= safeCurrent) ?? null)
-      : null,
+    nextUserPick,
     slots,
   };
 }

--- a/src/lib/mappers/draftUiMappers.ts
+++ b/src/lib/mappers/draftUiMappers.ts
@@ -1,4 +1,4 @@
-import type { DraftState, DraftParticipant, DraftPick } from '@/types/draft';
+import type { DraftState, DraftParticipant, DraftPick, DraftType } from '@/types/draft';
 import { buildDraftRoomSequence } from '@/lib/draftRoomSequencing';
 import type { DraftLiveState } from '@/contexts/DraftContext';
 import type { DraftClockPayload } from '@/services/realtime/draftStateWire';
@@ -42,6 +42,7 @@ export type LivePickHeaderData = {
   totalPicks: number;
   round: number;
   direction: string;
+  draftType: DraftType;
   status: string;
   pickDeadlineAt?: string | null;
   clock?: DraftClockPayload;
@@ -122,6 +123,7 @@ export function toLivePickHeaderData(
     totalPicks: draft.totalPicks,
     round: draft.round,
     direction: draft.direction,
+    draftType: draft.settings.draftType,
     status: draft.status,
     pickDeadlineAt: draft.pickDeadlineAt ? formatDateToIso(draft.pickDeadlineAt) : null,
     clock: liveState?.clock,
@@ -197,13 +199,23 @@ function buildDraftPickTrainState(params: {
   totalPicks: number;
   round: number;
   direction: string;
+  draftType: DraftType;
   status?: string;
   participants: DraftPickTrainParticipant[];
   picks: DraftPickTrainPick[];
   yourSlot?: number;
 }): DraftPickTrainState {
-  const { currentPick, totalPicks, round, direction, status, participants, picks, yourSlot } =
-    params;
+  const {
+    currentPick,
+    totalPicks,
+    round,
+    direction,
+    draftType,
+    status,
+    participants,
+    picks,
+    yourSlot,
+  } = params;
   const isComplete =
     String(status ?? '').toUpperCase() === 'COMPLETED' ||
     (Number.isFinite(totalPicks) && totalPicks > 0 && currentPick > totalPicks);
@@ -216,6 +228,7 @@ function buildDraftPickTrainState(params: {
     picks,
     yourSlot,
     status,
+    draftType,
   });
 
   return {
@@ -247,6 +260,7 @@ export function toDraftPickTrainState(params: {
     totalPicks: params.draft.totalPicks,
     round: params.draft.round,
     direction: params.draft.direction,
+    draftType: params.draft.settings.draftType,
     status: params.draft.status,
     participants: params.participants.map((participant) => ({
       slot: participant.draftOrder,
@@ -271,6 +285,7 @@ export function toDraftPickTrainStateFromHeaderData(params: {
     totalPicks: params.draftData.totalPicks,
     round: params.draftData.round,
     direction: params.draftData.direction,
+    draftType: params.draftData.draftType,
     status: params.draftData.status,
     participants: params.draftData.participants,
     picks: params.draftData.picks,
@@ -291,7 +306,7 @@ export type WatchlistEntry = {
   name: string;
   position: string;
   club: string;
-  avgPoints?: number;
+  statlyZScore?: number;
   drafted: boolean;
   watchlist: WatchlistItem;
 };
@@ -315,7 +330,7 @@ export function toWatchlistEntries(
       name: p.name,
       position: p.position,
       club: p.club,
-      avgPoints: p.avgPoints,
+      statlyZScore: p.statlyZScore,
       drafted: drafted.has(p.id),
       watchlist: w,
     });

--- a/src/lib/statlyZPresentation.ts
+++ b/src/lib/statlyZPresentation.ts
@@ -1,0 +1,64 @@
+import type { FantasyCategoryKey } from '@/types/fantasyCategories';
+
+export const STATLY_Z_DESCRIPTION =
+  "Statly Z combines a player's results across your league's scoring categories. Higher is better. It updates as the available player pool changes; Partial means some category data is missing.";
+
+type StatlyZInput = {
+  statlyZScore?: number;
+  statlyZBreakdown?: Array<{ category: FantasyCategoryKey; value: number; zScore: number }>;
+  statlyZMissingCategories?: FantasyCategoryKey[];
+};
+
+export type StatlyZPresentation = {
+  state: 'complete' | 'partial' | 'no-data' | 'pending';
+  value: string;
+  accessibleLabel: string;
+};
+
+function formatStatlyZScore(score: number): string {
+  const rounded = Number(score.toFixed(2));
+  return (Object.is(rounded, -0) ? 0 : rounded).toFixed(2);
+}
+
+export function getStatlyZPresentation(player: StatlyZInput): StatlyZPresentation {
+  const missingCategories = Array.isArray(player.statlyZMissingCategories)
+    ? player.statlyZMissingCategories
+    : null;
+  const breakdown = Array.isArray(player.statlyZBreakdown) ? player.statlyZBreakdown : null;
+  const hasNoUsableData =
+    missingCategories !== null &&
+    missingCategories.length > 0 &&
+    breakdown !== null &&
+    breakdown.length === 0;
+
+  if (hasNoUsableData) {
+    return {
+      state: 'no-data',
+      value: '—',
+      accessibleLabel: 'Statly Z unavailable because category data is missing',
+    };
+  }
+
+  if (typeof player.statlyZScore !== 'number' || !Number.isFinite(player.statlyZScore)) {
+    return {
+      state: 'pending',
+      value: 'Pending',
+      accessibleLabel: 'Statly Z pending',
+    };
+  }
+
+  const value = formatStatlyZScore(player.statlyZScore);
+  if (missingCategories && missingCategories.length > 0) {
+    return {
+      state: 'partial',
+      value,
+      accessibleLabel: `Statly Z ${value}, partial category coverage`,
+    };
+  }
+
+  return {
+    state: 'complete',
+    value,
+    accessibleLabel: `Statly Z ${value}`,
+  };
+}

--- a/src/server/draft/domain/draftRules.ts
+++ b/src/server/draft/domain/draftRules.ts
@@ -1,4 +1,6 @@
-import { DraftDirection, DraftStatus } from '@prisma/client';
+import { DraftStatus } from '@prisma/client';
+
+import { getDraftPickCoordinate } from '@/lib/draftOrder';
 
 import type {
   DraftAggregate,
@@ -7,17 +9,14 @@ import type {
   DraftTypeValue,
 } from './draftTypes';
 
-function calculateLinearTurn(
+function calculateTurn(
+  draftType: DraftTypeValue,
   currentPick: number,
   participants: DraftParticipantSnapshot[]
 ): DraftTurn {
   const teamCount = participants.length;
-  if (teamCount === 0) {
-    throw new Error('Draft has no participants');
-  }
-
-  const round = Math.ceil(currentPick / teamCount);
-  const slot = ((currentPick - 1) % teamCount) + 1;
+  const coordinate = getDraftPickCoordinate(draftType, currentPick, teamCount);
+  const { round, slot } = coordinate;
   const participant = participants.find((item) => item.slot === slot);
   if (!participant) {
     throw new Error(`Draft order is missing slot ${slot}`);
@@ -26,7 +25,7 @@ function calculateLinearTurn(
   return {
     round,
     slot,
-    direction: DraftDirection.FORWARD,
+    direction: coordinate.direction,
     participant,
   };
 }
@@ -35,29 +34,7 @@ export function calculateSnakeTurn(
   currentPick: number,
   participants: DraftParticipantSnapshot[]
 ): DraftTurn {
-  const teamCount = participants.length;
-  if (teamCount === 0) {
-    throw new Error('Draft has no participants');
-  }
-
-  const round = Math.ceil(currentPick / teamCount);
-  const direction = round % 2 === 1 ? DraftDirection.FORWARD : DraftDirection.REVERSE;
-  const slot =
-    direction === DraftDirection.FORWARD
-      ? ((currentPick - 1) % teamCount) + 1
-      : teamCount - ((currentPick - 1) % teamCount);
-
-  const participant = participants.find((item) => item.slot === slot);
-  if (!participant) {
-    throw new Error(`Draft order is missing slot ${slot}`);
-  }
-
-  return {
-    round,
-    slot,
-    direction,
-    participant,
-  };
+  return calculateTurn('SNAKE', currentPick, participants);
 }
 
 export function calculateDraftTurn(
@@ -65,11 +42,7 @@ export function calculateDraftTurn(
   currentPick: number,
   participants: DraftParticipantSnapshot[]
 ): DraftTurn {
-  if (draftType === 'LINEAR') {
-    return calculateLinearTurn(currentPick, participants);
-  }
-
-  return calculateSnakeTurn(currentPick, participants);
+  return calculateTurn(draftType, currentPick, participants);
 }
 
 export function getRosterPickLimit(draft: DraftAggregate): number {

--- a/src/server/draft/repository/DraftRepository.ts
+++ b/src/server/draft/repository/DraftRepository.ts
@@ -1,5 +1,4 @@
-import type { Prisma as PrismaNS } from '@prisma/client';
-import { DraftStatus } from '@prisma/client';
+import { DraftStatus, Prisma as PrismaNS } from '@prisma/client';
 
 import { prisma } from '@/lib/prisma';
 import { normalizeDraftAutoPickRules, normalizeDraftPositionLimits } from '@/lib/draftSettings';
@@ -18,6 +17,38 @@ import type {
 import { parseSelectedCategories } from '../readModels/draftPlayerReadModel';
 
 type TxClient = PrismaNS.TransactionClient;
+
+const MAX_TRANSACTION_ATTEMPTS = 3;
+const TRANSACTION_RETRY_BASE_DELAY_MS = 25;
+
+export type DraftTransactionOptions = {
+  timeout?: number;
+  retryPolicy?: 'default' | 'idempotent';
+};
+
+function isRetryableTransactionFailure(
+  error: unknown,
+  applicationWorkStarted: boolean,
+  retryPolicy: DraftTransactionOptions['retryPolicy']
+): boolean {
+  if (!(error instanceof PrismaNS.PrismaClientKnownRequestError)) {
+    return false;
+  }
+
+  if (error.code === 'P2034') {
+    return true;
+  }
+
+  // SQLite reports lock/acquisition and in-flight query timeouts as P1008. The default may replay
+  // only when Prisma never invoked application work. Callers that persist a desired state can opt
+  // into replay after callback entry; commands with non-idempotent effects must retain the default.
+  return error.code === 'P1008' && (!applicationWorkStarted || retryPolicy === 'idempotent');
+}
+
+async function waitForTransactionRetry(attempt: number): Promise<void> {
+  const delayMs = TRANSACTION_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
 
 export type LiveDraftPickExpirySchedule = {
   draftId: string;
@@ -153,8 +184,43 @@ function toPickSnapshot(pick: {
 }
 
 export class DraftRepository {
-  async transaction<T>(work: (tx: TxClient) => Promise<T>, timeout = 20000): Promise<T> {
-    return prisma.$transaction((tx) => work(tx), { timeout });
+  async transaction<T>(
+    work: (tx: TxClient) => Promise<T>,
+    timeoutOrOptions: number | DraftTransactionOptions = 20000
+  ): Promise<T> {
+    const options =
+      typeof timeoutOrOptions === 'number'
+        ? { timeout: timeoutOrOptions, retryPolicy: 'default' as const }
+        : {
+            timeout: timeoutOrOptions.timeout ?? 20000,
+            retryPolicy: timeoutOrOptions.retryPolicy ?? ('default' as const),
+          };
+
+    for (let attempt = 1; attempt <= MAX_TRANSACTION_ATTEMPTS; attempt += 1) {
+      let applicationWorkStarted = false;
+      try {
+        return await prisma.$transaction(
+          (tx) => {
+            applicationWorkStarted = true;
+            return work(tx);
+          },
+          {
+            timeout: options.timeout,
+            isolationLevel: PrismaNS.TransactionIsolationLevel.Serializable,
+          }
+        );
+      } catch (error) {
+        if (
+          !isRetryableTransactionFailure(error, applicationWorkStarted, options.retryPolicy) ||
+          attempt === MAX_TRANSACTION_ATTEMPTS
+        ) {
+          throw error;
+        }
+        await waitForTransactionRetry(attempt);
+      }
+    }
+
+    throw new Error('Draft transaction retry limit exceeded');
   }
 
   async listLiveDraftPickExpirySchedules(tx: TxClient): Promise<LiveDraftPickExpirySchedule[]> {
@@ -423,14 +489,10 @@ export class DraftRepository {
     });
   }
 
-  async removeQueuedPlayer(tx: TxClient, draftId: string, memberId: string, playerId: string) {
+  async removePlayerFromAllDraftQueues(tx: TxClient, draftId: string, playerId: string) {
     await tx.preDraftQueue.deleteMany({
-      where: { draftId, memberId, playerId },
+      where: { draftId, playerId },
     });
-  }
-
-  async removeQueuedPlayerById(tx: TxClient, queueItemId: string) {
-    await tx.preDraftQueue.delete({ where: { id: queueItemId } });
   }
 
   async advanceDraft(

--- a/src/server/draft/services/DraftApplicationService.ts
+++ b/src/server/draft/services/DraftApplicationService.ts
@@ -382,7 +382,7 @@ export class DraftApplicationService {
           auto: false,
         });
 
-        await draftRepository.removeQueuedPlayer(tx, draftId, actingParticipant.memberId, playerId);
+        await draftRepository.removePlayerFromAllDraftQueues(tx, draftId, playerId);
 
         const nextState = buildNextDraftState(draft);
         const transitionedAt = new Date();
@@ -588,9 +588,7 @@ export class DraftApplicationService {
           auto: true,
         });
 
-        if (queueItem) {
-          await draftRepository.removeQueuedPlayerById(tx, queueItem.id);
-        }
+        await draftRepository.removePlayerFromAllDraftQueues(tx, draftId, selectedPlayer.id);
 
         const nextState = buildNextDraftState(draft);
         const transitionedAt = new Date();

--- a/src/server/draft/services/DraftPrivateStateService.ts
+++ b/src/server/draft/services/DraftPrivateStateService.ts
@@ -1,8 +1,15 @@
 import 'server-only';
 
+import { DraftStatus, type Prisma } from '@prisma/client';
+
 import { logger } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
-import { getDraftMembershipAccess } from '@/server/leagues/membership';
+import { draftRepository } from '@/server/draft/repository/DraftRepository';
+import { getDraftMembershipAccess, isActivePrismaMembership } from '@/server/leagues/membership';
+import {
+  resolveCanonicalPlayerIds,
+  STATLY_LEGACY_PLAYER_PROVIDER,
+} from '@/server/players/playerIdentityService';
 
 import type { PreDraftQueueItem, WatchlistItem } from '@/lib/draftLobby';
 
@@ -12,6 +19,24 @@ export class DraftPrivateStateAccessError extends Error {
   constructor(message = 'Not a member of this draft') {
     super(message);
     this.name = 'DraftPrivateStateAccessError';
+  }
+}
+
+export class DraftPrivateStateValidationError extends Error {
+  readonly kind = 'bad_request' as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'DraftPrivateStateValidationError';
+  }
+}
+
+export class DraftPrivateStateConflictError extends Error {
+  readonly kind = 'conflict' as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'DraftPrivateStateConflictError';
   }
 }
 
@@ -30,7 +55,18 @@ interface RemoveWatchlistItemInput extends ActorDraftInput {
   playerId: string;
 }
 
+interface AddPreDraftQueueItemInput extends ActorDraftInput {
+  playerId: string;
+  rank?: number;
+  notes?: string;
+}
+
+interface RemovePreDraftQueueItemInput extends ActorDraftInput {
+  playerId: string;
+}
+
 interface ReplacePreDraftQueueInput extends ActorDraftInput {
+  unresolvedPlayerPolicy: 'reject' | 'remove';
   queue: Array<{
     playerId: string;
     rank: number;
@@ -38,12 +74,26 @@ interface ReplacePreDraftQueueInput extends ActorDraftInput {
   }>;
 }
 
+export interface ReplacePreDraftQueueResult {
+  memberId: string;
+  queue: PreDraftQueueItem[];
+  removedPlayerIds: string[];
+}
+
 const privatePlayerSelect = {
   id: true,
   name: true,
   position: true,
   club: true,
+  active: true,
 } as const;
+
+type DraftOrderReadClient = Pick<Prisma.TransactionClient, 'draftOrder'>;
+
+type QueueWriteItem = {
+  playerId: string;
+  notes?: string;
+};
 
 async function resolveActiveMemberId(input: ActorDraftInput): Promise<string> {
   const access = await getDraftMembershipAccess(input.draftId, input.actorUserId);
@@ -52,6 +102,96 @@ async function resolveActiveMemberId(input: ActorDraftInput): Promise<string> {
   }
 
   return access.memberId;
+}
+
+async function resolveDraftParticipant(
+  client: DraftOrderReadClient,
+  input: ActorDraftInput,
+  requireMutableQueue = false
+): Promise<string> {
+  const participant = await client.draftOrder.findFirst({
+    where: {
+      draftId: input.draftId,
+      member: { userId: input.actorUserId },
+    },
+    select: {
+      memberId: true,
+      member: {
+        select: {
+          leagueId: true,
+          isActive: true,
+          status: true,
+        },
+      },
+      draft: { select: { leagueId: true, status: true } },
+    },
+  });
+
+  if (
+    !participant ||
+    participant.member.leagueId !== participant.draft.leagueId ||
+    !isActivePrismaMembership(participant.member)
+  ) {
+    throw new DraftPrivateStateAccessError();
+  }
+
+  if (requireMutableQueue && participant.draft.status === DraftStatus.COMPLETED) {
+    throw new DraftPrivateStateConflictError('A completed draft queue cannot be changed');
+  }
+
+  return participant.memberId;
+}
+
+function normalizeRequestedQueue(
+  queue: ReplacePreDraftQueueInput['queue']
+): Array<ReplacePreDraftQueueInput['queue'][number] & { inputIndex: number }> {
+  const normalized = queue.map((item, inputIndex) => ({
+    ...item,
+    playerId: String(item.playerId ?? '').trim(),
+    inputIndex,
+  }));
+
+  if (
+    normalized.some(
+      (item) => !item.playerId || !Number.isInteger(item.rank) || Number(item.rank) <= 0
+    )
+  ) {
+    throw new DraftPrivateStateValidationError('Queue items require a player and positive rank');
+  }
+
+  return normalized.sort((a, b) => a.rank - b.rank || a.inputIndex - b.inputIndex);
+}
+
+async function replaceQueueRows(
+  tx: Prisma.TransactionClient,
+  draftId: string,
+  memberId: string,
+  queue: QueueWriteItem[]
+): Promise<PreDraftQueueItem[]> {
+  await tx.preDraftQueue.deleteMany({ where: { draftId, memberId } });
+
+  if (queue.length > 0) {
+    await tx.preDraftQueue.createMany({
+      data: queue.map((item, index) => ({
+        draftId,
+        memberId,
+        playerId: item.playerId,
+        rank: index + 1,
+        notes: item.notes,
+      })),
+    });
+  }
+
+  const persistedQueue = await tx.preDraftQueue.findMany({
+    where: { draftId, memberId },
+    include: { player: { select: privatePlayerSelect } },
+    orderBy: [{ rank: 'asc' }, { createdAt: 'asc' }],
+  });
+
+  return persistedQueue.map((item) => ({
+    ...item,
+    notes: item.notes ?? undefined,
+  }));
 }
 
 async function logPrivateStateActivity(input: {
@@ -156,11 +296,18 @@ export class DraftPrivateStateService {
   }
 
   async getPreDraftQueue(input: ActorDraftInput): Promise<PreDraftQueueItem[]> {
-    const memberId = await resolveActiveMemberId(input);
+    const memberId = await resolveDraftParticipant(prisma, input);
     const queue = await prisma.preDraftQueue.findMany({
-      where: { draftId: input.draftId, memberId },
+      where: {
+        draftId: input.draftId,
+        memberId,
+        player: {
+          active: true,
+          picks: { none: { draftId: input.draftId } },
+        },
+      },
       include: { player: { select: privatePlayerSelect } },
-      orderBy: { rank: 'asc' },
+      orderBy: [{ rank: 'asc' }, { createdAt: 'asc' }],
     });
 
     return queue.map((item) => ({
@@ -169,43 +316,219 @@ export class DraftPrivateStateService {
     }));
   }
 
-  async replacePreDraftQueue(input: ReplacePreDraftQueueInput): Promise<PreDraftQueueItem[]> {
-    const memberId = await resolveActiveMemberId(input);
-    const queue = await prisma.$transaction(async (tx) => {
-      await tx.preDraftQueue.deleteMany({
-        where: { draftId: input.draftId, memberId },
-      });
+  async addToPreDraftQueue(input: AddPreDraftQueueItemInput): Promise<PreDraftQueueItem> {
+    const result = await draftRepository.transaction(
+      async (tx) => {
+        const memberId = await resolveDraftParticipant(tx, input, true);
 
-      for (const item of input.queue) {
-        await tx.preDraftQueue.create({
-          data: {
-            draftId: input.draftId,
-            memberId,
+        const requestedId = String(input.playerId ?? '').trim();
+        if (!requestedId) {
+          throw new DraftPrivateStateValidationError('Player is required');
+        }
+        if (
+          input.rank !== undefined &&
+          (!Number.isInteger(input.rank) || Number(input.rank) <= 0)
+        ) {
+          throw new DraftPrivateStateValidationError('Queue rank must be a positive integer');
+        }
+
+        const resolvedIds = await resolveCanonicalPlayerIds(
+          [requestedId],
+          STATLY_LEGACY_PLAYER_PROVIDER,
+          tx
+        );
+        const playerId = resolvedIds.get(requestedId);
+        if (!playerId) {
+          throw new DraftPrivateStateValidationError('Player not found');
+        }
+
+        const [player, picked, currentQueue] = await Promise.all([
+          tx.player.findUnique({
+            where: { id: playerId },
+            select: { id: true, active: true },
+          }),
+          tx.pick.findUnique({
+            where: { draftId_playerId: { draftId: input.draftId, playerId } },
+            select: { id: true },
+          }),
+          tx.preDraftQueue.findMany({
+            where: {
+              draftId: input.draftId,
+              memberId,
+              player: {
+                active: true,
+                picks: { none: { draftId: input.draftId } },
+              },
+            },
+            orderBy: [{ rank: 'asc' }, { createdAt: 'asc' }],
+            select: { playerId: true, notes: true },
+          }),
+        ]);
+
+        if (!player?.active || picked) {
+          throw new DraftPrivateStateConflictError('Player is no longer available');
+        }
+
+        const existing = currentQueue.find((item) => item.playerId === playerId);
+        const nextQueue = currentQueue
+          .filter((item) => item.playerId !== playerId)
+          .map((item) => ({
             playerId: item.playerId,
-            rank: item.rank,
-            notes: item.notes,
-          },
+            notes: item.notes ?? undefined,
+          }));
+        const targetIndex =
+          input.rank === undefined
+            ? existing
+              ? currentQueue.indexOf(existing)
+              : nextQueue.length
+            : Math.min(Math.max(input.rank - 1, 0), nextQueue.length);
+        nextQueue.splice(targetIndex, 0, {
+          playerId,
+          notes: input.notes ?? existing?.notes ?? undefined,
         });
-      }
 
-      return tx.preDraftQueue.findMany({
-        where: { draftId: input.draftId, memberId },
-        include: { player: { select: privatePlayerSelect } },
-        orderBy: { rank: 'asc' },
-      });
-    });
+        const persistedQueue = await replaceQueueRows(tx, input.draftId, memberId, nextQueue);
+        const persisted = persistedQueue.find((item) => item.playerId === playerId);
+        if (!persisted) {
+          throw new DraftPrivateStateConflictError('Queue changed while it was being updated');
+        }
+        return { memberId, queueItem: persisted };
+      },
+      { retryPolicy: 'idempotent' }
+    );
 
     await logPrivateStateActivity({
       draftId: input.draftId,
-      memberId,
+      memberId: result.memberId,
       action: 'queue_updated',
-      details: { queueSize: input.queue.length },
+      details: {
+        playerId: result.queueItem.playerId,
+        action: 'added',
+        rank: result.queueItem.rank,
+      },
     });
 
-    return queue.map((item) => ({
-      ...item,
-      notes: item.notes ?? undefined,
-    }));
+    return result.queueItem;
+  }
+
+  async removeFromPreDraftQueue(input: RemovePreDraftQueueItemInput): Promise<boolean> {
+    const deleted = await draftRepository.transaction(
+      async (tx) => {
+        const memberId = await resolveDraftParticipant(tx, input, true);
+        const requestedId = String(input.playerId ?? '').trim();
+        const resolvedIds = await resolveCanonicalPlayerIds(
+          requestedId ? [requestedId] : [],
+          STATLY_LEGACY_PLAYER_PROVIDER,
+          tx
+        );
+        const playerId = resolvedIds.get(requestedId);
+        if (!playerId) return { count: 0, memberId, playerId: requestedId };
+
+        const currentQueue = await tx.preDraftQueue.findMany({
+          where: { draftId: input.draftId, memberId },
+          orderBy: [{ rank: 'asc' }, { createdAt: 'asc' }],
+          select: { playerId: true, notes: true },
+        });
+        const containsPlayer = currentQueue.some((item) => item.playerId === playerId);
+        if (!containsPlayer) return { count: 0, memberId, playerId };
+
+        await replaceQueueRows(
+          tx,
+          input.draftId,
+          memberId,
+          currentQueue
+            .filter((item) => item.playerId !== playerId)
+            .map((item) => ({
+              playerId: item.playerId,
+              notes: item.notes ?? undefined,
+            }))
+        );
+
+        return { count: 1, memberId, playerId };
+      },
+      { retryPolicy: 'idempotent' }
+    );
+
+    if (deleted.count > 0) {
+      await logPrivateStateActivity({
+        draftId: input.draftId,
+        memberId: deleted.memberId,
+        action: 'queue_updated',
+        details: { playerId: deleted.playerId, action: 'removed' },
+      });
+    }
+
+    return deleted.count > 0;
+  }
+
+  async replacePreDraftQueue(
+    input: ReplacePreDraftQueueInput
+  ): Promise<ReplacePreDraftQueueResult> {
+    const result = await draftRepository.transaction(
+      async (tx) => {
+        const memberId = await resolveDraftParticipant(tx, input, true);
+        const orderedInput = normalizeRequestedQueue(input.queue);
+        const requestedIds = orderedInput.map((item) => item.playerId);
+        const resolvedIds = await resolveCanonicalPlayerIds(
+          requestedIds,
+          STATLY_LEGACY_PLAYER_PROVIDER,
+          tx
+        );
+        const unresolvedIds = requestedIds.filter((playerId) => !resolvedIds.has(playerId));
+        if (input.unresolvedPlayerPolicy === 'reject' && unresolvedIds.length > 0) {
+          throw new DraftPrivateStateValidationError('Queue contains an unknown player');
+        }
+
+        const seenPlayerIds = new Set<string>();
+        const canonicalQueue: QueueWriteItem[] = [];
+        for (const item of orderedInput) {
+          const playerId = resolvedIds.get(item.playerId);
+          if (!playerId || seenPlayerIds.has(playerId)) continue;
+          seenPlayerIds.add(playerId);
+          canonicalQueue.push({ playerId, notes: item.notes });
+        }
+
+        const canonicalIds = canonicalQueue.map((item) => item.playerId);
+        const [players, picks] = await Promise.all([
+          tx.player.findMany({
+            where: { id: { in: canonicalIds } },
+            select: { id: true, active: true },
+          }),
+          tx.pick.findMany({
+            where: { draftId: input.draftId, playerId: { in: canonicalIds } },
+            select: { playerId: true },
+          }),
+        ]);
+        const activePlayerIds = new Set(
+          players.filter((player) => player.active).map((player) => player.id)
+        );
+        const pickedPlayerIds = new Set(picks.map((pick) => pick.playerId));
+        const unavailablePlayerIds = canonicalIds.filter(
+          (playerId) => !activePlayerIds.has(playerId) || pickedPlayerIds.has(playerId)
+        );
+        const removedPlayerIds = Array.from(new Set([...unresolvedIds, ...unavailablePlayerIds]));
+        const acceptedQueue = canonicalQueue.filter(
+          (item) => activePlayerIds.has(item.playerId) && !pickedPlayerIds.has(item.playerId)
+        );
+
+        const queue = await replaceQueueRows(tx, input.draftId, memberId, acceptedQueue);
+
+        return { memberId, queue, removedPlayerIds };
+      },
+      { retryPolicy: 'idempotent' }
+    );
+
+    await logPrivateStateActivity({
+      draftId: input.draftId,
+      memberId: result.memberId,
+      action: 'queue_updated',
+      details: {
+        queueSize: result.queue.length,
+        removedUnavailableCount: result.removedPlayerIds.length,
+      },
+    });
+
+    return result;
   }
 }
 

--- a/src/server/draft/services/DraftProjectionService.ts
+++ b/src/server/draft/services/DraftProjectionService.ts
@@ -251,6 +251,7 @@ export class DraftProjectionService {
         totalPicks: draft.totalPicks,
         round: draft.round,
         direction: draft.direction,
+        draftType: draft.league.settings.draftType ?? DraftType.SNAKE,
         clock,
         onClockMemberId,
         participants: draft.orders.map((order) => ({

--- a/src/services/realtime/draftStateWire.ts
+++ b/src/services/realtime/draftStateWire.ts
@@ -96,6 +96,7 @@ export const DraftRoomSnapshotPayloadSchema = z
       totalPicks: z.number().int().nonnegative(),
       round: z.number().int().positive(),
       direction: z.enum(['FORWARD', 'REVERSE']),
+      draftType: z.enum(['SNAKE', 'LINEAR']).optional(),
       clock: DraftClockPayloadSchema,
       onClockMemberId: z.string().nullable(),
       participants: z.array(DraftRoomSnapshotParticipantSchema),

--- a/tests/integration/draftFullConvergence.test.ts
+++ b/tests/integration/draftFullConvergence.test.ts
@@ -146,13 +146,13 @@ async function seedFixture(): Promise<void> {
       })),
     });
 
-    await tx.preDraftQueue.create({
-      data: {
+    await tx.preDraftQueue.createMany({
+      data: [memberIds[0], memberIds[1]].map((memberId) => ({
         draftId: FIXTURE.draftId,
-        memberId: memberIds[0],
+        memberId,
         playerId: queuedPlayerId,
         rank: 1,
-      },
+      })),
     });
   });
 }

--- a/tests/unit/DraftApplicationService.completionProjection.test.ts
+++ b/tests/unit/DraftApplicationService.completionProjection.test.ts
@@ -9,7 +9,7 @@ const { draftRepository, statlyZStatsLookup } = vi.hoisted(() => ({
     findPlayer: vi.fn(),
     listAvailableAutoPickCandidates: vi.fn(),
     createPick: vi.fn(),
-    removeQueuedPlayerById: vi.fn(),
+    removePlayerFromAllDraftQueues: vi.fn(),
     advanceDraft: vi.fn(),
     updateDraftTiming: vi.fn(),
     transitionDraftClock: vi.fn(),
@@ -120,6 +120,79 @@ describe('DraftApplicationService completion projection', () => {
       overall: 2,
     });
     draftRepository.createDraftEvents.mockResolvedValue([{ id: 'event-1' }, { id: 'event-2' }]);
+  });
+
+  it('removes a manual selection from every queue inside the pick transaction', async () => {
+    draftRepository.getDraftAggregate.mockResolvedValue({
+      id: 'draft-1',
+      leagueId: 'league-1',
+      status: DraftStatus.LIVE,
+      currentPick: 1,
+      totalPicks: 3,
+      round: 1,
+      direction: DraftDirection.FORWARD,
+      startedAt: new Date('2026-06-07T00:00:00.000Z'),
+      completedAt: null,
+      pickStartedAt: new Date('2026-06-07T00:00:00.000Z'),
+      pickDeadlineAt: new Date('2026-06-07T00:02:00.000Z'),
+      pausedRemainingSeconds: null,
+      clockDurationSeconds: 120,
+      schedulingVersion: 3,
+      eventSequence: 0,
+      settings: {
+        rosterSize: 3,
+        benchSize: 0,
+        pickSeconds: 120,
+        allowAutoPick: true,
+        selectedCategories: ['goals', 'tackles'],
+        positionLimits: {},
+        autoPickRules: {},
+        draftType: 'SNAKE',
+      },
+      participants: [
+        {
+          memberId: 'member-1',
+          userId: 'user-1',
+          slot: 1,
+          displayName: 'Manager One',
+          role: 'OWNER',
+        },
+      ],
+      picks: [],
+    });
+    draftRepository.findPlayer.mockResolvedValue({
+      id: 'player-1',
+      name: 'Player One',
+      position: 'MID',
+      club: 'Carlton',
+      active: true,
+    });
+    draftRepository.createPick.mockResolvedValue({
+      id: 'pick-1',
+      draftId: 'draft-1',
+      overall: 1,
+      round: 1,
+      slot: 1,
+      memberId: 'member-1',
+      playerId: 'player-1',
+      auto: false,
+      player: { id: 'player-1', name: 'Player One', position: 'MID', club: 'Carlton' },
+      member: {
+        user: { id: 'user-1', displayName: 'Manager One', email: 'manager@example.com' },
+      },
+    });
+
+    const service = new DraftApplicationService({ projectDraft: vi.fn() } as never);
+    await service.makePick({ draftId: 'draft-1', actorUserId: 'user-1', playerId: 'player-1' });
+
+    expect(draftRepository.removePlayerFromAllDraftQueues).toHaveBeenCalledWith(
+      {},
+      'draft-1',
+      'player-1'
+    );
+    expect(draftRepository.removePlayerFromAllDraftQueues.mock.invocationCallOrder[0]).toBeLessThan(
+      draftRepository.transitionDraftClock.mock.invocationCallOrder[0]
+    );
   });
 
   it('projects canonical roster ownership and persists completion for reconciliation after the final auto-pick', async () => {
@@ -402,7 +475,11 @@ describe('DraftApplicationService completion projection', () => {
       {},
       expect.objectContaining({ playerId: 'queued-player', auto: true })
     );
-    expect(draftRepository.removeQueuedPlayerById).toHaveBeenCalledWith({}, 'queue-1');
+    expect(draftRepository.removePlayerFromAllDraftQueues).toHaveBeenCalledWith(
+      {},
+      'draft-1',
+      'queued-player'
+    );
     expect(result.data.wasQueued).toBe(true);
   });
 

--- a/tests/unit/DraftContext.initialFetch.test.tsx
+++ b/tests/unit/DraftContext.initialFetch.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { fetchApi, socketState } = vi.hoisted(() => ({
@@ -81,12 +82,24 @@ function createV1FallbackEmit() {
 
 function DraftStateProbe() {
   const draft = useDraft();
+  const [queueMutationStatus, setQueueMutationStatus] = useState('idle');
+
+  async function updateMixedQueue(): Promise<void> {
+    setQueueMutationStatus('pending');
+    try {
+      await draft.updateQueue(['picked-player', 'progressive-player']);
+      setQueueMutationStatus('resolved');
+    } catch (error) {
+      setQueueMutationStatus(`rejected:${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
 
   return (
     <div>
       <div data-testid="loading">{String(draft.isLoading)}</div>
       <div data-testid="draft-name">{draft.draft?.name ?? 'missing'}</div>
       <div data-testid="league-id">{draft.draft?.leagueId ?? 'missing'}</div>
+      <div data-testid="draft-type">{draft.draft?.settings.draftType ?? 'missing'}</div>
       <div data-testid="current-pick">{draft.draft?.currentPick ?? 'missing'}</div>
       <div data-testid="pick-deadline">
         {draft.draft?.pickDeadlineAt?.toISOString?.() ?? 'missing'}
@@ -108,6 +121,12 @@ function DraftStateProbe() {
       <div data-testid="queue-order">
         {draft.participants.flatMap((participant) => participant.queue ?? []).join(',')}
       </div>
+      <div data-testid="draft-error">{draft.error ?? 'none'}</div>
+      <div data-testid="can-make-pick">{String(draft.canMakePick)}</div>
+      <div data-testid="queue-mutation-status">{queueMutationStatus}</div>
+      <button type="button" onClick={() => void updateMixedQueue()}>
+        Update mixed queue
+      </button>
       <button type="button" onClick={() => void draft.makePick('player-1')}>
         Pick player 1
       </button>
@@ -119,6 +138,80 @@ function DraftStateProbe() {
       </button>
     </div>
   );
+}
+
+const pickedPlayer = {
+  id: 'picked-player',
+  name: 'Picked Player',
+  position: 'MID',
+  club: 'Sydney',
+  isAvailable: false,
+};
+
+const pickedPlayerPick = {
+  id: 'pick-picked-player',
+  overall: 1,
+  round: 1,
+  slot: 1,
+  player: pickedPlayer,
+  member: {
+    id: 'member-2',
+    userId: 'user-2',
+    displayName: 'Opponent',
+  },
+  auto: false,
+  madeAt: '2026-06-07T00:00:00.000Z',
+};
+
+function makeQueueTestSnapshot({
+  picks = [],
+  queue = [],
+}: {
+  picks?: Array<typeof pickedPlayerPick>;
+  queue?: string[];
+}) {
+  return {
+    draft: {
+      id: 'draft-1',
+      name: 'Queue Convergence Draft',
+      leagueId: 'league-1',
+      status: 'LIVE',
+      currentPick: picks.length + 1,
+      totalPicks: 4,
+      round: 1,
+      direction: 'FORWARD',
+    } as any,
+    participants: [
+      {
+        id: 'member-1',
+        memberId: 'member-1',
+        userId: 'user-1',
+        displayName: 'Tester',
+        slot: 1,
+        queue,
+      },
+      {
+        id: 'member-2',
+        memberId: 'member-2',
+        userId: 'user-2',
+        displayName: 'Opponent',
+        slot: 2,
+        queue: [],
+      },
+    ] as any,
+    availablePlayers: [
+      {
+        id: 'catalogue-player',
+        name: 'Catalogue Player',
+        position: 'DEF',
+        club: 'Carlton',
+        isAvailable: true,
+        statlyZScore: 0,
+      },
+    ],
+    picks: picks as any,
+    ts: 1,
+  };
 }
 
 describe('DraftProvider initial hydration', () => {
@@ -324,6 +417,58 @@ describe('DraftProvider initial hydration', () => {
 
     expect(emit.mock.calls.filter((call) => call[0] === 'draft:join:v2')).toHaveLength(
       joinCountBeforeSnapshot
+    );
+  });
+
+  it('preserves a hydrated linear draft type when an older v2 snapshot omits it', async () => {
+    const emit = createV2AcknowledgingEmit(2);
+    socketState.current = {
+      connected: true,
+      emit,
+      on: vi.fn(),
+      off: vi.fn(),
+      io: { on: vi.fn(), off: vi.fn() },
+    };
+    fetchApi.mockResolvedValue({
+      success: true,
+      data: { players: [], pagination: { hasMore: false }, queue: [], watchlist: [] },
+    });
+
+    render(
+      <DraftProvider
+        draftId="draft-1"
+        userId="user-1"
+        initialSnapshot={{
+          draft: {
+            id: 'draft-1',
+            name: 'Linear Draft',
+            leagueId: 'league-1',
+            status: 'LIVE',
+            currentPick: 1,
+            totalPicks: 2,
+            round: 1,
+            direction: 'FORWARD',
+            settings: { draftType: 'LINEAR' },
+          } as any,
+          participants: [],
+          availablePlayers: [],
+          picks: [],
+          ts: 1,
+        }}
+      >
+        <DraftStateProbe />
+      </DraftProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('draft-name')).toHaveTextContent('Realtime Draft');
+      expect(screen.getByTestId('draft-type')).toHaveTextContent('LINEAR');
+    });
+
+    expect(emit).toHaveBeenCalledWith(
+      'draft:join:v2',
+      { draftId: 'draft-1', generation: 1 },
+      expect.any(Function)
     );
   });
 
@@ -2252,6 +2397,300 @@ describe('DraftProvider initial hydration', () => {
 
     expect(screen.getByTestId('watchlist-order')).toHaveTextContent('player-2');
     expect(screen.getByTestId('watchlist-order')).not.toHaveTextContent('old-watchlist-player');
+  });
+
+  it('does not let delayed private hydration reintroduce a player picked while it was pending', async () => {
+    const handlers = new Map<string, (...args: any[]) => void>();
+    let resolveQueue: ((value: unknown) => void) | undefined;
+    socketState.current = {
+      connected: true,
+      emit: createV1FallbackEmit(),
+      on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+        handlers.set(event, handler);
+      }),
+      off: vi.fn(),
+      io: { on: vi.fn(), off: vi.fn() },
+    };
+
+    fetchApi.mockImplementation(async (endpoint: string) => {
+      if (endpoint === 'drafts/draft-1/pre-queue') {
+        return new Promise((resolve) => {
+          resolveQueue = resolve;
+        });
+      }
+      if (endpoint === 'drafts/draft-1/watchlist') {
+        return { success: true, data: { watchlist: [] } };
+      }
+
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    render(
+      <DraftProvider
+        draftId="draft-1"
+        userId="user-1"
+        initialSnapshot={makeQueueTestSnapshot({ queue: ['picked-player', 'progressive-player'] })}
+      >
+        <DraftStateProbe />
+      </DraftProvider>
+    );
+
+    await waitFor(() => expect(resolveQueue).toBeDefined());
+
+    act(() => {
+      handlers.get('draft:delta')?.({
+        type: 'PICK_MADE',
+        ts: 2,
+        payload: {
+          pick: pickedPlayerPick,
+          currentPick: 2,
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pick-order')).toHaveTextContent('pick-picked-player');
+      expect(screen.getByTestId('queue-order')).toHaveTextContent('progressive-player');
+      expect(screen.getByTestId('queue-order')).not.toHaveTextContent('picked-player');
+    });
+
+    await act(async () => {
+      resolveQueue?.({
+        success: true,
+        data: {
+          queue: [
+            { playerId: 'picked-player', rank: 1 },
+            { playerId: 'progressive-player', rank: 2 },
+          ],
+        },
+      });
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('queue-order')).toHaveTextContent('progressive-player');
+    expect(screen.getByTestId('queue-order')).not.toHaveTextContent('picked-player');
+    expect(screen.getByTestId('draft-error')).toHaveTextContent('none');
+  });
+
+  it('sanitizes known drafted IDs without rejecting IDs absent from the progressive catalogue', async () => {
+    let mutationBody: { queue?: Array<{ playerId: string; rank: number }> } | undefined;
+    fetchApi.mockImplementation(async (endpoint: string, options?: RequestInit) => {
+      if (endpoint === 'drafts/draft-1/pre-queue' && options?.method === 'PUT') {
+        const parsedBody = JSON.parse(String(options.body)) as {
+          queue: Array<{ playerId: string; rank: number }>;
+        };
+        mutationBody = parsedBody;
+        return { success: true, data: { queue: parsedBody.queue } };
+      }
+      if (endpoint === 'drafts/draft-1/pre-queue') {
+        return { success: true, data: { queue: [] } };
+      }
+      if (endpoint === 'drafts/draft-1/watchlist') {
+        return { success: true, data: { watchlist: [] } };
+      }
+
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    render(
+      <DraftProvider
+        draftId="draft-1"
+        userId="user-1"
+        initialSnapshot={makeQueueTestSnapshot({ picks: [pickedPlayerPick] })}
+      >
+        <DraftStateProbe />
+      </DraftProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update mixed queue' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('queue-mutation-status')).toHaveTextContent('resolved');
+    });
+
+    expect(mutationBody).toEqual({
+      queue: [{ playerId: 'progressive-player', rank: 1 }],
+    });
+    expect(screen.getByTestId('queue-order')).toHaveTextContent('progressive-player');
+    expect(screen.getByTestId('draft-error')).toHaveTextContent('none');
+  });
+
+  it('does not let private hydration started during a queue PUT overwrite its confirmed response', async () => {
+    let queueReads = 0;
+    let resolvePut: ((value: unknown) => void) | undefined;
+    let resolveRacingQueueRead: ((value: unknown) => void) | undefined;
+    socketState.current = {
+      connected: true,
+      emit: createV2AcknowledgingEmit(1),
+      on: vi.fn(),
+      off: vi.fn(),
+      io: { on: vi.fn(), off: vi.fn() },
+    };
+
+    fetchApi.mockImplementation(async (endpoint: string, options?: RequestInit) => {
+      if (endpoint === 'drafts/draft-1/pre-queue' && options?.method === 'PUT') {
+        return new Promise((resolve) => {
+          resolvePut = resolve;
+        });
+      }
+      if (endpoint === 'drafts/draft-1/pre-queue') {
+        queueReads += 1;
+        if (queueReads === 1) {
+          return {
+            success: true,
+            data: { queue: [{ playerId: 'initial-player', rank: 1 }] },
+          };
+        }
+
+        return new Promise((resolve) => {
+          resolveRacingQueueRead = resolve;
+        });
+      }
+      if (endpoint === 'drafts/draft-1/watchlist') {
+        return { success: true, data: { watchlist: [] } };
+      }
+
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    render(
+      <DraftProvider
+        draftId="draft-1"
+        userId="user-1"
+        initialSnapshot={makeQueueTestSnapshot({ queue: ['initial-player'] })}
+      >
+        <DraftStateProbe />
+      </DraftProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('queue-order')).toHaveTextContent('initial-player');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update mixed queue' }));
+    await waitFor(() => {
+      expect(resolvePut).toBeDefined();
+      expect(screen.getByTestId('queue-mutation-status')).toHaveTextContent('pending');
+      expect(screen.getByTestId('can-make-pick')).toHaveTextContent('true');
+    });
+
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible');
+    act(() => document.dispatchEvent(new Event('visibilitychange')));
+    await waitFor(() => expect(resolveRacingQueueRead).toBeDefined());
+
+    await act(async () => {
+      resolvePut?.({
+        success: true,
+        data: { queue: [{ playerId: 'progressive-player', rank: 1 }] },
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('queue-mutation-status')).toHaveTextContent('resolved');
+      expect(screen.getByTestId('queue-order')).toHaveTextContent('progressive-player');
+    });
+
+    await act(async () => {
+      resolveRacingQueueRead?.({
+        success: true,
+        data: { queue: [{ playerId: 'stale-hydration-player', rank: 1 }] },
+      });
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('queue-order')).toHaveTextContent('progressive-player');
+    expect(screen.getByTestId('queue-order')).not.toHaveTextContent('stale-hydration-player');
+    expect(screen.getByTestId('draft-error')).toHaveTextContent('none');
+  });
+
+  it('prunes a drafted player from the persisted queue response before committing it', async () => {
+    fetchApi.mockImplementation(async (endpoint: string, options?: RequestInit) => {
+      if (endpoint === 'drafts/draft-1/pre-queue' && options?.method === 'PUT') {
+        return {
+          success: true,
+          data: {
+            queue: [
+              { playerId: 'picked-player', rank: 1 },
+              { playerId: 'progressive-player', rank: 2 },
+            ],
+          },
+        };
+      }
+      if (endpoint === 'drafts/draft-1/pre-queue') {
+        return { success: true, data: { queue: [] } };
+      }
+      if (endpoint === 'drafts/draft-1/watchlist') {
+        return { success: true, data: { watchlist: [] } };
+      }
+
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    render(
+      <DraftProvider
+        draftId="draft-1"
+        userId="user-1"
+        initialSnapshot={makeQueueTestSnapshot({ picks: [pickedPlayerPick] })}
+      >
+        <DraftStateProbe />
+      </DraftProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update mixed queue' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('queue-mutation-status')).toHaveTextContent('resolved');
+      expect(screen.getByTestId('queue-order')).toHaveTextContent('progressive-player');
+      expect(screen.getByTestId('queue-order')).not.toHaveTextContent('picked-player');
+    });
+  });
+
+  it('rejects a failed queue PUT without promoting it to a fatal draft error', async () => {
+    let queueReads = 0;
+    fetchApi.mockImplementation(async (endpoint: string, options?: RequestInit) => {
+      if (endpoint === 'drafts/draft-1/pre-queue' && options?.method === 'PUT') {
+        throw new Error('Queue service unavailable');
+      }
+      if (endpoint === 'drafts/draft-1/pre-queue') {
+        queueReads += 1;
+        return {
+          success: true,
+          data: { queue: [{ playerId: 'progressive-player', rank: 1 }] },
+        };
+      }
+      if (endpoint === 'drafts/draft-1/watchlist') {
+        return { success: true, data: { watchlist: [] } };
+      }
+
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    render(
+      <DraftProvider
+        draftId="draft-1"
+        userId="user-1"
+        initialSnapshot={makeQueueTestSnapshot({ picks: [pickedPlayerPick] })}
+      >
+        <DraftStateProbe />
+      </DraftProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('queue-order')).toHaveTextContent('progressive-player');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update mixed queue' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('queue-mutation-status')).toHaveTextContent(
+        'rejected:Queue service unavailable'
+      );
+      expect(queueReads).toBeGreaterThanOrEqual(2);
+    });
+
+    expect(screen.getByTestId('draft-error')).toHaveTextContent('none');
+    expect(screen.getByTestId('queue-order')).toHaveTextContent('progressive-player');
   });
 
   it('applies revisioned pause and resume clocks immediately and ignores a stale lifecycle delta', async () => {

--- a/tests/unit/DraftLeftRail.test.tsx
+++ b/tests/unit/DraftLeftRail.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it } from 'vitest';
 
@@ -51,10 +51,7 @@ describe('DraftLeftRail', () => {
   it('defaults to the queue before the draft starts', () => {
     renderRail({ draftStatus: 'SCHEDULED' });
 
-    expect(screen.getByRole('tab', { name: /queue 2/i })).toHaveAttribute(
-      'aria-selected',
-      'true'
-    );
+    expect(screen.getByRole('tab', { name: /queue 2/i })).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByText('Queue panel content')).toBeInTheDocument();
     expect(screen.queryByText('Caleb Daniel')).not.toBeInTheDocument();
   });
@@ -62,12 +59,20 @@ describe('DraftLeftRail', () => {
   it('defaults to the roster once the draft is live', () => {
     renderRail({ draftStatus: 'LIVE' });
 
-    expect(screen.getByRole('tab', { name: /roster/i })).toHaveAttribute(
-      'aria-selected',
-      'true'
-    );
-    expect(screen.getByText('Caleb Daniel')).toBeInTheDocument();
-    expect(screen.getByText('Empty slot')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /roster/i })).toHaveAttribute('aria-selected', 'true');
+    const filledSlot = screen.getByText('Caleb Daniel').closest('li');
+    const emptySlot = screen.getByText('Empty slot').closest('li');
+    if (!filledSlot || !emptySlot) throw new Error('Expected filled and empty roster slots');
+
+    expect(filledSlot).toHaveAttribute('data-roster-state', 'filled');
+    expect(filledSlot).toHaveClass('bg-[color:var(--draft-broadcast-roster-filled)]');
+    expect(within(filledSlot).getByText('Bench 1')).toBeInTheDocument();
+    expect(within(filledSlot).getByText('Caleb Daniel')).toBeInTheDocument();
+    expect(emptySlot).toHaveAttribute('data-roster-state', 'empty');
+    expect(emptySlot).toHaveClass('bg-background');
+    expect(emptySlot).toHaveClass('border-dashed');
+    expect(within(emptySlot).getByText('Bench 2')).toBeInTheDocument();
+    expect(within(emptySlot).getByText('Empty slot')).toBeInTheDocument();
     expect(screen.queryByText('Queue panel content')).not.toBeInTheDocument();
   });
 

--- a/tests/unit/DraftPickTrain.test.tsx
+++ b/tests/unit/DraftPickTrain.test.tsx
@@ -94,7 +94,7 @@ describe('DraftPickTrain', () => {
 });
 
 describe('toDraftPickTrainState', () => {
-  it('maps snake order, pick statuses, and user-next insertion across a round boundary', () => {
+  it('maps a bounded snake-order window without appending a distant user pick', () => {
     const participants = [
       {
         id: 'member-1',
@@ -146,6 +146,7 @@ describe('toDraftPickTrainState', () => {
       round: 2,
       direction: 'REVERSE',
       status: 'LIVE',
+      settings: { draftType: 'SNAKE' },
     } as DraftState;
     const picks = [
       {
@@ -176,12 +177,11 @@ describe('toDraftPickTrainState', () => {
       yourSlot: 1,
     });
 
-    expect(state.slots.map((slot) => slot.overall)).toEqual([6, 7, 8, 9, 10, 11, 12]);
-    expect(state.slots.map((slot) => slot.slot)).toEqual([6, 6, 5, 4, 3, 2, 1]);
+    expect(state.slots.map((slot) => slot.overall)).toEqual([6, 7, 8, 9, 10, 11]);
+    expect(state.slots.map((slot) => slot.slot)).toEqual([6, 6, 5, 4, 3, 2]);
     expect(state.slots.map((slot) => slot.status)).toEqual([
       'completed',
       'current',
-      'upcoming',
       'upcoming',
       'upcoming',
       'upcoming',
@@ -196,14 +196,7 @@ describe('toDraftPickTrainState', () => {
       teamName: 'Zeta FC',
       isUserPick: false,
     });
-    expect(state.slots[6]).toMatchObject({
-      overall: 12,
-      round: 2,
-      slot: 1,
-      isUserPick: true,
-      displayName: 'Alpha',
-      teamName: 'Alpha FC',
-    });
+    expect(state.slots.every((slot) => !slot.isUserPick)).toBe(true);
   });
 
   it('clamps completed drafts to the final pick and does not render a next user pick', () => {
@@ -230,6 +223,7 @@ describe('toDraftPickTrainState', () => {
       round: 2,
       direction: 'REVERSE',
       status: 'COMPLETED',
+      settings: { draftType: 'SNAKE' },
     } as DraftState;
     const picks = Array.from({ length: 4 }, (_, index) => ({
       id: `pick-${index + 1}`,

--- a/tests/unit/DraftPrivateStateService.test.ts
+++ b/tests/unit/DraftPrivateStateService.test.ts
@@ -1,50 +1,108 @@
+import { DraftStatus, Prisma } from '@prisma/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getDraftMembershipAccess, prisma } = vi.hoisted(() => {
-  const transactionClient = {
-    preDraftQueue: {
-      deleteMany: vi.fn(),
-      create: vi.fn(),
-      findMany: vi.fn(),
-    },
-  };
-
-  return {
-    getDraftMembershipAccess: vi.fn(),
-    prisma: {
-      draftWatchlist: {
-        findMany: vi.fn(),
-        upsert: vi.fn(),
-        deleteMany: vi.fn(),
-      },
+const { draftRepository, getDraftMembershipAccess, prisma, resolveCanonicalPlayerIds } = vi.hoisted(
+  () => {
+    const transactionClient = {
+      draftOrder: { findFirst: vi.fn() },
+      player: { findMany: vi.fn(), findUnique: vi.fn() },
+      pick: { findMany: vi.fn(), findUnique: vi.fn() },
       preDraftQueue: {
+        deleteMany: vi.fn(),
+        createMany: vi.fn(),
         findMany: vi.fn(),
       },
-      lobbyActivity: {
-        create: vi.fn(),
+    };
+
+    return {
+      draftRepository: {
+        transaction: vi.fn(async (callback: (tx: typeof transactionClient) => unknown) =>
+          callback(transactionClient)
+        ),
       },
-      $transaction: vi.fn(async (callback: (tx: typeof transactionClient) => unknown) =>
-        callback(transactionClient)
-      ),
-      transactionClient,
-    },
-  };
-});
+      getDraftMembershipAccess: vi.fn(),
+      resolveCanonicalPlayerIds: vi.fn(),
+      prisma: {
+        draftOrder: { findFirst: vi.fn() },
+        draftWatchlist: {
+          findMany: vi.fn(),
+          upsert: vi.fn(),
+          deleteMany: vi.fn(),
+        },
+        preDraftQueue: { findMany: vi.fn() },
+        lobbyActivity: { create: vi.fn() },
+        transactionClient,
+      },
+    };
+  }
+);
 
 vi.mock('server-only', () => ({}));
 vi.mock('@/lib/prisma', () => ({ prisma }));
 vi.mock('@/lib/logger', () => ({
   logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
 }));
-vi.mock('@/server/leagues/membership', () => ({ getDraftMembershipAccess }));
+vi.mock('@/server/draft/repository/DraftRepository', () => ({
+  draftRepository,
+}));
+vi.mock('@/server/leagues/membership', () => ({
+  getDraftMembershipAccess,
+  isActivePrismaMembership: (membership: { isActive: boolean; status: string }) =>
+    membership.isActive &&
+    !['declined', 'inactive', 'removed'].includes(membership.status.trim().toLowerCase()),
+}));
+vi.mock('@/server/players/playerIdentityService', () => ({
+  STATLY_LEGACY_PLAYER_PROVIDER: 'statly-legacy',
+  resolveCanonicalPlayerIds,
+}));
 
 import {
   DraftPrivateStateAccessError,
+  DraftPrivateStateConflictError,
   DraftPrivateStateService,
+  DraftPrivateStateValidationError,
 } from '@/server/draft/services/DraftPrivateStateService';
 
 const actor = { draftId: 'draft-1', actorUserId: 'user-1' };
-const player = { id: 'player-1', name: 'Player One', position: 'MID', club: 'CAR' };
+const memberId = 'member-1';
+const player = {
+  id: 'player-1',
+  name: 'Player One',
+  position: 'MID',
+  club: 'CAR',
+  active: true,
+};
+
+function participant(
+  draftStatus: DraftStatus = DraftStatus.LIVE,
+  membership: { isActive: boolean; status: string } = { isActive: true, status: 'ACTIVE' }
+) {
+  return {
+    memberId,
+    member: { leagueId: 'league-1', ...membership },
+    draft: { leagueId: 'league-1', status: draftStatus },
+  };
+}
+
+function queueRow(playerId: string, rank: number, active = true) {
+  return {
+    id: `queue-${playerId}`,
+    draftId: actor.draftId,
+    memberId,
+    playerId,
+    rank,
+    notes: null,
+    createdAt: new Date(`2026-08-01T00:00:0${rank}.000Z`),
+    updatedAt: new Date(`2026-08-01T00:00:0${rank}.000Z`),
+    player: {
+      id: playerId,
+      name: `Player ${playerId}`,
+      position: 'MID',
+      club: 'CAR',
+      active,
+    },
+  };
+}
 
 describe('DraftPrivateStateService', () => {
   beforeEach(() => {
@@ -52,10 +110,19 @@ describe('DraftPrivateStateService', () => {
     getDraftMembershipAccess.mockResolvedValue({
       leagueId: 'league-1',
       userId: actor.actorUserId,
-      memberId: 'member-1',
+      memberId,
       isMember: true,
       canManage: false,
     });
+    prisma.draftOrder.findFirst.mockResolvedValue(participant());
+    prisma.transactionClient.draftOrder.findFirst.mockResolvedValue(participant());
+    prisma.transactionClient.preDraftQueue.deleteMany.mockResolvedValue({ count: 0 });
+    prisma.transactionClient.preDraftQueue.createMany.mockResolvedValue({ count: 0 });
+    prisma.transactionClient.preDraftQueue.findMany.mockResolvedValue([]);
+    prisma.transactionClient.pick.findMany.mockResolvedValue([]);
+    resolveCanonicalPlayerIds.mockImplementation(
+      async (ids: string[]) => new Map(ids.map((id) => [id, id]))
+    );
   });
 
   it('rejects inactive or cross-league actors before reading private state', async () => {
@@ -78,7 +145,7 @@ describe('DraftPrivateStateService', () => {
       {
         id: 'watch-1',
         draftId: actor.draftId,
-        memberId: 'member-1',
+        memberId,
         playerId: player.id,
         priority: 1,
         notes: null,
@@ -90,7 +157,7 @@ describe('DraftPrivateStateService', () => {
     prisma.draftWatchlist.upsert.mockResolvedValue({
       id: 'watch-1',
       draftId: actor.draftId,
-      memberId: 'member-1',
+      memberId,
       playerId: player.id,
       priority: 2,
       notes: null,
@@ -105,11 +172,11 @@ describe('DraftPrivateStateService', () => {
 
     expect(getDraftMembershipAccess).toHaveBeenCalledWith(actor.draftId, actor.actorUserId);
     expect(prisma.draftWatchlist.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { draftId: actor.draftId, memberId: 'member-1' } })
+      expect.objectContaining({ where: { draftId: actor.draftId, memberId } })
     );
     expect(prisma.draftWatchlist.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        create: expect.objectContaining({ memberId: 'member-1', playerId: player.id }),
+        create: expect.objectContaining({ memberId, playerId: player.id }),
       })
     );
     expect(watchlist[0]?.notes).toBeUndefined();
@@ -124,46 +191,424 @@ describe('DraftPrivateStateService', () => {
     ).resolves.toBeUndefined();
 
     expect(prisma.draftWatchlist.deleteMany).toHaveBeenCalledWith({
-      where: { draftId: actor.draftId, memberId: 'member-1', playerId: player.id },
+      where: { draftId: actor.draftId, memberId, playerId: player.id },
     });
     expect(prisma.lobbyActivity.create).not.toHaveBeenCalled();
   });
 
-  it('replaces the authenticated member queue atomically', async () => {
-    prisma.transactionClient.preDraftQueue.deleteMany.mockResolvedValue({ count: 1 });
-    prisma.transactionClient.preDraftQueue.create.mockResolvedValue({ id: 'queue-1' });
-    prisma.transactionClient.preDraftQueue.findMany.mockResolvedValue([
-      {
-        id: 'queue-1',
+  it('filters inactive and already-picked players from private queue reads', async () => {
+    prisma.preDraftQueue.findMany.mockResolvedValue([queueRow('available-player', 2)]);
+
+    const queue = await new DraftPrivateStateService().getPreDraftQueue(actor);
+
+    expect(prisma.draftOrder.findFirst).toHaveBeenCalledWith({
+      where: {
         draftId: actor.draftId,
-        memberId: 'member-1',
-        playerId: player.id,
-        rank: 1,
-        notes: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        player,
+        member: { userId: actor.actorUserId },
       },
+      select: {
+        memberId: true,
+        member: {
+          select: {
+            leagueId: true,
+            isActive: true,
+            status: true,
+          },
+        },
+        draft: { select: { leagueId: true, status: true } },
+      },
+    });
+    expect(prisma.preDraftQueue.findMany).toHaveBeenCalledWith({
+      where: {
+        draftId: actor.draftId,
+        memberId,
+        player: {
+          active: true,
+          picks: { none: { draftId: actor.draftId } },
+        },
+      },
+      include: {
+        player: {
+          select: {
+            id: true,
+            name: true,
+            position: true,
+            club: true,
+            active: true,
+          },
+        },
+      },
+      orderBy: [{ rank: 'asc' }, { createdAt: 'asc' }],
+    });
+    expect(queue.map((item) => item.playerId)).toEqual(['available-player']);
+  });
+
+  it('keeps an already queued player at its existing rank when compatibility add omits rank', async () => {
+    prisma.transactionClient.player.findUnique.mockResolvedValue({
+      id: 'queued-player',
+      active: true,
+    });
+    prisma.transactionClient.pick.findUnique.mockResolvedValue(null);
+    prisma.transactionClient.preDraftQueue.findMany
+      .mockResolvedValueOnce([
+        { playerId: 'first-player', notes: 'first note' },
+        { playerId: 'queued-player', notes: 'queued note' },
+        { playerId: 'third-player', notes: null },
+      ])
+      .mockResolvedValueOnce([
+        { ...queueRow('first-player', 1), notes: 'first note' },
+        { ...queueRow('queued-player', 2), notes: 'queued note' },
+        queueRow('third-player', 3),
+      ]);
+
+    const result = await new DraftPrivateStateService().addToPreDraftQueue({
+      ...actor,
+      playerId: 'queued-player',
+    });
+
+    expect(prisma.transactionClient.preDraftQueue.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          draftId: actor.draftId,
+          memberId,
+          playerId: 'first-player',
+          rank: 1,
+          notes: 'first note',
+        },
+        {
+          draftId: actor.draftId,
+          memberId,
+          playerId: 'queued-player',
+          rank: 2,
+          notes: 'queued note',
+        },
+        {
+          draftId: actor.draftId,
+          memberId,
+          playerId: 'third-player',
+          rank: 3,
+          notes: undefined,
+        },
+      ],
+    });
+    expect(result).toEqual(
+      expect.objectContaining({ playerId: 'queued-player', rank: 2, notes: 'queued note' })
+    );
+  });
+
+  it('reorders an existing player, removes filtered stale rows, and preserves contiguous noted entries', async () => {
+    prisma.transactionClient.player.findUnique.mockResolvedValue({
+      id: 'queued-player',
+      active: true,
+    });
+    prisma.transactionClient.pick.findUnique.mockResolvedValue(null);
+    prisma.transactionClient.preDraftQueue.findMany
+      .mockResolvedValueOnce([
+        { playerId: 'first-player', notes: 'first note' },
+        { playerId: 'second-player', notes: 'second note' },
+        { playerId: 'queued-player', notes: 'queued note' },
+      ])
+      .mockResolvedValueOnce([
+        { ...queueRow('queued-player', 1), notes: 'queued note' },
+        { ...queueRow('first-player', 2), notes: 'first note' },
+        { ...queueRow('second-player', 3), notes: 'second note' },
+      ]);
+
+    const result = await new DraftPrivateStateService().addToPreDraftQueue({
+      ...actor,
+      playerId: 'queued-player',
+      rank: 1,
+    });
+
+    expect(prisma.transactionClient.preDraftQueue.findMany).toHaveBeenNthCalledWith(1, {
+      where: {
+        draftId: actor.draftId,
+        memberId,
+        player: {
+          active: true,
+          picks: { none: { draftId: actor.draftId } },
+        },
+      },
+      orderBy: [{ rank: 'asc' }, { createdAt: 'asc' }],
+      select: { playerId: true, notes: true },
+    });
+    expect(prisma.transactionClient.preDraftQueue.deleteMany).toHaveBeenCalledWith({
+      where: { draftId: actor.draftId, memberId },
+    });
+    expect(prisma.transactionClient.preDraftQueue.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          draftId: actor.draftId,
+          memberId,
+          playerId: 'queued-player',
+          rank: 1,
+          notes: 'queued note',
+        },
+        {
+          draftId: actor.draftId,
+          memberId,
+          playerId: 'first-player',
+          rank: 2,
+          notes: 'first note',
+        },
+        {
+          draftId: actor.draftId,
+          memberId,
+          playerId: 'second-player',
+          rank: 3,
+          notes: 'second note',
+        },
+      ],
+    });
+    expect(result).toEqual(
+      expect.objectContaining({ playerId: 'queued-player', rank: 1, notes: 'queued note' })
+    );
+  });
+
+  it('resolves a compatibility alias, deletes the intended item, and compacts remaining ranks', async () => {
+    resolveCanonicalPlayerIds.mockResolvedValue(
+      new Map([['legacy-player-id', 'canonical-player-id']])
+    );
+    prisma.transactionClient.preDraftQueue.deleteMany.mockResolvedValue({ count: 1 });
+    prisma.transactionClient.preDraftQueue.findMany
+      .mockResolvedValueOnce([
+        { playerId: 'first-player', notes: 'first note' },
+        { playerId: 'canonical-player-id', notes: 'removed note' },
+        { playerId: 'third-player', notes: 'third note' },
+      ])
+      .mockResolvedValueOnce([
+        { ...queueRow('first-player', 1), notes: 'first note' },
+        { ...queueRow('third-player', 2), notes: 'third note' },
+      ]);
+
+    await expect(
+      new DraftPrivateStateService().removeFromPreDraftQueue({
+        ...actor,
+        playerId: 'legacy-player-id',
+      })
+    ).resolves.toBe(true);
+
+    expect(draftRepository.transaction).toHaveBeenCalledWith(expect.any(Function), {
+      retryPolicy: 'idempotent',
+    });
+    expect(resolveCanonicalPlayerIds).toHaveBeenCalledWith(
+      ['legacy-player-id'],
+      'statly-legacy',
+      prisma.transactionClient
+    );
+    expect(prisma.transactionClient.preDraftQueue.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          draftId: actor.draftId,
+          memberId,
+          playerId: 'first-player',
+          rank: 1,
+          notes: 'first note',
+        },
+        {
+          draftId: actor.draftId,
+          memberId,
+          playerId: 'third-player',
+          rank: 2,
+          notes: 'third note',
+        },
+      ],
+    });
+    expect(prisma.transactionClient.preDraftQueue.deleteMany).toHaveBeenCalledWith({
+      where: { draftId: actor.draftId, memberId },
+    });
+  });
+
+  it('canonicalizes, deduplicates, filters unavailable players, and persists contiguous ranks', async () => {
+    resolveCanonicalPlayerIds.mockResolvedValue(
+      new Map([
+        ['picked-alias', 'picked-player'],
+        ['inactive-alias', 'inactive-player'],
+        ['available-alias', 'available-player'],
+        ['available-player', 'available-player'],
+      ])
+    );
+    prisma.transactionClient.player.findMany.mockResolvedValue([
+      { id: 'picked-player', active: true },
+      { id: 'inactive-player', active: false },
+      { id: 'available-player', active: true },
+    ]);
+    prisma.transactionClient.pick.findMany.mockResolvedValue([{ playerId: 'picked-player' }]);
+    prisma.transactionClient.preDraftQueue.createMany.mockResolvedValue({ count: 1 });
+    prisma.transactionClient.preDraftQueue.findMany.mockResolvedValue([
+      queueRow('available-player', 1),
     ]);
 
-    const service = new DraftPrivateStateService();
-    const queue = await service.replacePreDraftQueue({
+    const result = await new DraftPrivateStateService().replacePreDraftQueue({
       ...actor,
-      queue: [{ playerId: player.id, rank: 1 }],
+      unresolvedPlayerPolicy: 'reject',
+      queue: [
+        { playerId: 'available-player', rank: 40 },
+        { playerId: 'available-alias', rank: 30, notes: 'keep this note' },
+        { playerId: 'inactive-alias', rank: 20 },
+        { playerId: 'picked-alias', rank: 10 },
+      ],
     });
 
-    expect(prisma.$transaction).toHaveBeenCalledOnce();
-    expect(prisma.transactionClient.preDraftQueue.deleteMany).toHaveBeenCalledWith({
-      where: { draftId: actor.draftId, memberId: 'member-1' },
+    expect(draftRepository.transaction).toHaveBeenCalledWith(expect.any(Function), {
+      retryPolicy: 'idempotent',
     });
-    expect(prisma.transactionClient.preDraftQueue.create).toHaveBeenCalledWith({
-      data: expect.objectContaining({
+    expect(resolveCanonicalPlayerIds).toHaveBeenCalledWith(
+      ['picked-alias', 'inactive-alias', 'available-alias', 'available-player'],
+      'statly-legacy',
+      prisma.transactionClient
+    );
+    expect(prisma.transactionClient.player.findMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ['picked-player', 'inactive-player', 'available-player'] },
+      },
+      select: { id: true, active: true },
+    });
+    expect(prisma.transactionClient.pick.findMany).toHaveBeenCalledWith({
+      where: {
         draftId: actor.draftId,
-        memberId: 'member-1',
-        playerId: player.id,
-        rank: 1,
-      }),
+        playerId: { in: ['picked-player', 'inactive-player', 'available-player'] },
+      },
+      select: { playerId: true },
     });
-    expect(queue.map((item) => item.playerId)).toEqual([player.id]);
+    expect(prisma.transactionClient.preDraftQueue.deleteMany).toHaveBeenCalledWith({
+      where: { draftId: actor.draftId, memberId },
+    });
+    expect(prisma.transactionClient.preDraftQueue.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          draftId: actor.draftId,
+          memberId,
+          playerId: 'available-player',
+          rank: 1,
+          notes: 'keep this note',
+        },
+      ],
+    });
+    expect(result).toEqual({
+      memberId,
+      queue: [expect.objectContaining({ playerId: 'available-player', rank: 1 })],
+      removedPlayerIds: ['picked-player', 'inactive-player'],
+    });
+  });
+
+  it('rejects unknown players without replacing the persisted queue', async () => {
+    resolveCanonicalPlayerIds.mockResolvedValue(new Map());
+
+    await expect(
+      new DraftPrivateStateService().replacePreDraftQueue({
+        ...actor,
+        unresolvedPlayerPolicy: 'reject',
+        queue: [{ playerId: 'unknown-player', rank: 1 }],
+      })
+    ).rejects.toBeInstanceOf(DraftPrivateStateValidationError);
+
+    expect(prisma.transactionClient.preDraftQueue.deleteMany).not.toHaveBeenCalled();
+    expect(prisma.transactionClient.preDraftQueue.createMany).not.toHaveBeenCalled();
+  });
+
+  it('reports unknown players while persisting valid entries for compatibility callers', async () => {
+    resolveCanonicalPlayerIds.mockResolvedValue(
+      new Map([['available-player', 'available-player']])
+    );
+    prisma.transactionClient.player.findMany.mockResolvedValue([
+      { id: 'available-player', active: true },
+    ]);
+    prisma.transactionClient.preDraftQueue.createMany.mockResolvedValue({ count: 1 });
+    prisma.transactionClient.preDraftQueue.findMany.mockResolvedValue([
+      queueRow('available-player', 1),
+    ]);
+
+    const result = await new DraftPrivateStateService().replacePreDraftQueue({
+      ...actor,
+      unresolvedPlayerPolicy: 'remove',
+      queue: [
+        { playerId: 'unknown-player', rank: 1 },
+        { playerId: 'available-player', rank: 2 },
+      ],
+    });
+
+    expect(prisma.transactionClient.preDraftQueue.deleteMany).toHaveBeenCalledWith({
+      where: { draftId: actor.draftId, memberId },
+    });
+    expect(prisma.transactionClient.preDraftQueue.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          draftId: actor.draftId,
+          memberId,
+          playerId: 'available-player',
+          rank: 1,
+          notes: undefined,
+        },
+      ],
+    });
+    expect(result).toEqual({
+      memberId,
+      queue: [expect.objectContaining({ playerId: 'available-player', rank: 1 })],
+      removedPlayerIds: ['unknown-player'],
+    });
+  });
+
+  it('revalidates active membership when the repository retries a queue write', async () => {
+    const conflict = new Prisma.PrismaClientKnownRequestError('write conflict', {
+      code: 'P2034',
+      clientVersion: 'test',
+    });
+    prisma.transactionClient.draftOrder.findFirst
+      .mockResolvedValueOnce(participant())
+      .mockResolvedValueOnce(participant(DraftStatus.LIVE, { isActive: false, status: 'REMOVED' }));
+    resolveCanonicalPlayerIds.mockRejectedValueOnce(conflict);
+    draftRepository.transaction.mockImplementationOnce(
+      async (callback: (tx: typeof prisma.transactionClient) => unknown) => {
+        await expect(callback(prisma.transactionClient)).rejects.toBe(conflict);
+        return callback(prisma.transactionClient);
+      }
+    );
+
+    await expect(
+      new DraftPrivateStateService().addToPreDraftQueue({
+        ...actor,
+        playerId: 'available-player',
+      })
+    ).rejects.toBeInstanceOf(DraftPrivateStateAccessError);
+
+    expect(prisma.transactionClient.draftOrder.findFirst).toHaveBeenCalledTimes(2);
+    expect(draftRepository.transaction).toHaveBeenCalledWith(expect.any(Function), {
+      retryPolicy: 'idempotent',
+    });
+    expect(resolveCanonicalPlayerIds).toHaveBeenCalledOnce();
+    expect(prisma.transactionClient.preDraftQueue.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid ranks and completed draft mutations with typed errors', async () => {
+    const service = new DraftPrivateStateService();
+
+    await expect(
+      service.replacePreDraftQueue({
+        ...actor,
+        unresolvedPlayerPolicy: 'reject',
+        queue: [{ playerId: player.id, rank: 0 }],
+      })
+    ).rejects.toBeInstanceOf(DraftPrivateStateValidationError);
+
+    prisma.transactionClient.draftOrder.findFirst.mockResolvedValue(
+      participant(DraftStatus.COMPLETED)
+    );
+    await expect(
+      service.replacePreDraftQueue({
+        ...actor,
+        unresolvedPlayerPolicy: 'reject',
+        queue: [{ playerId: player.id, rank: 1 }],
+      })
+    ).rejects.toBeInstanceOf(DraftPrivateStateConflictError);
+  });
+
+  it('requires the authenticated league member to be a persisted draft participant', async () => {
+    prisma.draftOrder.findFirst.mockResolvedValue(null);
+
+    await expect(new DraftPrivateStateService().getPreDraftQueue(actor)).rejects.toBeInstanceOf(
+      DraftPrivateStateAccessError
+    );
+    expect(prisma.preDraftQueue.findMany).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/DraftProjectionService.test.ts
+++ b/tests/unit/DraftProjectionService.test.ts
@@ -27,14 +27,14 @@ afterEach(() => {
 });
 
 describe('DraftProjectionService', () => {
-  it('builds a membership-scoped room snapshot with the persisted deadline and revision', async () => {
+  it('builds a membership-scoped linear room snapshot with persisted order and clock state', async () => {
     prismaMock.draft.findFirst.mockResolvedValue({
       id: 'draft-1',
       leagueId: 'league-1',
       status: DraftStatus.LIVE,
-      currentPick: 1,
+      currentPick: 3,
       totalPicks: 22,
-      round: 1,
+      round: 2,
       direction: DraftDirection.FORWARD,
       schedulingVersion: 7,
       eventSequence: 0,
@@ -47,7 +47,7 @@ describe('DraftProjectionService', () => {
         name: 'Test AFL Champions League',
         settings: {
           pickSeconds: 120,
-          draftType: DraftType.SNAKE,
+          draftType: DraftType.LINEAR,
         },
       },
       orders: [
@@ -62,6 +62,20 @@ describe('DraftProjectionService', () => {
               id: 'user-1',
               displayName: 'Robert',
               email: 'robert@example.com',
+            },
+          },
+        },
+        {
+          slot: 2,
+          memberId: 'member-2',
+          member: {
+            userId: 'user-2',
+            role: LeagueRole.MANAGER,
+            teamName: 'Second Team',
+            user: {
+              id: 'user-2',
+              displayName: 'Second Manager',
+              email: 'second@example.com',
             },
           },
         },
@@ -88,6 +102,7 @@ describe('DraftProjectionService', () => {
       revision: 7,
       state: {
         status: 'LIVE',
+        draftType: 'LINEAR',
         onClockMemberId: 'member-1',
         clock: {
           status: 'LIVE',
@@ -96,7 +111,7 @@ describe('DraftProjectionService', () => {
           startedAt: '2026-06-14T12:00:00.000Z',
           deadlineAt: '2026-06-14T12:02:00.000Z',
         },
-        participants: [{ id: 'member-1' }],
+        participants: [{ id: 'member-1' }, { id: 'member-2' }],
       },
     });
     expect(prismaMock.draft.findFirst.mock.calls[0]?.[0]?.include).not.toHaveProperty(

--- a/tests/unit/DraftQueue.component.test.tsx
+++ b/tests/unit/DraftQueue.component.test.tsx
@@ -1,0 +1,182 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import DraftQueue from '@/components/draft/DraftQueue';
+import type { DraftPlayer } from '@/types/draft';
+
+const knownPlayer: DraftPlayer = {
+  id: 'player-known',
+  name: 'Known Player',
+  position: 'MID',
+  club: 'Carlton',
+  isAvailable: true,
+};
+
+const availablePlayer: DraftPlayer = {
+  id: 'player-available',
+  name: 'Available Player',
+  position: 'FWD',
+  club: 'Sydney',
+  isAvailable: true,
+};
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe('DraftQueue component', () => {
+  it('preserves canonical queue ids, counts, and indices while player details hydrate', () => {
+    render(
+      <DraftQueue
+        queue={['player-ghost', knownPlayer.id]}
+        availablePlayers={[knownPlayer, availablePlayer]}
+        onQueueUpdate={vi.fn()}
+        isLoading={false}
+      />
+    );
+
+    expect(screen.getByText('2 queued')).toBeInTheDocument();
+
+    const queuedPlayers = screen.getByRole('list', { name: 'Queued players' });
+    const queueItems = within(queuedPlayers).getAllByRole('listitem');
+
+    expect(queueItems).toHaveLength(2);
+    expect(queueItems[0]).toHaveTextContent('1');
+    expect(queueItems[0]).toHaveTextContent('Queued player');
+    expect(queueItems[0]).toHaveTextContent('Player details loading');
+    expect(queueItems[1]).toHaveTextContent('2');
+    expect(queueItems[1]).toHaveTextContent('Known Player');
+
+    const availableSection = screen.getByRole('region', { name: 'Available players for queue' });
+    expect(within(availableSection).queryByText('Known Player')).not.toBeInTheDocument();
+    expect(within(availableSection).getByText('Available Player')).toBeInTheDocument();
+  });
+
+  it('marks queue surfaces busy and disables mutation controls until an add is persisted', async () => {
+    const user = userEvent.setup();
+    const deferred = createDeferred<void>();
+    const onQueueUpdate = vi.fn(() => deferred.promise);
+
+    render(
+      <DraftQueue
+        queue={[knownPlayer.id]}
+        availablePlayers={[knownPlayer, availablePlayer]}
+        onQueueUpdate={onQueueUpdate}
+        isLoading={false}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(onQueueUpdate).toHaveBeenCalledWith([knownPlayer.id, availablePlayer.id]);
+    expect(screen.getByRole('region', { name: 'Draft queue' })).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+    expect(screen.getByRole('region', { name: 'Available players for queue' })).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+    expect(screen.getByText('Saving queue…')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit draft queue' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Clear draft queue' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+
+    deferred.resolve();
+
+    await waitFor(() =>
+      expect(screen.getByRole('region', { name: 'Draft queue' })).toHaveAttribute(
+        'aria-busy',
+        'false'
+      )
+    );
+    expect(screen.getByRole('button', { name: 'Add' })).toBeEnabled();
+  });
+
+  it('recovers its controls when the room-level queue callback rejects', async () => {
+    const user = userEvent.setup();
+    const onQueueUpdate = vi.fn().mockRejectedValue(new Error('Queue request failed'));
+
+    render(
+      <DraftQueue
+        queue={[knownPlayer.id]}
+        availablePlayers={[knownPlayer, availablePlayer]}
+        onQueueUpdate={onQueueUpdate}
+        isLoading={false}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(onQueueUpdate).toHaveBeenCalledWith([knownPlayer.id, availablePlayer.id]);
+    await waitFor(() =>
+      expect(screen.getByRole('region', { name: 'Draft queue' })).toHaveAttribute(
+        'aria-busy',
+        'false'
+      )
+    );
+    expect(screen.getByRole('button', { name: 'Add' })).toBeEnabled();
+    expect(screen.getByText('1 queued')).toBeInTheDocument();
+  });
+
+  it('keeps clear pending until the confirmed queue mutation settles', async () => {
+    const user = userEvent.setup();
+    const deferred = createDeferred<void>();
+    const onQueueUpdate = vi.fn(() => deferred.promise);
+    let confirmOptions:
+      | {
+          onConfirm: () => void | Promise<void>;
+        }
+      | undefined;
+    const confirm = vi.fn((options: { onConfirm: () => void | Promise<void> }) => {
+      confirmOptions = options;
+    });
+
+    render(
+      <DraftQueue
+        queue={[knownPlayer.id]}
+        availablePlayers={[knownPlayer]}
+        onQueueUpdate={onQueueUpdate}
+        isLoading={false}
+        confirm={confirm}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Clear draft queue' }));
+
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(confirmOptions).toBeDefined();
+
+    let clearPromise: Promise<void> | undefined;
+    act(() => {
+      clearPromise = Promise.resolve(confirmOptions?.onConfirm());
+    });
+
+    expect(onQueueUpdate).toHaveBeenCalledWith([]);
+    expect(screen.getByRole('region', { name: 'Draft queue' })).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+    expect(screen.getByRole('button', { name: 'Clear draft queue' })).toBeDisabled();
+
+    await act(async () => {
+      deferred.resolve();
+      await clearPromise;
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole('region', { name: 'Draft queue' })).toHaveAttribute(
+        'aria-busy',
+        'false'
+      )
+    );
+  });
+});

--- a/tests/unit/DraftQueuePickRace.test.ts
+++ b/tests/unit/DraftQueuePickRace.test.ts
@@ -1,0 +1,350 @@
+import { execFileSync } from 'node:child_process';
+import { accessSync, constants as fsConstants, copyFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join, resolve } from 'node:path';
+
+import { Prisma, PrismaClient } from '@prisma/client';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const ids = {
+  draft: 'queue-pick-race-draft',
+  league: 'queue-pick-race-league',
+  settings: 'queue-pick-race-settings',
+  ownerUser: 'queue-pick-race-owner-user',
+  ownerMember: 'queue-pick-race-owner-member',
+  opponentUser: 'queue-pick-race-opponent-user',
+  opponentMember: 'queue-pick-race-opponent-member',
+  selectedPlayer: 'queue-pick-race-selected-player',
+  remainingPlayer: 'queue-pick-race-remaining-player',
+} as const;
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+type InteractiveTransactionOptions = {
+  maxWait?: number;
+  timeout?: number;
+  isolationLevel?: Prisma.TransactionIsolationLevel;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolvePromise!: Deferred<T>['resolve'];
+  let rejectPromise!: Deferred<T>['reject'];
+  const promise = new Promise<T>((resolveValue, rejectValue) => {
+    resolvePromise = resolveValue;
+    rejectPromise = rejectValue;
+  });
+
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+function resolveExecutablePath(executable: string): string {
+  for (const directory of (process.env.PATH ?? '').split(delimiter).filter(Boolean)) {
+    const candidate = join(directory, executable);
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      return candidate;
+    } catch {
+      // Try the next PATH entry.
+    }
+  }
+
+  throw new Error(`${executable} is required to run the queue/pick race test`);
+}
+
+function createRequestOrderedClient(
+  client: PrismaClient,
+  queueTransactionRequested: Deferred<void>,
+  allowQueueTransactionToStart: Deferred<void>
+): PrismaClient {
+  let shouldOrderNextTransaction = true;
+  const runTransaction = client.$transaction.bind(client);
+
+  return new Proxy(client, {
+    get(target, property) {
+      if (property === '$transaction') {
+        return async <T>(
+          work: (tx: Prisma.TransactionClient) => Promise<T>,
+          options?: InteractiveTransactionOptions
+        ): Promise<T> => {
+          if (shouldOrderNextTransaction) {
+            shouldOrderNextTransaction = false;
+            queueTransactionRequested.resolve(undefined);
+            await allowQueueTransactionToStart.promise;
+          }
+
+          return runTransaction(work, options);
+        };
+      }
+
+      const value = Reflect.get(target, property, target);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+async function seedDraft(client: PrismaClient): Promise<void> {
+  const startedAt = new Date('2026-08-01T12:00:00.000Z');
+
+  await client.user.createMany({
+    data: [
+      {
+        id: ids.ownerUser,
+        email: 'queue-pick-race-owner@example.test',
+        passwordHash: 'test-only',
+        displayName: 'Queue Race Owner',
+      },
+      {
+        id: ids.opponentUser,
+        email: 'queue-pick-race-opponent@example.test',
+        passwordHash: 'test-only',
+        displayName: 'Queue Race Opponent',
+      },
+    ],
+  });
+  await client.player.createMany({
+    data: [
+      {
+        id: ids.selectedPlayer,
+        name: 'Selected Player',
+        club: 'Carlton',
+        position: 'MID',
+      },
+      {
+        id: ids.remainingPlayer,
+        name: 'Remaining Player',
+        club: 'Sydney',
+        position: 'FWD',
+      },
+    ],
+  });
+  await client.leagueSettings.create({
+    data: {
+      id: ids.settings,
+      rosterSize: 1,
+      benchSize: 0,
+      maxTeams: 2,
+      pickSeconds: 120,
+      allowAutoPick: true,
+      draftType: 'SNAKE',
+      pickOrder: 'MANUAL',
+      waiverRule: 'WEEKLY',
+      startAt: startedAt,
+      timeZone: 'Australia/Melbourne',
+      locked: true,
+    },
+  });
+  await client.league.create({
+    data: {
+      id: ids.league,
+      name: 'Queue Pick Race League',
+      inviteCode: 'QUEUE-RACE',
+      ownerId: ids.ownerUser,
+      settingsId: ids.settings,
+    },
+  });
+  await client.leagueMember.createMany({
+    data: [
+      {
+        id: ids.ownerMember,
+        leagueId: ids.league,
+        userId: ids.ownerUser,
+        role: 'OWNER',
+        teamName: 'Queue Race Owners',
+        draftSlot: 1,
+      },
+      {
+        id: ids.opponentMember,
+        leagueId: ids.league,
+        userId: ids.opponentUser,
+        role: 'MANAGER',
+        teamName: 'Queue Race Opponents',
+        draftSlot: 2,
+      },
+    ],
+  });
+  await client.draft.create({
+    data: {
+      id: ids.draft,
+      leagueId: ids.league,
+      status: 'LIVE',
+      currentPick: 1,
+      totalPicks: 2,
+      round: 1,
+      direction: 'FORWARD',
+      lobbyStatus: 'LIVE',
+      startedAt,
+      pickStartedAt: startedAt,
+      pickDeadlineAt: new Date(startedAt.getTime() + 120_000),
+      clockDurationSeconds: 120,
+    },
+  });
+  await client.draftOrder.createMany({
+    data: [
+      { draftId: ids.draft, memberId: ids.ownerMember, slot: 1 },
+      { draftId: ids.draft, memberId: ids.opponentMember, slot: 2 },
+    ],
+  });
+  await client.preDraftQueue.createMany({
+    data: [ids.ownerMember, ids.opponentMember].map((memberId) => ({
+      draftId: ids.draft,
+      memberId,
+      playerId: ids.selectedPlayer,
+      rank: 1,
+    })),
+  });
+}
+
+describe.sequential('draft queue request ordering and accepted-pick convergence', () => {
+  let databaseDirectory: string | undefined;
+  let client: PrismaClient | undefined;
+  let privateStateService: InstanceType<
+    typeof import('@/server/draft/services/DraftPrivateStateService').DraftPrivateStateService
+  >;
+  let applicationService: InstanceType<
+    typeof import('@/server/draft/services/DraftApplicationService').DraftApplicationService
+  >;
+  let queueTransactionRequested: Deferred<void>;
+  let allowQueueTransactionToStart: Deferred<void>;
+
+  beforeAll(async () => {
+    databaseDirectory = mkdtempSync(join(tmpdir(), 'statly-draft-queue-race-'));
+    const databasePath = resolve(databaseDirectory, 'queue-pick-race.db');
+    const databaseUrl = `file:${databasePath}`;
+    const schemaPath = resolve(databaseDirectory, 'schema.prisma');
+    const prismaCli = resolve(process.cwd(), 'node_modules/.bin/prisma');
+
+    copyFileSync(resolve(process.cwd(), 'prisma/schema.prisma'), schemaPath);
+    const schemaSql = execFileSync(
+      prismaCli,
+      ['migrate', 'diff', '--from-empty', '--to-schema-datamodel', schemaPath, '--script'],
+      {
+        cwd: databaseDirectory,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          DATABASE_URL: databaseUrl,
+          PRISMA_HIDE_UPDATE_MESSAGE: '1',
+        },
+      }
+    );
+    execFileSync(resolveExecutablePath('sqlite3'), [databasePath], {
+      cwd: databaseDirectory,
+      input: schemaSql,
+      stdio: 'pipe',
+    });
+
+    client = new PrismaClient({ datasourceUrl: databaseUrl });
+    await client.$connect();
+    await seedDraft(client);
+
+    queueTransactionRequested = createDeferred<void>();
+    allowQueueTransactionToStart = createDeferred<void>();
+    // Prisma's SQLite client serializes competing interactive transactions. This barrier instead
+    // orders concurrent service requests at the repository boundary without claiming DB overlap.
+    const gatedClient = createRequestOrderedClient(
+      client,
+      queueTransactionRequested,
+      allowQueueTransactionToStart
+    );
+
+    vi.resetModules();
+    vi.doMock('@/lib/prisma', () => ({ prisma: gatedClient }));
+    vi.doMock('@/lib/logger', () => ({
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    }));
+    vi.doMock('@/server/rosters/RosterProjectionService', () => ({
+      RosterProjectionService: class {
+        async projectDraft(): Promise<void> {}
+      },
+    }));
+    vi.doMock('@/server/leagues/membership', () => ({
+      getDraftMembershipAccess: vi.fn(),
+      isActivePrismaMembership: (member: { isActive: boolean; status: string }) =>
+        member.isActive &&
+        !['declined', 'inactive', 'removed'].includes(member.status.trim().toLowerCase()),
+    }));
+
+    const [{ DraftPrivateStateService }, { DraftApplicationService }] = await Promise.all([
+      import('@/server/draft/services/DraftPrivateStateService'),
+      import('@/server/draft/services/DraftApplicationService'),
+    ]);
+    privateStateService = new DraftPrivateStateService();
+    applicationService = new DraftApplicationService({ projectDraft: vi.fn() } as never);
+  }, 60_000);
+
+  afterAll(async () => {
+    allowQueueTransactionToStart?.resolve(undefined);
+    vi.doUnmock('@/server/leagues/membership');
+    vi.doUnmock('@/server/rosters/RosterProjectionService');
+    vi.doUnmock('@/lib/logger');
+    vi.doUnmock('@/lib/prisma');
+    vi.resetModules();
+    await client?.$disconnect();
+    if (databaseDirectory?.startsWith(join(tmpdir(), 'statly-draft-queue-race-'))) {
+      rmSync(databaseDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it('filters a picked player when its queue request starts first but persists after the pick', async () => {
+    const queueReplacement = privateStateService.replacePreDraftQueue({
+      draftId: ids.draft,
+      actorUserId: ids.ownerUser,
+      unresolvedPlayerPolicy: 'reject',
+      queue: [
+        { playerId: ids.selectedPlayer, rank: 1 },
+        { playerId: ids.remainingPlayer, rank: 2 },
+      ],
+    });
+
+    await queueTransactionRequested.promise;
+
+    let acceptedPick: Awaited<ReturnType<typeof applicationService.makePick>> | undefined;
+    try {
+      acceptedPick = await applicationService.makePick({
+        draftId: ids.draft,
+        actorUserId: ids.ownerUser,
+        playerId: ids.selectedPlayer,
+      });
+    } finally {
+      allowQueueTransactionToStart.resolve(undefined);
+    }
+    const replacement = await queueReplacement;
+
+    expect(acceptedPick?.data.pick.player.id).toBe(ids.selectedPlayer);
+    expect(acceptedPick?.data.idempotent).not.toBe(true);
+    expect(replacement.removedPlayerIds).toContain(ids.selectedPlayer);
+    expect(replacement.queue.map((item) => item.playerId)).toEqual([ids.remainingPlayer]);
+
+    const [draft, picks, queues] = await Promise.all([
+      client!.draft.findUniqueOrThrow({ where: { id: ids.draft } }),
+      client!.pick.findMany({ where: { draftId: ids.draft } }),
+      client!.preDraftQueue.findMany({
+        where: { draftId: ids.draft },
+        orderBy: [{ memberId: 'asc' }, { rank: 'asc' }],
+      }),
+    ]);
+
+    expect(draft).toMatchObject({ status: 'LIVE', currentPick: 2, schedulingVersion: 1 });
+    expect(picks).toEqual([
+      expect.objectContaining({
+        draftId: ids.draft,
+        memberId: ids.ownerMember,
+        playerId: ids.selectedPlayer,
+        overall: 1,
+      }),
+    ]);
+    expect(queues).toEqual([
+      expect.objectContaining({
+        draftId: ids.draft,
+        memberId: ids.ownerMember,
+        playerId: ids.remainingPlayer,
+        rank: 1,
+      }),
+    ]);
+    expect(queues.some((item) => item.playerId === ids.selectedPlayer)).toBe(false);
+  });
+});

--- a/tests/unit/DraftRepository.transaction.test.ts
+++ b/tests/unit/DraftRepository.transaction.test.ts
@@ -1,0 +1,132 @@
+import { Prisma } from '@prisma/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { prisma } = vi.hoisted(() => ({
+  prisma: {
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/prisma', () => ({ prisma }));
+
+import { DraftRepository } from '@/server/draft/repository/DraftRepository';
+
+describe('DraftRepository transaction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('runs draft commands at serializable isolation', async () => {
+    const tx = { id: 'transaction-client' };
+    prisma.$transaction.mockImplementation(async (work: (client: typeof tx) => unknown) =>
+      work(tx)
+    );
+
+    const repository = new DraftRepository();
+    const result = await repository.transaction(
+      async (client) => (client as unknown as typeof tx).id
+    );
+
+    expect(result).toBe('transaction-client');
+    expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+      timeout: 20_000,
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    });
+  });
+
+  it('retries bounded Prisma write conflicts', async () => {
+    const conflict = new Prisma.PrismaClientKnownRequestError('write conflict', {
+      code: 'P2034',
+      clientVersion: 'test',
+    });
+    prisma.$transaction
+      .mockRejectedValueOnce(conflict)
+      .mockRejectedValueOnce(conflict)
+      .mockResolvedValueOnce('committed');
+
+    const repository = new DraftRepository();
+
+    await expect(repository.transaction(async () => 'unused')).resolves.toBe('committed');
+    expect(prisma.$transaction).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries a SQLite timeout only when acquisition fails before application work starts', async () => {
+    const timeout = new Prisma.PrismaClientKnownRequestError('database did not respond', {
+      code: 'P1008',
+      clientVersion: 'test',
+    });
+    const tx = { id: 'transaction-client' };
+    prisma.$transaction
+      .mockRejectedValueOnce(timeout)
+      .mockImplementationOnce(async (work: (client: typeof tx) => unknown) => work(tx));
+    const work = vi.fn(async () => 'committed');
+
+    const repository = new DraftRepository();
+
+    await expect(repository.transaction(work)).resolves.toBe('committed');
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+    expect(work).toHaveBeenCalledOnce();
+  });
+
+  it('does not replay application work after an ambiguous SQLite timeout', async () => {
+    const timeout = new Prisma.PrismaClientKnownRequestError('database did not respond', {
+      code: 'P1008',
+      clientVersion: 'test',
+    });
+    const tx = { id: 'transaction-client' };
+    prisma.$transaction.mockImplementation(async (work: (client: typeof tx) => unknown) =>
+      work(tx)
+    );
+    const work = vi.fn().mockRejectedValue(timeout);
+
+    const repository = new DraftRepository();
+
+    await expect(repository.transaction(work)).rejects.toBe(timeout);
+    expect(prisma.$transaction).toHaveBeenCalledOnce();
+    expect(work).toHaveBeenCalledOnce();
+  });
+
+  it('retries a post-callback SQLite timeout when the caller declares idempotent work', async () => {
+    const timeout = new Prisma.PrismaClientKnownRequestError('database did not respond', {
+      code: 'P1008',
+      clientVersion: 'test',
+    });
+    const tx = { id: 'transaction-client' };
+    prisma.$transaction.mockImplementation(async (work: (client: typeof tx) => unknown) =>
+      work(tx)
+    );
+    const work = vi.fn().mockRejectedValueOnce(timeout).mockResolvedValueOnce('committed');
+
+    const repository = new DraftRepository();
+
+    await expect(repository.transaction(work, { retryPolicy: 'idempotent' })).resolves.toBe(
+      'committed'
+    );
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+    expect(work).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry unrelated transaction failures', async () => {
+    prisma.$transaction.mockRejectedValue(new Error('boom'));
+
+    const repository = new DraftRepository();
+
+    await expect(repository.transaction(async () => 'unused')).rejects.toThrow('boom');
+    expect(prisma.$transaction).toHaveBeenCalledOnce();
+  });
+
+  it('removes a selected player from every queue in the draft', async () => {
+    const deleteMany = vi.fn().mockResolvedValue({ count: 2 });
+    const repository = new DraftRepository();
+
+    await repository.removePlayerFromAllDraftQueues(
+      { preDraftQueue: { deleteMany } } as never,
+      'draft-1',
+      'player-1'
+    );
+
+    expect(deleteMany).toHaveBeenCalledWith({
+      where: { draftId: 'draft-1', playerId: 'player-1' },
+    });
+  });
+});

--- a/tests/unit/DraftWatchlist.test.tsx
+++ b/tests/unit/DraftWatchlist.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import DraftWatchlist from '@/components/DraftWatchlist';
+import type { DraftPlayer } from '@/types/draft';
+
+function player(
+  id: string,
+  name: string,
+  statlyZ: Pick<DraftPlayer, 'statlyZScore' | 'statlyZBreakdown' | 'statlyZMissingCategories'>
+): DraftPlayer {
+  return {
+    id,
+    name,
+    position: 'MID',
+    club: 'Test Club',
+    isAvailable: true,
+    ...statlyZ,
+  };
+}
+
+const availablePlayers: DraftPlayer[] = [
+  {
+    ...player('positive', 'Positive Score', {
+      statlyZScore: 1.24,
+      statlyZBreakdown: [{ category: 'goals', value: 2, zScore: 1.24 }],
+      statlyZMissingCategories: [],
+    }),
+    adp: 7,
+  },
+  player('zero', 'Zero Score', {
+    statlyZScore: 0,
+    statlyZBreakdown: [{ category: 'goals', value: 1, zScore: 0 }],
+    statlyZMissingCategories: [],
+  }),
+  player('partial', 'Partial Score', {
+    statlyZScore: 0.5,
+    statlyZBreakdown: [{ category: 'goals', value: 1.5, zScore: 0.5 }],
+    statlyZMissingCategories: ['tackles'],
+  }),
+  player('no-data', 'No Data', {
+    statlyZScore: 0,
+    statlyZBreakdown: [],
+    statlyZMissingCategories: ['goals'],
+  }),
+  player('pending', 'Pending Score', {}),
+];
+
+const watchlistItems = [
+  {
+    playerId: 'positive',
+    priority: 2,
+    addedAt: '2026-08-01T00:00:00.000Z',
+  },
+  {
+    playerId: 'zero',
+    priority: 1,
+    addedAt: '2026-08-01T00:00:00.000Z',
+  },
+  {
+    playerId: 'partial',
+    priority: 3,
+    addedAt: '2026-08-01T00:00:00.000Z',
+  },
+  {
+    playerId: 'no-data',
+    priority: 4,
+    addedAt: '2026-08-01T00:00:00.000Z',
+  },
+  {
+    playerId: 'pending',
+    priority: 5,
+    addedAt: '2026-08-01T00:00:00.000Z',
+  },
+  {
+    playerId: 'drafted',
+    priority: 6,
+    addedAt: '2026-08-01T00:00:00.000Z',
+    player: {
+      id: 'drafted',
+      name: 'Drafted Player',
+      position: 'FWD',
+      club: 'Drafted Club',
+    },
+  },
+];
+
+describe('DraftWatchlist', () => {
+  it('uses Statly Z consistently and reports unavailable coverage honestly', () => {
+    render(
+      <DraftWatchlist
+        players={availablePlayers}
+        draftedPlayerIds={['drafted']}
+        onDraftPlayer={vi.fn()}
+        canDraft
+        watchlistItems={watchlistItems}
+        onRemoveFromWatchlist={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Statly Z 1.24')).toHaveTextContent('Statly Z 1.24');
+    expect(screen.getByLabelText('Statly Z 0.00')).toHaveTextContent('Statly Z 0.00');
+    expect(screen.getByLabelText('Statly Z 0.50, partial category coverage')).toHaveTextContent(
+      'Statly Z 0.50'
+    );
+    expect(screen.getByText('Partial')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Statly Z unavailable because category data is missing')
+    ).toHaveTextContent('Statly Z —');
+    expect(screen.getByLabelText('Statly Z pending')).toHaveTextContent('Statly Z Pending');
+    expect(
+      screen.getByLabelText('Statly Z unavailable for this drafted or unavailable player')
+    ).toHaveTextContent('Statly Z —');
+
+    const draftedRow = screen.getByText('Drafted Player').closest('li');
+    expect(draftedRow).not.toBeNull();
+    expect(within(draftedRow as HTMLElement).getByText('Drafted')).toBeInTheDocument();
+    expect(screen.getByText('ADP 7')).toBeInTheDocument();
+    expect(screen.queryByText(/\d+(?:\.\d+)? avg/i)).not.toBeInTheDocument();
+  });
+
+  it('preserves explicit watchlist priority order', () => {
+    render(
+      <DraftWatchlist
+        players={availablePlayers}
+        draftedPlayerIds={['drafted']}
+        onDraftPlayer={vi.fn()}
+        canDraft
+        watchlistItems={watchlistItems}
+        onRemoveFromWatchlist={vi.fn()}
+      />
+    );
+
+    const rows = screen.getAllByRole('listitem');
+    expect(rows.map((row) => within(row).getByRole('heading').textContent)).toEqual([
+      'Zero Score',
+      'Positive Score',
+      'Partial Score',
+      'No Data',
+      'Pending Score',
+      'Drafted Player',
+    ]);
+  });
+
+  it('disables only queue actions while a queue update is pending', () => {
+    render(
+      <DraftWatchlist
+        players={availablePlayers}
+        draftedPlayerIds={['drafted']}
+        onDraftPlayer={vi.fn()}
+        canDraft
+        watchlistItems={watchlistItems}
+        onAddToQueue={vi.fn()}
+        onRemoveFromWatchlist={vi.fn()}
+        isQueueMutationPending
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Add Positive Score to draft queue' })
+    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Draft Positive Score' })).not.toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'Remove Positive Score from watchlist' })
+    ).not.toBeDisabled();
+  });
+});

--- a/tests/unit/LivePickHeader.a11y.test.tsx
+++ b/tests/unit/LivePickHeader.a11y.test.tsx
@@ -9,6 +9,7 @@ const draftData = {
   totalPicks: 12,
   round: 1,
   direction: 'FORWARD',
+  draftType: 'SNAKE' as const,
   status: 'LIVE',
   pickDeadlineAt: new Date(Date.now() + 120_000).toISOString(),
   participants: [
@@ -74,7 +75,8 @@ describe('LivePickHeader', () => {
     expect(pickTrain).toBeInTheDocument();
     expect(screen.queryByLabelText('Latest draft activity')).not.toBeInTheDocument();
     expect(screen.queryByText('Latest pick')).not.toBeInTheDocument();
-    const nextPickStatus = screen.getByRole('status', { name: /you are up next/i });
+    const nextPickStatus = screen.getByRole('status', { name: 'Your next pick is pick 2' });
+    expect(nextPickStatus).toHaveTextContent('Your next pick: Pick 2');
     expect(nextPickStatus).toHaveClass('bg-[color:var(--draft-broadcast-yellow)]');
     expect(nextPickStatus).not.toHaveClass('bg-accent');
     expect(screen.getByText('On the clock')).toBeInTheDocument();

--- a/tests/unit/PickFeed.test.tsx
+++ b/tests/unit/PickFeed.test.tsx
@@ -1,15 +1,12 @@
 import type { ImgHTMLAttributes } from 'react';
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import PickFeed from '@/components/PickFeed';
 
 vi.mock('next/image', () => ({
-  default: ({
-    alt,
-    src,
-    ...props
-  }: ImgHTMLAttributes<HTMLImageElement> & { src: string }) => (
+  default: ({ alt, src, ...props }: ImgHTMLAttributes<HTMLImageElement> & { src: string }) => (
     <img alt={alt} src={src} {...props} />
   ),
 }));
@@ -113,10 +110,16 @@ describe('PickFeed', () => {
     render(<PickFeed {...defaultProps} />);
 
     const feed = screen.getByLabelText('Pick feed');
-    const latestPick = within(feed).getByText('Errol Gulden').closest('div');
+    const latestPick = within(feed)
+      .getByText('Errol Gulden')
+      .closest<HTMLElement>('[data-pick-state]');
 
     expect(latestPick).not.toBeNull();
+    expect(latestPick).toHaveTextContent('Slot 3');
+    expect(latestPick).toHaveTextContent('Pick 3');
+    expect(latestPick).not.toHaveTextContent('View context');
     expect(screen.getByAltText('Sydney logo')).toHaveAttribute('src', '/logos/Sydney.svg');
+    expect(screen.queryByText('View context')).not.toBeInTheDocument();
   });
 
   it('filters to my picks', () => {
@@ -125,6 +128,13 @@ describe('PickFeed', () => {
     fireEvent.click(screen.getByRole('button', { name: /mine/i }));
 
     expect(screen.getByText('Nick Daicos')).toBeInTheDocument();
+    const mineCard = screen.getByText('Nick Daicos').closest<HTMLElement>('[data-pick-state]');
+    if (!mineCard) throw new Error('Expected the user pick card');
+    expect(mineCard).toHaveAttribute('data-pick-state', 'mine');
+    expect(within(mineCard).getByText('Mine').querySelector('svg')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
     expect(screen.queryByText('Marcus Bontempelli')).not.toBeInTheDocument();
     expect(screen.queryByText('Errol Gulden')).not.toBeInTheDocument();
     expect(screen.getByText('Showing 1 of 3 total picks')).toBeInTheDocument();
@@ -136,23 +146,37 @@ describe('PickFeed', () => {
     fireEvent.click(screen.getByRole('button', { name: /watchlist/i }));
 
     expect(screen.getByText('Errol Gulden')).toBeInTheDocument();
+    const watchlistCard = screen
+      .getByText('Errol Gulden')
+      .closest<HTMLElement>('[data-pick-state]');
+    if (!watchlistCard) throw new Error('Expected the watchlist pick card');
+    expect(watchlistCard).toHaveAttribute('data-pick-state', 'watchlist');
+    expect(watchlistCard).toHaveClass('border-[color:var(--draft-broadcast-watchlist-border)]');
+    expect(watchlistCard).toHaveClass('bg-[color:var(--draft-broadcast-watchlist-hit)]');
+    expect(within(watchlistCard).getByText('Watchlist').querySelector('svg')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
     expect(screen.queryByText('Marcus Bontempelli')).not.toBeInTheDocument();
     expect(screen.queryByText('Nick Daicos')).not.toBeInTheDocument();
     expect(screen.getAllByText('Watchlist')).toHaveLength(2);
   });
 
-  it('toggles auto-scroll state with an accessible label', () => {
+  it('toggles auto-scroll state with an accessible switch', async () => {
+    const user = userEvent.setup();
     render(<PickFeed {...defaultProps} />);
 
-    const toggle = screen.getByRole('button', { name: 'Toggle auto-scroll' });
+    const toggle = screen.getByRole('switch', { name: 'Auto-scroll on new picks' });
 
-    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
     expect(screen.getByText('Auto-scroll on new picks')).toBeInTheDocument();
+    expect(screen.queryByText('Live rail')).not.toBeInTheDocument();
 
-    fireEvent.click(toggle);
+    toggle.focus();
+    await user.keyboard(' ');
 
-    expect(toggle).toHaveAttribute('aria-pressed', 'false');
-    expect(screen.getByText('Manual scroll mode')).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    expect(screen.queryByText('Manual scroll mode')).not.toBeInTheDocument();
   });
 
   it('fills its parent column while keeping picks in the scrollable body', () => {

--- a/tests/unit/PlayerGrid.a11y.test.tsx
+++ b/tests/unit/PlayerGrid.a11y.test.tsx
@@ -118,7 +118,7 @@ describe('PlayerGrid accessibility', () => {
     const statlyZInfo = screen.getByRole('button', { name: 'About Statly Z' });
     expect(statlyZSort).not.toHaveAttribute('title');
 
-    fireEvent.focus(statlyZInfo);
+    act(() => statlyZInfo.focus());
     const statlyZTooltip = await screen.findByRole('tooltip');
     expect(statlyZTooltip).toHaveTextContent(
       "Statly Z combines a player's results across your league's scoring categories. Higher is better."
@@ -127,7 +127,8 @@ describe('PlayerGrid accessibility', () => {
     expect(statlyZSort).not.toHaveAttribute('aria-describedby');
 
     fireEvent.keyDown(document, { key: 'Escape' });
-    await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument());
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    expect(statlyZInfo).toHaveFocus();
 
     fireEvent.click(statlyZSort);
     expect(defaultProps.onSortChange).toHaveBeenCalledWith('statlyZ');

--- a/tests/unit/PlayerGrid.a11y.test.tsx
+++ b/tests/unit/PlayerGrid.a11y.test.tsx
@@ -81,7 +81,7 @@ describe('PlayerGrid accessibility', () => {
     Element.prototype.scrollIntoView = vi.fn();
   });
 
-  it('renders the player list as a native table with accessible actions', () => {
+  it('renders the player list as a native table with accessible actions', async () => {
     const onPlayerSelect = vi.fn();
     const onAddToQueue = vi.fn();
 
@@ -114,11 +114,23 @@ describe('PlayerGrid accessibility', () => {
 
     const playerRow = within(table).getByRole('row', { name: /marcus bontempelli/i });
     expect(within(playerRow).getByText('3.42')).toBeInTheDocument();
-    expect(within(playerRow).queryByText(/combined z score/i)).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Sort by Statly Z' })).toHaveAttribute(
-      'title',
-      "Combined Z score across this league's selected scoring categories."
+    const statlyZSort = screen.getByRole('button', { name: 'Sort by Statly Z' });
+    const statlyZInfo = screen.getByRole('button', { name: 'About Statly Z' });
+    expect(statlyZSort).not.toHaveAttribute('title');
+
+    fireEvent.focus(statlyZInfo);
+    const statlyZTooltip = await screen.findByRole('tooltip');
+    expect(statlyZTooltip).toHaveTextContent(
+      "Statly Z combines a player's results across your league's scoring categories. Higher is better."
     );
+    expect(statlyZInfo).toHaveAttribute('aria-describedby', statlyZTooltip.id);
+    expect(statlyZSort).not.toHaveAttribute('aria-describedby');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument());
+
+    fireEvent.click(statlyZSort);
+    expect(defaultProps.onSortChange).toHaveBeenCalledWith('statlyZ');
     fireEvent.click(screen.getByRole('button', { name: 'Sort by Goals' }));
     expect(defaultProps.onSortChange).toHaveBeenCalledWith('category:goals');
     expect(within(playerRow).getByRole('cell', { name: 'Goals: 1.1' })).toBeInTheDocument();
@@ -168,6 +180,16 @@ describe('PlayerGrid accessibility', () => {
     await waitFor(() => {
       expect(selectButton).not.toBeDisabled();
     });
+  });
+
+  it('disables only queue actions while a queue update is pending', () => {
+    render(<PlayerGrid {...defaultProps} isQueueMutationPending />);
+
+    expect(screen.getByRole('button', { name: /add marcus bontempelli to queue/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /select marcus bontempelli/i })).not.toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: /add marcus bontempelli to watchlist/i })
+    ).not.toBeDisabled();
   });
 
   it('keeps unrelated watchlist buttons available while one player is pending', () => {

--- a/tests/unit/Tooltip.accessibility.test.tsx
+++ b/tests/unit/Tooltip.accessibility.test.tsx
@@ -14,18 +14,20 @@ describe('Tooltip accessibility', () => {
     const trigger = screen.getByRole('button', { name: 'Availability' });
     const triggerWrapper = trigger.parentElement as HTMLElement;
 
+    expect(trigger).not.toHaveAttribute('aria-describedby');
     expect(triggerWrapper).not.toHaveAttribute('aria-describedby');
 
     fireEvent.focus(trigger);
 
     const tooltip = await screen.findByRole('tooltip');
     expect(tooltip.id).not.toBe('');
-    expect(triggerWrapper).toHaveAttribute('aria-describedby', tooltip.id);
+    expect(trigger).toHaveAttribute('aria-describedby', tooltip.id);
+    expect(triggerWrapper).not.toHaveAttribute('aria-describedby');
     expect(document.getElementById(tooltip.id)).toBe(tooltip);
 
     fireEvent.blur(trigger);
 
-    expect(triggerWrapper).not.toHaveAttribute('aria-describedby');
+    expect(trigger).not.toHaveAttribute('aria-describedby');
     await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument());
   });
 
@@ -42,11 +44,12 @@ describe('Tooltip accessibility', () => {
     fireEvent.mouseEnter(triggerWrapper);
 
     const tooltip = screen.getByRole('tooltip');
-    expect(triggerWrapper).toHaveAttribute('aria-describedby', tooltip.id);
+    expect(trigger).toHaveAttribute('aria-describedby', tooltip.id);
+    expect(triggerWrapper).not.toHaveAttribute('aria-describedby');
 
     fireEvent.mouseLeave(triggerWrapper);
 
-    expect(triggerWrapper).not.toHaveAttribute('aria-describedby');
+    expect(trigger).not.toHaveAttribute('aria-describedby');
     await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument());
   });
 
@@ -74,7 +77,31 @@ describe('Tooltip accessibility', () => {
     expect(firstTooltip).not.toBeNull();
     expect(secondTooltip).not.toBeNull();
     expect(firstTooltip?.id).not.toBe(secondTooltip?.id);
-    expect(firstTrigger.parentElement).toHaveAttribute('aria-describedby', firstTooltip?.id);
-    expect(secondTrigger.parentElement).toHaveAttribute('aria-describedby', secondTooltip?.id);
+    expect(firstTrigger).toHaveAttribute('aria-describedby', firstTooltip?.id);
+    expect(secondTrigger).toHaveAttribute('aria-describedby', secondTooltip?.id);
+  });
+
+  it('preserves an existing description and dismisses the tooltip with Escape', async () => {
+    render(
+      <>
+        <span id="existing-help">Existing help</span>
+        <Tooltip content="Additional help" portal={false}>
+          <button type="button" aria-describedby="existing-help">
+            Help
+          </button>
+        </Tooltip>
+      </>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Help' });
+    fireEvent.focus(trigger);
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(trigger).toHaveAttribute('aria-describedby', `existing-help ${tooltip.id}`);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument());
+    expect(trigger).toHaveAttribute('aria-describedby', 'existing-help');
   });
 });

--- a/tests/unit/Tooltip.accessibility.test.tsx
+++ b/tests/unit/Tooltip.accessibility.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 import Tooltip from '@/components/ui/Tooltip';
 
@@ -81,7 +81,7 @@ describe('Tooltip accessibility', () => {
     expect(secondTrigger).toHaveAttribute('aria-describedby', secondTooltip?.id);
   });
 
-  it('preserves an existing description and dismisses the tooltip with Escape', async () => {
+  it('preserves an existing description and dismisses the tooltip immediately with Escape', () => {
     render(
       <>
         <span id="existing-help">Existing help</span>
@@ -94,14 +94,39 @@ describe('Tooltip accessibility', () => {
     );
 
     const trigger = screen.getByRole('button', { name: 'Help' });
-    fireEvent.focus(trigger);
+    act(() => trigger.focus());
 
     const tooltip = screen.getByRole('tooltip');
     expect(trigger).toHaveAttribute('aria-describedby', `existing-help ${tooltip.id}`);
 
     fireEvent.keyDown(document, { key: 'Escape' });
 
-    await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument());
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     expect(trigger).toHaveAttribute('aria-describedby', 'existing-help');
+    expect(trigger).toHaveFocus();
+  });
+
+  it('cancels delayed disclosure when Escape is pressed before the tooltip opens', () => {
+    vi.useFakeTimers();
+
+    try {
+      render(
+        <Tooltip content="Delayed help" delay={200} portal={false}>
+          <button type="button">Delayed trigger</button>
+        </Tooltip>
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Delayed trigger' });
+      act(() => trigger.focus());
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      act(() => vi.advanceTimersByTime(200));
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+      expect(trigger).not.toHaveAttribute('aria-describedby');
+      expect(trigger).toHaveFocus();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/unit/UnifiedDraftRoom.liveShell.test.tsx
+++ b/tests/unit/UnifiedDraftRoom.liveShell.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import UnifiedDraftRoom from '@/components/draft/UnifiedDraftRoom';
@@ -15,14 +16,18 @@ type DraftRoomPlayerFixture = {
 const playerGridSpy = vi.hoisted(() => vi.fn());
 const draftLeftRailSpy = vi.hoisted(() => vi.fn());
 const pickFeedSpy = vi.hoisted(() => vi.fn());
+const draftWatchlistSpy = vi.hoisted(() => vi.fn());
 const openLeagueSocialSpy = vi.hoisted(() => vi.fn());
 const setLeagueContextSpy = vi.hoisted(() => vi.fn());
+const updateQueueSpy = vi.hoisted(() => vi.fn());
 
 const draftContext = vi.hoisted<{
   status: 'SCHEDULED' | 'LIVE' | 'PAUSED' | 'COMPLETED';
   availablePlayers: DraftRoomPlayerFixture[];
+  isSaving: boolean;
 }>(() => ({
   status: 'LIVE',
+  isSaving: false,
   availablePlayers: [
     {
       id: 'player-1',
@@ -120,7 +125,10 @@ vi.mock('@/components/draft/DraftLeftRail', () => ({
 }));
 
 vi.mock('@/components/DraftWatchlist', () => ({
-  default: () => <div>Watchlist panel</div>,
+  default: (props: { isLoading: boolean; isQueueMutationPending: boolean }) => {
+    draftWatchlistSpy(props);
+    return <div>Watchlist panel</div>;
+  },
 }));
 
 vi.mock('@/components/draft/ConnectionStatus', () => ({
@@ -136,7 +144,14 @@ vi.mock('@/components/draft/DraftControls', () => ({
 }));
 
 vi.mock('@/components/draft/DraftQueue', () => ({
-  default: () => <div>Draft queue panel</div>,
+  default: ({ onQueueUpdate }: { onQueueUpdate: (queue: string[]) => Promise<void> }) => (
+    <div>
+      Draft queue panel
+      <button type="button" onClick={() => void onQueueUpdate(['player-1'])}>
+        Trigger queue update
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('@/components/draft/DraftStatusBanner', () => ({
@@ -144,7 +159,12 @@ vi.mock('@/components/draft/DraftStatusBanner', () => ({
 }));
 
 vi.mock('@/components/draft/PlayerGrid', () => ({
-  default: (props: { players: Array<{ name: string }>; sortBy: string }) => {
+  default: (props: {
+    players: Array<{ name: string }>;
+    sortBy: string;
+    isLoading: boolean;
+    isQueueMutationPending: boolean;
+  }) => {
     playerGridSpy(props);
 
     return (
@@ -185,7 +205,7 @@ vi.mock('@/contexts/DraftContext', () => ({
     error: null,
     forceRefresh: vi.fn(),
     isLoading: false,
-    isSaving: false,
+    isSaving: draftContext.isSaving,
     liveState: { isYourTurn: false },
     makePick: vi.fn(),
     participants: [
@@ -229,7 +249,7 @@ vi.mock('@/contexts/DraftContext', () => ({
     removeFromWatchlist: vi.fn(),
     selectedCategories: [],
     toggleWatchlist: vi.fn(),
-    updateQueue: vi.fn(),
+    updateQueue: updateQueueSpy,
     watchlistItems: [],
   }),
 }));
@@ -239,9 +259,13 @@ describe('UnifiedDraftRoom live shell composition', () => {
     playerGridSpy.mockClear();
     draftLeftRailSpy.mockClear();
     pickFeedSpy.mockClear();
+    draftWatchlistSpy.mockClear();
     openLeagueSocialSpy.mockClear();
     setLeagueContextSpy.mockClear();
+    updateQueueSpy.mockReset();
+    updateQueueSpy.mockResolvedValue(undefined);
     draftContext.status = 'LIVE';
+    draftContext.isSaving = false;
     draftContext.availablePlayers = [
       {
         id: 'player-1',
@@ -396,6 +420,70 @@ describe('UnifiedDraftRoom live shell composition', () => {
       'Average Scored',
       'Pending Score',
     ]);
+  });
+
+  it('keeps draft-action and queue-action pending state independent', () => {
+    draftContext.isSaving = true;
+
+    render(<UnifiedDraftRoom draftId="draft-1" userId="statly-dev-tester" />);
+
+    expect(playerGridSpy.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({ isLoading: true, isQueueMutationPending: false })
+    );
+    expect(draftWatchlistSpy.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({ isLoading: true, isQueueMutationPending: false })
+    );
+  });
+
+  it('keeps the draft board mounted and offers Retry after a queue update fails', async () => {
+    const user = userEvent.setup();
+    let resolveRetry: (() => void) | undefined;
+    updateQueueSpy.mockRejectedValueOnce(new Error('Queue request failed'));
+    updateQueueSpy.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRetry = resolve;
+        })
+    );
+
+    render(<UnifiedDraftRoom draftId="draft-1" userId="statly-dev-tester" />);
+
+    await user.click(screen.getByRole('button', { name: 'Trigger queue update' }));
+
+    const feedback = await screen.findByRole('alert');
+    expect(feedback).toHaveTextContent(
+      'Your queue could not be saved. The draft is still live; review the current queue and retry.'
+    );
+    expect(screen.getByRole('region', { name: 'Draft board' })).toBeInTheDocument();
+    expect(screen.queryByText('Draft Error')).not.toBeInTheDocument();
+
+    const retryButton = screen.getByRole('button', { name: 'Retry queue update' });
+    await user.click(retryButton);
+
+    const retryingButton = await screen.findByRole('button', { name: 'Retry queue update' });
+    expect(retryingButton).toBe(retryButton);
+    expect(retryingButton).toHaveAttribute('aria-disabled', 'true');
+    expect(retryingButton).toHaveFocus();
+    expect(screen.getByRole('status')).toHaveTextContent('Retrying queue update…');
+    expect(screen.getByRole('status')).not.toContainElement(retryingButton);
+    expect(playerGridSpy.mock.calls.at(-1)?.[0].isLoading).toBe(false);
+    expect(playerGridSpy.mock.calls.at(-1)?.[0].isQueueMutationPending).toBe(true);
+    expect(draftWatchlistSpy.mock.calls.at(-1)?.[0].isLoading).toBe(false);
+    expect(draftWatchlistSpy.mock.calls.at(-1)?.[0].isQueueMutationPending).toBe(true);
+    expect(updateQueueSpy).toHaveBeenNthCalledWith(1, ['player-1']);
+    expect(updateQueueSpy).toHaveBeenNthCalledWith(2, ['player-1']);
+
+    await act(async () => {
+      resolveRetry?.();
+      await Promise.resolve();
+    });
+
+    const dismissButton = await screen.findByRole('button', { name: 'Dismiss' });
+    expect(dismissButton).toBe(retryButton);
+    expect(dismissButton).toHaveFocus();
+    expect(screen.getByRole('status')).toHaveTextContent('Queue saved.');
+    expect(playerGridSpy.mock.calls.at(-1)?.[0].isQueueMutationPending).toBe(false);
+    expect(draftWatchlistSpy.mock.calls.at(-1)?.[0].isQueueMutationPending).toBe(false);
   });
 
   it('keeps desktop and mobile pick feed content ids unique when the mobile feed is open', () => {

--- a/tests/unit/draftRoomSequencing.test.ts
+++ b/tests/unit/draftRoomSequencing.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { buildDraftRoomSequence, getDraftRoomTimerState } from '@/lib/draftRoomSequencing';
+import {
+  buildDraftRoomSequence,
+  getDraftRoomTimerState,
+  getSlotForOverallPick,
+} from '@/lib/draftRoomSequencing';
 
 const participants = Array.from({ length: 6 }, (_, index) => ({
   id: `member-${index + 1}`,
@@ -11,7 +15,7 @@ const participants = Array.from({ length: 6 }, (_, index) => ({
 }));
 
 describe('buildDraftRoomSequence', () => {
-  it('returns current, completed, upcoming, and next user pick slots in snake order', () => {
+  it('keeps the visible snake-order window bounded while projecting the next user pick', () => {
     const sequence = buildDraftRoomSequence({
       currentPick: 7,
       totalPicks: 18,
@@ -45,13 +49,49 @@ describe('buildDraftRoomSequence', () => {
       displayName: 'Team 6',
       status: 'current',
     });
-    expect(sequence.slots.map((slot) => slot.overall)).toEqual([6, 7, 8, 9, 10, 11, 12]);
-    expect(sequence.slots.map((slot) => slot.slot)).toEqual([6, 6, 5, 4, 3, 2, 1]);
+    expect(sequence.slots.map((slot) => slot.overall)).toEqual([6, 7, 8, 9, 10, 11]);
+    expect(sequence.slots.map((slot) => slot.slot)).toEqual([6, 6, 5, 4, 3, 2]);
     expect(sequence.nextUserPick).toMatchObject({
       overall: 12,
       picksUntil: 5,
       estimatedSecondsUntil: 600,
     });
+  });
+
+  it('projects a linear-draft pick without appending it to the visible window', () => {
+    const sequence = buildDraftRoomSequence({
+      currentPick: 8,
+      totalPicks: 18,
+      participants,
+      picks: [],
+      yourSlot: 1,
+      draftType: 'LINEAR',
+      windowBefore: 1,
+      windowAfter: 2,
+    });
+
+    expect(sequence.current).toMatchObject({ overall: 8, round: 2, slot: 2 });
+    expect(sequence.slots.map((slot) => slot.overall)).toEqual([7, 8, 9, 10]);
+    expect(sequence.slots.map((slot) => slot.slot)).toEqual([1, 2, 3, 4]);
+    expect(sequence.nextUserPick).toMatchObject({
+      overall: 13,
+      round: 3,
+      slot: 1,
+      picksUntil: 5,
+    });
+  });
+
+  it('ignores a user slot that is not part of the persisted draft order', () => {
+    const sequence = buildDraftRoomSequence({
+      currentPick: 7,
+      totalPicks: 18,
+      participants,
+      picks: [],
+      yourSlot: 7,
+    });
+
+    expect(sequence.nextUserPick).toBeNull();
+    expect(sequence.slots.every((slot) => !slot.isUserPick)).toBe(true);
   });
 
   it('handles completed drafts without inventing a live current slot', () => {
@@ -67,6 +107,15 @@ describe('buildDraftRoomSequence', () => {
     expect(sequence.current).toBeNull();
     expect(sequence.nextUserPick).toBeNull();
     expect(sequence.phase).toBe('COMPLETED');
+  });
+});
+
+describe('getSlotForOverallPick', () => {
+  it('keeps the compatibility sentinel for invalid numeric input', () => {
+    expect(getSlotForOverallPick(0, 6)).toBe(0);
+    expect(getSlotForOverallPick(1.5, 6)).toBe(0);
+    expect(getSlotForOverallPick(1, 0)).toBe(0);
+    expect(getSlotForOverallPick(1, 6.5)).toBe(0);
   });
 });
 

--- a/tests/unit/preDraftQueueAuthorization.test.ts
+++ b/tests/unit/preDraftQueueAuthorization.test.ts
@@ -4,19 +4,30 @@ import { join } from 'node:path';
 import { NextRequest } from 'next/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { DraftPrivateStateAccessError, draftPrivateStateService, getAuthenticatedUserId } =
-  vi.hoisted(() => {
-    class MockDraftPrivateStateAccessError extends Error {}
+const {
+  DraftPrivateStateAccessError,
+  DraftPrivateStateConflictError,
+  DraftPrivateStateValidationError,
+  draftPrivateStateService,
+  getAuthenticatedUserId,
+} = vi.hoisted(() => {
+  class MockDraftPrivateStateAccessError extends Error {}
+  class MockDraftPrivateStateConflictError extends Error {}
+  class MockDraftPrivateStateValidationError extends Error {}
 
-    return {
-      DraftPrivateStateAccessError: MockDraftPrivateStateAccessError,
-      draftPrivateStateService: {
-        getPreDraftQueue: vi.fn(),
-        replacePreDraftQueue: vi.fn(),
-      },
-      getAuthenticatedUserId: vi.fn(),
-    };
-  });
+  return {
+    DraftPrivateStateAccessError: MockDraftPrivateStateAccessError,
+    DraftPrivateStateConflictError: MockDraftPrivateStateConflictError,
+    DraftPrivateStateValidationError: MockDraftPrivateStateValidationError,
+    draftPrivateStateService: {
+      getPreDraftQueue: vi.fn(),
+      addToPreDraftQueue: vi.fn(),
+      removeFromPreDraftQueue: vi.fn(),
+      replacePreDraftQueue: vi.fn(),
+    },
+    getAuthenticatedUserId: vi.fn(),
+  };
+});
 
 vi.mock('@/lib/serverAuth', () => ({ getAuthenticatedUserId }));
 vi.mock('@/lib/logger', () => ({
@@ -24,19 +35,40 @@ vi.mock('@/lib/logger', () => ({
 }));
 vi.mock('@/server/draft/services/DraftPrivateStateService', () => ({
   DraftPrivateStateAccessError,
+  DraftPrivateStateConflictError,
+  DraftPrivateStateValidationError,
   draftPrivateStateService,
 }));
 
-import { GET, PUT } from '@/app/api/drafts/[id]/pre-queue/route';
+import { GET as GET_PRE_QUEUE, PUT as PUT_PRE_QUEUE } from '@/app/api/drafts/[id]/pre-queue/route';
+import {
+  DELETE as DELETE_QUEUE,
+  GET as GET_QUEUE,
+  POST as POST_QUEUE,
+  PUT as PUT_QUEUE,
+} from '@/app/api/drafts/[id]/queue/route';
 
 const root = process.cwd();
 const read = (path: string) => readFileSync(join(root, path), 'utf8');
 const draftId = 'draft-1';
 const actorUserId = 'user-1';
+const memberId = 'member-1';
 const context = { params: Promise.resolve({ id: draftId }) };
+const queueEntry = {
+  id: 'queue-1',
+  draftId,
+  memberId,
+  playerId: 'player-1',
+  rank: 1,
+  notes: undefined,
+};
 
 function request(path: string, init?: ConstructorParameters<typeof NextRequest>[1]): NextRequest {
   return new NextRequest(`http://localhost:3000${path}`, init);
+}
+
+async function responseData(response: Response) {
+  return (await response.json()).data;
 }
 
 describe('pre-draft queue authorization', () => {
@@ -48,8 +80,8 @@ describe('pre-draft queue authorization', () => {
     getAuthenticatedUserId.mockResolvedValue(null);
 
     const responses = await Promise.all([
-      GET(request(`/api/drafts/${draftId}/pre-queue`), context),
-      PUT(
+      GET_PRE_QUEUE(request(`/api/drafts/${draftId}/pre-queue`), context),
+      PUT_PRE_QUEUE(
         request(`/api/drafts/${draftId}/pre-queue`, {
           method: 'PUT',
           body: JSON.stringify({ queue: [] }),
@@ -63,50 +95,150 @@ describe('pre-draft queue authorization', () => {
     expect(draftPrivateStateService.replacePreDraftQueue).not.toHaveBeenCalled();
   });
 
-  it('maps inactive or cross-league membership failures to forbidden', async () => {
+  it('maps private-state access, validation, and conflict errors to stable statuses', async () => {
     getAuthenticatedUserId.mockResolvedValue(actorUserId);
     draftPrivateStateService.getPreDraftQueue.mockRejectedValueOnce(
       new DraftPrivateStateAccessError('Not a member of this draft')
     );
     draftPrivateStateService.replacePreDraftQueue.mockRejectedValueOnce(
-      new DraftPrivateStateAccessError('Not a member of this draft')
+      new DraftPrivateStateValidationError('Queue contains an unknown player')
+    );
+    draftPrivateStateService.addToPreDraftQueue.mockRejectedValueOnce(
+      new DraftPrivateStateConflictError('Player is no longer available')
     );
 
-    const responses = await Promise.all([
-      GET(request(`/api/drafts/${draftId}/pre-queue`), context),
-      PUT(
-        request(`/api/drafts/${draftId}/pre-queue`, {
-          method: 'PUT',
-          body: JSON.stringify({ queue: [] }),
-        }),
-        context
-      ),
-    ]);
-
-    expect(responses.map((response) => response.status)).toEqual([403, 403]);
-  });
-
-  it('ignores spoofed legacy member IDs and uses the authenticated actor', async () => {
-    getAuthenticatedUserId.mockResolvedValue(actorUserId);
-    draftPrivateStateService.getPreDraftQueue.mockResolvedValue([]);
-    draftPrivateStateService.replacePreDraftQueue.mockResolvedValue([]);
-
-    const getResponse = await GET(
-      request(`/api/drafts/${draftId}/pre-queue?memberId=spoofed-member`),
+    const forbidden = await GET_PRE_QUEUE(request(`/api/drafts/${draftId}/pre-queue`), context);
+    const badRequest = await PUT_PRE_QUEUE(
+      request(`/api/drafts/${draftId}/pre-queue`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ queue: [{ playerId: 'unknown-player', rank: 1 }] }),
+      }),
       context
     );
-    const putResponse = await PUT(
+    const conflict = await POST_QUEUE(
+      request(`/api/drafts/${draftId}/queue`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ playerId: 'picked-player' }),
+      }),
+      context
+    );
+
+    expect([forbidden.status, badRequest.status, conflict.status]).toEqual([403, 400, 409]);
+  });
+
+  it('delegates pre-queue replacement to the authenticated actor and returns its result privately', async () => {
+    getAuthenticatedUserId.mockResolvedValue(actorUserId);
+    const result = {
+      memberId,
+      queue: [queueEntry],
+      removedPlayerIds: ['picked-player'],
+    };
+    draftPrivateStateService.replacePreDraftQueue.mockResolvedValue(result);
+
+    const response = await PUT_PRE_QUEUE(
       request(`/api/drafts/${draftId}/pre-queue`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           memberId: 'spoofed-member',
-          queue: [{ playerId: 'player-1', rank: 1 }],
+          queue: [
+            { playerId: 'player-1', rank: 2, notes: 'second' },
+            { playerId: 'picked-player', rank: 1 },
+          ],
         }),
       }),
       context
     );
 
+    expect(draftPrivateStateService.replacePreDraftQueue).toHaveBeenCalledWith({
+      draftId,
+      actorUserId,
+      unresolvedPlayerPolicy: 'reject',
+      queue: [
+        { playerId: 'player-1', rank: 2, notes: 'second' },
+        { playerId: 'picked-player', rank: 1 },
+      ],
+    });
+    expect(draftPrivateStateService.replacePreDraftQueue.mock.calls[0]?.[0]).not.toHaveProperty(
+      'memberId'
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('private, no-store');
+    expect(await responseData(response)).toEqual(result);
+  });
+
+  it('validates queue shape after authentication and before service access', async () => {
+    getAuthenticatedUserId.mockResolvedValue(actorUserId);
+
+    const responses = await Promise.all([
+      PUT_PRE_QUEUE(
+        request(`/api/drafts/${draftId}/pre-queue`, {
+          method: 'PUT',
+          body: JSON.stringify({ queue: [{ playerId: '', rank: 1 }] }),
+        }),
+        context
+      ),
+      PUT_PRE_QUEUE(
+        request(`/api/drafts/${draftId}/pre-queue`, {
+          method: 'PUT',
+          body: JSON.stringify({ queue: [{ playerId: 'player-1', rank: 0 }] }),
+        }),
+        context
+      ),
+    ]);
+
+    expect(responses.map((response) => response.status)).toEqual([422, 422]);
+    expect(draftPrivateStateService.replacePreDraftQueue).not.toHaveBeenCalled();
+  });
+
+  it('delegates every compatibility queue operation and keeps successful responses private', async () => {
+    getAuthenticatedUserId.mockResolvedValue(actorUserId);
+    draftPrivateStateService.addToPreDraftQueue.mockResolvedValue(queueEntry);
+    draftPrivateStateService.removeFromPreDraftQueue.mockResolvedValue(true);
+    draftPrivateStateService.getPreDraftQueue.mockResolvedValue([queueEntry]);
+    draftPrivateStateService.replacePreDraftQueue.mockResolvedValue({
+      memberId,
+      queue: [queueEntry],
+      removedPlayerIds: ['picked-player'],
+    });
+
+    const responses = await Promise.all([
+      POST_QUEUE(
+        request(`/api/drafts/${draftId}/queue`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ playerId: 'player-1', rank: 3 }),
+        }),
+        context
+      ),
+      DELETE_QUEUE(
+        request(`/api/drafts/${draftId}/queue?playerId=player-1`, { method: 'DELETE' }),
+        context
+      ),
+      GET_QUEUE(request(`/api/drafts/${draftId}/queue`), context),
+      PUT_QUEUE(
+        request(`/api/drafts/${draftId}/queue`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ queue: ['player-1', 'picked-player'] }),
+        }),
+        context
+      ),
+    ]);
+
+    expect(draftPrivateStateService.addToPreDraftQueue).toHaveBeenCalledWith({
+      draftId,
+      actorUserId,
+      playerId: 'player-1',
+      rank: 3,
+    });
+    expect(draftPrivateStateService.removeFromPreDraftQueue).toHaveBeenCalledWith({
+      draftId,
+      actorUserId,
+      playerId: 'player-1',
+    });
     expect(draftPrivateStateService.getPreDraftQueue).toHaveBeenCalledWith({
       draftId,
       actorUserId,
@@ -114,52 +246,35 @@ describe('pre-draft queue authorization', () => {
     expect(draftPrivateStateService.replacePreDraftQueue).toHaveBeenCalledWith({
       draftId,
       actorUserId,
-      queue: [{ playerId: 'player-1', rank: 1 }],
+      unresolvedPlayerPolicy: 'remove',
+      queue: [
+        { playerId: 'player-1', rank: 1 },
+        { playerId: 'picked-player', rank: 2 },
+      ],
     });
-    expect(draftPrivateStateService.replacePreDraftQueue.mock.calls[0]?.[0]).not.toHaveProperty(
-      'memberId'
-    );
-    expect(getResponse.headers.get('cache-control')).toBe('private, no-store');
-    expect(putResponse.status).toBe(200);
+    expect(responses.map((response) => response.status)).toEqual([201, 200, 200, 200]);
+    expect(
+      responses.every((response) => response.headers.get('cache-control') === 'private, no-store')
+    ).toBe(true);
+    expect(await responseData(responses[3])).toEqual({
+      memberId,
+      queue: [queueEntry],
+      failedIds: ['picked-player'],
+    });
   });
 
-  it('validates queue shape after authentication and before service access', async () => {
-    getAuthenticatedUserId.mockResolvedValue(actorUserId);
-
-    const response = await PUT(
-      request(`/api/drafts/${draftId}/pre-queue`, {
-        method: 'PUT',
-        body: JSON.stringify({ memberId: 'spoofed-member', queue: [{ playerId: '', rank: 1 }] }),
-      }),
-      context
-    );
-
-    expect(response.status).toBe(400);
-    expect(draftPrivateStateService.replacePreDraftQueue).not.toHaveBeenCalled();
-  });
-
-  it('keeps the compatibility queue route on PreDraftQueue and server-derived membership', () => {
-    const source = read('src/app/api/drafts/[id]/queue/route.ts');
-
-    expect(source).toContain('getAuthenticatedUserId');
-    expect(source).toContain('getDraftMembershipAccess');
-    expect(source).toContain('access.memberId');
-    expect(source).toContain('preDraftQueue');
-    expect(source).toContain('resolveCanonicalPlayerId');
-    expect(source).toContain('resolveCanonicalPlayerIds');
-    expect(source).toContain('z.string().trim().min(1)');
-    expect(source).not.toMatch(/\bqueueItem\b/i);
-    expect(source).not.toContain('memberId: z.string().min(1)');
-  });
-
-  it('auto-pick reaches PreDraftQueue through the draft service and repository', () => {
+  it('keeps auto-pick on canonical PreDraftQueue and global drafted-player cleanup', () => {
     const routeSource = read('src/app/api/drafts/[id]/auto-pick/route.ts');
     const repositorySource = read('src/server/draft/repository/DraftRepository.ts');
+    const serviceSource = read('src/server/draft/services/DraftApplicationService.ts');
 
     expect(routeSource).toContain('draftApplicationService.autoPick');
     expect(repositorySource).toContain('tx.preDraftQueue.findFirst');
-    expect(repositorySource).toContain('tx.preDraftQueue.deleteMany');
-    expect(repositorySource).toContain('tx.preDraftQueue.delete');
+    expect(repositorySource).toContain('removePlayerFromAllDraftQueues');
+    expect(repositorySource).toContain('where: { draftId, playerId }');
     expect(repositorySource).not.toContain('tx.queueItem');
+    expect(serviceSource).toContain(
+      'draftRepository.removePlayerFromAllDraftQueues(tx, draftId, selectedPlayer.id)'
+    );
   });
 });


### PR DESCRIPTION
## Goal

Make the live draft room converge reliably as picks occur while improving its ordering, queue, Statly Z, roster, feed, and accessibility presentation.

## Root cause

Queued players could remain persisted after another team drafted them, while the browser also treated a progressively hydrated player catalogue as queue authority. Concurrent private-state hydration could overwrite a confirmed queue write, queue failures escalated into the room-level fatal state, compatibility deletion could leave rank gaps, and draft-order consumers implicitly assumed snake ordering.

## What changed

- Remove every accepted manual or automatic pick from all queues in the same serializable Prisma transaction.
- Add bounded transaction retries, an indexed draft/player cleanup path, and retry-scoped authorization revalidation.
- Centralize canonical player resolution, filter picked/inactive entries authoritatively, preserve strict modern and partial-success compatibility semantics, and compact queue ranks while retaining notes.
- Reconcile queue state from persisted picks across initial hydration, snapshots, replay, realtime events, and confirmed queue responses without using catalogue hydration as authority.
- Prevent stale private-state reads from overwriting successful writes and keep queue failures recoverable inside the live room.
- Centralize snake/linear pick coordinates and propagate draft type through projection and realtime boundaries.
- Add the Statly Z explanation/presentation, compact next-pick treatment, drafted-roster visual distinction, watchlist/feed refinements, and simplified auto-scroll presentation.
- Preserve keyboard focus, accessible names, semantic theme tokens, independent queue/pick pending states, and non-duplicated live-region announcements.

## Verification

- `npm run lint:ci`
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run docs:check`
- Focused unit suite: 17 files, 120 tests passed
- Component/helper suite: 2 files, 12 tests passed
- Disposable real-SQLite request-ordering regression verifies that a queue request begun before an accepted pick cannot reinsert the selected player when it persists afterward
- Diff and secret/protected-path audits passed

The focused DraftContext suite still emits pre-existing React `act(...)` warnings while passing. Repository-wide integration, build, and browser matrices are left to the required CI gates.

## Security and data impact

- Queue writes authenticate and revalidate active league membership and draft participation inside each transaction attempt.
- Queries and cleanup remain explicitly draft/member scoped; protected fantasy state stays canonical in Prisma.
- The migration adds a non-destructive `(draftId, playerId)` queue index only.
- No dependency or production configuration change is required.
- `.env*`, `.Renviron`, `prisma/dev.db`, generated build output, and generated `next-env.d.ts` are excluded.

## Compatibility and residual risk

- The modern pre-queue route rejects unknown identities without destructive replacement.
- The legacy queue route retains partial-success response behavior while removing unavailable entries.
- Prisma/SQLite serializes competing interactive transactions, so the disposable test covers deterministic in-flight request ordering; serialization retry branches are covered separately by repository unit tests.

## Summary by Sourcery

Harden the draft room’s private queue and pick handling so drafted players are consistently removed from queues, state hydration and realtime updates converge reliably, and draft ordering correctly respects linear vs snake formats.

New Features:
- Add canonical queue mutation endpoints backed by DraftPrivateStateService, including support for legacy compatibility responses and unresolved-player policies.
- Introduce Statly Z presentation utilities and UI updates that explain score coverage, including partial and unavailable states, across player grids and watchlists.
- Expose draft type through snapshots and UI mapping so live pick headers and sequencing components can distinguish snake and linear drafts.

Bug Fixes:
- Ensure queued players are filtered out once drafted or marked inactive across reads, mutations, realtime deltas, and private-state hydration.
- Prevent delayed private-state hydration or overlapping queue reads from overwriting confirmed queue PUT responses in the live draft room.
- Stop queue failures from promoting to fatal draft errors while preserving current queue display and allowing retries.
- Fix tooltip accessibility so descriptions attach to the actual trigger element and coexist with existing aria-describedby content.

Enhancements:
- Centralize draft pick coordinate calculation via a shared draftOrder utility used by sequencing logic, draft rules, and turn computation.
- Refine draft queue and watchlist UX with clearer pending states, independent queue mutation feedback, non-destructive retry flows, and roster styling that distinguishes filled from empty slots.
- Improve DraftPrivateStateService with participant-based authorization, stricter rank validation, canonical player resolution, and transaction-scoped queue replacement that compacts ranks and retains notes.
- Add bounded, serializable transaction retries in DraftRepository, including idempotent replay for certain SQLite timeouts and draft-wide queue cleanup when a player is selected.

Build:
- Add a Prisma migration creating a composite index on PreDraftQueue (draftId, playerId) to support efficient draft-wide queue cleanup after picks.

Tests:
- Expand unit and integration coverage for queue authorization, DraftPrivateStateService behaviors, DraftContext hydration and convergence scenarios, draft sequencing, Statly Z presentation, and transaction retry semantics.
- Add a disposable SQLite-backed regression test that verifies a queue request started before an accepted pick cannot reinsert the selected player when its transaction persists afterward.
- Introduce focused component tests for DraftQueue, DraftWatchlist, UnifiedDraftRoom, PickFeed, DraftLeftRail, LivePickHeader, Tooltip, and draft mappers to validate UX and accessibility changes.