### PR TITLE
Rehearse and restore local AFL factual releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,20 @@ jobs:
         run: npm run outcomes:prisma:validate
       - name: Generate isolated outcomes client
         run: npm run outcomes:prisma:generate
+      - name: Resolve disposable PostgreSQL service container
+        shell: bash
+        run: |
+          mapfile -t container_ids < <(
+            docker ps --no-trunc \
+              --filter "ancestor=postgres:16-alpine" \
+              --filter "publish=5432" \
+              --format '{{.ID}}'
+          )
+          if [[ ${#container_ids[@]} -ne 1 || ! ${container_ids[0]} =~ ^[a-f0-9]{64}$ ]]; then
+            echo "Expected one immutable PostgreSQL service container ID; found ${#container_ids[@]}." >&2
+            exit 1
+          fi
+          echo "AFL_OUTCOMES_TEST_CONTAINER_ID=${container_ids[0]}" >> "$GITHUB_ENV"
       - name: PostgreSQL integration tests
         run: npm run test:outcomes:int:provisioned
 

--- a/docs/architecture/afl-trade-intelligence.md
+++ b/docs/architecture/afl-trade-intelligence.md
@@ -316,6 +316,14 @@ view artifacts, and release-pinned JSON, CSV and valid OOXML export bytes. This 
 inside the generated disposable schema. It uses no live provider access, cloud service, schedule,
 hosted deployment, valuation model, production authority, or protected fantasy data.
 
+The same disposable harness now proves local database recovery for that exact release state. It uses
+the container's PostgreSQL 16 tools to create a custom-format dump, closes the scoped pool, destroys
+the generated schema, verifies the schema is absent, and restores it in one transaction. New
+connections must reproduce the sealed candidates, full 15-event lifecycle, recovered active pointer,
+projection, service, API, archive response, and authenticated JSON, CSV and OOXML exports byte for
+byte. This is disposable local recovery evidence only; it is not evidence for hosted retention,
+point-in-time recovery, cross-host recovery, disaster recovery, or production restore authority.
+
 ### Maturity-review acceptance criteria
 
 The broader Statly data-platform maturity review identified contract drift, name-derived player IDs,
@@ -1733,12 +1741,12 @@ model-execution evidence, complete-trade assessment contracts, and independent p
 That foundation is not equivalent to a live factual dataset or an approved trade grade. Completion is
 reported by milestone, never as one blended percentage:
 
-| Milestone                 | Current state | Completion evidence                                                                                                                                                                                                                                                                                                     |
-| ------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Engineering foundation    | Complete      | Normalized migrations and contracts, disposable real-PostgreSQL rehearsal, supported checks, build, cleanup, and review are complete.                                                                                                                                                                                   |
-| Non-production operations | Partial       | The source-independent fitzRoy private-candidate and full factual-release PostgreSQL rehearsals are complete, including local parity, rollback, no-fallback withdrawal, and recovery; hosted services, real-source capture, historical reconciliation, backup restore, and alert burn-in still need execution evidence. |
-| Factual production        | Not complete  | No reviewed real-data factual release has been activated and verified across every public read/export surface.                                                                                                                                                                                                          |
-| Valuation production      | Not complete  | No locked real-data player/pick model and complete-trade valuation publication has passed Gates 3, 4, and 5 and been activated.                                                                                                                                                                                         |
+| Milestone                 | Current state | Completion evidence                                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Engineering foundation    | Complete      | Normalized migrations and contracts, disposable real-PostgreSQL rehearsal, supported checks, build, cleanup, and review are complete.                                                                                                                                                                                                                                      |
+| Non-production operations | Partial       | The source-independent fitzRoy private-candidate, full factual-release, and disposable dump/destroy/restore PostgreSQL rehearsals are complete, including local parity, rollback, no-fallback withdrawal, recovery, and restored parity; hosted services, real-source capture, historical reconciliation, hosted restore, and alert burn-in still need execution evidence. |
+| Factual production        | Not complete  | No reviewed real-data factual release has been activated and verified across every public read/export surface.                                                                                                                                                                                                                                                             |
+| Valuation production      | Not complete  | No locked real-data player/pick model and complete-trade valuation publication has passed Gates 3, 4, and 5 and been activated.                                                                                                                                                                                                                                            |
 
 The remaining work proceeds through these independently verifiable gates:
 
@@ -1853,7 +1861,7 @@ stale-revision rejection, exact selection, and no-fallback withdrawal behavior. 
 fitzRoy factual-release rehearsal additionally proves the implemented PostgreSQL transactions and
 local API, projection, export, and archive-page parity against its deterministic candidate. Neither
 proves live raw-source custody, current external source rights, human review, parity against a real
-corpus, hosted cache invalidation, backup/restore, or a production release.
+corpus, hosted cache invalidation, hosted backup/restore, disaster recovery, or a production release.
 
 Selecting the isolated target in design does not mean it is provisioned, ready, authoritative, or
 approved. The current external blockers are exact machine-recorded source decisions and field uses,

--- a/docs/architecture/afl-trade-intelligence.md
+++ b/docs/architecture/afl-trade-intelligence.md
@@ -302,16 +302,19 @@ PostgreSQL target, object storage, factual release views, or valuation artifact 
 apply the protected fantasy schema or SQLite migration history to them or introduce the public schema
 into an unapproved target.
 
-The source-independent Stage 2A rehearsal now also exercises the complete fitzRoy factual path in the
-disposable real-PostgreSQL harness. A deterministic `non_production` provider envelope passes the
-same Gate, attested capture, custody, decoder, field-map, normalization, governed player/club
-resolution, source-fact, and factual-reconciliation contracts used by the deployed boundary. It
-conserves one decoded row into one numeric fact and one reconciled metric, constructs one private
-content-addressed factual candidate, replays the exact evidence idempotently, and rejects changed
-decoded evidence under the same capture and field-map identity. The candidate is deliberately not
-registered: the rehearsal leaves the release manifest set empty, the registry at revision zero, and
-all public activation state unchanged. It uses no live provider access, cloud service, schedule,
-fixture fallback in a deployed path, valuation model, or protected fantasy data.
+The source-independent Stage 2A rehearsal now exercises two explicit fitzRoy factual layers in the
+disposable real-PostgreSQL harness. First, a deterministic `non_production` provider envelope passes
+the Gate, attested capture, custody, decoder, field-map, normalization, governed player/club and match
+resolution, appearance/metric fact, and factual-reconciliation contracts. That layer conserves and
+exactly replays one private content-addressed candidate without publication. Second, the local release
+rehearsal promotes reviewed baseline and replacement generations into separate immutable captures,
+events, assets and gap-free acquisition-spell versions; seals their release candidates; and executes
+registration, validation, approval, activation, supersession, explicit rollback, no-fallback
+withdrawal, and freshly authorized recovery. The recovered replacement is verified across the
+PostgreSQL read service, local API adapter, archive-page response, persisted projection, all declared
+view artifacts, and release-pinned JSON, CSV and valid OOXML export bytes. This activation exists only
+inside the generated disposable schema. It uses no live provider access, cloud service, schedule,
+hosted deployment, valuation model, production authority, or protected fantasy data.
 
 ### Maturity-review acceptance criteria
 
@@ -1152,9 +1155,10 @@ state-dependent projection, and Gate 4/Gate 5/activation-authority checks as the
 Activation
 re-evaluates the exact Gate 0A source terms and request, rechecks Gate 4, separately requires the Gate 5
 product decision, and requires an expiring exact-revision operational authorization with an open
-rollback window and the write barrier engaged. This is a conformance contract for the future PostgreSQL
-adapter, not the durable registry itself; fixture decisions and authorizations are accepted only in the
-`test_fixture` environment and carry no real authority.
+rollback window and the write barrier engaged. The PostgreSQL adapter now persists this contract under
+one locked expected-revision chain and is exercised in generated disposable schemas. Those local
+`test_fixture` and `non_production` decisions and authorizations carry no external reviewer or
+production authority.
 
 The factual publication lane uses explicit compatibility versions. Existing archive-only records keep
 the release-v1/projection-v1 contract unchanged. A factual candidate uses
@@ -1729,12 +1733,12 @@ model-execution evidence, complete-trade assessment contracts, and independent p
 That foundation is not equivalent to a live factual dataset or an approved trade grade. Completion is
 reported by milestone, never as one blended percentage:
 
-| Milestone                 | Current state | Completion evidence                                                                                                                                                                                                        |
-| ------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Engineering foundation    | Complete      | Normalized migrations and contracts, disposable real-PostgreSQL rehearsal, supported checks, build, cleanup, and review are complete.                                                                                      |
-| Non-production operations | Partial       | The source-independent fitzRoy-to-private-candidate PostgreSQL rehearsal is complete; hosted services, real-source capture, historical reconciliation, restore rehearsal, and alert burn-in still need execution evidence. |
-| Factual production        | Not complete  | No reviewed real-data factual release has been activated and verified across every public read/export surface.                                                                                                             |
-| Valuation production      | Not complete  | No locked real-data player/pick model and complete-trade valuation publication has passed Gates 3, 4, and 5 and been activated.                                                                                            |
+| Milestone                 | Current state | Completion evidence                                                                                                                                                                                                                                                                                                     |
+| ------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Engineering foundation    | Complete      | Normalized migrations and contracts, disposable real-PostgreSQL rehearsal, supported checks, build, cleanup, and review are complete.                                                                                                                                                                                   |
+| Non-production operations | Partial       | The source-independent fitzRoy private-candidate and full factual-release PostgreSQL rehearsals are complete, including local parity, rollback, no-fallback withdrawal, and recovery; hosted services, real-source capture, historical reconciliation, backup restore, and alert burn-in still need execution evidence. |
+| Factual production        | Not complete  | No reviewed real-data factual release has been activated and verified across every public read/export surface.                                                                                                                                                                                                          |
+| Valuation production      | Not complete  | No locked real-data player/pick model and complete-trade valuation publication has passed Gates 3, 4, and 5 and been activated.                                                                                                                                                                                         |
 
 The remaining work proceeds through these independently verifiable gates:
 
@@ -1845,9 +1849,11 @@ evidence, pathway-specific pick support, model validation, complete-party assess
 publication parity, and its own product and release Gates.
 
 Passing the factual manifest and lifecycle fixture tests proves content integrity, transition rules,
-stale-revision rejection, exact selection, and no-fallback withdrawal behavior. It does not prove raw
-source byte custody, PostgreSQL transactions, source rights, human review, public dataset contents,
-parity against a real corpus, cache invalidation, backup/restore, or a production release.
+stale-revision rejection, exact selection, and no-fallback withdrawal behavior. The disposable
+fitzRoy factual-release rehearsal additionally proves the implemented PostgreSQL transactions and
+local API, projection, export, and archive-page parity against its deterministic candidate. Neither
+proves live raw-source custody, current external source rights, human review, parity against a real
+corpus, hosted cache invalidation, backup/restore, or a production release.
 
 Selecting the isolated target in design does not mean it is provisioned, ready, authoritative, or
 approved. The current external blockers are exact machine-recorded source decisions and field uses,

--- a/docs/runbooks/afl-trade-intelligence-operations.md
+++ b/docs/runbooks/afl-trade-intelligence-operations.md
@@ -603,11 +603,28 @@ prove all of the following on real PostgreSQL:
    release candidate, release manifest, projection, registry event, active pointer, valuation output,
    or fantasy record; the release registry remains at revision zero.
 
-The successful Stage 2A rehearsal boundary is 8 integration files and 40 tests, including the full
-migration/drift/reapply suite and four fitzRoy factual-rehearsal checks. Record the exact commit and
-command output in the delivery checkpoint. A later code-only change requires a fresh exact-commit
-run. This evidence does not satisfy real-source, hosted durability, backup/restore, alerting, schedule,
-or activation requirements.
+The private-candidate checks remain a prerequisite, not the end of the local rehearsal. The same
+disposable command now also exercises a release-specific test that:
+
+1. promotes the reviewed identity, match, appearance, goals and games facts into two separate sealed
+   factual-release candidates without mutating the original staged capture;
+2. registers, validates, approves and activates a baseline release, then repeats that governed path
+   for a replacement release with generation-specific capture, event, asset and spell-version
+   membership;
+3. verifies the read service, `/api/draft-trades/outcomes`, archive page, persisted projection, six
+   view artifacts, and release-pinned JSON, CSV and structurally validated OOXML exports all resolve
+   the replacement release and projection;
+4. revalidates and activates the superseded baseline as an explicit rollback, withdraws that active
+   baseline and proves the public selector reports `no_active_release` with no fallback, then
+   revalidates and activates the replacement as explicit recovery; and
+5. authenticates the complete append-only 15-event registry history and leaves the recovered
+   replacement active only inside the disposable schema.
+
+Record the exact commit and command output in the delivery checkpoint. A later code-only change
+requires a fresh exact-commit run. This remains local `non_production` engineering evidence. It uses
+no network or live source, creates no hosted or billable resource, grants no reviewer or production
+authority, and does not satisfy real-source custody, hosted durability, backup/restore, alerting,
+scheduling, deployment, or production-activation requirements.
 
 ### Reviewing provider identities and matches
 

--- a/docs/runbooks/afl-trade-intelligence-operations.md
+++ b/docs/runbooks/afl-trade-intelligence-operations.md
@@ -620,11 +620,19 @@ disposable command now also exercises a release-specific test that:
 5. authenticates the complete append-only 15-event registry history and leaves the recovered
    replacement active only inside the disposable schema.
 
+The restore-specific test then creates a custom-format `pg_dump` with the PostgreSQL 16 tools inside
+that same harness-owned container, closes the application pool, destroys the exact generated schema,
+and proves `to_regnamespace` can no longer resolve it. A single-transaction `pg_restore` recreates the
+schema from the dump. Fresh connections must reproduce the exact sealed-candidate rows, 15-event
+registry, active release and projection, service result, API response content, archive-page response,
+and authenticated JSON, CSV and OOXML exports observed before destruction. The harness supplies only
+its parsed immutable container ID to the test process and removes that exact container afterward.
+
 Record the exact commit and command output in the delivery checkpoint. A later code-only change
 requires a fresh exact-commit run. This remains local `non_production` engineering evidence. It uses
 no network or live source, creates no hosted or billable resource, grants no reviewer or production
-authority, and does not satisfy real-source custody, hosted durability, backup/restore, alerting,
-scheduling, deployment, or production-activation requirements.
+authority, and does not satisfy real-source custody, hosted durability or hosted backup/restore,
+alerting, scheduling, deployment, or production-activation requirements.
 
 ### Reviewing provider identities and matches
 

--- a/prisma/afl-trade-outcomes/migrations/0044_governed_provider_release_membership/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0044_governed_provider_release_membership/migration.sql
@@ -156,6 +156,27 @@ BEGIN
               AND assignment_head."decision_id" = resolution."decision_id"
               AND assignment_head."revision" = resolution."assignment_revision"
               AND assignment_head."status" = 'active'
+             JOIN "outcome_provider_identity_candidate" identity_candidate
+               ON identity_candidate."identity_candidate_id" = resolution."identity_candidate_id"
+             JOIN "outcome_provider_decoded_row" decoded
+               ON decoded."provider_decoded_row_id" = identity_candidate."provider_decoded_row_id"
+             JOIN "outcome_provider_normalization_run" normalization_run
+               ON normalization_run."normalization_run_id" = decoded."normalization_run_id"
+              AND normalization_run."capture_id" = decoded."capture_id"
+             JOIN "outcome_source_capture" resolution_capture
+               ON resolution_capture."capture_id" = normalization_run."capture_id"
+             JOIN "outcome_source_capture_season" resolution_capture_scope
+               ON resolution_capture_scope."capture_id" = resolution_capture."capture_id"
+              AND resolution_capture_scope."competition" = decoded."competition"
+              AND resolution_capture_scope."season_year" = decoded."season_year"
+             JOIN "outcome_release_source_capture" capture_member
+               ON capture_member."release_id" = NEW."release_id"
+             JOIN "outcome_source_capture" release_capture
+               ON release_capture."capture_id" = capture_member."capture_id"
+             JOIN "outcome_source_capture_season" release_capture_scope
+               ON release_capture_scope."capture_id" = release_capture."capture_id"
+              AND release_capture_scope."competition" = decoded."competition"
+              AND release_capture_scope."season_year" = decoded."season_year"
              JOIN "outcome_release_review_decision" review
                ON review."release_id" = NEW."release_id"
               AND review."decision_id" = resolution."decision_id"
@@ -163,6 +184,47 @@ BEGIN
               AND resolution."resolution_scope" = 'provider_identity'
               AND resolution."player_identity_id" = asset."player_identity_id"
               AND resolution."player_id" = asset."player_id"
+              AND resolution_capture."environment" = release_environment
+              AND resolution_capture."effective_at" <= cutoff
+              AND resolution_capture."captured_at" <= cutoff
+              AND release_capture."environment" = release_environment
+              AND release_capture."status" = 'approved'::"OutcomeRecordStatus"
+              AND release_capture."effective_at" <= cutoff
+              AND release_capture."captured_at" <= cutoff
+              AND (
+                (
+                  release_capture."capture_id" = resolution_capture."capture_id"
+                  AND resolution_capture."status" = 'approved'::"OutcomeRecordStatus"
+                )
+                OR (
+                  resolution_capture."status" = 'staged'::"OutcomeRecordStatus"
+                  AND
+                  release_capture."manifest_json"->>'privateCaptureId' =
+                    resolution_capture."capture_id"
+                  AND EXISTS (
+                    SELECT 1
+                      FROM "outcome_review_decision" capture_approval
+                     WHERE capture_approval."decision_id" =
+                             release_capture."manifest_json"->>'approvalDecisionId'
+                       AND capture_approval."subject_type" = 'source_capture'
+                       AND capture_approval."subject_id" = resolution_capture."capture_id"
+                       AND capture_approval."decision" = 'approved'
+                       AND capture_approval."decided_at" <= cutoff
+                       AND NOT EXISTS (
+                         SELECT 1 FROM "outcome_review_decision" approval_successor
+                          WHERE approval_successor."supersedes_decision_id" =
+                                  capture_approval."decision_id"
+                       )
+                  )
+                )
+              )
+              AND normalization_run."status" = 'staged'::"OutcomeRecordStatus"
+              AND normalization_run."finalized_at" IS NOT NULL
+              AND normalization_run."finalized_at" <= cutoff
+              AND decoded."row_status" = 'staged'::"OutcomeRecordStatus"
+              AND decoded."recorded_at" <= cutoff
+              AND decoded."competition" = target_competition
+              AND decoded."season_year" = target_season_year
               AND resolution."decided_at" <= cutoff
               AND resolution."effective_at" <= cutoff
               AND NOT EXISTS (

--- a/prisma/afl-trade-outcomes/migrations/0044_governed_provider_release_membership/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0044_governed_provider_release_membership/migration.sql
@@ -1,0 +1,409 @@
+DROP TRIGGER "outcome_release_event_version_eligibility" ON "outcome_release_event_version";
+
+CREATE FUNCTION "validate_outcome_release_event_version_membership"() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+  cutoff TIMESTAMPTZ;
+  release_environment "OutcomeEnvironment";
+  target_status "OutcomeRecordStatus";
+  target_time TIMESTAMPTZ;
+  target_effective_time TIMESTAMPTZ;
+  target_kind "OutcomeEventKind";
+  target_source_import_row_id TEXT;
+  target_competition TEXT;
+  target_season_year INTEGER;
+BEGIN
+  SELECT "effective_through", "environment"::"OutcomeEnvironment"
+    INTO cutoff, release_environment
+    FROM "outcome_release_manifest"
+   WHERE "release_id" = NEW."release_id";
+  IF cutoff IS NULL THEN
+    RAISE EXCEPTION 'Release membership requires one existing release cutoff';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('outcome-release-parent:' || NEW."event_version_id", 0)
+  );
+  SELECT version."status", version."recorded_at",
+         version."event_date"::timestamp AT TIME ZONE 'UTC', version."kind",
+         version."source_import_row_id", event."competition", event."season_year"
+    INTO target_status, target_time, target_effective_time, target_kind,
+         target_source_import_row_id, target_competition, target_season_year
+    FROM "outcome_event_version" version
+    JOIN "outcome_event" event ON event."event_id" = version."event_id"
+   WHERE version."event_version_id" = NEW."event_version_id";
+
+  IF target_status IS DISTINCT FROM 'approved'::"OutcomeRecordStatus"
+     OR target_time IS NULL OR target_time > cutoff OR target_effective_time > cutoff THEN
+    RAISE EXCEPTION 'Release membership requires approved evidence whose knowledge and effective times are within the release cutoff';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM "outcome_import_row" source_row
+      JOIN "outcome_import_run" import_run
+        ON import_run."import_run_id" = source_row."import_run_id"
+      JOIN "outcome_import_partition_row" partition_row
+        ON partition_row."import_row_id" = source_row."import_row_id"
+       AND partition_row."import_run_id" = source_row."import_run_id"
+      JOIN "outcome_import_partition" partition
+        ON partition."import_partition_id" = partition_row."import_partition_id"
+       AND partition."import_run_id" = partition_row."import_run_id"
+      JOIN "outcome_source_capture" capture ON capture."capture_id" = import_run."capture_id"
+      JOIN "outcome_source_capture_season" capture_scope
+        ON capture_scope."capture_id" = capture."capture_id"
+      JOIN "outcome_release_source_capture" member
+        ON member."capture_id" = capture."capture_id"
+       AND member."release_id" = NEW."release_id"
+     WHERE source_row."import_row_id" = target_source_import_row_id
+       AND source_row."parse_status" = 'approved'::"OutcomeRecordStatus"
+       AND import_run."status" = 'approved'::"OutcomeRecordStatus"
+       AND source_row."recorded_at" <= cutoff
+       AND import_run."completed_at" IS NOT NULL
+       AND import_run."completed_at" <= cutoff
+       AND capture."environment" = release_environment
+       AND partition."competition" = target_competition
+       AND partition."season_year" = target_season_year
+       AND capture_scope."competition" = target_competition
+       AND capture_scope."season_year" = target_season_year
+  ) THEN
+    RAISE EXCEPTION 'Released events require same-release, same-environment, same-season source provenance';
+  END IF;
+
+  IF (SELECT count(*) FROM "outcome_event_party"
+       WHERE "event_version_id" = NEW."event_version_id") < 1
+     OR (SELECT count(*) FROM "outcome_event_asset"
+          WHERE "event_version_id" = NEW."event_version_id") < 1 THEN
+    RAISE EXCEPTION 'Released events require at least one AFL club party and one typed asset';
+  END IF;
+  IF target_kind = 'trade'
+     AND (SELECT count(*) FROM "outcome_event_party"
+           WHERE "event_version_id" = NEW."event_version_id") < 2 THEN
+    RAISE EXCEPTION 'Released trades require at least two AFL club parties and one typed asset';
+  END IF;
+  IF target_kind IN (
+       'national_draft', 'preseason_draft', 'rookie_draft', 'midseason_draft',
+       'supplemental_selection'
+     ) AND (SELECT count(*) FROM "outcome_draft_selection"
+             WHERE "event_version_id" = NEW."event_version_id") < 1 THEN
+    RAISE EXCEPTION 'Released draft events require at least one typed selection';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM "outcome_event_asset"
+     WHERE "event_version_id" = NEW."event_version_id"
+       AND "status" <> 'approved'::"OutcomeRecordStatus"
+  ) OR EXISTS (
+    SELECT 1 FROM "outcome_draft_selection"
+     WHERE "event_version_id" = NEW."event_version_id"
+       AND ("status" <> 'approved'::"OutcomeRecordStatus" OR "player_id" IS NULL)
+  ) THEN
+    RAISE EXCEPTION 'Released event children must be approved and structurally complete';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM "outcome_event_asset" asset
+     WHERE asset."event_version_id" = NEW."event_version_id"
+       AND asset."kind" = 'player'
+       AND NOT (
+         EXISTS (
+           SELECT 1
+             FROM "outcome_player_identity_assignment" assignment
+            WHERE assignment."identity_id" = asset."player_identity_id"
+              AND assignment."player_id" = asset."player_id"
+              AND assignment."status" = 'approved'::"OutcomeRecordStatus"
+              AND (
+                EXISTS (
+                  SELECT 1 FROM "outcome_release_identity_assignment" member
+                   WHERE member."assignment_id" = assignment."assignment_id"
+                     AND member."release_id" = NEW."release_id"
+                ) OR EXISTS (
+                  SELECT 1 FROM "outcome_release_review_decision" review
+                   WHERE review."decision_id" = assignment."decision_id"
+                     AND review."release_id" = NEW."release_id"
+                )
+              )
+         ) OR EXISTS (
+           SELECT 1
+             FROM "outcome_review_decision" review
+            WHERE review."decision_id" = asset."external_identity_decision_id"
+              AND review."decision" = 'approved'
+              AND review."canonical_record_type" = 'player'
+              AND review."canonical_record_id" = asset."player_id"
+              AND review."decided_at" <= cutoff
+              AND (
+                review."subject_type" = 'external_provider_identity'
+                OR (
+                  release_environment = 'test_fixture'::"OutcomeEnvironment"
+                  AND review."subject_type" = 'external_provider_identity_fixture'
+                )
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM "outcome_review_decision" successor
+                 WHERE successor."supersedes_decision_id" = review."decision_id"
+              )
+         ) OR EXISTS (
+           SELECT 1
+             FROM "outcome_provider_player_resolution" resolution
+             JOIN "outcome_provider_player_resolution_head" resolution_head
+               ON resolution_head."resolution_id" = resolution."resolution_id"
+              AND resolution_head."resolution_case_id" = resolution."resolution_case_id"
+              AND resolution_head."revision" = resolution."revision"
+             JOIN "outcome_provider_identity_assignment_head" assignment_head
+               ON assignment_head."assignment_case_id" = resolution."assignment_case_id"
+              AND assignment_head."entity_kind" = 'player'
+              AND assignment_head."identity_id" = resolution."player_identity_id"
+              AND assignment_head."decision_id" = resolution."decision_id"
+              AND assignment_head."revision" = resolution."assignment_revision"
+              AND assignment_head."status" = 'active'
+             JOIN "outcome_release_review_decision" review
+               ON review."release_id" = NEW."release_id"
+              AND review."decision_id" = resolution."decision_id"
+            WHERE resolution."outcome" = 'approved'
+              AND resolution."resolution_scope" = 'provider_identity'
+              AND resolution."player_identity_id" = asset."player_identity_id"
+              AND resolution."player_id" = asset."player_id"
+              AND resolution."decided_at" <= cutoff
+              AND resolution."effective_at" <= cutoff
+              AND NOT EXISTS (
+                SELECT 1 FROM "outcome_review_decision" successor
+                 WHERE successor."supersedes_decision_id" = resolution."decision_id"
+              )
+         )
+       )
+  ) THEN
+    RAISE EXCEPTION 'Released player assets require an exact current legacy assignment or governed provider resolution';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM "outcome_draft_selection" selection
+     WHERE selection."event_version_id" = NEW."event_version_id"
+       AND NOT EXISTS (
+         SELECT 1
+           FROM "outcome_player_identity_assignment" assignment
+          WHERE assignment."identity_id" = selection."player_identity_id"
+            AND assignment."player_id" = selection."player_id"
+            AND assignment."status" = 'approved'::"OutcomeRecordStatus"
+            AND (
+              EXISTS (
+                SELECT 1 FROM "outcome_release_identity_assignment" member
+                 WHERE member."assignment_id" = assignment."assignment_id"
+                   AND member."release_id" = NEW."release_id"
+              ) OR EXISTS (
+                SELECT 1 FROM "outcome_release_review_decision" review
+                 WHERE review."decision_id" = assignment."decision_id"
+                   AND review."release_id" = NEW."release_id"
+              )
+            )
+       )
+       AND NOT EXISTS (
+         SELECT 1
+           FROM "outcome_review_decision" review
+          WHERE review."decision_id" = selection."external_identity_decision_id"
+            AND review."decision" = 'approved'
+            AND review."canonical_record_type" = 'player'
+            AND review."canonical_record_id" = selection."player_id"
+            AND review."decided_at" <= cutoff
+            AND (
+              review."subject_type" = 'external_provider_identity'
+              OR (
+                release_environment = 'test_fixture'::"OutcomeEnvironment"
+                AND review."subject_type" = 'external_provider_identity_fixture'
+              )
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM "outcome_review_decision" successor
+               WHERE successor."supersedes_decision_id" = review."decision_id"
+            )
+       )
+  ) THEN
+    RAISE EXCEPTION 'Released draft selections require their exact reviewed identity assignment';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM "outcome_event_party" party
+    JOIN "outcome_club" club ON club."club_id" = party."club_id"
+    WHERE party."event_version_id" = NEW."event_version_id"
+      AND club."status" <> 'approved'::"OutcomeRecordStatus"
+  ) OR EXISTS (
+    SELECT 1 FROM "outcome_event_asset" asset
+    LEFT JOIN "outcome_club" from_club ON from_club."club_id" = asset."from_club_id"
+    LEFT JOIN "outcome_club" to_club ON to_club."club_id" = asset."to_club_id"
+    LEFT JOIN "outcome_player" player ON player."player_id" = asset."player_id"
+    LEFT JOIN "outcome_draft_pick" pick ON pick."pick_id" = asset."pick_id"
+    WHERE asset."event_version_id" = NEW."event_version_id"
+      AND (asset."to_club_id" IS NULL
+        OR to_club."status" <> 'approved'::"OutcomeRecordStatus"
+        OR (target_kind = 'trade' AND asset."from_club_id" IS NULL)
+        OR (asset."from_club_id" IS NOT NULL
+          AND from_club."status" <> 'approved'::"OutcomeRecordStatus")
+        OR (asset."player_id" IS NOT NULL
+          AND player."status" <> 'approved'::"OutcomeRecordStatus")
+        OR (asset."pick_id" IS NOT NULL
+          AND pick."status" <> 'approved'::"OutcomeRecordStatus"))
+  ) OR EXISTS (
+    SELECT 1 FROM "outcome_draft_selection" selection
+    JOIN "outcome_club" club ON club."club_id" = selection."club_id"
+    LEFT JOIN "outcome_player" player ON player."player_id" = selection."player_id"
+    LEFT JOIN "outcome_draft_pick" pick ON pick."pick_id" = selection."pick_id"
+    WHERE selection."event_version_id" = NEW."event_version_id"
+      AND (club."status" <> 'approved'::"OutcomeRecordStatus"
+        OR player."status" <> 'approved'::"OutcomeRecordStatus"
+        OR (selection."pick_id" IS NOT NULL
+          AND pick."status" <> 'approved'::"OutcomeRecordStatus"))
+  ) THEN
+    RAISE EXCEPTION 'Released assets require a receiving club and only approved canonical clubs, players, and picks';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM (
+      SELECT "source_import_row_id" FROM "outcome_event_party"
+       WHERE "event_version_id" = NEW."event_version_id"
+      UNION ALL
+      SELECT "source_import_row_id" FROM "outcome_event_asset"
+       WHERE "event_version_id" = NEW."event_version_id"
+      UNION ALL
+      SELECT "source_import_row_id" FROM "outcome_draft_selection"
+       WHERE "event_version_id" = NEW."event_version_id"
+    ) child
+    WHERE NOT EXISTS (
+      SELECT 1
+        FROM "outcome_import_row" source_row
+        JOIN "outcome_import_run" import_run
+          ON import_run."import_run_id" = source_row."import_run_id"
+        JOIN "outcome_import_partition_row" partition_row
+          ON partition_row."import_row_id" = source_row."import_row_id"
+         AND partition_row."import_run_id" = source_row."import_run_id"
+        JOIN "outcome_import_partition" partition
+          ON partition."import_partition_id" = partition_row."import_partition_id"
+         AND partition."import_run_id" = partition_row."import_run_id"
+        JOIN "outcome_source_capture" capture ON capture."capture_id" = import_run."capture_id"
+        JOIN "outcome_source_capture_season" capture_scope
+          ON capture_scope."capture_id" = capture."capture_id"
+        JOIN "outcome_release_source_capture" member
+          ON member."capture_id" = capture."capture_id"
+         AND member."release_id" = NEW."release_id"
+       WHERE source_row."import_row_id" = child."source_import_row_id"
+         AND source_row."parse_status" = 'approved'::"OutcomeRecordStatus"
+         AND import_run."status" = 'approved'::"OutcomeRecordStatus"
+         AND source_row."recorded_at" <= cutoff
+         AND import_run."completed_at" IS NOT NULL
+         AND import_run."completed_at" <= cutoff
+         AND capture."environment" = release_environment
+         AND partition."competition" = target_competition
+         AND partition."season_year" = target_season_year
+         AND capture_scope."competition" = target_competition
+         AND capture_scope."season_year" = target_season_year
+    )
+  ) THEN
+    RAISE EXCEPTION 'Released event children require same-release, same-environment, same-season source provenance';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM "outcome_event_asset" asset
+     WHERE asset."event_version_id" = NEW."event_version_id"
+       AND ((asset."from_club_id" IS NOT NULL AND NOT EXISTS (
+              SELECT 1 FROM "outcome_event_party" party
+               WHERE party."event_version_id" = NEW."event_version_id"
+                 AND party."club_id" = asset."from_club_id"
+            )) OR (asset."to_club_id" IS NOT NULL AND NOT EXISTS (
+              SELECT 1 FROM "outcome_event_party" party
+               WHERE party."event_version_id" = NEW."event_version_id"
+                 AND party."club_id" = asset."to_club_id"
+            )))
+  ) OR EXISTS (
+    SELECT 1 FROM "outcome_draft_selection" selection
+     WHERE selection."event_version_id" = NEW."event_version_id"
+       AND NOT EXISTS (
+         SELECT 1 FROM "outcome_event_party" party
+          WHERE party."event_version_id" = NEW."event_version_id"
+            AND party."club_id" = selection."club_id"
+       )
+  ) THEN
+    RAISE EXCEPTION 'Released assets and selections must reference an AFL club party in the event';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER "outcome_release_event_version_eligibility"
+BEFORE INSERT ON "outcome_release_event_version"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_release_event_version_membership"();
+
+-- PostgreSQL executes BEFORE INSERT triggers before resolving an ON CONFLICT
+-- branch. Validate an existing head as the compare-and-swap source here, then
+-- let the existing BEFORE UPDATE branch validate the exact same transition.
+CREATE OR REPLACE FUNCTION "validate_outcome_reconciled_factual_head"()
+RETURNS TRIGGER AS $$
+DECLARE fact_row RECORD;
+DECLARE current_head RECORD;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended('reconciled-factual-head:' || NEW."subject_key", 0));
+  SELECT r."expected_head_revision", r."head_revision", r."recorded_at", fr."finalized_at"
+    INTO fact_row FROM "outcome_reconciled_factual_metric" r
+    JOIN "outcome_factual_reconciliation_run" fr ON fr."factual_run_id" = r."factual_run_id"
+   WHERE r."reconciled_fact_id" = NEW."reconciled_fact_id";
+  IF NOT FOUND OR fact_row."finalized_at" IS NOT NULL OR NEW."revision" <> fact_row."head_revision" OR
+     NEW."updated_at" <> fact_row."recorded_at" THEN
+    RAISE EXCEPTION 'Reconciled factual head must bind the exact open-run result revision';
+  END IF;
+  IF TG_OP = 'INSERT' THEN
+    SELECT "revision", "updated_at"
+      INTO current_head
+      FROM "outcome_reconciled_factual_metric_head"
+     WHERE "subject_key" = NEW."subject_key"
+     FOR UPDATE;
+    IF FOUND THEN
+      IF current_head."revision" <> fact_row."expected_head_revision" OR
+         NEW."revision" <> current_head."revision" + 1 OR
+         NEW."updated_at" < current_head."updated_at" THEN
+        RAISE EXCEPTION 'Reconciled factual head compare-and-swap revision is stale';
+      END IF;
+    ELSIF fact_row."expected_head_revision" <> 0 OR NEW."revision" <> 1 THEN
+      RAISE EXCEPTION 'Initial reconciled factual head must use revision one';
+    END IF;
+  ELSE
+    IF NEW."subject_key" <> OLD."subject_key" OR OLD."revision" <> fact_row."expected_head_revision" OR
+       NEW."revision" <> OLD."revision" + 1 OR NEW."updated_at" < OLD."updated_at" THEN
+      RAISE EXCEPTION 'Reconciled factual head compare-and-swap revision is stale';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- One activation event can commit the target release becoming published and
+-- the prior active release becoming superseded. The independent foreign keys
+-- already bind every commitment to the exact event revision and an immutable
+-- release manifest; requiring both columns to identify the event target makes
+-- the second, superseded commitment impossible.
+ALTER TABLE "outcome_record_state_commitment"
+  DROP CONSTRAINT "outcome_record_state_commitment_exact_event_release_fkey";
+
+CREATE FUNCTION "validate_outcome_record_state_event_membership"() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE registry_event JSONB;
+BEGIN
+  SELECT "event_json" INTO registry_event
+    FROM "outcome_registry_event"
+   WHERE "revision" = NEW."event_revision"
+   FOR KEY SHARE;
+  IF NOT FOUND OR NOT EXISTS (
+    SELECT 1
+      FROM jsonb_array_elements(
+        COALESCE(registry_event->'content'->'affectedRecordStates', '[]'::jsonb)
+      ) affected
+     WHERE affected->>'releaseId' = NEW."release_id"
+       AND affected->>'recordStateId' = NEW."record_state_id"
+       AND affected->'recordState' = NEW."record_state_json"
+  ) THEN
+    RAISE EXCEPTION 'A record-state commitment must match one exact affected release state declared by its registry event';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER "outcome_record_state_commitment_event_membership"
+BEFORE INSERT ON "outcome_record_state_commitment"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_record_state_event_membership"();

--- a/src/server/aflTradeIntelligence/development/disposablePostgresHarness.ts
+++ b/src/server/aflTradeIntelligence/development/disposablePostgresHarness.ts
@@ -91,7 +91,8 @@ function parseRecoveredContainerId(stdout: string): string | undefined {
 
 function createTestEnvironment(
   environment: NodeJS.ProcessEnv,
-  databaseUrl: string
+  databaseUrl: string,
+  containerId: string
 ): NodeJS.ProcessEnv {
   const allowedKeys = [
     'CI',
@@ -112,6 +113,7 @@ function createTestEnvironment(
   return {
     ...allowedEnvironment,
     AFL_OUTCOMES_DATABASE_URL: databaseUrl,
+    AFL_OUTCOMES_TEST_CONTAINER_ID: containerId,
     AFL_OUTCOMES_TEST_DATABASE_URL: databaseUrl,
     NODE_ENV: 'test',
     PRISMA_HIDE_UPDATE_MESSAGE: '1',
@@ -258,7 +260,7 @@ export async function runDisposableAflTradeOutcomesTests(
     });
 
     const databaseUrl = `postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:${hostPort}/${POSTGRES_DATABASE}`;
-    const testEnvironment = createTestEnvironment(environment, databaseUrl);
+    const testEnvironment = createTestEnvironment(environment, databaseUrl, containerId);
     const schemaPath = resolve(options.workspaceRoot, 'prisma/afl-trade-outcomes/schema.prisma');
     assertNoSchemaAdjacentPrismaEnvironmentFile(schemaPath, options.schemaEnvironmentFileExists);
     const commands = [

--- a/src/server/aflTradeIntelligence/development/localFitzRoyFactualRehearsal.ts
+++ b/src/server/aflTradeIntelligence/development/localFitzRoyFactualRehearsal.ts
@@ -12,6 +12,7 @@ import {
   AFL_TRADE_FACTUAL_RECONCILIATION_POLICY_SCHEMA_VERSION,
   aflTradeFactualReconciliationRunSchema,
   createAflTradeFactualReconciliationPolicy,
+  createAflTradeReconciledSubjectKey,
 } from '../outcomes/factualReconciliationContracts';
 import { reconcileAflTradeFactualFacts } from '../outcomes/factualReconciliationService';
 import {
@@ -511,7 +512,13 @@ async function resolutionDecision(
 ) {
   const replay = await client.query<{ evidence_json: unknown }>(
     `SELECT evidence_json FROM outcome_review_decision
-      WHERE subject_type='provider_resolution_case' AND subject_id=$1`,
+      WHERE subject_type='provider_resolution_case' AND subject_id=$1
+        AND NOT EXISTS (
+          SELECT 1 FROM outcome_review_decision successor
+           WHERE successor.supersedes_decision_id=outcome_review_decision.decision_id
+        )
+      ORDER BY decided_at DESC,decision_id DESC
+      LIMIT 1`,
     [proposal.content.resolutionCaseId]
   );
   if (replay.rows[0]) {
@@ -1351,8 +1358,45 @@ async function createAndPersistFactualRun(
       persisted: { idempotentReplay: true },
     };
   }
+  if (
+    batch.metricFact.content.factKind !== 'player_season_metric' ||
+    batch.metricFact.content.seasonClubScope.kind !== 'resolved_single_club' ||
+    batch.appearanceFact.content.factKind !== 'player_appearance'
+  ) {
+    throw new TypeError('The local factual run requires exact goals and appearance subjects.');
+  }
+  const currentSubjectKeys = [
+    createAflTradeReconciledSubjectKey({
+      environment: ENVIRONMENT,
+      competition: batch.metricFact.content.competition,
+      seasonYear: batch.metricFact.content.seasonYear,
+      playerId: batch.metricFact.content.player.playerId,
+      clubScope: {
+        kind: 'resolved_single_club',
+        clubId: batch.metricFact.content.seasonClubScope.club.clubId,
+      },
+      matchId: null,
+      metricCode: batch.metricFact.content.metricCode,
+      definitionVersion: batch.metricFact.content.definitionVersion,
+    }),
+    createAflTradeReconciledSubjectKey({
+      environment: ENVIRONMENT,
+      competition: batch.appearanceFact.content.competition,
+      seasonYear: batch.appearanceFact.content.seasonYear,
+      playerId: batch.appearanceFact.content.player.playerId,
+      clubScope: {
+        kind: 'resolved_single_club',
+        clubId: batch.appearanceFact.content.representedClub.clubId,
+      },
+      matchId: batch.appearanceFact.content.match.matchId,
+      metricCode: 'games',
+      definitionVersion: 'games/v1',
+    }),
+  ];
   const currentHeads = await client.query<{ subject_key: string; revision: number }>(
-    `SELECT subject_key,revision FROM outcome_reconciled_factual_metric_head`
+    `SELECT subject_key,revision FROM outcome_reconciled_factual_metric_head
+      WHERE subject_key=ANY($1::text[])`,
+    [currentSubjectKeys]
   );
   const sourceMemberships = [batch.matchFact, batch.appearanceFact, batch.metricFact].map(
     (fact) => ({

--- a/src/server/aflTradeIntelligence/development/localFitzRoyFactualRehearsal.ts
+++ b/src/server/aflTradeIntelligence/development/localFitzRoyFactualRehearsal.ts
@@ -10,13 +10,16 @@ import { createAflTradeFactualReconciliationFinalization } from '../outcomes/acq
 import {
   AFL_TRADE_FACTUAL_RECONCILIATION_AUTHORITY_BOUNDARY,
   AFL_TRADE_FACTUAL_RECONCILIATION_POLICY_SCHEMA_VERSION,
+  aflTradeFactualReconciliationRunSchema,
   createAflTradeFactualReconciliationPolicy,
 } from '../outcomes/factualReconciliationContracts';
 import { reconcileAflTradeFactualFacts } from '../outcomes/factualReconciliationService';
 import {
+  AFL_TRADE_APPEARANCE_CANDIDATE_SCHEMA_VERSION,
   AFL_TRADE_SOURCE_FACT_AUTHORITY_BOUNDARY,
   AFL_TRADE_SOURCE_FACT_BATCH_SCHEMA_VERSION,
   AFL_TRADE_SOURCE_FACT_SCHEMA_VERSION,
+  createAflTradeProviderAppearanceCandidate,
   createAflTradeSourceFact,
   createAflTradeSourceFactBatch,
 } from '../outcomes/factualObservationContracts';
@@ -47,6 +50,9 @@ import {
   AFL_TRADE_PROVIDER_RESOLUTION_SCHEMA_VERSION,
   createAflTradeProviderResolutionDecision,
   createAflTradeProviderResolutionProposal,
+  createAflTradeReviewedFixtureFingerprint,
+  normalizeAflTradeProviderClubAlias,
+  aflTradeProviderResolutionDecisionSchema,
   type AflTradeProviderResolutionDecision,
   type AflTradeProviderResolutionProposal,
 } from '../source/providerResolutionContracts';
@@ -59,6 +65,7 @@ import {
   LOCAL_FITZROY_REHEARSAL_INSTANTS,
   LOCAL_FITZROY_REHEARSAL_RUNTIME,
   createLocalAflTradeFitzRoyFactualRehearsalFixture,
+  type LocalFitzRoyFactualRehearsalGeneration,
 } from './localFitzRoyFactualRehearsalFixture';
 
 const ENVIRONMENT = 'non_production' as const;
@@ -74,13 +81,15 @@ type GovernedEvidenceKind =
   | 'provider_resolution_method'
   | 'canonical_target_snapshot'
   | 'provider_resolution_evidence'
-  | 'reviewer_authority_evidence';
+  | 'reviewer_authority_evidence'
+  | 'provider_resolution_policy';
 
 const governedEvidencePrefix: Record<GovernedEvidenceKind, string> = {
   provider_resolution_method: 'provider-resolution-method',
   canonical_target_snapshot: 'canonical-target-snapshot',
   provider_resolution_evidence: 'provider-resolution-evidence',
   reviewer_authority_evidence: 'reviewer-authority-evidence',
+  provider_resolution_policy: 'provider-resolution-policy',
 };
 
 interface StagedProviderRow {
@@ -100,6 +109,19 @@ interface StagedProviderRow {
   recorded_club_id: string;
   recorded_club_name: string;
   identity_candidate_sha256: string;
+  match_candidate_id: string;
+  match_candidate_sha256: string;
+  match_candidate_json: {
+    nativeMatchId: string;
+    roundLabel: string;
+    matchDateText: string;
+    homeClubNativeId: string;
+    homeClubName: string;
+    awayClubNativeId: string;
+    awayClubName: string;
+    providerStatus: string;
+    orderIndependentSha256: string;
+  };
   metric_candidate_json: {
     metricCode: 'goals';
     definitionVersion: string;
@@ -117,7 +139,7 @@ interface NativeNamespaceEvidence {
   environment: typeof ENVIRONMENT;
   provider: string;
   capabilityId: string;
-  entityKind: 'player' | 'club';
+  entityKind: 'player' | 'club' | 'match';
   namespaceVersion: string;
   identityScope: { kind: 'competition'; competition: 'AFLM' };
   validFromSeason: number;
@@ -213,7 +235,7 @@ async function ensureFieldMapReview(
 ): Promise<void> {
   const existing = await client.query(
     `SELECT decision_id FROM outcome_review_decision WHERE decision_id=$1`,
-    ['local-rehearsal-field-map-review']
+    [fieldMap.approvalDecisionId]
   );
   if (existing.rows.length === 0) {
     await client.query(
@@ -222,7 +244,7 @@ async function ensureFieldMapReview(
      VALUES ($1,'provider_field_map',$2,'approved',$3,
              jsonb_build_object('fieldMapSha256',$4::text),$5,$6)`,
       [
-        'local-rehearsal-field-map-review',
+        fieldMap.approvalDecisionId,
         fieldMap.mapId,
         'Source-independent local rehearsal field map.',
         fieldMapSha256,
@@ -326,7 +348,7 @@ async function ensureGovernedEvidence(
 
 async function ensureNativeNamespace(
   client: AflOutcomeSqlClient,
-  entityKind: 'player' | 'club'
+  entityKind: 'player' | 'club' | 'match'
 ): Promise<NativeNamespaceEvidence> {
   const definitionSha256 = sha256AflTradeCanonicalJson({
     environment: ENVIRONMENT,
@@ -418,11 +440,14 @@ async function loadStagedProviderRow(
             identity.identity_candidate_id,identity.native_entity_id,identity.recorded_name,
             identity.recorded_club_id,identity.recorded_club_name,
             identity.candidate_sha256 AS identity_candidate_sha256,
+            match.match_candidate_id,match.candidate_sha256 AS match_candidate_sha256,
+            match.candidate_json AS match_candidate_json,
             metric.candidate_json AS metric_candidate_json
        FROM outcome_provider_normalization_run run
        JOIN outcome_provider_field_map field_map USING (field_map_id)
        JOIN outcome_provider_decoded_row row USING (normalization_run_id)
        JOIN outcome_provider_identity_candidate identity USING (provider_decoded_row_id)
+       JOIN outcome_provider_match_candidate match USING (provider_decoded_row_id)
        JOIN outcome_provider_metric_candidate metric USING (provider_decoded_row_id)
       WHERE run.normalization_run_id=$1 AND metric.metric_code='goals'`,
     [normalizationRunId]
@@ -435,6 +460,11 @@ async function loadStagedProviderRow(
     !row.native_entity_id ||
     !row.recorded_club_id ||
     !row.recorded_club_name ||
+    !row.match_candidate_json.nativeMatchId ||
+    !row.match_candidate_json.matchDateText ||
+    !row.match_candidate_json.homeClubNativeId ||
+    !row.match_candidate_json.awayClubNativeId ||
+    row.match_candidate_json.providerStatus !== 'Final' ||
     row.metric_candidate_json.availability !== 'exact'
   ) {
     throw new TypeError('The local rehearsal staging row is not exactly promotable.');
@@ -444,16 +474,17 @@ async function loadStagedProviderRow(
 
 function resolutionStaging(
   row: StagedProviderRow,
-  namespace: NativeNamespaceEvidence,
+  namespace: NativeNamespaceEvidence | null,
   issueSet: { id: string; sha256: string },
-  normalizationFinalization: { id: string; sha256: string }
+  normalizationFinalization: { id: string; sha256: string },
+  candidateSha256 = row.identity_candidate_sha256
 ) {
   return {
     normalizationRunId: row.normalization_run_id,
     stagingSha256: row.staging_sha256,
     providerDecodedRowId: row.provider_decoded_row_id,
     sourceRowSha256: row.source_row_sha256,
-    candidateSha256: row.identity_candidate_sha256,
+    candidateSha256,
     environment: ENVIRONMENT,
     provider: PROVIDER,
     capabilityId: CAPABILITY_ID,
@@ -470,13 +501,28 @@ function resolutionStaging(
   } as const;
 }
 
-function resolutionDecision(
+async function resolutionDecision(
+  client: AflOutcomeSqlClient,
   proposal: AflTradeProviderResolutionProposal,
-  entityKind: 'player' | 'club',
+  entityKind: 'player' | 'club' | 'club_alias' | 'match',
   identityId: string,
   assignmentCaseId: string,
   reviewerAuthority: AflTradeProviderResolutionDecision['content']['reviewerAuthority']
 ) {
+  const replay = await client.query<{ evidence_json: unknown }>(
+    `SELECT evidence_json FROM outcome_review_decision
+      WHERE subject_type='provider_resolution_case' AND subject_id=$1`,
+    [proposal.content.resolutionCaseId]
+  );
+  if (replay.rows[0]) {
+    return aflTradeProviderResolutionDecisionSchema.parse(replay.rows[0].evidence_json);
+  }
+  const assignmentHead = await client.query<{ revision: number; decision_id: string }>(
+    `SELECT revision,decision_id FROM outcome_provider_identity_assignment_head
+      WHERE assignment_case_id=$1`,
+    [assignmentCaseId]
+  );
+  const currentAssignment = assignmentHead.rows[0] ?? null;
   return createAflTradeProviderResolutionDecision({
     schemaVersion: AFL_TRADE_PROVIDER_RESOLUTION_SCHEMA_VERSION,
     proposal,
@@ -486,8 +532,8 @@ function resolutionDecision(
       assignmentCaseId,
       entityKind,
       identityId,
-      expectedRevision: 0,
-      supersedesDecisionId: null,
+      expectedRevision: currentAssignment?.revision ?? 0,
+      supersedesDecisionId: currentAssignment?.decision_id ?? null,
       nextStatus: 'active',
     },
     outcome: 'approved',
@@ -512,6 +558,7 @@ async function resolveProviderIdentities(client: AflOutcomeSqlClient, row: Stage
   });
   const playerNamespace = await ensureNativeNamespace(client, 'player');
   const clubNamespace = await ensureNativeNamespace(client, 'club');
+  const matchNamespace = await ensureNativeNamespace(client, 'match');
   const method = await ensureGovernedEvidence(client, 'provider_resolution_method', {
     methodVersion: 'local-fitzroy-rehearsal/v1',
   });
@@ -522,6 +569,18 @@ async function resolveProviderIdentities(client: AflOutcomeSqlClient, row: Stage
   const clubSnapshot = await ensureGovernedEvidence(client, 'canonical_target_snapshot', {
     clubId: 'afl-club:local-rehearsal',
     displayName: row.recorded_club_name,
+  });
+  const awayClubSnapshot = await ensureGovernedEvidence(client, 'canonical_target_snapshot', {
+    clubId: 'afl-club:local-rehearsal-away',
+    displayName: row.match_candidate_json.awayClubName,
+  });
+  const matchSnapshot = await ensureGovernedEvidence(client, 'canonical_target_snapshot', {
+    matchId: 'afl-match:local-rehearsal-2026-r1',
+    canonicalMatchDate: row.match_candidate_json.matchDateText,
+    canonicalRoundLabel: row.match_candidate_json.roundLabel,
+  });
+  const aliasPolicy = await ensureGovernedEvidence(client, 'provider_resolution_policy', {
+    policyVersion: 'local-fitzroy-rehearsal-home-side-alias/v1',
   });
   const supportingEvidence = await ensureGovernedEvidence(client, 'provider_resolution_evidence', {
     source: 'local-fitzroy-rehearsal',
@@ -564,8 +623,26 @@ async function resolveProviderIdentities(client: AflOutcomeSqlClient, row: Stage
   );
   await client.query(
     `INSERT INTO outcome_club (club_id,current_name,status)
-     VALUES ('afl-club:local-rehearsal',$1,'approved') ON CONFLICT DO NOTHING`,
-    [row.recorded_club_name]
+     VALUES ('afl-club:local-rehearsal',$1,'approved'),
+            ('afl-club:local-rehearsal-away',$2,'approved')
+     ON CONFLICT DO NOTHING`,
+    [row.recorded_club_name, row.match_candidate_json.awayClubName]
+  );
+  await client.query(
+    `INSERT INTO outcome_match
+      (match_id,competition,season_year,provider,native_match_id,round_label,
+       match_date,home_club_id,away_club_id)
+     VALUES ('afl-match:local-rehearsal-2026-r1',$1,$2,$3,$4,$5,$6,
+             'afl-club:local-rehearsal','afl-club:local-rehearsal-away')
+     ON CONFLICT DO NOTHING`,
+    [
+      COMPETITION,
+      SEASON_YEAR,
+      null,
+      null,
+      row.match_candidate_json.roundLabel,
+      row.match_candidate_json.matchDateText,
+    ]
   );
   const reviewerAuthority = {
     principalRef: PRINCIPAL_REF,
@@ -613,7 +690,8 @@ async function resolveProviderIdentities(client: AflOutcomeSqlClient, row: Stage
     supportingEvidence: [supportingEvidence],
     proposedAt: '2026-08-12T00:03:00.000Z',
   });
-  const playerDecision = resolutionDecision(
+  const playerDecision = await resolutionDecision(
+    client,
     playerProposal,
     'player',
     playerIdentityId,
@@ -654,17 +732,225 @@ async function resolveProviderIdentities(client: AflOutcomeSqlClient, row: Stage
     supportingEvidence: [supportingEvidence],
     proposedAt: '2026-08-12T00:03:01.000Z',
   });
-  const clubDecision = resolutionDecision(
+  const clubDecision = await resolutionDecision(
+    client,
     clubProposal,
     'club',
     clubIdentityId,
     clubAssignmentCaseId,
     reviewerAuthority
   );
+  const homeOccurrence = {
+    source: 'match_side' as const,
+    matchCandidateId: row.match_candidate_id,
+    side: 'home' as const,
+  };
+  const normalizedHomeName = normalizeAflTradeProviderClubAlias(
+    row.match_candidate_json.homeClubName
+  );
+  const homeAliasId = createAflTradeContentAddress('provider-club-alias', {
+    provider: PROVIDER,
+    competition: COMPETITION,
+    normalizationPolicyId: aliasPolicy.id,
+    normalizedName: normalizedHomeName,
+    validFromSeason: SEASON_YEAR,
+    validThroughSeason: SEASON_YEAR,
+  });
+  const homeAssignmentCaseId = createAflTradeContentAddress('provider-identity-assignment-case', {
+    entityKind: 'club_alias',
+    identityId: homeAliasId,
+  });
+  const homeProposal = createAflTradeProviderResolutionProposal({
+    schemaVersion: AFL_TRADE_PROVIDER_RESOLUTION_PROPOSAL_SCHEMA_VERSION,
+    resolutionCaseId: createAflTradeContentAddress('provider-resolution-case', {
+      subjectType: 'provider_club_candidate',
+      occurrence: homeOccurrence,
+    }),
+    subjectType: 'provider_club_candidate',
+    occurrence: homeOccurrence,
+    candidate: {
+      nativeClubId: row.match_candidate_json.homeClubNativeId,
+      recordedName: row.match_candidate_json.homeClubName,
+    },
+    proposedTarget: {
+      scope: 'temporal_alias',
+      clubId: 'afl-club:local-rehearsal',
+      validFromSeason: SEASON_YEAR,
+      validThroughSeason: SEASON_YEAR,
+      normalizedName: normalizedHomeName,
+      aliasId: homeAliasId,
+      assignmentCaseId: homeAssignmentCaseId,
+      normalizationPolicy: aliasPolicy,
+    },
+    alternativeClubIds: [],
+    method,
+    staging: resolutionStaging(
+      row,
+      null,
+      issueSet,
+      normalizationFinalization,
+      row.match_candidate_sha256
+    ),
+    canonicalTargetSnapshot: clubSnapshot,
+    supportingEvidence: [supportingEvidence],
+    proposedAt: '2026-08-12T00:03:02.000Z',
+  });
+  const homeDecision = await resolutionDecision(
+    client,
+    homeProposal,
+    'club_alias',
+    homeAliasId,
+    homeAssignmentCaseId,
+    reviewerAuthority
+  );
+  const awayClubIdentityId = createAflTradeContentAddress('provider-club-identity', {
+    nativeIdNamespaceId: clubNamespace.namespaceId,
+    nativeClubId: row.match_candidate_json.awayClubNativeId,
+  });
+  const awayAssignmentCaseId = createAflTradeContentAddress('provider-identity-assignment-case', {
+    entityKind: 'club',
+    identityId: awayClubIdentityId,
+  });
+  const awayOccurrence = {
+    source: 'match_side' as const,
+    matchCandidateId: row.match_candidate_id,
+    side: 'away' as const,
+  };
+  const awayProposal = createAflTradeProviderResolutionProposal({
+    schemaVersion: AFL_TRADE_PROVIDER_RESOLUTION_PROPOSAL_SCHEMA_VERSION,
+    resolutionCaseId: createAflTradeContentAddress('provider-resolution-case', {
+      subjectType: 'provider_club_candidate',
+      occurrence: awayOccurrence,
+    }),
+    subjectType: 'provider_club_candidate',
+    occurrence: awayOccurrence,
+    candidate: {
+      nativeClubId: row.match_candidate_json.awayClubNativeId,
+      recordedName: row.match_candidate_json.awayClubName,
+    },
+    proposedTarget: {
+      scope: 'provider_identity',
+      clubIdentityId: awayClubIdentityId,
+      assignmentCaseId: awayAssignmentCaseId,
+      clubId: 'afl-club:local-rehearsal-away',
+    },
+    alternativeClubIds: [],
+    method,
+    staging: resolutionStaging(
+      row,
+      clubNamespace,
+      issueSet,
+      normalizationFinalization,
+      row.match_candidate_sha256
+    ),
+    canonicalTargetSnapshot: awayClubSnapshot,
+    supportingEvidence: [supportingEvidence],
+    proposedAt: '2026-08-12T00:03:03.000Z',
+  });
+  const awayDecision = await resolutionDecision(
+    client,
+    awayProposal,
+    'club',
+    awayClubIdentityId,
+    awayAssignmentCaseId,
+    reviewerAuthority
+  );
   const repository = new PostgresAflTradeProviderResolutionRepository(client);
   const execution = { principalRef: PRINCIPAL_REF, environment: ENVIRONMENT } as const;
   const playerPersistence = await repository.persistDecision(playerDecision, execution);
   const clubPersistence = await repository.persistDecision(clubDecision, execution);
+  const homePersistence = await repository.persistDecision(homeDecision, execution);
+  const awayPersistence = await repository.persistDecision(awayDecision, execution);
+  const fixtureFingerprintSha256 = createAflTradeReviewedFixtureFingerprint({
+    competition: COMPETITION,
+    seasonYear: SEASON_YEAR,
+    canonicalRoundLabel: row.match_candidate_json.roundLabel,
+    canonicalMatchDate: row.match_candidate_json.matchDateText,
+    clubIds: ['afl-club:local-rehearsal', 'afl-club:local-rehearsal-away'],
+  });
+  const matchIdentityId = createAflTradeContentAddress('provider-match-identity', {
+    nativeIdNamespaceId: matchNamespace.namespaceId,
+    nativeMatchId: row.match_candidate_json.nativeMatchId,
+  });
+  const matchAssignmentCaseId = createAflTradeContentAddress('provider-identity-assignment-case', {
+    entityKind: 'match',
+    identityId: matchIdentityId,
+  });
+  const matchProposal = createAflTradeProviderResolutionProposal({
+    schemaVersion: AFL_TRADE_PROVIDER_RESOLUTION_PROPOSAL_SCHEMA_VERSION,
+    resolutionCaseId: createAflTradeContentAddress('provider-resolution-case', {
+      subjectType: 'provider_match_candidate',
+      matchCandidateId: row.match_candidate_id,
+    }),
+    subjectType: 'provider_match_candidate',
+    matchCandidateId: row.match_candidate_id,
+    candidate: {
+      nativeMatchId: row.match_candidate_json.nativeMatchId,
+      roundLabel: row.match_candidate_json.roundLabel,
+      matchDateText: row.match_candidate_json.matchDateText,
+      homeClubNativeId: row.match_candidate_json.homeClubNativeId,
+      homeClubName: row.match_candidate_json.homeClubName,
+      awayClubNativeId: row.match_candidate_json.awayClubNativeId,
+      awayClubName: row.match_candidate_json.awayClubName,
+      orderIndependentSha256: row.match_candidate_json.orderIndependentSha256,
+    },
+    proposedTarget: {
+      matchIdentityKind: 'provider_native',
+      matchIdentityId,
+      assignmentCaseId: matchAssignmentCaseId,
+      matchId: 'afl-match:local-rehearsal-2026-r1',
+      canonicalMatchDate: row.match_candidate_json.matchDateText,
+      canonicalRoundLabel: row.match_candidate_json.roundLabel,
+      homeClubId: 'afl-club:local-rehearsal',
+      awayClubId: 'afl-club:local-rehearsal-away',
+      fixtureFingerprintSha256,
+      homeClubResolutionDecisionId: homeDecision.decisionId,
+      awayClubResolutionDecisionId: awayDecision.decisionId,
+    },
+    alternativeMatchIds: [],
+    method,
+    staging: resolutionStaging(
+      row,
+      matchNamespace,
+      issueSet,
+      normalizationFinalization,
+      row.match_candidate_sha256
+    ),
+    canonicalTargetSnapshot: matchSnapshot,
+    supportingEvidence: [supportingEvidence],
+    proposedAt: '2026-08-12T00:03:04.000Z',
+  });
+  const matchDecision = await resolutionDecision(
+    client,
+    matchProposal,
+    'match',
+    matchIdentityId,
+    matchAssignmentCaseId,
+    reviewerAuthority
+  );
+  const matchPersistence = await repository.persistDecision(matchDecision, execution);
+  const homeClub = {
+    clubId: 'afl-club:local-rehearsal',
+    resolutionDecision: { id: homeDecision.decisionId, sha256: homeDecision.decisionSha256 },
+    assignment: {
+      assignmentCaseId: homeAssignmentCaseId,
+      entityKind: 'club_alias' as const,
+      revision: homeDecision.content.assignmentRevision!.expectedRevision + 1,
+      decisionId: homeDecision.decisionId,
+      status: 'active' as const,
+    },
+  };
+  const awayClub = {
+    clubId: 'afl-club:local-rehearsal-away',
+    resolutionDecision: { id: awayDecision.decisionId, sha256: awayDecision.decisionSha256 },
+    assignment: {
+      assignmentCaseId: awayAssignmentCaseId,
+      entityKind: 'club' as const,
+      revision: awayDecision.content.assignmentRevision!.expectedRevision + 1,
+      decisionId: awayDecision.decisionId,
+      status: 'active' as const,
+    },
+  };
   return {
     normalizationFinalizedAt,
     normalizationFinalization,
@@ -681,7 +967,7 @@ async function resolveProviderIdentities(client: AflOutcomeSqlClient, row: Stage
       assignment: {
         assignmentCaseId: playerAssignmentCaseId,
         entityKind: 'player' as const,
-        revision: 1,
+        revision: playerDecision.content.assignmentRevision!.expectedRevision + 1,
         decisionId: playerDecision.decisionId,
         status: 'active' as const,
       },
@@ -698,13 +984,46 @@ async function resolveProviderIdentities(client: AflOutcomeSqlClient, row: Stage
       assignment: {
         assignmentCaseId: clubAssignmentCaseId,
         entityKind: 'club' as const,
-        revision: 1,
+        revision: clubDecision.content.assignmentRevision!.expectedRevision + 1,
         decisionId: clubDecision.decisionId,
         status: 'active' as const,
       },
     },
-    reviewDecisionId: playerDecision.decisionId,
-    idempotentReplay: playerPersistence.idempotentReplay && clubPersistence.idempotentReplay,
+    homeClub,
+    awayClub,
+    match: {
+      resolutionCaseId: matchProposal.content.resolutionCaseId,
+      revision: matchPersistence.revision,
+      decision: { id: matchDecision.decisionId, sha256: matchDecision.decisionSha256 },
+      canonicalTargetSnapshot: matchSnapshot,
+      matchCandidateId: row.match_candidate_id,
+      matchIdentityId,
+      matchId: 'afl-match:local-rehearsal-2026-r1',
+      canonicalMatchDate: row.match_candidate_json.matchDateText,
+      canonicalRoundLabel: row.match_candidate_json.roundLabel,
+      homeClub,
+      awayClub,
+      assignment: {
+        assignmentCaseId: matchAssignmentCaseId,
+        entityKind: 'match' as const,
+        revision: matchDecision.content.assignmentRevision!.expectedRevision + 1,
+        decisionId: matchDecision.decisionId,
+        status: 'active' as const,
+      },
+    },
+    reviewDecisionIds: [
+      playerDecision.decisionId,
+      clubDecision.decisionId,
+      homeDecision.decisionId,
+      awayDecision.decisionId,
+      matchDecision.decisionId,
+    ],
+    idempotentReplay:
+      playerPersistence.idempotentReplay &&
+      clubPersistence.idempotentReplay &&
+      homePersistence.idempotentReplay &&
+      awayPersistence.idempotentReplay &&
+      matchPersistence.idempotentReplay,
   };
 }
 
@@ -722,7 +1041,11 @@ async function createAndPersistFactBatch(
     id: goalsDefinition.metricDefinitionId,
     sha256: referenceFromId(goalsDefinition.metricDefinitionId).sha256,
   };
-  const source = {
+  const semanticNaturalKeySha256 = sha256AflTradeCanonicalJson({
+    matchId: row.match_candidate_json.nativeMatchId,
+    playerId: row.native_entity_id,
+  });
+  const sourceBase = {
     captureId,
     normalizationRunId: row.normalization_run_id,
     normalizationFinalization: resolutions.normalizationFinalization,
@@ -731,25 +1054,14 @@ async function createAndPersistFactBatch(
     providerDecodedRowId: row.provider_decoded_row_id,
     sourceRowNumber: row.source_row_number,
     sourceRowSha256: row.source_row_sha256,
-    semanticNaturalKeySha256: sha256AflTradeCanonicalJson({
-      matchId: 'provider-match-1',
-      playerId: row.native_entity_id,
-    }),
-    candidateDigests: {
-      identity: row.identity_candidate_sha256,
-      match: null,
-      metric: sha256AflTradeCanonicalJson(row.metric_candidate_json),
-      achievement: null,
-      appearance: null,
-    },
+    semanticNaturalKeySha256,
     rowStatus: row.row_status,
     issueSet: resolutions.issueSet,
     blockingIssueCount: 0,
     openBlockingIssueCount: 0,
     blockingIssueClosures: [],
-    consumedSourceFields: ['goals', 'player_id'],
   } as const;
-  const fact = createAflTradeSourceFact({
+  const factBase = {
     schemaVersion: AFL_TRADE_SOURCE_FACT_SCHEMA_VERSION,
     publicAssetBoundary: AFL_DRAFT_TRADE_OUTCOME_PUBLIC_ASSET_BOUNDARY,
     authorityBoundary: AFL_TRADE_SOURCE_FACT_AUTHORITY_BOUNDARY,
@@ -762,7 +1074,89 @@ async function createAndPersistFactBatch(
     fieldMapSha256: row.field_map_sha256,
     effectiveAt: LOCAL_FITZROY_REHEARSAL_INSTANTS.effectiveAt,
     recordedAt: LOCAL_FITZROY_REHEARSAL_INSTANTS.factBatchCreatedAt,
-    source,
+  } as const;
+  const matchFact = createAflTradeSourceFact({
+    ...factBase,
+    source: {
+      ...sourceBase,
+      candidateDigests: {
+        identity: null,
+        match: row.match_candidate_sha256,
+        metric: null,
+        achievement: null,
+        appearance: null,
+      },
+      consumedSourceFields: ['status'],
+    },
+    factKind: 'match_universe',
+    matchCandidateId: row.match_candidate_id,
+    match: resolutions.match,
+    completionPolicy: reference('match-universe-policy', {
+      policyVersion: 'local-fitzroy-rehearsal/v1',
+    }),
+    completion: { state: 'completed', providerStatus: row.match_candidate_json.providerStatus },
+  });
+  const appearanceCandidate = createAflTradeProviderAppearanceCandidate({
+    schemaVersion: AFL_TRADE_APPEARANCE_CANDIDATE_SCHEMA_VERSION,
+    environment: ENVIRONMENT,
+    provider: PROVIDER,
+    capabilityId: CAPABILITY_ID,
+    competition: COMPETITION,
+    seasonYear: SEASON_YEAR,
+    captureId,
+    normalizationRunId: row.normalization_run_id,
+    normalizationFinalization: resolutions.normalizationFinalization,
+    normalizationFinalizedAt: resolutions.normalizationFinalizedAt,
+    stagingSha256: row.staging_sha256,
+    providerDecodedRowId: row.provider_decoded_row_id,
+    sourceRowNumber: row.source_row_number,
+    sourceRowSha256: row.source_row_sha256,
+    semanticNaturalKeySha256,
+    fieldMapSha256: row.field_map_sha256,
+    identityCandidateId: row.identity_candidate_id,
+    identityCandidateSha256: row.identity_candidate_sha256,
+    matchCandidateId: row.match_candidate_id,
+    matchCandidateSha256: row.match_candidate_sha256,
+    appearanceState: 'observed',
+    sourceFields: ['match_id', 'player_id'],
+    derivationPolicy: reference('player-appearance-policy', {
+      policyVersion: 'local-fitzroy-rehearsal/v1',
+    }),
+  });
+  const appearanceFact = createAflTradeSourceFact({
+    ...factBase,
+    source: {
+      ...sourceBase,
+      candidateDigests: {
+        identity: row.identity_candidate_sha256,
+        match: row.match_candidate_sha256,
+        metric: null,
+        achievement: null,
+        appearance: appearanceCandidate.candidateSha256,
+      },
+      consumedSourceFields: ['match_id', 'player_id'],
+    },
+    factKind: 'player_appearance',
+    player: resolutions.player,
+    representedClub: resolutions.club,
+    match: resolutions.match,
+    appearanceCandidate,
+    appearanceState: 'observed',
+  });
+  const metricSource = {
+    ...sourceBase,
+    candidateDigests: {
+      identity: row.identity_candidate_sha256,
+      match: null,
+      metric: sha256AflTradeCanonicalJson(row.metric_candidate_json),
+      achievement: null,
+      appearance: null,
+    },
+    consumedSourceFields: ['goals', 'player_id'],
+  } as const;
+  const metricFact = createAflTradeSourceFact({
+    ...factBase,
+    source: metricSource,
     factKind: 'player_season_metric',
     player: resolutions.player,
     seasonClubScope: { kind: 'resolved_single_club', club: resolutions.club },
@@ -776,12 +1170,15 @@ async function createAndPersistFactBatch(
       reasonCode: null,
     },
   });
+  const facts = [matchFact, appearanceFact, metricFact].sort((left, right) =>
+    left.factId.localeCompare(right.factId)
+  );
   const rowAccounting = [
     {
       providerDecodedRowId: row.provider_decoded_row_id,
       sourceRowSha256: row.source_row_sha256,
       disposition: 'normalized' as const,
-      factIds: [fact.factId],
+      factIds: facts.map(({ factId }) => factId),
       issueSet: resolutions.issueSet,
       issueIds: [],
       blockingIssueIds: [],
@@ -831,11 +1228,11 @@ async function createAndPersistFactBatch(
     createdAt: LOCAL_FITZROY_REHEARSAL_INSTANTS.factBatchCreatedAt,
     sourceRowCount: 1,
     sourceIssueCount: 0,
-    facts: [fact],
+    facts,
     rowAccounting,
     counts: {
-      matchUniverse: 0,
-      playerAppearances: 0,
+      matchUniverse: 1,
+      playerAppearances: 1,
       playerMatchMetrics: 0,
       playerSeasonMetrics: 1,
       playerAchievements: 0,
@@ -847,7 +1244,7 @@ async function createAndPersistFactBatch(
     batch,
     { environment: ENVIRONMENT }
   );
-  return { batch, fact, metricDefinition, persisted };
+  return { batch, matchFact, appearanceFact, metricFact, metricDefinition, persisted };
 }
 
 async function ensureFactualPolicyReview(
@@ -931,25 +1328,46 @@ async function createAndPersistFactualRun(
       absenceSemantics: 'absence_is_unknown_never_zero_or_did_not_play',
       completionConflict: 'distinct_preferred_completion_states_are_conflicting',
       appearanceSources: [{ priority: 1, provider: PROVIDER, capabilityId: CAPABILITY_ID }],
-      matchUniverseSources: [
-        { priority: 1, provider: 'official_afl', capabilityId: 'official-afl-results' },
-      ],
+      matchUniverseSources: [{ priority: 1, provider: PROVIDER, capabilityId: CAPABILITY_ID }],
     },
     createdAt: '2026-08-12T00:03:40.000Z',
   });
   await ensureFactualPolicyReview(client, policy.policyId, approval);
   const repository = new PostgresAflTradeFactualReconciliationRepository(client);
   await repository.persistPolicy(policy, { environment: ENVIRONMENT });
+  const replay = await client.query<{ receipt_json: unknown }>(
+    `SELECT run.receipt_json
+       FROM outcome_factual_reconciliation_run run
+       JOIN outcome_factual_reconciliation_metric_input metric USING (factual_run_id)
+       JOIN outcome_factual_reconciliation_appearance_input appearance USING (factual_run_id)
+       JOIN outcome_factual_reconciliation_match_input match USING (factual_run_id)
+      WHERE metric.metric_fact_id=$1 AND appearance.appearance_fact_id=$2
+        AND match.match_fact_id=$3`,
+    [batch.metricFact.factId, batch.appearanceFact.factId, batch.matchFact.factId]
+  );
+  if (replay.rows[0]) {
+    return {
+      run: aflTradeFactualReconciliationRunSchema.parse(replay.rows[0].receipt_json),
+      persisted: { idempotentReplay: true },
+    };
+  }
+  const currentHeads = await client.query<{ subject_key: string; revision: number }>(
+    `SELECT subject_key,revision FROM outcome_reconciled_factual_metric_head`
+  );
+  const sourceMemberships = [batch.matchFact, batch.appearanceFact, batch.metricFact].map(
+    (fact) => ({
+      factBatchId: batch.batch.batchId,
+      factBatchSha256: batch.batch.batchSha256,
+      fact,
+    })
+  );
   const run = reconcileAflTradeFactualFacts({
     policy,
-    sourceMemberships: [
-      {
-        factBatchId: batch.batch.batchId,
-        factBatchSha256: batch.batch.batchSha256,
-        fact: batch.fact,
-      },
-    ],
-    currentHeadRevisions: [],
+    sourceMemberships,
+    currentHeadRevisions: currentHeads.rows.map(({ subject_key, revision }) => ({
+      subjectKey: subject_key,
+      revision,
+    })),
     startedAt: LOCAL_FITZROY_REHEARSAL_INSTANTS.reconciliationStartedAt,
     completedAt: LOCAL_FITZROY_REHEARSAL_INSTANTS.reconciliationCompletedAt,
   });
@@ -967,17 +1385,21 @@ function createPrivateCandidate(input: {
   gate0aReceipt: AflDraftTradeOutcomeFactualReleaseManifest['content']['sourceRightsBindings'][number]['gate0aReceipt'];
   factual: Awaited<ReturnType<typeof createAndPersistFactualRun>>;
   factBatch: Awaited<ReturnType<typeof createAndPersistFactBatch>>;
-  reviewDecisionId: string;
+  reviewDecisionIds: string[];
 }) {
-  const result = input.factual.run.content.results[0];
-  const head = input.factual.run.content.headAdvances[0];
+  const goalsResult = input.factual.run.content.results.find(
+    ({ content }) => content.resultKind === 'source_metric' && content.metricCode === 'goals'
+  );
+  const gamesResult = input.factual.run.content.results.find(
+    ({ content }) => content.resultKind === 'derived_games' && content.metricCode === 'games'
+  );
   if (
-    !result ||
-    !head ||
-    result.content.resultKind !== 'source_metric' ||
-    result.content.metricCode !== 'goals'
+    !goalsResult ||
+    !gamesResult ||
+    input.factual.run.content.results.length !== 2 ||
+    input.factual.run.content.headAdvances.length !== 2
   ) {
-    throw new TypeError('The local rehearsal requires one reconciled source metric.');
+    throw new TypeError('The local rehearsal requires exact goals and derived-games results.');
   }
   const recordedAt = LOCAL_FITZROY_REHEARSAL_INSTANTS.candidateCreatedAt;
   const consumedSourceFields = input.gate0aReceipt.content.request.fieldUses
@@ -1036,9 +1458,17 @@ function createPrivateCandidate(input: {
         seasonYear: SEASON_YEAR,
       },
     ],
-    reconciledMetrics: [
-      {
-        ordinal: 1,
+    reconciledMetrics: input.factual.run.content.results.map((result, index) => {
+      const head = input.factual.run.content.headAdvances.find(
+        ({ reconciledFactId }) => reconciledFactId === result.reconciledFactId
+      );
+      if (!head) throw new TypeError('A reconciled metric is missing its exact head advance.');
+      if (result.content.metricCode !== 'goals' && result.content.metricCode !== 'games') {
+        throw new TypeError('The local rehearsal contains an unsupported reconciled metric.');
+      }
+      const metricCode: 'goals' | 'games' = result.content.metricCode;
+      return {
+        ordinal: index + 1,
         recordSha256: result.factSha256,
         recordedAt,
         reconciledFactId: result.reconciledFactId,
@@ -1052,24 +1482,22 @@ function createPrivateCandidate(input: {
             : null,
         competition: result.content.competition,
         seasonYear: result.content.seasonYear,
-        metricCode: 'goals' as const,
+        metricCode,
         definition: result.content.definition,
         state: result.content.availability.state,
         effectiveThrough: result.content.effectiveThrough,
-      },
-    ],
+      };
+    }),
     achievementRuns: [],
     reconciledAchievements: [],
     spellMetrics: [],
-    reviewDecisions: [
-      {
-        ordinal: 1,
-        recordSha256: sha256AflTradeCanonicalJson({ decisionId: input.reviewDecisionId }),
-        recordedAt,
-        decisionId: input.reviewDecisionId,
-        subjectType: 'provider_identity',
-      },
-    ],
+    reviewDecisions: [...input.reviewDecisionIds].sort().map((decisionId, index) => ({
+      ordinal: index + 1,
+      recordSha256: sha256AflTradeCanonicalJson({ decisionId }),
+      recordedAt,
+      decisionId,
+      subjectType: 'provider_identity',
+    })),
   };
   const memberSetSha256 = sha256AflTradeCanonicalJson(members);
   const archiveDataset = reference('archive-dataset', { fixture: 'local-fitzroy-rehearsal' });
@@ -1085,7 +1513,7 @@ function createPrivateCandidate(input: {
     environment: ENVIRONMENT,
     scopeKey: AFL_DRAFT_TRADE_PUBLIC_OUTCOME_SCOPE,
     createdAt: recordedAt,
-    effectiveThrough: LOCAL_FITZROY_REHEARSAL_INSTANTS.effectiveAt,
+    effectiveThrough: recordedAt,
     archiveDatasetId: archiveDataset.id,
     sourceSnapshotSetId: sourceSnapshotSet.id,
     outcomeEvaluationSetId: reference('outcome-evaluation', {
@@ -1093,8 +1521,8 @@ function createPrivateCandidate(input: {
     }).id,
     acquisitionSpellRuleId: acquisitionSpellRule.id,
     metricRegistryVersion: AFL_DRAFT_TRADE_OUTCOME_METRIC_REGISTRY_VERSION,
-    metricDefinitions: AFL_DRAFT_TRADE_OUTCOME_METRIC_DEFINITIONS.filter(
-      ({ metric }) => metric === 'goals'
+    metricDefinitions: AFL_DRAFT_TRADE_OUTCOME_METRIC_DEFINITIONS.filter(({ metric }) =>
+      ['goals', 'games'].includes(metric)
     ),
     sourceRightsBindings: [
       {
@@ -1113,7 +1541,7 @@ function createPrivateCandidate(input: {
     exceptionReportArtifact: createAflTradeCanonicalJsonArtifactRef({ exceptions: [] }, recordedAt),
     supportedScope: ['One source-independent non-production fitzRoy goals observation'],
     excludedScope: ['Live source access', 'Public activation', 'Valuation and fantasy ownership'],
-    outcomeRecordCount: 1,
+    outcomeRecordCount: 2,
     exceptionCount: 0,
     unresolvedIdentityCount: 0,
     unresolvedLineageCount: 0,
@@ -1153,10 +1581,20 @@ function createPrivateCandidate(input: {
   });
 }
 
-export async function runLocalAflTradeFitzRoyFactualRehearsal(
+export interface LocalAflTradeFitzRoyFactualRehearsalOptions {
+  goals?: string;
+  generation?: LocalFitzRoyFactualRehearsalGeneration;
+}
+
+export interface PreparedLocalAflTradeFitzRoyFactualReleaseCandidate {
+  receipt: LocalAflTradeFitzRoyFactualRehearsalReceipt;
+  candidate: ReturnType<typeof createPrivateCandidate>;
+}
+
+export async function prepareLocalAflTradeFitzRoyFactualReleaseCandidate(
   client: AflOutcomeSqlClient,
-  options?: { goals?: string }
-): Promise<LocalAflTradeFitzRoyFactualRehearsalReceipt> {
+  options?: LocalAflTradeFitzRoyFactualRehearsalOptions
+): Promise<PreparedLocalAflTradeFitzRoyFactualReleaseCandidate> {
   await assertDisposableRehearsalDatabase(client);
   await client.query(
     `INSERT INTO outcome_competition_season (competition,season_year)
@@ -1225,9 +1663,9 @@ export async function runLocalAflTradeFitzRoyFactualRehearsal(
     gate0aReceipt: ingestion.receipt.content.authorizationReceipt,
     factual,
     factBatch,
-    reviewDecisionId: resolutions.reviewDecisionId,
+    reviewDecisionIds: resolutions.reviewDecisionIds,
   });
-  return {
+  const receipt: LocalAflTradeFitzRoyFactualRehearsalReceipt = {
     environment: ENVIRONMENT,
     publicationEligible: false,
     captureId: ingestion.staging.capture.captureId,
@@ -1243,4 +1681,12 @@ export async function runLocalAflTradeFitzRoyFactualRehearsal(
       factBatch.persisted.idempotentReplay &&
       factual.persisted.idempotentReplay,
   };
+  return { receipt, candidate };
+}
+
+export async function runLocalAflTradeFitzRoyFactualRehearsal(
+  client: AflOutcomeSqlClient,
+  options?: LocalAflTradeFitzRoyFactualRehearsalOptions
+): Promise<LocalAflTradeFitzRoyFactualRehearsalReceipt> {
+  return (await prepareLocalAflTradeFitzRoyFactualReleaseCandidate(client, options)).receipt;
 }

--- a/src/server/aflTradeIntelligence/development/localFitzRoyFactualRehearsalFixture.ts
+++ b/src/server/aflTradeIntelligence/development/localFitzRoyFactualRehearsalFixture.ts
@@ -8,6 +8,7 @@ import {
   AFL_TRADE_FITZROY_CAPTURE_REQUEST_SCHEMA_VERSION,
   createAflTradeFitzRoyInvocation,
   type AflTradeFitzRoyCaptureDiagnostics,
+  type AflTradeFitzRoyCaptureRequest,
 } from '../source/fitzRoyCaptureContracts';
 import {
   type AflTradeFitzRoyCaptureDependencies,
@@ -69,6 +70,20 @@ export const LOCAL_FITZROY_REHEARSAL_FIELDS: Array<{
     timezone: null,
   },
   {
+    name: 'match_date',
+    storageType: 'character',
+    classes: ['character'],
+    levels: null,
+    timezone: null,
+  },
+  {
+    name: 'status',
+    storageType: 'character',
+    classes: ['character'],
+    levels: null,
+    timezone: null,
+  },
+  {
     name: 'player_id',
     storageType: 'character',
     classes: ['character'],
@@ -89,24 +104,29 @@ export const LOCAL_FITZROY_REHEARSAL_FIELDS: Array<{
     levels: null,
     timezone: null,
   },
+  {
+    name: 'home_club_id',
+    storageType: 'character',
+    classes: ['character'],
+    levels: null,
+    timezone: null,
+  },
+  {
+    name: 'away_club_id',
+    storageType: 'character',
+    classes: ['character'],
+    levels: null,
+    timezone: null,
+  },
   { name: 'home', storageType: 'character', classes: ['character'], levels: null, timezone: null },
   { name: 'away', storageType: 'character', classes: ['character'], levels: null, timezone: null },
   { name: 'round', storageType: 'character', classes: ['character'], levels: null, timezone: null },
   { name: 'goals', storageType: 'integer', classes: ['integer'], levels: null, timezone: null },
 ];
 
-const captureRequest = {
-  schemaVersion: AFL_TRADE_FITZROY_CAPTURE_REQUEST_SCHEMA_VERSION,
-  capabilityId: 'footywire-player-stats',
-  competition: 'AFLM',
-  authorizationSeason: 2026,
-  parameters: { season: 2026, checkExisting: true },
-} as const;
-
-const invocation = createAflTradeFitzRoyInvocation(captureRequest);
-const sourceBytes = Uint8Array.from([88, 10, 0, 0, 0, 3]);
-
-function approvedSourceAuthority(): AflTradeFitzRoyCaptureCommand {
+function approvedSourceAuthority(
+  captureRequest: AflTradeFitzRoyCaptureRequest
+): AflTradeFitzRoyCaptureCommand {
   const field = (sourceField: string) => ({
     sourceField,
     normalizedField: sourceField,
@@ -237,7 +257,9 @@ function durableRepository(artifactClass: 'raw_source' | 'capture_metadata') {
   return { ...fixture, assurance: 'durable_object_storage' as const, custodyProfile };
 }
 
-function captureDiagnostics(): AflTradeFitzRoyCaptureDiagnostics {
+function captureDiagnostics(
+  invocation: ReturnType<typeof createAflTradeFitzRoyInvocation>
+): AflTradeFitzRoyCaptureDiagnostics {
   return {
     schemaVersion: 'afl-trade-fitzroy-diagnostics/v1',
     capabilityId: invocation.capabilityId,
@@ -313,9 +335,13 @@ function decodedTableExecutor(goals: string): AflTradeFitzRoyDecoderExecutor {
           [
             { kind: 'integer', value: '2026' },
             { kind: 'text', value: 'provider-match-1' },
+            { kind: 'text', value: '2026-03-20T08:00:00.000Z' },
+            { kind: 'text', value: 'Final' },
             { kind: 'text', value: 'provider-player-1' },
             { kind: 'text', value: 'Player One' },
             { kind: 'text', value: 'provider-club-1' },
+            { kind: 'text', value: 'provider-club-1' },
+            { kind: 'text', value: 'provider-club-2' },
             { kind: 'text', value: 'Carlton' },
             { kind: 'text', value: 'Fremantle' },
             { kind: 'text', value: 'Round 1' },
@@ -327,11 +353,26 @@ function decodedTableExecutor(goals: string): AflTradeFitzRoyDecoderExecutor {
   };
 }
 
-export function createLocalAflTradeFitzRoyFactualRehearsalFixture(options?: { goals?: string }) {
-  const command = approvedSourceAuthority();
+export type LocalFitzRoyFactualRehearsalGeneration = 'baseline' | 'replacement';
+
+export function createLocalAflTradeFitzRoyFactualRehearsalFixture(options?: {
+  goals?: string;
+  generation?: LocalFitzRoyFactualRehearsalGeneration;
+}) {
+  const generation = options?.generation ?? 'replacement';
+  const captureRequest = {
+    schemaVersion: AFL_TRADE_FITZROY_CAPTURE_REQUEST_SCHEMA_VERSION,
+    capabilityId: 'footywire-player-stats',
+    competition: 'AFLM',
+    authorizationSeason: 2026,
+    parameters: { season: 2026, checkExisting: generation === 'replacement' },
+  } as const;
+  const invocation = createAflTradeFitzRoyInvocation(captureRequest);
+  const sourceBytes = Uint8Array.from([88, 10, 0, 0, 0, generation === 'baseline' ? 2 : 3]);
+  const command = approvedSourceAuthority(captureRequest);
   const rawArtifactRepository = durableRepository('raw_source');
   const metadataArtifactRepository = durableRepository('capture_metadata');
-  const diagnostics = captureDiagnostics();
+  const diagnostics = captureDiagnostics(invocation);
   const diagnosticsBytes = encoded(diagnostics);
   const egressCondition = command.sourceRights.content.conditions.find(
     ({ conditionId }) => conditionId === 'provider-egress-control'
@@ -393,7 +434,10 @@ export function createLocalAflTradeFitzRoyFactualRehearsalFixture(options?: { go
   };
   const fieldMap = parseAflTradeFitzRoyFieldMap({
     schemaVersion: AFL_TRADE_FITZROY_FIELD_MAP_SCHEMA_VERSION,
-    mapId: 'footywire-player-stats-local-rehearsal-v1',
+    mapId:
+      generation === 'baseline'
+        ? 'footywire-player-stats-local-rehearsal-baseline-v1'
+        : 'footywire-player-stats-local-rehearsal-v1',
     capabilityId: captureRequest.capabilityId,
     fitzRoyVersion: '1.7.0',
     sourceSchemaSha256: createDecodedFieldSchemaSha256(LOCAL_FITZROY_REHEARSAL_FIELDS),
@@ -405,10 +449,13 @@ export function createLocalAflTradeFitzRoyFactualRehearsalFixture(options?: { go
     validThroughSeason: 2026,
     seasonField: { sourceField: 'season', required: true },
     roundLabelField: { sourceField: 'round', required: true },
-    observedDateField: null,
+    observedDateField: { sourceField: 'match_date', required: true },
     naturalKeyFields: ['match_id', 'player_id'],
     approvedAt: '2026-08-11T23:59:00.000Z',
-    approvalDecisionId: 'local-rehearsal-field-map-review',
+    approvalDecisionId:
+      generation === 'baseline'
+        ? 'local-rehearsal-field-map-review-baseline'
+        : 'local-rehearsal-field-map-review',
     identity: {
       nativeId: { sourceField: 'player_id', required: true },
       recordedName: { sourceField: 'player_name', required: true },
@@ -419,12 +466,12 @@ export function createLocalAflTradeFitzRoyFactualRehearsalFixture(options?: { go
       nativeMatchId: { sourceField: 'match_id', required: true },
       season: { sourceField: 'season', required: true },
       roundLabel: { sourceField: 'round', required: true },
-      matchDate: null,
-      homeClubNativeId: null,
+      matchDate: { sourceField: 'match_date', required: true },
+      homeClubNativeId: { sourceField: 'home_club_id', required: true },
       homeClubName: { sourceField: 'home', required: true },
-      awayClubNativeId: null,
+      awayClubNativeId: { sourceField: 'away_club_id', required: true },
       awayClubName: { sourceField: 'away', required: true },
-      status: null,
+      status: { sourceField: 'status', required: true },
     },
     metrics: [
       {

--- a/src/server/aflTradeIntelligence/development/localFitzRoyFactualReleaseRehearsal.ts
+++ b/src/server/aflTradeIntelligence/development/localFitzRoyFactualReleaseRehearsal.ts
@@ -1,0 +1,1234 @@
+import { Buffer } from 'node:buffer';
+
+import { strToU8, zipSync } from 'fflate';
+
+import type { AflDraftTradeOutcomeListItem } from '@/types/aflDraftTradeOutcomes';
+
+import {
+  createAflTradeByteArtifactRef,
+  createAflTradeCanonicalJsonArtifactRef,
+} from '../artifacts/artifactReference';
+import {
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+  sha256AflTradeCanonicalJson,
+} from '../artifacts/contentAddress';
+import { createPostgresAflTradeGateDecisionLedgerRepository } from '../governance/postgresGateDecisionLedgerRepository';
+import {
+  aflTradeGateDecisionProposalSchema,
+  aflTradeGateDecisionRecordSchema,
+  type AflTradeGateCode,
+  type AflTradeGovernedArtifactRef,
+} from '../governance/gateDecisionTypes';
+import { createAflTradeFactualReleaseCandidate } from '../outcomes/factualReleaseCandidateContracts';
+import { createAflTradeFactualProjectionItemSet } from '../outcomes/factualProjectionItemSetContracts';
+import {
+  createAflDraftTradeOutcomeActivationAuthorization,
+  createAflDraftTradeOutcomeFactualProjectionManifest,
+  createAflDraftTradeOutcomeFactualReleaseManifest,
+} from '../outcomes/outcomeReleaseContracts';
+import { PostgresAflTradeFactualProjectionItemSetRepository } from '../outcomes/postgresFactualProjectionItemSetRepository';
+import { PostgresAflTradeFactualReleaseCandidateWriter } from '../outcomes/postgresFactualReleaseCandidateRepository';
+import {
+  createPostgresAflDraftTradeOutcomeReleaseRepository,
+  type AflOutcomeSqlClient,
+} from '../outcomes/postgresOutcomeReleaseRepository';
+import {
+  AFL_DRAFT_TRADE_OUTCOME_METRIC_DEFINITIONS,
+  AFL_DRAFT_TRADE_PUBLIC_OUTCOME_SCOPE,
+} from '../outcomes/outcomeReadService';
+
+import {
+  prepareLocalAflTradeFitzRoyFactualReleaseCandidate,
+  type PreparedLocalAflTradeFitzRoyFactualReleaseCandidate,
+} from './localFitzRoyFactualRehearsal';
+import { createLocalAflTradeFitzRoyFactualRehearsalFixture } from './localFitzRoyFactualRehearsalFixture';
+
+const ENVIRONMENT = 'non_production' as const;
+const ACTOR = 'local-fitzroy-factual-release-rehearsal';
+const PLAYER_ID = 'afl-player:local-rehearsal';
+const CLUB_ID = 'afl-club:local-rehearsal';
+
+const lifecycleTimes = {
+  baseline: {
+    projection: '2026-08-12T00:05:10.000Z',
+    register: '2026-08-12T00:05:20.000Z',
+    validate: '2026-08-12T00:05:30.000Z',
+    approve: '2026-08-12T00:05:40.000Z',
+    activate: '2026-08-12T00:05:50.000Z',
+  },
+  replacement: {
+    projection: '2026-08-12T00:06:10.000Z',
+    register: '2026-08-12T00:06:20.000Z',
+    validate: '2026-08-12T00:06:30.000Z',
+    approve: '2026-08-12T00:06:40.000Z',
+    activate: '2026-08-12T00:06:50.000Z',
+  },
+} as const;
+
+const recoveryTimes = {
+  rollback: {
+    validate: '2026-08-12T00:07:10.000Z',
+    approve: '2026-08-12T00:07:20.000Z',
+    activate: '2026-08-12T00:07:30.000Z',
+  },
+  withdraw: '2026-08-12T00:07:40.000Z',
+  recovery: {
+    validate: '2026-08-12T00:07:50.000Z',
+    approve: '2026-08-12T00:08:00.000Z',
+    activate: '2026-08-12T00:08:10.000Z',
+  },
+} as const;
+
+type Generation = keyof typeof lifecycleTimes;
+
+export interface LocalAflTradeFactualReleaseSelection {
+  releaseId: string;
+  projectionId: string;
+}
+
+export interface LocalAflTradeFactualReleaseRehearsalReceipt {
+  environment: typeof ENVIRONMENT;
+  baseline: LocalAflTradeFactualReleaseSelection;
+  replacement: LocalAflTradeFactualReleaseSelection;
+  rollbackSelection: LocalAflTradeFactualReleaseSelection;
+  withdrawalSelection: null;
+  recoverySelection: LocalAflTradeFactualReleaseSelection;
+  activeSelection: LocalAflTradeFactualReleaseSelection;
+}
+
+function reference(prefix: string, content: unknown): string {
+  return createAflTradeContentAddress(prefix, content);
+}
+
+function shaFromId(id: string): string {
+  const match = /^[^:]+:([a-f0-9]{64})$/.exec(id);
+  if (!match) throw new TypeError('The local release rehearsal requires content-addressed IDs.');
+  return match[1]!;
+}
+
+function lifecycleEvidence(action: string, releaseId: string): string {
+  return reference('artifact', { action, releaseId, rehearsal: 'local-fitzroy-factual-release' });
+}
+
+function releaseAssetVersionId(eventVersionId: string): string {
+  return reference('event-asset-version', {
+    eventVersionId,
+    playerId: PLAYER_ID,
+    clubId: CLUB_ID,
+  });
+}
+
+function csvCell(value: string | number): string {
+  const text = String(value);
+  return /[",\r\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+function xmlText(value: string | number): string {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function columnName(index: number): string {
+  let value = index + 1;
+  let name = '';
+  while (value > 0) {
+    value -= 1;
+    name = String.fromCharCode(65 + (value % 26)) + name;
+    value = Math.floor(value / 26);
+  }
+  return name;
+}
+
+function workbookBytes(rows: readonly (readonly (string | number)[])[]): Uint8Array {
+  const sheetRows = rows
+    .map(
+      (row, rowIndex) =>
+        `<row r="${rowIndex + 1}">${row
+          .map((value, columnIndex) => {
+            const cell = `${columnName(columnIndex)}${rowIndex + 1}`;
+            return typeof value === 'number'
+              ? `<c r="${cell}"><v>${value}</v></c>`
+              : `<c r="${cell}" t="inlineStr"><is><t>${xmlText(value)}</t></is></c>`;
+          })
+          .join('')}</row>`
+    )
+    .join('');
+  const xml = (value: string) => strToU8(`<?xml version="1.0" encoding="UTF-8"?>${value}`);
+  return zipSync(
+    {
+      '[Content_Types].xml': xml(
+        '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/></Types>'
+      ),
+      '_rels/.rels': xml(
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>'
+      ),
+      'xl/workbook.xml': xml(
+        '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Factual release" sheetId="1" r:id="rId1"/></sheets></workbook>'
+      ),
+      'xl/_rels/workbook.xml.rels': xml(
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>'
+      ),
+      'xl/worksheets/sheet1.xml': xml(
+        `<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>${sheetRows}</sheetData></worksheet>`
+      ),
+    },
+    { level: 6, mtime: new Date('1980-01-01T00:00:00.000Z') }
+  );
+}
+
+export function createLocalAflTradeFactualReleaseExportBytes(input: {
+  releaseId: string;
+  publicItems: readonly AflDraftTradeOutcomeListItem[];
+}): { json: Uint8Array; csv: Uint8Array; xlsx: Uint8Array } {
+  const rows = input.publicItems.map((item) => {
+    const value = (metric: 'games' | 'goals') =>
+      item.checks.find((check) => check.metric === metric)?.observedValue ?? '';
+    return [item.player.displayName, item.clubName, item.year, value('games'), value('goals')] as const;
+  });
+  const table = [
+    ['releaseId', input.releaseId],
+    ['player', 'club', 'season', 'games', 'goals'],
+    ...rows,
+  ] as const;
+  return {
+    json: Buffer.from(
+      canonicalizeAflTradeJson({
+        schemaVersion: 'afl-draft-trade-outcome-export/v1',
+        releaseId: input.releaseId,
+        items: input.publicItems,
+      })
+    ),
+    csv: Buffer.from(table.map((row) => row.map(csvCell).join(',')).join('\n')),
+    xlsx: workbookBytes(table),
+  };
+}
+
+function createPublicationGateDecision(input: {
+  gate: Extract<AflTradeGateCode, 'gate_4_publication_api_readiness' | 'gate_5_comprehension_accessibility'>;
+  generation: Generation;
+  decidedAt: string;
+  affectedArtifacts: readonly AflTradeGovernedArtifactRef[];
+}) {
+  const decisionKey = `local-fitzroy-${input.generation}-${input.gate}`;
+  const authorityEvidenceId = reference('artifact', {
+    decisionKey,
+    authority: 'local-non-production-reviewer',
+  });
+  const scope = {
+    scopeKey: AFL_DRAFT_TRADE_PUBLIC_OUTCOME_SCOPE,
+    description: 'Disposable local fitzRoy factual-release rehearsal only.',
+    dimensions: [
+      { name: 'environment', values: [ENVIRONMENT] },
+      { name: 'competition', values: ['AFLM'] },
+      { name: 'season', values: ['2026'] },
+    ],
+    exclusions: ['Production authority', 'Hosted deployment', 'Live source access'],
+  };
+  const proposalContent = {
+    schemaVersion: 'afl-trade-gate-proposal/v1' as const,
+    gate: input.gate,
+    decisionKey,
+    version: 1,
+    environment: ENVIRONMENT,
+    scope,
+    proposal: 'Admit this exact reconciled local factual release and projection pair.',
+    alternativesConsidered: ['Keep the disposable local scope on its previous release.'],
+    accountableOwner: ACTOR,
+    reviewRequirement: 'accountable_owner_only' as const,
+    requiredReviewerRoles: [],
+    conditions: [],
+    evidenceIds: [authorityEvidenceId],
+    affectedArtifacts: [...input.affectedArtifacts],
+    proposedAt: input.decidedAt,
+    proposedBy: ACTOR,
+    proposalOrigin: 'agent_assisted' as const,
+  };
+  const proposal = aflTradeGateDecisionProposalSchema.parse({
+    proposalId: reference('gate-proposal', proposalContent),
+    content: proposalContent,
+  });
+  const decisionContent = {
+    schemaVersion: 'afl-trade-gate-decision/v1' as const,
+    proposalId: proposal.proposalId,
+    gate: input.gate,
+    decisionKey,
+    version: 1,
+    environment: ENVIRONMENT,
+    scope,
+    state: 'approved' as const,
+    authorityKind: 'external_human_record' as const,
+    accountableOwner: ACTOR,
+    decidedBy: ACTOR,
+    reviewers: [],
+    authorityEvidenceIds: [authorityEvidenceId],
+    conditionResults: [],
+    rationale: 'Exact local parity and release evidence passed inside disposable PostgreSQL.',
+    limitations: ['Non-production local rehearsal authority only.'],
+    decidedAt: input.decidedAt,
+    effectiveAt: input.decidedAt,
+    revalidateAt: '2027-08-12T00:00:00.000Z',
+    supersedesDecisionId: null,
+    affectedArtifacts: [...input.affectedArtifacts],
+    withdrawalActions: [],
+  };
+  const decision = aflTradeGateDecisionRecordSchema.parse({
+    decisionId: reference('gate-decision', decisionContent),
+    content: decisionContent,
+  });
+  return { proposal, decision };
+}
+
+interface PrivateCaptureRow {
+  attempt_id: string;
+  source_artifact_id: string;
+  environment: string;
+  provider: string;
+  dataset: string;
+  dataset_version: string;
+  access_mechanism: string;
+  capability_id: string | null;
+  competition: string;
+  anchor_season_year: number;
+  effective_at: string | Date;
+  captured_at: string | Date;
+  manifest_json: unknown;
+  attempt_evidence_artifact_id: string | null;
+  attempt_started_at: string | Date;
+  attempt_completed_at: string | Date | null;
+  attempt_json: unknown;
+}
+
+async function promotePrivateCaptureForRelease(
+  client: AflOutcomeSqlClient,
+  prepared: PreparedLocalAflTradeFitzRoyFactualReleaseCandidate,
+  generation: Generation
+): Promise<PreparedLocalAflTradeFitzRoyFactualReleaseCandidate> {
+  const privateCandidate = prepared.candidate;
+  const privateMember = privateCandidate.content.members.sourceCaptures[0];
+  if (!privateMember || privateCandidate.content.members.sourceCaptures.length !== 1) {
+    throw new TypeError('The local release promotion requires exactly one private capture.');
+  }
+  const approvalDecisionId = reference('review-decision', {
+    privateCaptureId: privateMember.captureId,
+    factualRunId: prepared.receipt.factualRunId,
+    purpose: 'local-factual-release-capture-approval',
+  });
+  const promotedSnapshotId = reference('source-snapshot', {
+    privateSourceSnapshotId: privateMember.sourceSnapshotId,
+    approvalDecisionId,
+  });
+  const promotedAttemptId = reference('source-capture-attempt', {
+    privateCaptureId: privateMember.captureId,
+    promotedSnapshotId,
+    approvalDecisionId,
+  });
+  const promotedCaptureId = reference('source-capture', {
+    promotedSnapshotId,
+    promotedAttemptId,
+    approvalDecisionId,
+  });
+  await client.transaction(async (transaction) => {
+    const source = await transaction.query<PrivateCaptureRow>(
+      `SELECT capture.attempt_id,capture.source_artifact_id,capture.environment::text,
+              capture.provider,capture.dataset,capture.dataset_version,capture.access_mechanism,
+              capture.capability_id,capture.competition,capture.anchor_season_year,
+              capture.effective_at,capture.captured_at,capture.manifest_json,
+              attempt.evidence_artifact_id AS attempt_evidence_artifact_id,
+              attempt.started_at AS attempt_started_at,
+              attempt.completed_at AS attempt_completed_at,attempt.attempt_json
+         FROM outcome_source_capture capture
+         JOIN outcome_source_capture_attempt attempt USING (attempt_id)
+        WHERE capture.capture_id=$1
+        FOR KEY SHARE`,
+      [privateMember.captureId]
+    );
+    const row = source.rows[0];
+    if (!row || source.rows.length !== 1 || row.environment !== ENVIRONMENT) {
+      throw new TypeError('The private capture is unavailable in the non-production scope.');
+    }
+    await transaction.query(
+      `INSERT INTO outcome_review_decision
+        (decision_id,subject_type,subject_id,decision,rationale,evidence_json,decided_by,decided_at)
+       VALUES ($1,'source_capture',$2,'approved',$3,$4::jsonb,$5,$6)
+       ON CONFLICT (decision_id) DO NOTHING`,
+      [
+        approvalDecisionId,
+        privateMember.captureId,
+        'Approve an immutable release-specific view of the issue-free local capture.',
+        canonicalizeAflTradeJson({
+          environment: ENVIRONMENT,
+          factBatchId: prepared.receipt.factBatchId,
+          factualRunId: prepared.receipt.factualRunId,
+        }),
+        ACTOR,
+        privateCandidate.content.createdAt,
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_source_capture_attempt
+        (attempt_id,environment,provider,dataset,capability_id,evidence_artifact_id,status,
+         started_at,completed_at,attempt_json)
+       VALUES ($1,$2,$3,$4,$5,$6,'captured',$7,$8,$9::jsonb)
+       ON CONFLICT (attempt_id) DO NOTHING`,
+      [
+        promotedAttemptId,
+        row.environment,
+        row.provider,
+        row.dataset,
+        row.capability_id,
+        row.attempt_evidence_artifact_id,
+        row.attempt_started_at,
+        row.attempt_completed_at,
+        canonicalizeAflTradeJson({
+          privateAttemptId: row.attempt_id,
+          privateCaptureId: privateMember.captureId,
+          approvalDecisionId,
+          evidence: row.attempt_json,
+        }),
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_source_capture
+        (capture_id,attempt_id,source_snapshot_id,source_artifact_id,environment,provider,dataset,
+         dataset_version,access_mechanism,capability_id,competition,anchor_season_year,
+         effective_at,captured_at,status,manifest_json)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,'approved',$15::jsonb)
+       ON CONFLICT (capture_id) DO NOTHING`,
+      [
+        promotedCaptureId,
+        promotedAttemptId,
+        promotedSnapshotId,
+        row.source_artifact_id,
+        row.environment,
+        row.provider,
+        row.dataset,
+        row.dataset_version,
+        row.access_mechanism,
+        row.capability_id,
+        row.competition,
+        row.anchor_season_year,
+        row.effective_at,
+        row.captured_at,
+        canonicalizeAflTradeJson({
+          privateCaptureId: privateMember.captureId,
+          approvalDecisionId,
+          evidence: row.manifest_json,
+        }),
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_source_capture_season (capture_id,competition,season_year)
+       VALUES ($1,$2,$3) ON CONFLICT DO NOTHING`,
+      [promotedCaptureId, row.competition, row.anchor_season_year]
+    );
+  });
+
+  const promotedSourceMember = {
+    ...privateMember,
+    recordSha256: sha256AflTradeCanonicalJson({
+      privateCaptureId: privateMember.captureId,
+      promotedCaptureId,
+      approvalDecisionId,
+    }),
+    captureId: promotedCaptureId,
+    sourceSnapshotId: promotedSnapshotId,
+  };
+  const promotedEventId = reference('outcome-event', { promotedCaptureId });
+  const promotedEventVersionId = reference('outcome-event-version', {
+    promotedEventId,
+    promotedCaptureId,
+  });
+  const promotedSpellId = reference('acquisition-spell', {
+    playerId: PLAYER_ID,
+    clubId: CLUB_ID,
+    acquisition: 'local-fitzroy-factual-release',
+  });
+  const promotedSpellVersionId = reference('acquisition-spell-version', {
+    promotedSpellId,
+    promotedEventVersionId,
+    generation,
+  });
+  const approvalMember = {
+    ordinal: 0,
+    recordSha256: sha256AflTradeCanonicalJson({ approvalDecisionId }),
+    recordedAt: privateCandidate.content.createdAt,
+    decisionId: approvalDecisionId,
+    subjectType: 'source_capture',
+  };
+  const reviewDecisions = [
+    ...privateCandidate.content.members.reviewDecisions,
+    approvalMember,
+  ]
+    .sort((left, right) => left.decisionId.localeCompare(right.decisionId))
+    .map((member, index) => ({ ...member, ordinal: index + 1 }));
+  const members = {
+    ...privateCandidate.content.members,
+    sourceCaptures: [{ ...promotedSourceMember, ordinal: 1 }],
+    eventVersions: privateCandidate.content.members.eventVersions.map((member) => ({
+      ...member,
+      eventId: promotedEventId,
+      eventVersionId: promotedEventVersionId,
+      recordSha256: sha256AflTradeCanonicalJson({
+        promotedEventId,
+        promotedEventVersionId,
+        promotedCaptureId,
+      }),
+    })),
+    acquisitionSpells: privateCandidate.content.members.acquisitionSpells.map((member) => ({
+      ...member,
+      spellId: promotedSpellId,
+      spellVersionId: promotedSpellVersionId,
+      recordSha256: sha256AflTradeCanonicalJson({
+        promotedSpellId,
+        promotedSpellVersionId,
+        promotedEventVersionId,
+      }),
+    })),
+    reviewDecisions,
+  };
+  const memberSetSha256 = sha256AflTradeCanonicalJson(members);
+  const sourceSnapshotSet = {
+    id: reference('source-snapshot-set', { promotedSnapshotId }),
+    sha256: '',
+  };
+  sourceSnapshotSet.sha256 = shaFromId(sourceSnapshotSet.id);
+  const privateRelease = privateCandidate.content.targetReleaseManifest;
+  const release = createAflDraftTradeOutcomeFactualReleaseManifest({
+    ...privateRelease.content,
+    sourceSnapshotSetId: sourceSnapshotSet.id,
+    sourceRightsBindings: privateRelease.content.sourceRightsBindings.map((binding) => ({
+      ...binding,
+      sourceSnapshotId: promotedSnapshotId,
+    })),
+    sourceMemberSetSha256: memberSetSha256,
+  });
+  const counts = Object.fromEntries(
+    Object.entries(members).map(([kind, values]) => [kind, values.length])
+  ) as typeof privateCandidate.content.counts;
+  const candidate = createAflTradeFactualReleaseCandidate({
+    ...privateCandidate.content,
+    targetRelease: { id: release.releaseId, sha256: shaFromId(release.releaseId) },
+    targetReleaseManifest: release,
+    sourceSnapshotSet,
+    members,
+    memberSetSha256,
+    counts,
+  });
+  return {
+    receipt: {
+      ...prepared.receipt,
+      captureId: promotedCaptureId,
+      candidateId: candidate.candidateId,
+      idempotentReplay: false,
+    },
+    candidate,
+  };
+}
+
+async function ensureCandidateParents(
+  client: AflOutcomeSqlClient,
+  prepared: PreparedLocalAflTradeFitzRoyFactualReleaseCandidate,
+  generation: Generation
+): Promise<void> {
+  const candidate = prepared.candidate;
+  const captureId = candidate.content.members.sourceCaptures[0]?.captureId;
+  const event = candidate.content.members.eventVersions[0];
+  const spell = candidate.content.members.acquisitionSpells[0];
+  if (!captureId || !event || !spell) {
+    throw new TypeError(
+      'The local release rehearsal requires one capture, event, and acquisition spell.'
+    );
+  }
+  const assetVersionId = releaseAssetVersionId(event.eventVersionId);
+  const games = await readReconciledValues(client, prepared.receipt.factualRunId);
+  const importRunId = reference('import-run', { captureId, purpose: 'local-release-parent' });
+  const importRowId = reference('import-row', {
+    importRunId,
+    eventVersionId: event.eventVersionId,
+  });
+  const importPartitionId = reference('import-partition', {
+    importRunId,
+    competition: 'AFLM',
+    seasonYear: 2026,
+  });
+  const rowSha256 = sha256AflTradeCanonicalJson({
+    importRunId,
+    eventVersionId: event.eventVersionId,
+  });
+  await client.transaction(async (transaction) => {
+    const playerResolution = await transaction.query<{ player_identity_id: string | null }>(
+      `SELECT player_identity_id
+         FROM outcome_provider_player_resolution
+        WHERE player_id=$1
+        ORDER BY revision DESC
+        LIMIT 1`,
+      [PLAYER_ID]
+    );
+    const playerIdentityId = playerResolution.rows[0]?.player_identity_id;
+    if (!playerIdentityId) {
+      throw new TypeError('The local event asset requires its reviewed canonical player identity.');
+    }
+    await transaction.query(
+      `INSERT INTO outcome_import_run
+        (import_run_id,capture_id,import_kind,parser_version,started_at,completed_at,status,manifest_json)
+       VALUES ($1,$2,'local_factual_release_parent','local-rehearsal/v1',$3,$3,'approved',$4::jsonb)
+       ON CONFLICT (import_run_id) DO NOTHING`,
+      [importRunId, captureId, candidate.content.createdAt, canonicalizeAflTradeJson({ captureId })]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_import_row
+        (import_row_id,import_run_id,source_locator,source_ordinal,record_kind,row_sha256,
+         parse_status,raw_payload,recorded_at)
+       VALUES ($1,$2,'local://fitzroy/rehearsal/event',1,'event',$3,'approved',$4::jsonb,$5)
+       ON CONFLICT (import_row_id) DO NOTHING`,
+      [
+        importRowId,
+        importRunId,
+        rowSha256,
+        canonicalizeAflTradeJson({ eventId: event.eventId }),
+        candidate.content.createdAt,
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_import_partition
+        (import_partition_id,import_run_id,partition_key,partition_kind,competition,
+         season_year,row_count,rows_sha256,partition_json)
+       VALUES ($1,$2,'AFLM:2026','season','AFLM',2026,1,$3,$4::jsonb)
+       ON CONFLICT (import_partition_id) DO NOTHING`,
+      [
+        importPartitionId,
+        importRunId,
+        sha256AflTradeCanonicalJson([{ importRowId, rowSha256 }]),
+        canonicalizeAflTradeJson({ competition: 'AFLM', seasonYear: 2026 }),
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_import_partition_row
+        (import_partition_id,import_row_id,import_run_id,ordinal)
+       VALUES ($1,$2,$3,1) ON CONFLICT DO NOTHING`,
+      [importPartitionId, importRowId, importRunId]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_event (event_id,competition,season_year,stable_key)
+       VALUES ($1,'AFLM',2026,$2)
+       ON CONFLICT (event_id) DO NOTHING`,
+      [event.eventId, `local-fitzroy-factual-release-${captureId}`]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_event_version
+        (event_version_id,event_id,version,kind,acquisition_mechanism,event_date,
+         official_name,status,source_import_row_id,recorded_at)
+       VALUES ($1,$2,1,'other_acquisition','pre_draft','2026-01-01',
+               'Local fitzRoy factual rehearsal','approved',$3,$4)
+       ON CONFLICT (event_version_id) DO NOTHING`,
+      [event.eventVersionId, event.eventId, importRowId, candidate.content.createdAt]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_event_party
+        (event_version_id,club_id,source_import_row_id,role,ordinal)
+       VALUES ($1,$2,$3,'receiving_club',1)
+       ON CONFLICT (event_version_id,club_id) DO NOTHING`,
+      [event.eventVersionId, CLUB_ID, importRowId]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_event_asset
+        (asset_version_id,event_version_id,asset_key,kind,player_id,player_identity_id,
+         from_club_id,to_club_id,source_import_row_id,raw_description,status)
+       VALUES ($1,$2,'local-rehearsal-player','player',$3,$4,NULL,$5,$6,'Player One','approved')
+       ON CONFLICT (asset_version_id) DO NOTHING`,
+      [assetVersionId, event.eventVersionId, PLAYER_ID, playerIdentityId, CLUB_ID, importRowId]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_acquisition_spell_rule
+        (rule_id,rule_version,definition_json,status,created_at)
+       VALUES ($1,'local-fitzroy-factual-release/v1',$2::jsonb,'approved',$3)
+       ON CONFLICT (rule_id) DO NOTHING`,
+      [
+        candidate.content.acquisitionSpellRule.id,
+        canonicalizeAflTradeJson({ rule: 'local source-independent rehearsal spell' }),
+        candidate.content.createdAt,
+      ]
+    );
+    const storedSpell = await transaction.query<{ spell_version_id: string }>(
+      `SELECT spell_version_id FROM outcome_acquisition_spell_version
+        WHERE spell_version_id=$1`,
+      [spell.spellVersionId]
+    );
+    if (!storedSpell.rows[0]) {
+      const predecessor = await transaction.query<{
+        spell_version_id: string;
+        version: number;
+      }>(
+        `SELECT current_spell.spell_version_id,current_spell.version
+           FROM outcome_acquisition_spell_version current_spell
+          WHERE current_spell.spell_id=$1
+            AND NOT EXISTS (
+              SELECT 1 FROM outcome_acquisition_spell_version successor
+               WHERE successor.supersedes_spell_version_id=current_spell.spell_version_id
+            )
+          FOR UPDATE`,
+        [spell.spellId]
+      );
+      const prior = predecessor.rows[0];
+      if ((generation === 'baseline') !== (prior === undefined)) {
+        throw new TypeError('The local acquisition-spell generation does not match its version chain.');
+      }
+      await transaction.query(
+        `INSERT INTO outcome_acquisition_spell_version
+          (spell_version_id,spell_id,version,player_id,club_id,start_event_version_id,
+           start_asset_version_id,start_date,end_date,end_reason,rule_id,status,
+           supersedes_spell_version_id,recorded_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,NULL,$10,'approved',$11,$12)`,
+        [
+          spell.spellVersionId,
+          spell.spellId,
+          (prior?.version ?? 0) + 1,
+          spell.playerId,
+          spell.clubId,
+          event.eventVersionId,
+          assetVersionId,
+          spell.startDate,
+          spell.endDate,
+          candidate.content.acquisitionSpellRule.id,
+          prior?.spell_version_id ?? null,
+          candidate.content.createdAt,
+        ]
+      );
+    }
+    await transaction.query(
+      `INSERT INTO outcome_acquisition_spell_metric
+        (spell_version_id,metric_code,metric_definition_version,numeric_value,numerator,
+         denominator,coverage_state,observation_count,effective_through,evidence_json)
+       VALUES ($1,'games','games/v1',$2,NULL,NULL,'complete',1,'2026-03-20',$3::jsonb)
+       ON CONFLICT (spell_version_id,metric_code) DO NOTHING`,
+      [
+        spell.spellVersionId,
+        games.games,
+        canonicalizeAflTradeJson({
+          factualRunId: prepared.receipt.factualRunId,
+          source: 'reconciled_player_appearance',
+        }),
+      ]
+    );
+  });
+}
+
+async function readReconciledValues(
+  client: AflOutcomeSqlClient,
+  factualRunId: string
+): Promise<{ games: number; goals: number }> {
+  const result = await client.query<{ metric_code: string; numeric_value: string }>(
+    `SELECT metric_code,numeric_value::text
+       FROM outcome_reconciled_factual_metric
+      WHERE factual_run_id=$1 AND state='measured' AND metric_code IN ('games','goals')`,
+    [factualRunId]
+  );
+  const values = Object.fromEntries(
+    result.rows.map(({ metric_code, numeric_value }) => [metric_code, Number(numeric_value)])
+  );
+  if (!Number.isSafeInteger(values.games) || !Number.isSafeInteger(values.goals)) {
+    throw new TypeError('The release projection requires exact reconciled games and goals values.');
+  }
+  return { games: values.games, goals: values.goals };
+}
+
+async function assertCandidateEvidenceWithinCutoff(
+  client: AflOutcomeSqlClient,
+  prepared: PreparedLocalAflTradeFitzRoyFactualReleaseCandidate
+): Promise<void> {
+  const candidate = prepared.candidate;
+  const cutoff = Date.parse(candidate.content.effectiveThrough);
+  const evidence = await client.query<{
+    evidence_kind: string;
+    evidence_id: string;
+    status: string;
+    recorded_at: string | Date;
+  }>(
+    `SELECT 'source_capture' AS evidence_kind,capture_id AS evidence_id,status::text,
+            captured_at AS recorded_at
+       FROM outcome_source_capture
+      WHERE capture_id = ANY($1::text[])
+     UNION ALL
+     SELECT 'review_decision',decision_id,'approved',decided_at
+       FROM outcome_review_decision
+      WHERE decision_id = ANY($2::text[])
+     UNION ALL
+     SELECT 'event_version',event_version_id,status::text,recorded_at
+       FROM outcome_event_version
+      WHERE event_version_id = ANY($3::text[])
+     UNION ALL
+     SELECT 'acquisition_spell',spell_version_id,status::text,recorded_at
+       FROM outcome_acquisition_spell_version
+      WHERE spell_version_id = ANY($4::text[])`,
+    [
+      candidate.content.members.sourceCaptures.map(({ captureId }) => captureId),
+      candidate.content.members.reviewDecisions.map(({ decisionId }) => decisionId),
+      candidate.content.members.eventVersions.map(({ eventVersionId }) => eventVersionId),
+      candidate.content.members.acquisitionSpells.map(({ spellVersionId }) => spellVersionId),
+    ]
+  );
+  const expectedCount =
+    candidate.content.members.sourceCaptures.length +
+    candidate.content.members.reviewDecisions.length +
+    candidate.content.members.eventVersions.length +
+    candidate.content.members.acquisitionSpells.length;
+  const invalid = evidence.rows.filter(
+    ({ status, recorded_at }) =>
+      status !== 'approved' || Date.parse(new Date(recorded_at).toISOString()) > cutoff
+  );
+  if (evidence.rows.length !== expectedCount || invalid.length > 0) {
+    throw new TypeError(
+      `The sealed candidate evidence is not within its cutoff: ${canonicalizeAflTradeJson({
+        expectedCount,
+        actualCount: evidence.rows.length,
+        invalid: invalid.map((row) => ({
+          ...row,
+          recorded_at: new Date(row.recorded_at).toISOString(),
+        })),
+      })}`
+    );
+  }
+}
+
+function metricDefinition(metric: 'games' | 'goals') {
+  const definition = AFL_DRAFT_TRADE_OUTCOME_METRIC_DEFINITIONS.find(
+    (candidate) => candidate.metric === metric
+  );
+  if (!definition) throw new TypeError(`The ${metric} metric definition is unavailable.`);
+  return definition;
+}
+
+async function createProjection(
+  client: AflOutcomeSqlClient,
+  prepared: PreparedLocalAflTradeFitzRoyFactualReleaseCandidate,
+  generation: Generation
+) {
+  const candidate = prepared.candidate;
+  const release = candidate.content.targetReleaseManifest;
+  const event = candidate.content.members.eventVersions[0];
+  if (!event) throw new TypeError('The public projection requires its exact release event.');
+  const assetVersionId = releaseAssetVersionId(event.eventVersionId);
+  const times = lifecycleTimes[generation];
+  const values = await readReconciledValues(client, prepared.receipt.factualRunId);
+  const rightsDecisionId = release.content.sourceRightsBindings[0]?.gateDecisionId;
+  if (!rightsDecisionId) throw new TypeError('The release is missing its source-rights decision.');
+  const observedArtifact = release.content.reconciliationReportArtifact.artifactId;
+  const itemSet = createAflTradeFactualProjectionItemSet([
+    {
+      ordinal: 1,
+      itemKey: `${event.eventId}:${PLAYER_ID}`,
+      item: {
+        eventId: event.eventId,
+        tradeId: null,
+        assetId: assetVersionId,
+        year: 2026,
+        acquisitionType: 'Local fitzRoy factual rehearsal',
+        aflClubId: CLUB_ID,
+        clubName: 'Carlton',
+        player: { aflPlayerId: PLAYER_ID, displayName: 'Player One', identityStatus: 'resolved' },
+        checks: (['games', 'goals'] as const).map((metric) => {
+          const definition = metricDefinition(metric);
+          return {
+            metric,
+            status: 'source_only' as const,
+            recordedValue: null,
+            observedValue: values[metric],
+            delta: null,
+            coverageRatio: null,
+            scopeLabel: 'AFLM 2026 through the rehearsed match',
+            effectiveThrough: release.content.effectiveThrough,
+            sources: [
+              {
+                role: 'observed' as const,
+                artifactId: observedArtifact,
+                locator: `local://fitzroy/reconciled/${prepared.receipt.factualRunId}/${metric}`,
+                rightsDecisionId,
+                metricDefinitionId: definition.metricDefinitionId,
+              },
+            ] as const,
+            message: `Observed ${definition.label.toLowerCase()} from the reconciled local fitzRoy candidate.`,
+          };
+        }),
+        achievements: [],
+      },
+    },
+  ]);
+  const publicItems = itemSet.members.map(({ item }) => item);
+  const logicalDatasetSha256 = sha256AflTradeCanonicalJson(publicItems);
+  const exportBytes = createLocalAflTradeFactualReleaseExportBytes({
+    releaseId: release.releaseId,
+    publicItems,
+  });
+  const artifact = (name: string) =>
+    createAflTradeCanonicalJsonArtifactRef(
+      { name, releaseId: release.releaseId, itemSetSha256: itemSet.itemSetSha256 },
+      times.projection
+    );
+  const projectionContent = {
+    schemaVersion: 'afl-draft-trade-outcome-projection/v2' as const,
+    publicAssetBoundary: release.content.publicAssetBoundary,
+    environment: ENVIRONMENT,
+    scopeKey: release.content.scopeKey,
+    createdAt: times.projection,
+    releaseId: release.releaseId,
+    archiveDatasetId: release.content.archiveDatasetId,
+    metricRegistryVersion: release.content.metricRegistryVersion,
+    effectiveThrough: release.content.effectiveThrough,
+    metricDefinitionIds: release.content.metricDefinitions
+      .map(({ metricDefinitionId }) => metricDefinitionId)
+      .sort(),
+    viewArtifacts: {
+      list: artifact('list'),
+      tradeDetail: artifact('trade-detail'),
+      club: artifact('club'),
+      player: artifact('player'),
+      year: artifact('year'),
+      dashboard: artifact('dashboard'),
+    },
+    exportArtifacts: {
+      json: createAflTradeByteArtifactRef(exportBytes.json, 'application/json', times.projection),
+      csv: createAflTradeByteArtifactRef(exportBytes.csv, 'text/csv', times.projection),
+      xlsx: createAflTradeByteArtifactRef(
+        exportBytes.xlsx,
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        times.projection
+      ),
+    },
+    parityReport: {
+      artifact: artifact('parity-report'),
+      status: 'passed' as const,
+      checkCount: 5,
+      failureCount: 0 as const,
+      checkedOutcomeRecordCount: release.content.outcomeRecordCount,
+      logicalDatasetSha256,
+    },
+    documentCount: itemSet.itemCount,
+    factualCandidateId: candidate.candidateId,
+    sourceMemberSetSha256: candidate.content.memberSetSha256,
+    publicListItemSetSha256: itemSet.itemSetSha256,
+    derivationSha256: sha256AflTradeCanonicalJson({
+      factualCandidateId: candidate.candidateId,
+      logicalDatasetSha256,
+      publicListItemSetSha256: itemSet.itemSetSha256,
+      sourceMemberSetSha256: candidate.content.memberSetSha256,
+    }),
+  };
+  const projection = createAflDraftTradeOutcomeFactualProjectionManifest(projectionContent);
+  return { release, projection, itemSet };
+}
+
+async function persistSourceAuthority(client: AflOutcomeSqlClient): Promise<void> {
+  const fixture = createLocalAflTradeFitzRoyFactualRehearsalFixture({ generation: 'baseline' });
+  const sourceRights = fixture.command.capture.sourceRights;
+  const proposal = fixture.command.capture.ledger.proposals[0];
+  const decision = fixture.command.capture.ledger.decisions[0];
+  if (!proposal || !decision) throw new TypeError('The fitzRoy Gate 0A authority is unavailable.');
+  const repository = createPostgresAflTradeGateDecisionLedgerRepository(client);
+  const current = await repository.load();
+  if (current.ledger.decisions.some(({ decisionId }) => decisionId === decision.decisionId)) return;
+  await repository.append({
+    expectedRevision: current.revision,
+    sourceRights,
+    proposal,
+    decision,
+  });
+}
+
+async function sealProjectAndActivate(
+  client: AflOutcomeSqlClient,
+  prepared: PreparedLocalAflTradeFitzRoyFactualReleaseCandidate,
+  generation: Generation
+): Promise<LocalAflTradeFactualReleaseSelection> {
+  await ensureCandidateParents(client, prepared, generation);
+  await assertCandidateEvidenceWithinCutoff(client, prepared);
+  await new PostgresAflTradeFactualReleaseCandidateWriter(client).persistCandidate(
+    prepared.candidate
+  );
+  const publication = await createProjection(client, prepared, generation);
+  await new PostgresAflTradeFactualProjectionItemSetRepository(client).persist({
+    projection: publication.projection,
+    itemSet: publication.itemSet,
+    finalizedAt: lifecycleTimes[generation].projection,
+  });
+  const affectedArtifacts = [
+    { kind: 'factual_release' as const, artifactId: publication.release.releaseId },
+    { kind: 'factual_projection' as const, artifactId: publication.projection.projectionId },
+  ];
+  const review = createPublicationGateDecision({
+    gate: 'gate_4_publication_api_readiness',
+    generation,
+    decidedAt: lifecycleTimes[generation].approve,
+    affectedArtifacts,
+  });
+  const operation = createPublicationGateDecision({
+    gate: 'gate_5_comprehension_accessibility',
+    generation,
+    decidedAt: lifecycleTimes[generation].activate,
+    affectedArtifacts,
+  });
+  const gateRepository = createPostgresAflTradeGateDecisionLedgerRepository(client);
+  let gateLedger = await gateRepository.load();
+  for (const gate of [review, operation]) {
+    if (!gateLedger.ledger.decisions.some(({ decisionId }) => decisionId === gate.decision.decisionId)) {
+      gateLedger = await gateRepository.appendDecision({
+        expectedRevision: gateLedger.revision,
+        proposal: gate.proposal,
+        decision: gate.decision,
+      });
+    }
+  }
+  const registryRepository = createPostgresAflDraftTradeOutcomeReleaseRepository(client);
+  let registry = await registryRepository.loadRegistry();
+  registry = await registryRepository.register({
+    expectedRevision: registry.revision,
+    manifest: publication.release,
+    actor: ACTOR,
+    evidenceId: lifecycleEvidence('register', publication.release.releaseId),
+    occurredAt: lifecycleTimes[generation].register,
+  });
+  registry = await registryRepository.apply({
+    action: 'validate',
+    releaseId: publication.release.releaseId,
+    expectedRevision: registry.revision,
+    occurredAt: lifecycleTimes[generation].validate,
+    actor: ACTOR,
+    evidenceId: lifecycleEvidence('validate', publication.release.releaseId),
+    environment: ENVIRONMENT,
+    projectionManifest: publication.projection,
+    gateDecisionLedger: gateLedger.ledger,
+  });
+  registry = await registryRepository.apply({
+    action: 'approve',
+    releaseId: publication.release.releaseId,
+    expectedRevision: registry.revision,
+    occurredAt: lifecycleTimes[generation].approve,
+    actor: ACTOR,
+    evidenceId: lifecycleEvidence('approve', publication.release.releaseId),
+    environment: ENVIRONMENT,
+    gateDecisionId: review.decision.decisionId,
+    gateDecisionLedger: gateLedger.ledger,
+  });
+  const activation = createAflDraftTradeOutcomeActivationAuthorization({
+    schemaVersion: 'afl-draft-trade-outcome-activation-authorization/v1',
+    environment: ENVIRONMENT,
+    scopeKey: publication.release.content.scopeKey,
+    releaseId: publication.release.releaseId,
+    projectionId: publication.projection.projectionId,
+    expectedRegistryRevision: registry.revision,
+    authorizedAt: lifecycleTimes[generation].approve,
+    expiresAt: '2027-08-12T00:00:00.000Z',
+    rollbackWindowEndsAt: '2027-08-12T00:00:00.000Z',
+    writeBarrier: 'engaged',
+    parityReportArtifactId: publication.projection.content.parityReport.artifact.artifactId,
+    authorityKind: 'external_human_record',
+    authorizedBy: ACTOR,
+    authorityEvidenceIds: [operation.decision.decisionId],
+  });
+  registry = await registryRepository.apply({
+    action: 'activate',
+    releaseId: publication.release.releaseId,
+    expectedRevision: registry.revision,
+    occurredAt: lifecycleTimes[generation].activate,
+    actor: ACTOR,
+    evidenceId: lifecycleEvidence('activate', publication.release.releaseId),
+    environment: ENVIRONMENT,
+    gateDecisionId: operation.decision.decisionId,
+    gateDecisionLedger: gateLedger.ledger,
+    sourceRightsDecisionLedger: gateLedger.ledger,
+    factualReviewDecisionLedger: gateLedger.ledger,
+    activationAuthorization: activation,
+  });
+  const active = registry.activeByScope[publication.release.content.scopeKey];
+  if (active?.releaseId !== publication.release.releaseId) {
+    throw new TypeError('The local factual release did not become the exact active selection.');
+  }
+  return {
+    releaseId: publication.release.releaseId,
+    projectionId: publication.projection.projectionId,
+  };
+}
+
+async function reactivateExistingRelease(
+  client: AflOutcomeSqlClient,
+  selection: LocalAflTradeFactualReleaseSelection,
+  generation: Generation,
+  phase: 'rollback' | 'recovery',
+  times: (typeof recoveryTimes)['rollback'] | (typeof recoveryTimes)['recovery']
+): Promise<LocalAflTradeFactualReleaseSelection> {
+  const registryRepository = createPostgresAflDraftTradeOutcomeReleaseRepository(client);
+  let registry = await registryRepository.loadRegistry();
+  const record = registry.releases[selection.releaseId];
+  const projection = record?.projectionManifest;
+  if (!record || !projection || projection.projectionId !== selection.projectionId) {
+    throw new TypeError(`The local ${phase} requires the exact retained release projection.`);
+  }
+  const affectedArtifacts = [
+    { kind: 'factual_release' as const, artifactId: selection.releaseId },
+    { kind: 'factual_projection' as const, artifactId: selection.projectionId },
+  ];
+  const review = createPublicationGateDecision({
+    gate: 'gate_4_publication_api_readiness',
+    generation,
+    decidedAt: lifecycleTimes[generation].approve,
+    affectedArtifacts,
+  });
+  const operation = createPublicationGateDecision({
+    gate: 'gate_5_comprehension_accessibility',
+    generation,
+    decidedAt: lifecycleTimes[generation].activate,
+    affectedArtifacts,
+  });
+  const gateLedger = (await createPostgresAflTradeGateDecisionLedgerRepository(client).load())
+    .ledger;
+  registry = await registryRepository.apply({
+    action: 'validate',
+    releaseId: selection.releaseId,
+    expectedRevision: registry.revision,
+    occurredAt: times.validate,
+    actor: ACTOR,
+    evidenceId: lifecycleEvidence(`${phase}-validate`, selection.releaseId),
+    environment: ENVIRONMENT,
+    projectionManifest: projection,
+    gateDecisionLedger: gateLedger,
+  });
+  registry = await registryRepository.apply({
+    action: 'approve',
+    releaseId: selection.releaseId,
+    expectedRevision: registry.revision,
+    occurredAt: times.approve,
+    actor: ACTOR,
+    evidenceId: lifecycleEvidence(`${phase}-approve`, selection.releaseId),
+    environment: ENVIRONMENT,
+    gateDecisionId: review.decision.decisionId,
+    gateDecisionLedger: gateLedger,
+  });
+  const activation = createAflDraftTradeOutcomeActivationAuthorization({
+    schemaVersion: 'afl-draft-trade-outcome-activation-authorization/v1',
+    environment: ENVIRONMENT,
+    scopeKey: record.scopeKey,
+    releaseId: selection.releaseId,
+    projectionId: selection.projectionId,
+    expectedRegistryRevision: registry.revision,
+    authorizedAt: times.approve,
+    expiresAt: '2027-08-12T00:00:00.000Z',
+    rollbackWindowEndsAt: '2027-08-12T00:00:00.000Z',
+    writeBarrier: 'engaged',
+    parityReportArtifactId: projection.content.parityReport.artifact.artifactId,
+    authorityKind: 'external_human_record',
+    authorizedBy: ACTOR,
+    authorityEvidenceIds: [operation.decision.decisionId],
+  });
+  registry = await registryRepository.apply({
+    action: 'activate',
+    releaseId: selection.releaseId,
+    expectedRevision: registry.revision,
+    occurredAt: times.activate,
+    actor: ACTOR,
+    evidenceId: lifecycleEvidence(`${phase}-activate`, selection.releaseId),
+    environment: ENVIRONMENT,
+    gateDecisionId: operation.decision.decisionId,
+    gateDecisionLedger: gateLedger,
+    sourceRightsDecisionLedger: gateLedger,
+    factualReviewDecisionLedger: gateLedger,
+    activationAuthorization: activation,
+  });
+  if (registry.activeByScope[record.scopeKey]?.releaseId !== selection.releaseId) {
+    throw new TypeError(`The local ${phase} did not restore the exact release selection.`);
+  }
+  return selection;
+}
+
+async function withdrawActiveRelease(
+  client: AflOutcomeSqlClient,
+  selection: LocalAflTradeFactualReleaseSelection
+): Promise<null> {
+  const registryRepository = createPostgresAflDraftTradeOutcomeReleaseRepository(client);
+  let registry = await registryRepository.loadRegistry();
+  registry = await registryRepository.apply({
+    action: 'withdraw',
+    releaseId: selection.releaseId,
+    expectedRevision: registry.revision,
+    occurredAt: recoveryTimes.withdraw,
+    actor: ACTOR,
+    evidenceId: lifecycleEvidence('withdraw', selection.releaseId),
+    reason: 'Prove that local withdrawal clears the active pointer without implicit fallback.',
+  });
+  const gateLedger = (await createPostgresAflTradeGateDecisionLedgerRepository(client).load())
+    .ledger;
+  const snapshot = await registryRepository.captureSelection(AFL_DRAFT_TRADE_PUBLIC_OUTCOME_SCOPE, {
+    evaluatedAt: recoveryTimes.withdraw,
+    sourceRightsDecisionLedger: gateLedger,
+  });
+  if (
+    registry.activeByScope[AFL_DRAFT_TRADE_PUBLIC_OUTCOME_SCOPE] !== undefined ||
+    snapshot.selection !== null ||
+    snapshot.unavailabilityReason !== 'no_active_release'
+  ) {
+    throw new TypeError('The local withdrawal did not fail closed with no active release.');
+  }
+  return null;
+}
+
+export async function runLocalAflTradeFactualReleaseRehearsal(
+  client: AflOutcomeSqlClient
+): Promise<LocalAflTradeFactualReleaseRehearsalReceipt> {
+  await persistSourceAuthority(client);
+  const baselinePrivate = await prepareLocalAflTradeFitzRoyFactualReleaseCandidate(client, {
+    generation: 'baseline',
+    goals: '1',
+  });
+  const baselinePrepared = await promotePrivateCaptureForRelease(
+    client,
+    baselinePrivate,
+    'baseline'
+  );
+  const baseline = await sealProjectAndActivate(client, baselinePrepared, 'baseline');
+  const replacementPrivate = await prepareLocalAflTradeFitzRoyFactualReleaseCandidate(client, {
+    generation: 'replacement',
+    goals: '2',
+  });
+  const replacementPrepared = await promotePrivateCaptureForRelease(
+    client,
+    replacementPrivate,
+    'replacement'
+  );
+  const replacement = await sealProjectAndActivate(client, replacementPrepared, 'replacement');
+  const rollbackSelection = await reactivateExistingRelease(
+    client,
+    baseline,
+    'baseline',
+    'rollback',
+    recoveryTimes.rollback
+  );
+  const withdrawalSelection = await withdrawActiveRelease(client, rollbackSelection);
+  const recoverySelection = await reactivateExistingRelease(
+    client,
+    replacement,
+    'replacement',
+    'recovery',
+    recoveryTimes.recovery
+  );
+  const registry = await createPostgresAflDraftTradeOutcomeReleaseRepository(client).loadRegistry();
+  const active = registry.activeByScope[AFL_DRAFT_TRADE_PUBLIC_OUTCOME_SCOPE];
+  const activeRecord = active ? registry.releases[active.releaseId] : undefined;
+  if (!active || !activeRecord?.projectionManifest) {
+    throw new TypeError('The local factual-release rehearsal ended without one active selection.');
+  }
+  return {
+    environment: ENVIRONMENT,
+    baseline,
+    replacement,
+    rollbackSelection,
+    withdrawalSelection,
+    recoverySelection,
+    activeSelection: {
+      releaseId: active.releaseId,
+      projectionId: activeRecord.projectionManifest.projectionId,
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/development/localFitzRoyFactualReleaseRehearsal.ts
+++ b/src/server/aflTradeIntelligence/development/localFitzRoyFactualReleaseRehearsal.ts
@@ -754,7 +754,7 @@ async function assertCandidateEvidenceWithinCutoff(
        FROM outcome_source_capture
       WHERE capture_id = ANY($1::text[])
      UNION ALL
-     SELECT 'review_decision',decision_id,'approved',decided_at
+     SELECT 'review_decision',decision_id,decision::text,decided_at
        FROM outcome_review_decision
       WHERE decision_id = ANY($2::text[])
      UNION ALL

--- a/src/server/aflTradeIntelligence/outcomes/postgresFactualObservationRepository.ts
+++ b/src/server/aflTradeIntelligence/outcomes/postgresFactualObservationRepository.ts
@@ -336,7 +336,7 @@ function requireCandidateDigests(
     const digests = fact.content.source.candidateDigests;
     if (
       !row ||
-      digests.identity !== row.identity_candidate_sha256 ||
+      (digests.identity !== null && digests.identity !== row.identity_candidate_sha256) ||
       (digests.match !== null && digests.match !== row.match_candidate_sha256)
     ) {
       throw new AflTradeFactualObservationPersistenceError(

--- a/tests/outcomes-integration/afl-fitzroy-factual-rehearsal-postgres.test.ts
+++ b/tests/outcomes-integration/afl-fitzroy-factual-rehearsal-postgres.test.ts
@@ -126,6 +126,38 @@ describe('source-independent non-production fitzRoy factual rehearsal', () => {
     expect(stored.rows[0]?.runs).toBe('1');
   });
 
+  it('records exact player, club-side, and provider-native match reviews before fact promotion', async () => {
+    const reviewed = await outcomesPool.query<{
+      player_id: string | null;
+      club_ids: string[] | null;
+      match_id: string | null;
+      match_outcome: string | null;
+      player_revision: number | null;
+      match_revision: number | null;
+    }>(
+      `SELECT
+        (SELECT player_id FROM outcome_provider_player_resolution
+          WHERE outcome='approved' ORDER BY revision DESC LIMIT 1) AS player_id,
+        (SELECT array_agg(DISTINCT club_id ORDER BY club_id)
+           FROM outcome_provider_club_resolution WHERE outcome='approved') AS club_ids,
+        (SELECT match_id FROM outcome_provider_match_resolution
+          WHERE outcome='approved' ORDER BY revision DESC LIMIT 1) AS match_id,
+        (SELECT outcome::text FROM outcome_provider_match_resolution
+          ORDER BY revision DESC LIMIT 1) AS match_outcome,
+        (SELECT max(revision) FROM outcome_provider_player_resolution) AS player_revision,
+        (SELECT max(revision) FROM outcome_provider_match_resolution) AS match_revision`
+    );
+
+    expect(reviewed.rows[0]).toEqual({
+      player_id: 'afl-player:local-rehearsal',
+      club_ids: ['afl-club:local-rehearsal', 'afl-club:local-rehearsal-away'],
+      match_id: 'afl-match:local-rehearsal-2026-r1',
+      match_outcome: 'approved',
+      player_revision: 1,
+      match_revision: 1,
+    });
+  });
+
   it('conserves the admitted row and leaves every publication authority untouched', async () => {
     const stored = await outcomesPool.query<{
       captures: string;
@@ -135,7 +167,10 @@ describe('source-independent non-production fitzRoy factual rehearsal', () => {
       failed_attempts: string;
       player_resolutions: string;
       club_resolutions: string;
+      match_resolutions: string;
       fact_batches: string;
+      match_universe_facts: string;
+      player_appearance_facts: string;
       metric_facts: string;
       factual_runs: string;
       reconciled_metrics: string;
@@ -152,7 +187,10 @@ describe('source-independent non-production fitzRoy factual rehearsal', () => {
         (SELECT count(*)::text FROM outcome_provider_normalization_attempt) AS failed_attempts,
         (SELECT count(*)::text FROM outcome_provider_player_resolution) AS player_resolutions,
         (SELECT count(*)::text FROM outcome_provider_club_resolution) AS club_resolutions,
+        (SELECT count(*)::text FROM outcome_provider_match_resolution) AS match_resolutions,
         (SELECT count(*)::text FROM outcome_provider_fact_batch) AS fact_batches,
+        (SELECT count(*)::text FROM outcome_provider_match_universe_fact) AS match_universe_facts,
+        (SELECT count(*)::text FROM outcome_provider_player_appearance_fact) AS player_appearance_facts,
         (SELECT count(*)::text FROM outcome_provider_numeric_metric_fact) AS metric_facts,
         (SELECT count(*)::text FROM outcome_factual_reconciliation_run) AS factual_runs,
         (SELECT count(*)::text FROM outcome_reconciled_factual_metric) AS reconciled_metrics,
@@ -169,11 +207,14 @@ describe('source-independent non-production fitzRoy factual rehearsal', () => {
       normalization_issues: '0',
       failed_attempts: '1',
       player_resolutions: '1',
-      club_resolutions: '1',
+      club_resolutions: '3',
+      match_resolutions: '1',
       fact_batches: '1',
+      match_universe_facts: '1',
+      player_appearance_facts: '1',
       metric_facts: '1',
       factual_runs: '1',
-      reconciled_metrics: '1',
+      reconciled_metrics: '2',
       factual_candidates: '0',
       release_manifests: '0',
       registry_revision: 0,

--- a/tests/outcomes-integration/afl-fitzroy-factual-release-postgres.test.ts
+++ b/tests/outcomes-integration/afl-fitzroy-factual-release-postgres.test.ts
@@ -1,0 +1,267 @@
+import type { ReactElement } from 'react';
+
+import { NextRequest } from 'next/server';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const { publicRuntime } = vi.hoisted(() => ({
+  publicRuntime: {
+    outcomeReadService: null as { list(request: unknown): Promise<unknown> } | null,
+  },
+}));
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/server/aflTradeIntelligence/runtime/publicReadRuntime', () => ({
+  getPublicAflTradeReadRuntime: async () => {
+    if (publicRuntime.outcomeReadService === null) {
+      throw new Error('The local factual-release read service has not been installed.');
+    }
+    return { outcomeReadService: publicRuntime.outcomeReadService };
+  },
+}));
+
+import AflDraftTradeOutcomesPage from '../../src/app/(public)/draft/outcomes/page';
+import { GET as getOutcomes } from '../../src/app/api/draft-trades/outcomes/route';
+import { runLocalAflTradeFactualReleaseRehearsal } from '@/server/aflTradeIntelligence/development/localFitzRoyFactualReleaseRehearsal';
+import { createPostgresAflTradeGateDecisionLedgerRepository } from '@/server/aflTradeIntelligence/governance/postgresGateDecisionLedgerRepository';
+import { doesAflTradeArtifactRefMatchBytes } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import { createPostgresAflDraftTradeOutcomeReadService } from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeProjectionReadRepository';
+import { AFL_DRAFT_TRADE_PUBLIC_OUTCOME_SCOPE } from '@/server/aflTradeIntelligence/outcomes/outcomeReadService';
+import { createLocalAflTradeFactualReleaseExportBytes } from '@/server/aflTradeIntelligence/development/localFitzRoyFactualReleaseRehearsal';
+import { extractAflTradeWorkbookOoxmlEvidence } from '@/server/aflTradeIntelligence/source/workbookOoxmlEvidence';
+import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('A disposable AFL_OUTCOMES_TEST_DATABASE_URL is required.');
+  })();
+const schemaName = `afl_fitzroy_factual_rehearsal_${process.pid}_${Date.now()}`;
+const adminPool = new Pool({ connectionString: databaseUrl });
+const outcomesPool = new Pool({
+  connectionString: databaseUrl,
+  options: `-c search_path=${schemaName}`,
+  max: 4,
+});
+
+function scopedDatabaseUrl(): string {
+  const scoped = new URL(databaseUrl);
+  scoped.searchParams.set('schema', schemaName);
+  return scoped.toString();
+}
+
+beforeAll(async () => {
+  await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
+  runOutcomesPrismaTestCommand(['migrate', 'deploy'], { databaseUrl: scopedDatabaseUrl() });
+});
+
+afterAll(async () => {
+  publicRuntime.outcomeReadService = null;
+  await outcomesPool.end();
+  try {
+    await adminPool.query(`DROP SCHEMA "${schemaName}" CASCADE`);
+  } finally {
+    await adminPool.end();
+  }
+});
+
+describe('local fitzRoy factual-release lifecycle', () => {
+  it('serves one active replacement release through the service, API, projection exports, and archive page', async () => {
+    const client = createPgAflOutcomeSqlClient(outcomesPool);
+    const rehearsal = await runLocalAflTradeFactualReleaseRehearsal(client);
+
+    expect(rehearsal.baseline.releaseId).not.toBe(rehearsal.replacement.releaseId);
+    expect(rehearsal.activeSelection).toMatchObject({
+      releaseId: rehearsal.replacement.releaseId,
+      projectionId: rehearsal.replacement.projectionId,
+    });
+    expect(rehearsal).toHaveProperty('rollbackSelection', rehearsal.baseline);
+    expect(rehearsal).toHaveProperty('withdrawalSelection', null);
+    expect(rehearsal).toHaveProperty('recoverySelection', rehearsal.replacement);
+
+    const lifecycleEvents = await outcomesPool.query<{
+      action: string;
+      release_id: string;
+      event_json: {
+        content: { priorActiveReleaseId: string | null; nextActiveReleaseId: string | null };
+      };
+    }>(
+      `SELECT action,release_id,event_json
+         FROM outcome_registry_event
+        ORDER BY revision`
+    );
+    expect(lifecycleEvents.rows.map(({ action }) => action)).toEqual([
+      'register',
+      'validate',
+      'approve',
+      'activate',
+      'register',
+      'validate',
+      'approve',
+      'activate',
+      'validate',
+      'approve',
+      'activate',
+      'withdraw',
+      'validate',
+      'approve',
+      'activate',
+    ]);
+    const rollbackEvent = lifecycleEvents.rows[10];
+    expect(rollbackEvent).toMatchObject({
+      release_id: rehearsal.baseline.releaseId,
+      event_json: {
+        content: {
+          priorActiveReleaseId: rehearsal.replacement.releaseId,
+          nextActiveReleaseId: rehearsal.baseline.releaseId,
+        },
+      },
+    });
+    const withdrawalEvent = lifecycleEvents.rows[11];
+    expect(withdrawalEvent).toMatchObject({
+      action: 'withdraw',
+      release_id: rehearsal.baseline.releaseId,
+      event_json: {
+        content: {
+          priorActiveReleaseId: rehearsal.baseline.releaseId,
+          nextActiveReleaseId: null,
+        },
+      },
+    });
+    const recoveryEvent = lifecycleEvents.rows[14];
+    expect(recoveryEvent).toMatchObject({
+      release_id: rehearsal.replacement.releaseId,
+      event_json: {
+        content: {
+          priorActiveReleaseId: null,
+          nextActiveReleaseId: rehearsal.replacement.releaseId,
+        },
+      },
+    });
+    await expect(
+      outcomesPool.query(
+        `INSERT INTO outcome_record_state_commitment
+          (event_revision,release_id,record_state_id,record_state_json)
+         VALUES (15,$1,$2,$3::jsonb)`,
+        [
+          rehearsal.baseline.releaseId,
+          `outcome-release-record-state:${'a'.repeat(64)}`,
+          JSON.stringify({ unexpected: true }),
+        ]
+      )
+    ).rejects.toThrow(/exact affected release state declared by its registry event/i);
+
+    const gateRepository = createPostgresAflTradeGateDecisionLedgerRepository(client);
+    const outcomeReadService = createPostgresAflDraftTradeOutcomeReadService({
+      client,
+      cursorSecret: Buffer.from('local-fitzroy-factual-release-cursor-secret'),
+      expectedEnvironment: 'non_production',
+      loadSourceRightsDecisionLedger: async () => (await gateRepository.load()).ledger,
+      now: () => '2026-08-12T00:10:00.000Z',
+    });
+    publicRuntime.outcomeReadService = outcomeReadService;
+    const query = {
+      scopeKey: AFL_DRAFT_TRADE_PUBLIC_OUTCOME_SCOPE,
+      year: 2026,
+      club: '',
+      q: '',
+      metric: null,
+      status: null,
+      limit: 25,
+      cursor: null,
+    } as const;
+    const direct = await outcomeReadService.list(query);
+    const apiResponse = await getOutcomes(
+      new NextRequest('http://localhost/api/draft-trades/outcomes?year=2026&limit=25')
+    );
+    const apiBody = await apiResponse.json();
+    const page = (await AflDraftTradeOutcomesPage({
+      searchParams: Promise.resolve({ year: '2026' }),
+    })) as ReactElement<{ response: typeof direct }>;
+    const storedProjection = await outcomesPool.query<{ manifest_json: any }>(
+      `SELECT manifest_json FROM outcome_projection_manifest WHERE projection_id=$1`,
+      [rehearsal.replacement.projectionId]
+    );
+    const projection = storedProjection.rows[0]?.manifest_json;
+
+    expect(apiResponse.status).toBe(200);
+    expect(direct.items).toEqual([
+      expect.objectContaining({
+        year: 2026,
+        player: expect.objectContaining({
+          aflPlayerId: 'afl-player:local-rehearsal',
+          displayName: 'Player One',
+          identityStatus: 'resolved',
+        }),
+        checks: expect.arrayContaining([
+          expect.objectContaining({ metric: 'games', observedValue: 1 }),
+          expect.objectContaining({ metric: 'goals', observedValue: 2 }),
+        ]),
+      }),
+    ]);
+    const resolvedReleaseIds = [
+      rehearsal.activeSelection.releaseId,
+      direct.consistency.release?.releaseId,
+      apiBody.data.consistency.release?.releaseId,
+      page.props.response.consistency.release?.releaseId,
+      projection?.content.releaseId,
+    ];
+    const resolvedProjectionIds = [
+      rehearsal.activeSelection.projectionId,
+      direct.consistency.release?.projectionId,
+      apiBody.data.consistency.release?.projectionId,
+      page.props.response.consistency.release?.projectionId,
+      projection?.projectionId,
+    ];
+    expect(new Set(resolvedReleaseIds)).toEqual(new Set([rehearsal.replacement.releaseId]));
+    expect(new Set(resolvedProjectionIds)).toEqual(new Set([rehearsal.replacement.projectionId]));
+    expect(Object.keys(projection.content.viewArtifacts).sort()).toEqual([
+      'club',
+      'dashboard',
+      'list',
+      'player',
+      'tradeDetail',
+      'year',
+    ]);
+    expect(Object.keys(projection.content.exportArtifacts).sort()).toEqual(['csv', 'json', 'xlsx']);
+    expect(Object.values(projection.content.exportArtifacts)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ artifactId: expect.stringMatching(/^artifact:/) }),
+      ])
+    );
+    const exportBytes = createLocalAflTradeFactualReleaseExportBytes({
+      releaseId: rehearsal.replacement.releaseId,
+      publicItems: direct.items,
+    });
+    expect(
+      doesAflTradeArtifactRefMatchBytes(
+        projection.content.exportArtifacts.json,
+        exportBytes.json,
+        'application/json'
+      )
+    ).toBe(true);
+    expect(
+      doesAflTradeArtifactRefMatchBytes(
+        projection.content.exportArtifacts.csv,
+        exportBytes.csv,
+        'text/csv'
+      )
+    ).toBe(true);
+    expect(
+      doesAflTradeArtifactRefMatchBytes(
+        projection.content.exportArtifacts.xlsx,
+        exportBytes.xlsx,
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+      )
+    ).toBe(true);
+    const jsonExport = JSON.parse(Buffer.from(exportBytes.json).toString('utf8'));
+    const csvExport = Buffer.from(exportBytes.csv).toString('utf8');
+    const xlsxExport = extractAflTradeWorkbookOoxmlEvidence(exportBytes.xlsx);
+    expect(jsonExport.releaseId).toBe(rehearsal.replacement.releaseId);
+    expect(csvExport).toContain(`releaseId,${rehearsal.replacement.releaseId}`);
+    expect(
+      xlsxExport.sheets[0]?.rows[0]?.cells.map(({ inlineText }) => inlineText)
+    ).toEqual(['releaseId', rehearsal.replacement.releaseId]);
+  });
+});

--- a/tests/outcomes-integration/afl-fitzroy-factual-release-postgres.test.ts
+++ b/tests/outcomes-integration/afl-fitzroy-factual-release-postgres.test.ts
@@ -89,7 +89,9 @@ describe('local fitzRoy factual-release lifecycle', () => {
     }>(
       `SELECT action,release_id,event_json
          FROM outcome_registry_event
-        ORDER BY revision`
+        WHERE scope_key=$1
+        ORDER BY revision`,
+      [AFL_DRAFT_TRADE_PUBLIC_OUTCOME_SCOPE]
     );
     expect(lifecycleEvents.rows.map(({ action }) => action)).toEqual([
       'register',

--- a/tests/outcomes-integration/afl-fitzroy-factual-release-restore-postgres.test.ts
+++ b/tests/outcomes-integration/afl-fitzroy-factual-release-restore-postgres.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { randomInt } from 'node:crypto';
 import type { ReactElement } from 'react';
 
 import { NextRequest } from 'next/server';
@@ -52,7 +53,9 @@ if (!/^[a-f0-9]{64}$/u.test(containerId)) {
   throw new Error('The disposable PostgreSQL container identifier is invalid.');
 }
 
-const schemaName = `afl_fitzroy_factual_rehearsal_${process.pid}_${Date.now()}`;
+const schemaName = `afl_fitzroy_factual_rehearsal_${process.pid}_${Date.now()}${randomInt(10_000)
+  .toString()
+  .padStart(4, '0')}`;
 const archivePath = `/tmp/${schemaName}.dump`;
 const adminPool = new Pool({ connectionString: databaseUrl });
 let outcomesPool: Pool | undefined;
@@ -253,9 +256,16 @@ afterAll(async () => {
   publicRuntime.outcomeReadService = null;
   await outcomesPool?.end();
   try {
-    await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    execFileSync('docker', ['exec', containerId, 'rm', '-f', '--', archivePath], {
+      stdio: 'pipe',
+      timeout: 30_000,
+    });
   } finally {
-    await adminPool.end();
+    try {
+      await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    } finally {
+      await adminPool.end();
+    }
   }
 });
 

--- a/tests/outcomes-integration/afl-fitzroy-factual-release-restore-postgres.test.ts
+++ b/tests/outcomes-integration/afl-fitzroy-factual-release-restore-postgres.test.ts
@@ -1,0 +1,315 @@
+import { execFileSync } from 'node:child_process';
+import type { ReactElement } from 'react';
+
+import { NextRequest } from 'next/server';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const { publicRuntime } = vi.hoisted(() => ({
+  publicRuntime: {
+    outcomeReadService: null as { list(request: unknown): Promise<unknown> } | null,
+  },
+}));
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/server/aflTradeIntelligence/runtime/publicReadRuntime', () => ({
+  getPublicAflTradeReadRuntime: async () => {
+    if (publicRuntime.outcomeReadService === null) {
+      throw new Error('The restored local factual-release read service has not been installed.');
+    }
+    return { outcomeReadService: publicRuntime.outcomeReadService };
+  },
+}));
+
+import AflDraftTradeOutcomesPage from '../../src/app/(public)/draft/outcomes/page';
+import { GET as getOutcomes } from '../../src/app/api/draft-trades/outcomes/route';
+import {
+  createLocalAflTradeFactualReleaseExportBytes,
+  runLocalAflTradeFactualReleaseRehearsal,
+} from '@/server/aflTradeIntelligence/development/localFitzRoyFactualReleaseRehearsal';
+import { doesAflTradeArtifactRefMatchBytes } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createPostgresAflTradeGateDecisionLedgerRepository } from '@/server/aflTradeIntelligence/governance/postgresGateDecisionLedgerRepository';
+import { aflTradeFactualReleaseCandidateSchema } from '@/server/aflTradeIntelligence/outcomes/factualReleaseCandidateContracts';
+import { AFL_DRAFT_TRADE_PUBLIC_OUTCOME_SCOPE } from '@/server/aflTradeIntelligence/outcomes/outcomeReadService';
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import { PostgresAflTradeFactualReleaseCandidateWriter } from '@/server/aflTradeIntelligence/outcomes/postgresFactualReleaseCandidateRepository';
+import { createPostgresAflDraftTradeOutcomeReadService } from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeProjectionReadRepository';
+import { createPostgresAflDraftTradeOutcomeReleaseRepository } from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { extractAflTradeWorkbookOoxmlEvidence } from '@/server/aflTradeIntelligence/source/workbookOoxmlEvidence';
+import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('A disposable AFL_OUTCOMES_TEST_DATABASE_URL is required.');
+  })();
+const containerId =
+  process.env.AFL_OUTCOMES_TEST_CONTAINER_ID ??
+  (() => {
+    throw new Error('A disposable AFL_OUTCOMES_TEST_CONTAINER_ID is required.');
+  })();
+if (!/^[a-f0-9]{64}$/u.test(containerId)) {
+  throw new Error('The disposable PostgreSQL container identifier is invalid.');
+}
+
+const schemaName = `afl_fitzroy_factual_rehearsal_${process.pid}_${Date.now()}`;
+const archivePath = `/tmp/${schemaName}.dump`;
+const adminPool = new Pool({ connectionString: databaseUrl });
+let outcomesPool: Pool | undefined;
+
+function createOutcomesPool(): Pool {
+  return new Pool({
+    connectionString: databaseUrl,
+    options: `-c search_path=${schemaName}`,
+    max: 4,
+  });
+}
+
+function currentOutcomesPool(): Pool {
+  if (outcomesPool === undefined) throw new Error('The disposable outcomes pool is unavailable.');
+  return outcomesPool;
+}
+
+function scopedDatabaseUrl(): string {
+  const scoped = new URL(databaseUrl);
+  scoped.searchParams.set('schema', schemaName);
+  return scoped.toString();
+}
+
+function runPostgresTool(tool: 'pg_dump' | 'pg_restore', args: string[]): void {
+  execFileSync('docker', ['exec', '--env', 'PGPASSWORD=statly_test', containerId, tool, ...args], {
+    stdio: 'pipe',
+    timeout: 30_000,
+  });
+}
+
+async function readReleaseSurfaceSnapshot(): Promise<unknown> {
+  const pool = currentOutcomesPool();
+  const client = createPgAflOutcomeSqlClient(pool);
+  const gateRepository = createPostgresAflTradeGateDecisionLedgerRepository(client);
+  const sourceRightsDecisionLedger = (await gateRepository.load()).ledger;
+  const releaseRepository = createPostgresAflDraftTradeOutcomeReleaseRepository(client);
+  const authenticatedRegistry = await releaseRepository.loadRegistry();
+  const authenticatedSelection = await releaseRepository.captureSelection(
+    AFL_DRAFT_TRADE_PUBLIC_OUTCOME_SCOPE,
+    {
+      evaluatedAt: '2026-08-12T00:10:00.000Z',
+      sourceRightsDecisionLedger,
+    }
+  );
+  const outcomeReadService = createPostgresAflDraftTradeOutcomeReadService({
+    client,
+    cursorSecret: Buffer.from('local-fitzroy-factual-restore-cursor-secret'),
+    expectedEnvironment: 'non_production',
+    loadSourceRightsDecisionLedger: async () => sourceRightsDecisionLedger,
+    now: () => '2026-08-12T00:10:00.000Z',
+  });
+  publicRuntime.outcomeReadService = outcomeReadService;
+  const query = {
+    scopeKey: AFL_DRAFT_TRADE_PUBLIC_OUTCOME_SCOPE,
+    year: 2026,
+    club: '',
+    q: '',
+    metric: null,
+    status: null,
+    limit: 25,
+    cursor: null,
+  } as const;
+  const direct = await outcomeReadService.list(query);
+  const apiResponse = await getOutcomes(
+    new NextRequest('http://localhost/api/draft-trades/outcomes?year=2026&limit=25')
+  );
+  const apiBody = await apiResponse.json();
+  const page = (await AflDraftTradeOutcomesPage({
+    searchParams: Promise.resolve({ year: '2026' }),
+  })) as ReactElement<{ response: typeof direct }>;
+  const registry = await pool.query<
+    Record<string, unknown> & { action: string; release_id: string; revision: number }
+  >(`SELECT * FROM outcome_registry_event ORDER BY revision`);
+  const active = await pool.query<
+    Record<string, unknown> & { release_id: string; revision: number }
+  >(`SELECT * FROM outcome_active_release WHERE scope_key=$1`, [
+    AFL_DRAFT_TRADE_PUBLIC_OUTCOME_SCOPE,
+  ]);
+  const candidates = await pool.query<
+    Record<string, unknown> & {
+      candidate_id: string;
+      candidate_json: unknown;
+      candidate_sha256: string;
+    }
+  >(
+    `SELECT *
+       FROM outcome_factual_release_candidate
+      ORDER BY candidate_id`
+  );
+  const projectionResult = await pool.query<{
+    manifest_json: {
+      content: {
+        exportArtifacts: Record<string, Parameters<typeof doesAflTradeArtifactRefMatchBytes>[0]>;
+        releaseId: string;
+      };
+      projectionId: string;
+    };
+  }>(
+    `SELECT manifest_json
+       FROM outcome_projection_manifest
+      WHERE release_id=$1`,
+    [active.rows[0]?.release_id]
+  );
+  const projection = projectionResult.rows[0]?.manifest_json;
+  if (projection === undefined || active.rows[0] === undefined) {
+    throw new Error('The restored factual release did not retain its active projection.');
+  }
+  const candidateWriter = new PostgresAflTradeFactualReleaseCandidateWriter(client);
+  const candidateAuthentication = await Promise.all(
+    candidates.rows.map(async (row) => {
+      const candidate = aflTradeFactualReleaseCandidateSchema.parse({
+        candidateId: row.candidate_id,
+        candidateSha256: row.candidate_sha256,
+        content: row.candidate_json,
+      });
+      return candidateWriter.persistCandidate(candidate);
+    })
+  );
+  const exportBytes = createLocalAflTradeFactualReleaseExportBytes({
+    releaseId: active.rows[0].release_id,
+    publicItems: direct.items,
+  });
+  const xlsx = extractAflTradeWorkbookOoxmlEvidence(exportBytes.xlsx);
+  const resolvedReleaseIds = [
+    authenticatedSelection.selection?.release.releaseId,
+    active.rows[0].release_id,
+    direct.consistency.release?.releaseId,
+    apiBody.data.consistency.release?.releaseId,
+    page.props.response.consistency.release?.releaseId,
+    projection.content.releaseId,
+    xlsx.sheets[0]?.rows[0]?.cells[1]?.inlineText,
+  ];
+  const resolvedProjectionIds = [
+    authenticatedSelection.selection?.release.projectionId,
+    direct.consistency.release?.projectionId,
+    apiBody.data.consistency.release?.projectionId,
+    page.props.response.consistency.release?.projectionId,
+    projection.projectionId,
+  ];
+  expect(authenticatedRegistry.revision).toBe(15);
+  expect(authenticatedSelection.registryRevision).toBe(15);
+  expect(active.rows[0].revision).toBe(15);
+  expect(candidateAuthentication).toEqual([
+    expect.objectContaining({ idempotentReplay: true }),
+    expect.objectContaining({ idempotentReplay: true }),
+  ]);
+  expect(new Set(resolvedReleaseIds)).toEqual(
+    new Set([authenticatedSelection.selection?.release.releaseId])
+  );
+  expect(new Set(resolvedProjectionIds)).toEqual(
+    new Set([authenticatedSelection.selection?.release.projectionId])
+  );
+
+  return {
+    active: active.rows,
+    authenticatedRegistry,
+    authenticatedSelection,
+    api: { data: apiBody.data, status: apiResponse.status, success: apiBody.success },
+    candidateAuthentication,
+    candidates: candidates.rows,
+    direct,
+    exportAuthentication: {
+      csv: doesAflTradeArtifactRefMatchBytes(
+        projection.content.exportArtifacts.csv,
+        exportBytes.csv,
+        'text/csv'
+      ),
+      json: doesAflTradeArtifactRefMatchBytes(
+        projection.content.exportArtifacts.json,
+        exportBytes.json,
+        'application/json'
+      ),
+      xlsx: doesAflTradeArtifactRefMatchBytes(
+        projection.content.exportArtifacts.xlsx,
+        exportBytes.xlsx,
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+      ),
+      xlsxReleaseId: xlsx.sheets[0]?.rows[0]?.cells[1]?.inlineText,
+    },
+    exportBytes: {
+      csv: Buffer.from(exportBytes.csv),
+      json: Buffer.from(exportBytes.json),
+      xlsx: Buffer.from(exportBytes.xlsx),
+    },
+    page: page.props.response,
+    projection,
+    registry: registry.rows,
+  };
+}
+
+beforeAll(async () => {
+  await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
+  runOutcomesPrismaTestCommand(['migrate', 'deploy'], { databaseUrl: scopedDatabaseUrl() });
+  outcomesPool = createOutcomesPool();
+});
+
+afterAll(async () => {
+  publicRuntime.outcomeReadService = null;
+  await outcomesPool?.end();
+  try {
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  } finally {
+    await adminPool.end();
+  }
+});
+
+describe('local fitzRoy factual-release backup and restore', () => {
+  it('restores the exact release authority and every local public surface after schema destruction', async () => {
+    await runLocalAflTradeFactualReleaseRehearsal(
+      createPgAflOutcomeSqlClient(currentOutcomesPool())
+    );
+    const before = await readReleaseSurfaceSnapshot();
+    expect(before).toMatchObject({
+      active: [expect.objectContaining({ revision: 15 })],
+      exportAuthentication: { csv: true, json: true, xlsx: true },
+      registry: [
+        expect.objectContaining({ action: 'register', revision: 1 }),
+        ...Array.from({ length: 13 }, () => expect.anything()),
+        expect.objectContaining({ action: 'activate', revision: 15 }),
+      ],
+    });
+
+    runPostgresTool('pg_dump', [
+      '--username',
+      'statly_test',
+      '--dbname',
+      'statly_outcomes_test',
+      '--format=custom',
+      `--file=${archivePath}`,
+      `--schema=${schemaName}`,
+      '--no-owner',
+      '--no-privileges',
+    ]);
+    await currentOutcomesPool().end();
+    outcomesPool = undefined;
+    publicRuntime.outcomeReadService = null;
+    await adminPool.query(`DROP SCHEMA "${schemaName}" CASCADE`);
+    const destroyed = await adminPool.query<{ absent: boolean }>(
+      `SELECT to_regnamespace($1) IS NULL AS absent`,
+      [schemaName]
+    );
+    expect(destroyed.rows[0]?.absent).toBe(true);
+
+    runPostgresTool('pg_restore', [
+      '--username',
+      'statly_test',
+      '--dbname',
+      'statly_outcomes_test',
+      '--exit-on-error',
+      '--single-transaction',
+      '--no-owner',
+      '--no-privileges',
+      archivePath,
+    ]);
+    outcomesPool = createOutcomesPool();
+
+    const after = await readReleaseSurfaceSnapshot();
+    expect(after).toEqual(before);
+  }, 60_000);
+});

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1054,6 +1054,7 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0041_valuation_publication_post_lock_time',
       '0042_pick_pav_model_execution_registry',
       '0043_external_identity_clock_skew_tolerance',
+      '0044_governed_provider_release_membership',
     ]);
 
     const tables = await query<{ table_name: string }>(

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -40,10 +40,7 @@ import {
   aflDraftTradeOutcomeFixtureHash,
   createAflDraftTradeOutcomeReleaseFixture,
 } from '../fixtures/aflDraftTradeOutcomeReleaseFixture';
-import {
-  OUTCOMES_PRISMA_SCHEMA_PATH,
-  runOutcomesPrismaTestCommand,
-} from './outcomesPrismaTestCli';
+import { OUTCOMES_PRISMA_SCHEMA_PATH, runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
 
 interface QueryResultLike<Row = Record<string, unknown>> {
   rows: readonly Row[];
@@ -775,7 +772,19 @@ const releaseId = `outcome-release:${'a'.repeat(64)}`;
 const projectionId = `outcome-projection:${'b'.repeat(64)}`;
 const secondProjectionId = `outcome-projection:${'c'.repeat(64)}`;
 
-async function seedNormalizedEventRelease(suffix: string) {
+async function seedNormalizedEventRelease(
+  suffix: string,
+  options: {
+    competition?: string;
+    seasonYear?: number;
+    effectiveThrough?: string;
+    createdAt?: string;
+  } = {}
+) {
+  const competition = options.competition ?? 'AFL';
+  const seasonYear = options.seasonYear ?? 2025;
+  const effectiveThrough = options.effectiveThrough ?? '2025-12-31T23:59:59Z';
+  const createdAt = options.createdAt ?? '2026-01-01T00:00:00Z';
   const ids = {
     releaseId: `outcome-release:${sha256AflTradeCanonicalJson({ fixture: 'normalized-event-release', suffix })}`,
     artifactId: `artifact-${suffix}`,
@@ -804,9 +813,8 @@ async function seedNormalizedEventRelease(suffix: string) {
   await query(
     `INSERT INTO outcome_release_manifest
       (release_id, scope_key, environment, created_at, effective_through, manifest_json)
-     VALUES ($1, 'public-afl-draft-trade-outcomes', 'test_fixture', '2026-01-01T00:00:00Z',
-             '2025-12-31T23:59:59Z', '{}'::jsonb)`,
-    [ids.releaseId]
+     VALUES ($1, 'public-afl-draft-trade-outcomes', 'test_fixture', $2, $3, '{}'::jsonb)`,
+    [ids.releaseId, createdAt, effectiveThrough]
   );
   await query(
     `INSERT INTO outcome_artifact_custody
@@ -826,7 +834,8 @@ async function seedNormalizedEventRelease(suffix: string) {
   );
   await query(
     `INSERT INTO outcome_competition_season (competition, season_year)
-     VALUES ('AFL', 2025) ON CONFLICT DO NOTHING`
+     VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+    [competition, seasonYear]
   );
   await query(
     `INSERT INTO outcome_source_capture
@@ -834,9 +843,9 @@ async function seedNormalizedEventRelease(suffix: string) {
        dataset, dataset_version, access_mechanism, competition, anchor_season_year, effective_at,
        captured_at, status, manifest_json)
      VALUES ($1, $2, $3, $4, 'test_fixture', 'fixture-workbook', 'annual-and-trades', 'v1',
-             'operator_import', 'AFL', 2025, '2025-01-01T00:00:00Z',
+             'operator_import', $5, $6, '2025-01-01T00:00:00Z',
              '2025-01-01T00:00:01Z', 'approved', '{}'::jsonb)`,
-    [ids.captureId, ids.attemptId, `snapshot-${suffix}`, ids.artifactId]
+    [ids.captureId, ids.attemptId, `snapshot-${suffix}`, ids.artifactId, competition, seasonYear]
   );
   await query(
     `INSERT INTO outcome_import_run
@@ -866,9 +875,16 @@ async function seedNormalizedEventRelease(suffix: string) {
     `INSERT INTO outcome_import_partition
       (import_partition_id, import_run_id, partition_key, partition_kind, competition,
        season_year, row_count, rows_sha256, partition_json)
-     VALUES ($1, $2, 'fixture-events:2025', 'workbook_trade_ledger', 'AFL', 2025,
-             $3, $4, '{}'::jsonb)`,
-    [`partition-${suffix}`, ids.importRunId, importRows.length, contentSha256]
+     VALUES ($1, $2, $3, 'workbook_trade_ledger', $4, $5, $6, $7, '{}'::jsonb)`,
+    [
+      `partition-${suffix}`,
+      ids.importRunId,
+      `fixture-events:${seasonYear}`,
+      competition,
+      seasonYear,
+      importRows.length,
+      contentSha256,
+    ]
   );
   for (const [ordinal, importRowId] of importRows.entries()) {
     await query(
@@ -918,8 +934,8 @@ async function seedNormalizedEventRelease(suffix: string) {
   );
   await query(
     `INSERT INTO outcome_event (event_id, competition, season_year, stable_key)
-     VALUES ($1, 'AFL', 2025, $2)`,
-    [ids.eventId, `fixture-trade-${suffix}`]
+     VALUES ($1, $2, $3, $4)`,
+    [ids.eventId, competition, seasonYear, `fixture-trade-${suffix}`]
   );
   await query(
     `INSERT INTO outcome_event_version
@@ -1958,6 +1974,60 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       legacy_assignment_count: '0',
       release_membership_count: '0',
     });
+  });
+
+  it('rejects a governed player resolution sourced outside the factual release', async () => {
+    const scenario = providerResolutionScenario;
+    if (!scenario) throw new Error('The provider resolution vertical slice did not initialize.');
+    const ids = await seedNormalizedEventRelease('provider-resolution-outside-release', {
+      competition: 'AFLM',
+      seasonYear: 2026,
+      effectiveThrough: '2026-12-31T23:59:59Z',
+      createdAt: '2027-01-01T00:00:00Z',
+    });
+
+    const connection = await outcomesPool.connect();
+    try {
+      await connection.query('BEGIN');
+      await connection.query(
+        `INSERT INTO outcome_event_asset
+          (asset_version_id, event_version_id, asset_key, kind, player_id, player_identity_id,
+           from_club_id, to_club_id, source_import_row_id, raw_description, status)
+         VALUES ('asset-governed-provider-resolution-outside-release', $1, 'provider-player',
+                 'player', $2, $3, $4, $5, $6, 'Provider Resolution A', 'approved')`,
+        [
+          ids.eventVersionId,
+          'afl-player:provider-resolution-a',
+          scenario.playerIdentityId,
+          ids.fromClubId,
+          ids.toClubId,
+          ids.lateAssetRowId,
+        ]
+      );
+      await connection.query(
+        `INSERT INTO outcome_release_review_decision
+          (release_id, decision_id, ordinal, record_sha256, membership_json)
+         VALUES ($1, $2, 1, $3, '{}'::jsonb)`,
+        [ids.releaseId, scenario.decisionA.decisionId, 'a'.repeat(64)]
+      );
+
+      await expect(
+        connection.query(
+          `INSERT INTO outcome_release_event_version
+            (release_id, event_version_id, ordinal, record_sha256, membership_json)
+           VALUES ($1, $2, 0, $3, '{}'::jsonb)`,
+          [ids.releaseId, ids.eventVersionId, 'b'.repeat(64)]
+        )
+      ).rejects.toMatchObject({
+        code: 'P0001',
+        message: expect.stringMatching(
+          /exact current legacy assignment or governed provider resolution/
+        ),
+      });
+    } finally {
+      await connection.query('ROLLBACK');
+      connection.release();
+    }
   });
 
   it('requires deactivation before remap and admits one concurrent next revision', async () => {

--- a/tests/unit/afl-trade-intelligence-disposable-postgres-harness.test.ts
+++ b/tests/unit/afl-trade-intelligence-disposable-postgres-harness.test.ts
@@ -80,6 +80,7 @@ describe('disposable AFL outcomes PostgreSQL harness', () => {
         'postgresql://statly_test:statly_test@127.0.0.1:49152/statly_outcomes_test',
       AFL_OUTCOMES_TEST_DATABASE_URL:
         'postgresql://statly_test:statly_test@127.0.0.1:49152/statly_outcomes_test',
+      AFL_OUTCOMES_TEST_CONTAINER_ID: firstContainerId,
     });
     expect(commands.filter((command) => command.command === '/test/node')).toEqual([
       {

--- a/tests/unit/afl-trade-intelligence-factual-observation-contracts.test.ts
+++ b/tests/unit/afl-trade-intelligence-factual-observation-contracts.test.ts
@@ -251,6 +251,35 @@ function metricContent(appearanceFactId: string, overrides: Record<string, unkno
   };
 }
 
+function seasonMetricContent(overrides: Record<string, unknown> = {}) {
+  return {
+    ...factBase(),
+    source: sourceEvidence({
+      identity: digest('7'),
+      match: null,
+      metric: digest('3'),
+      achievement: null,
+      appearance: null,
+    }),
+    factKind: 'player_season_metric' as const,
+    player: playerResolution(),
+    seasonClubScope: {
+      kind: 'resolved_single_club' as const,
+      club: clubResolution('afl-club:home'),
+    },
+    metricCode: 'goals' as const,
+    definitionVersion: 'goals/v1',
+    definition: immutableReference('metric-definition', 'goals/v1'),
+    unit: 'goals',
+    availability: {
+      state: 'measured' as const,
+      numericValue: '1',
+      reasonCode: null,
+    },
+    ...overrides,
+  };
+}
+
 function batchContent(facts: readonly AflTradeSourceFact[]) {
   const sortedFacts = [...facts].sort((left, right) => left.factId.localeCompare(right.factId));
   const rowFactIds = sortedFacts.map(({ factId }) => factId).sort();
@@ -430,6 +459,20 @@ describe('AFL trade factual source contracts', () => {
         })
       )
     ).toThrow();
+  });
+
+  it('requires every player-bound fact to bind its exact identity candidate digest', () => {
+    const content = seasonMetricContent();
+
+    expect(() =>
+      createAflTradeSourceFact({
+        ...content,
+        source: {
+          ...content.source,
+          candidateDigests: { ...content.source.candidateDigests, identity: null },
+        },
+      })
+    ).toThrow(/player_season_metric fact must bind only its exact required candidate digests/);
   });
 
   it('admits only an explicit staged appearance claim and never a source games metric', () => {

--- a/vitest.config.outcomes-int.ts
+++ b/vitest.config.outcomes-int.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   root,
   resolve: { alias: { '@': path.resolve(root, 'src') } },
+  esbuild: { jsx: 'automatic' },
   test: {
     name: 'outcomes-postgres-integration',
     environment: 'node',


### PR DESCRIPTION
## Summary

- rehearse deterministic fitzRoy identity and match review through one private factual candidate
- promote reviewed baseline and replacement facts into sealed factual-release candidates
- activate releases only inside disposable local PostgreSQL and prove service, API, projection, archive-page, and JSON/CSV/XLSX parity
- prove explicit rollback, no-fallback withdrawal, and freshly authorized recovery through the append-only 15-event registry
- create a PostgreSQL custom-format dump, destroy the exact generated schema, restore it transactionally, and re-authenticate the complete release state and export bytes
- document the completed disposable rehearsal without claiming hosted durability, live-source custody, or production authority

## Why

This completes the approved fully local factual-release rehearsal after #528. It closes the gap between the deterministic private-candidate evidence and a sealed, reversible factual release while keeping live capture, hosted deployment, AWS provisioning, valuation publication, and production activation outside this change.

## Verification

- `npm run docs:check` — passed; 23 Markdown files and 2039 tracked files
- `npm run lint:ci` — passed
- `npm run typecheck` — passed
- `npm run test:unit` — passed; 494 files and 3333 tests
- `DATABASE_URL_TEST=<disposable SQLite> npm run test:int` — passed; 3 files and 3 tests
- `npm run test:outcomes:int` — passed; 10 files and 43 tests against disposable PostgreSQL 16, including dump/destroy/restore and exact-container cleanup
- `NEXT_PUBLIC_FIREBASE_*=<non-secret CI placeholders> npm run build` — passed; 80 static pages generated
- `git diff --check origin/main...HEAD` — passed
- final standards review — no hard findings
- final specification review — no actionable findings

`npm run test:e2e` ran against an explicit disposable SQLite database: 18 tests passed and 8 existing dashboard/draft/league/login tests failed. Failures were Chromium navigation timeouts or existing route/recovery assertions plus one Firefox roster runtime error; none target the factual-release files in this pull request. The generated traces remain local and are not committed.

## Security, data, and deployment impact

- no AWS authentication, cloud resource, billable infrastructure, hosted service, deployment, or production activation
- no live provider access or real capture
- no protected fantasy database or repository environment file used
- `.env.example` and `prisma/dev.db` changes from the original worktree are excluded
- all release activation, withdrawal, recovery, dump, destruction, and restore occur inside a harness-owned disposable PostgreSQL container

## Follow-up

- let required CI and review gates reproduce the exact branch evidence
- completed a cold-start browser/API rehearsal against fresh disposable PostgreSQL 16: the live API, stored projection, authenticated JSON/CSV/XLSX bytes, and desktop/375px archive UI resolved the recovered replacement release; teardown removed the exact container and local runtime state
- retain live capture, hosted restore, production authorization, and valuation publication as later phases

## Summary by Sourcery

Extend the local non-production fitzRoy factual rehearsal to cover a full AFL factual-release lifecycle and disposable PostgreSQL backup/restore, including governed provider match/appearance facts, sealed release candidates, activation, rollback, withdrawal, recovery, and restored public surfaces.

New Features:
- Introduce a local factual-release rehearsal flow that promotes the private fitzRoy candidate into baseline and replacement release candidates, registers and activates them, and drives the append-only release registry.
- Add governed provider-side match, club-alias, and appearance modeling so the rehearsal creates match-universe, player-appearance, and metric facts from a single decoded row.
- Provide deterministic JSON/CSV/XLSX export generation for factual releases and wire them into projection manifests and parity checks.
- Implement a disposable PostgreSQL 16 backup and restore test that dumps the rehearsal schema, destroys it, restores from the dump, and verifies the release, registry, projection, service, API, archive page, and exports match exactly.

Enhancements:
- Refine the local fitzRoy rehearsal fixture to support baseline and replacement generations with richer match metadata and updated field-map approval identities.
- Extend factual reconciliation to incorporate match and appearance facts, track multiple metric heads, and replay reconciled runs idempotently.
- Relax factual observation persistence to tolerate missing identity digests when only match candidates are present.
- Expand the disposable PostgreSQL harness to propagate the container identifier into tests and adjust integration config for JSX-capable builds.

Documentation:
- Update architecture and operations runbooks to describe the extended local factual-release rehearsal, governed release membership rules, disposable backup/restore evidence, and current non-production maturity state.

Tests:
- Add integration tests that exercise the full local factual-release lifecycle, including activation of a replacement release, rollback to baseline, withdrawal to no-active-release, recovery, and registry/event invariants.
- Add integration tests that validate the PostgreSQL dump/destroy/restore path reproduces the exact release state, registry, read service outputs, API responses, archive page content, and export artifacts.
- Update existing fitzRoy rehearsal integration tests to assert new match/appearance facts, provider resolutions, and reconciled metric counts.
- Add unit tests for the disposable PostgreSQL harness environment wiring and confirm inclusion of the test container identifier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a local AFL factual-release rehearsal covering baseline and replacement releases, approval, activation, rollback, withdrawal, and recovery.
  - Added consistent projection, API, archive, and JSON/CSV/XLSX export verification.
  - Added PostgreSQL backup and restore validation with integrity checks.
  - Expanded factual coverage for matches, player appearances, club aliases, goals, and games metrics.

- **Bug Fixes**
  - Strengthened release validation to prevent mismatched, incomplete, or unauthorized records from being published.

- **Documentation**
  - Updated architecture and operations guidance to reflect the expanded non-production rehearsals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->