### PR TITLE
Build governed private evaluation workspace

### DIFF
--- a/docs/architecture/afl-trade-intelligence.md
+++ b/docs/architecture/afl-trade-intelligence.md
@@ -1731,11 +1731,28 @@ attribution. Realized contribution is credited once to the receiving real AFL cl
 departure. It is not reconstructed from a forecast, defaulted to zero when missing, or adjusted by
 later list-spot or scarcity policy.
 
-The calculation unit is the complete multi-party trade. Joint draws preserve shared factors and
+The canonical product aggregate is one complete **trade transaction**, containing every directed
+transfer between two, three, or four participating AFL clubs. It is never decomposed into independent
+bilateral trades for calculation, grading, explanation, or projection. Each participating club has
+exactly one **club package assessment** within that transaction. The assessment contains the club's
+complete **received package**, complete **given-up package**, aligned estimated-advantage distribution,
+and one package-level grade when the transaction is complete enough to grade. A trade therefore
+produces two, three, or four club package assessments together; it does not produce one overall winner
+card or a detached list of graded assets.
+
+An **asset contribution** is one original transaction root viewed from a club package: positive in the
+receiving club's received package and negative in the sending club's given-up package. Those two
+placements reference the same authenticated root and lineage rather than creating duplicate asset
+identities. Every asset remains subordinate to its club package assessment and may explain that
+assessment, but it never receives an independent letter grade.
+
+The calculation unit is the complete trade transaction. Joint draws preserve shared factors and
 correlated outcomes rather than summing independent point estimates. Lineage-frontier attribution
 credits each root exactly once, follows pick and player successors, and rejects missing or duplicated
 frontier coverage. Unavailable inputs propagate an unavailable value with reasons; the kernel does not
-coerce missing evidence to zero.
+coerce missing evidence to zero. Every club package assessment is derived from this same aligned draw
+set, so a missing root or unbalanced endpoint makes every affected package comparison and grade
+unavailable rather than allowing one club to appear complete in isolation.
 
 Every transfer root has one sending club and one receiving club. In each aligned draw and valuation
 view, the calculator derives three balancing party quantities in one named value unit:
@@ -1772,8 +1789,42 @@ complete-only: the explanation derives full coverage from the authenticated draw
 retains the assumption set's effective window rather than accepting caller-supplied coverage. Private
 synthetic explanations retain fabricated-evidence and publication-prohibited authority and cannot
 satisfy a governed release lane; no governed-release authority variant exists until a real governed
-Adapter can authenticate that ancestry. The local archive summary is projected from this same
-complete explanation, so partial root values cannot produce totals that disagree with trade detail.
+Adapter can authenticate that ancestry. The retained archive-summary artifact is projected from this
+same complete explanation, so partial root values cannot produce totals that disagree with trade
+detail. Wiring that artifact into archive cards remains part of the later atomic-batch reader cutover.
+
+The retained explanation contract is a deterministic **calculation narrative**, not a restatement of
+the final score. It tells the calculation's evidence-backed story at two connected levels:
+
+- the club package narrative shows the selected view, named value unit, received-package mean,
+  given-up-package mean, exact subtraction producing estimated advantage, joint uncertainty interval,
+  finish-ahead probabilities, grade-policy result, and the assets that materially drive the result;
+- each asset narrative shows the authenticated facts and model components that produced its additive
+  contribution, followed by its ordered lineage and its place in the club subtotal.
+
+A player asset narrative identifies the player and receiving acquisition spell, the evidence cutoff,
+games and complete seasons included, each season's measured contribution, the total realized
+contribution, the admitted remaining-value model run, and the arithmetic producing the selected-view
+asset contribution. A pick asset narrative identifies the stable pick entitlement separately from its
+displayed number, the trade-date selection estimate, the admitted comparison cohort's selection range,
+observation count, draft-class count, empirical outcome distribution and method, then follows every
+authenticated custody, renumbering, on-trade, transformation, final selection, resulting player, and
+realized or remaining contribution. Nominal pick numbers are labels inside that story, not pick
+identity.
+
+The current development panel renders authenticated package arithmetic and aggregate player and pick
+evidence from this narrative. Rendering every retained season, empirical distribution, method, and
+lineage step is target reader work; retaining those details does not by itself prove that every detail
+is already visible in the UI.
+
+Every numerical or factual sentence in a calculation narrative is regenerated from retained,
+content-addressed source facts, model artifacts, lineage events, calculation draws, or policy
+artifacts. Fixed templates may turn those structured facts into plain language; operators and callers
+cannot supply prose, substitute values, or add unbound claims, and unconstrained generated numerical
+or causal explanations are prohibited. The retained narrative binds every displayed claim to its
+source artifact and calculation identity so exact replay can reproduce the same claim set. When a
+required fact is unavailable, the narrative names the missing evidence or authority and makes the
+dependent contribution and grade unavailable instead of inventing a smooth story around the gap.
 
 At-trade package values use only the contemporaneous information set. Current package values retain
 realized receiving-club contribution separately from projected remaining contribution and enforce
@@ -1787,14 +1838,30 @@ an immutable package-policy artifact and are not production defaults. Optional c
 club timing and role-congestion assumptions in a separate layer and never relabels universal value.
 Market, contract, and commercial value remain separate and unavailable in this kernel.
 
-The four immutable snapshots represent at-trade, realized, remaining, and current views. At-trade
-knowledge cannot follow the real trade, while realized, remaining, and current share one present
-temporal context. The calculation enforces `current = realized + remaining` for every root, draw,
-club, and value layer rather than checking only aggregate means. Weighted snapshots report mean,
-median, an 80% central interval, downside and upside quantiles, low-return and elite probabilities,
-all pairwise club comparison probabilities, confidence evidence, and exact-versus-sampled uncertainty.
-Partially available distributions may expose a clearly labelled conditional summary, but never a
-whole-trade statistic or comparison over missing probability mass.
+The four immutable snapshots implement four synchronized **view lenses** over the same transaction:
+at-trade, realized, remaining, and current. They are not separate trades, asset collections, model
+runs, or independently selectable club results. A reader selects one lens for the transaction, and
+every club package, asset contribution, comparison, narrative, and lineage annotation resolves under
+that same lens. At-trade knowledge cannot follow the real trade, while realized, remaining, and
+current share one present temporal context.
+
+The retained ordered weighted draw set is the single numerical source for all four lenses. Replay
+must verify for every draw and selected value layer that:
+
+- draw keys and weights are identical across roots and parties;
+- every transaction root appears exactly once with one authenticated sender and receiver;
+- total received value equals total given-up value and the global estimated advantage is zero;
+- `current = realized + remaining` for every root, club, draw, and layer;
+- means, intervals, event probabilities, pairwise comparisons, asset contributions, package grades,
+  and calculation narratives derive from that same draw set; and
+- the numeric representation, rounding, quantile, tolerance, and grade-policy versions are pinned.
+
+Weighted snapshots report mean, median, an 80% central interval, downside and upside quantiles,
+low-return and elite probabilities, all pairwise club comparison probabilities for every participating
+club pair, confidence evidence, and exact-versus-sampled uncertainty. A failed root, direction,
+weight, identity, balance, temporal, or policy check makes every dependent club comparison and grade
+unavailable together. Partially available distributions may expose a clearly labelled conditional
+asset summary, but never a whole-trade statistic or comparison over missing probability mass.
 
 Explanations are rendered only from fixed templates and structured reason codes. Their statements
 separate measured facts, model estimates, assumptions, unavailable information, and low-confidence
@@ -1807,6 +1874,33 @@ chains end to end. The validator checks schemas and content addresses, graph and
 realized attribution, exactly-once terminal frontiers, deterministic calculation/snapshot/explanation
 replay, explanation parity, and the public ownership boundary. Tamper tests cover changed hashes,
 parents, lineage, realized evidence, snapshots, explanations, and forbidden fields.
+
+The target MVP historical-coverage contract indexes every retained canonical trade transaction rather than
+publishing only trades that happen to calculate successfully. Each indexed transaction resolves to
+exactly one reader state:
+
+- **calculated** means an admitted model automatically derived every club package assessment,
+  contribution, view, narrative, and grade from complete authenticated inputs; or
+- **unavailable** means the transaction remains visible but one or more named factual-evidence,
+  lineage, cohort-support, model-authority, temporal, or reconciliation requirements failed closed.
+
+There is no operator-entered score, manually completed asset value, partial package grade, or silent
+archive omission. A transaction with an ambiguous later split, merge, or multi-asset exchange retains
+and displays its authenticated known lineage, but its dependent contributions and club grades remain
+unavailable until an admitted economic-allocation rule resolves the ambiguity. Supporting every
+historical transformation shape therefore means representing, authenticating, and explaining its
+state; it does not mean inventing a numeric allocation for every shape at launch.
+
+Reader coverage reports count calculated and unavailable transactions separately by reason. A beta or
+public launch cannot rely on fabricated fixtures or manually assembled values: at least one real,
+admitted end-to-end model release must automatically calculate its supported historical cohort, while
+every transaction outside that cohort remains explicitly unavailable rather than inheriting a score
+from a different model version or evidence set.
+
+The current foundation does not yet perform this automatic cohort calculation. It retains the
+prepared-input, materialisation, lifecycle, projection, and exact-read seams needed by that target;
+later automation stages own complete construction, batch activation, archive coverage, and coverage
+reporting.
 
 A structurally valid fixture report always retains `publicationReady: false` and the remaining
 external blockers: a real historical-data run, component-model calibration exit criteria, downstream
@@ -1834,6 +1928,63 @@ authority.
 
 Failure leaves the public archive available without numerical valuation. Product design must not turn
 a failed or missing model into hidden fallback numbers.
+
+### Target MVP registered-reader valuation surface
+
+This section defines the target reader contract. The current local foundation admits only the
+explicit signed-in development reader and wires governed detail and exact JSON export. Archive cards
+still expose factual transactions and readiness without consuming retained `archive_summary` bytes.
+Broader registered-reader admission and atomic archive/detail/API/export parity arrive with the later
+private batch reader cutover.
+
+Any user may register, but valuation reads require an authenticated registered reader. Readers may
+open the archive and trade detail and download a permitted JSON calculation-evidence export. They
+cannot inspect construction authority or invoke activation, withdrawal, rollback, recovery, or
+reconstruction operations. Internal authenticated routes may serve the website and export, but the MVP
+does not document or promise a third-party valuation API.
+
+Every activated valuation generation retains one content-addressed projection manifest that binds:
+
+- the canonical archive-card data document for the transaction;
+- the canonical trade-detail document containing every club package and expandable asset narrative;
+- the generation artifact and exact calculation identities; and
+- the exact retained JSON export byte artifact, including its media type, digest, and byte length.
+
+Runtime HTML, React output, authentication state, filters, pagination, and build identifiers are not
+retained as calculation evidence. In the target surface, archive, detail, internal transport, and export authenticate and
+replay the same retained derivation before serving it. They expose the same generation and projection
+manifest identities, and export serves the retained bytes directly rather than serializing a fresh
+runtime object. The registered-reader export contains the public facts, model summaries, arithmetic,
+reason codes, and lineage needed to verify the published calculation; it excludes private source
+custody, review material, credentials, operator authority, and publication controls.
+
+The sole governed module interface is `inspect`, `execute`, and exact `read`. Its external selector is
+the composite `(valuationScopeKey, tradeId)` identity. `read` accepts only current selection or one
+explicit generation identifier; it has no latest-generation alias or silent fallback. Withdrawal makes
+the current valuation explicitly unavailable, while an authenticated exact historical generation read
+remains available with its inactive, superseded, or withdrawn lifecycle label. Retained legacy
+generation versions use exhaustive version dispatch and either an authenticated compatible projection
+or an explicit `projection_unavailable` state; the reader never invents missing projection bytes.
+
+Target lifecycle mutations are authenticated operator actions. Construction first retains a transition
+intent, dormant generation, projection documents, projection manifest, and exact export bytes. A
+serializable compare-and-swap activation then advances the composite lifecycle head and appends its
+receipt. A stable operation identifier makes retry resume or return that same attempt rather than
+creating another generation. Withdrawal removes current selection without fallback. Rollback may
+select a previously active generation only inside its retained authority window at trusted database
+time. Reconstruction verification is read-only: it replays retained parents and compares exact
+generation, manifest, document, narrative, and export bytes without changing the lifecycle head.
+
+MVP proof has two explicitly different lanes. The current fabricated `test_fixture`, non-production,
+publication-prohibited foundation proves deterministic generation construction, immutable staging,
+low-level serializable activation, authenticated detail and exact export, withdrawal, restart-safe
+historical reads, and reconstruction using disposable PostgreSQL. Its governed workspace deliberately
+returns construction unavailable, and unavailable real authority cannot rollback or recover a fixture
+grade. Later batch work must reintroduce rollback and recovery only with exact eligible reactivation
+authority. The real-private-input lane proves missing factual or model authority remains unavailable,
+activates no grade or export, and never borrows authority from the fixture lane. Unauthorized detail
+and export requests fail before database or artifact access. Archive parity and complete browser
+narrative assertions remain target reader proof rather than claims made by this foundation.
 
 ## Immutable publication
 

--- a/docs/runbooks/afl-trade-intelligence-operations.md
+++ b/docs/runbooks/afl-trade-intelligence-operations.md
@@ -771,6 +771,94 @@ owned by the immediately preceding disposable PostgreSQL rehearsal. Do not descr
 projection or a synthetic scenario as an activated public release. Real-data release review, model
 calibration and validation, hosted deployment, and production activation remain later procedures.
 
+### Rehearsing the governed private package-evaluation workspace
+
+The governed private workspace is a second, narrower local boundary behind the workbook screen. Its
+only application-facing operations are `inspect`, `execute`, and exact `read`. It does not accept
+caller-supplied player values, pick values, transfer directions, evidence, timestamps, grades,
+generation documents, or operator identities. The concrete local adapter derives the authenticated
+operator from the server session and binds one loopback outcomes database to one absolute private
+artifact root. The retained generation and every reader document remain `test_fixture`,
+non-production, and publication-prohibited.
+
+Before exercising this boundary, verify all of the following:
+
+- `NODE_ENV` is not `production`, development tools and private workbook reads are explicitly
+  enabled, and the workbook path and SHA-256 digest identify the reviewed private input;
+- `AFL_OUTCOMES_DATABASE_URL` is loopback PostgreSQL named exactly `statly_outcomes_test`;
+- `STATLY_LOCAL_OUTCOMES_RUNTIME_NONCE` is the 64-character nonce installed in that same database by
+  the current local stack launch;
+- `AFL_TRADE_LOCAL_ARTIFACT_ROOT` is one absolute, private, ignored filesystem directory; and
+- the signed-in identity is the authenticated local operator. A feature flag, Host header, route
+  parameter, JSON body, or development-auth literal is not operator authority.
+
+An inspection uses trusted PostgreSQL time and captures the composite `(valuationScopeKey, tradeId)`
+lifecycle head inside one repeatable-read transaction. It retains and authenticates the exact snapshot
+and inspection bytes before returning. Current real inspections fail closed with the earliest exact
+blocker, which may be `insufficient_data`, `model_not_approved`, or another declared unavailable
+reason. Externally approved player and pick model runs and the non-synthetic component draw-set
+materialization required to build a complete narrative do not yet exist. Therefore the real workspace
+must not construct, activate, rollback, or recover a grade. An unavailable inspection still retains
+its exact lifecycle head and short validity window so an authenticated operator can withdraw an
+already-active fixture generation or verify its retained reconstruction without positive model
+authority. Expired or stale inspections must be repeated; never extend their timestamps or edit
+retained JSON.
+
+When a fixture generation is active, open its private detail page through the signed-in archive. The
+automatic governed section must show one card and one package grade for every participating club,
+one global four-view selector, complete Received and Gave up ledgers, exact package subtraction,
+player games/seasons/rate evidence, pick cohort/sample evidence, and expandable labelled lineage.
+The page must also display the generation and projection-manifest identities. When current selection
+is absent, withdrawn, unauthenticated, or fails artifact authentication, the same section must show an
+explicit unavailable reason and no grade or export control. The separately labelled synthetic panel
+is never a substitute for this state.
+
+The signed-in exact export is internal transport only:
+
+```text
+GET /api/dev/afl-trade-evaluation/{tradeId}/export
+```
+
+It is not a documented third-party API. A successful response has `Content-Type: application/json`,
+`Cache-Control: private, no-store`, an attachment filename, and the exact generation and projection
+manifest IDs in response headers. Hash the downloaded bytes directly and compare that digest and byte
+length with the retained export artifact. Do not parse and reserialize the response before comparing
+it. A concealed reader, withdrawn generation, missing artifact, changed byte, manifest mismatch, or
+reconstruction failure returns no export bytes.
+
+Run the focused deterministic proof with the repository unit configuration, then the real PostgreSQL
+proof only against a disposable target:
+
+```sh
+npx vitest run --config vitest.config.unit.ts \
+  tests/unit/afl-trade-intelligence-governed-private-evaluation-workspace.test.ts \
+  tests/unit/afl-trade-intelligence-governed-evaluation-panel.test.tsx \
+  tests/unit/afl-trade-intelligence-private-local-workbook-reads.test.ts \
+  tests/unit/local-workbook-trade-evaluation-page.test.tsx \
+  tests/unit/afl-trade-intelligence-private-governed-exact-export-route.test.ts \
+  --coverage.enabled=false
+
+AFL_OUTCOMES_TEST_DATABASE_URL='<owned-disposable-loopback-postgresql>' \
+  npx vitest run --config vitest.config.outcomes-int.ts \
+  tests/outcomes-integration/afl-governed-private-evaluation-lifecycle-postgres.test.ts
+```
+
+The provisioned integration command is permitted only when the caller owns the disposable database.
+The proof applies the complete forward migration history, retains dormant artifacts before compare and
+swap, activates and exactly replays a seeded ready fixture, inspects and withdraws it through the real
+workspace, verifies the exact withdrawn generation without reactivation, rejects unavailable recovery
+and rollback, rejects mutation of append-only receipts, and proves the composite scope key prevents
+cross-scope reads. Remove only the container/schema and artifact directory created for that run.
+
+This is not yet the complete launch proof. Before any beta or public grade, implement and review the
+real ready inspector and automatic component draw-set materialization, expose construct, rollback,
+recover, and verify through an authenticated local operator adapter, recheck every retained release,
+Gate, admission, model, calculation-head, and private-authority token at serializable activation, and
+run a signed-in browser rehearsal covering archive, detail, all four views, asset drill-down, exact
+download bytes, withdrawal, and unavailable real inputs. Real HPN/PAV and pick-model runs still require
+their external approvals. Until those conditions pass, archive transactions remain factual records
+with grades explicitly unavailable.
+
 ### Rehearsing fixture-only valuation publication
 
 Run this only as part of the same disposable outcomes command:

--- a/prisma/afl-trade-outcomes/migrations/0058_governed_private_evaluation_lifecycle/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0058_governed_private_evaluation_lifecycle/migration.sql
@@ -1,0 +1,364 @@
+-- Governed private-evaluation lifecycle. All source, projection, and generation bytes must already
+-- exist in immutable artifact custody before a serializable transition can point at them.
+
+ALTER TABLE "outcome_operational_principal_authority"
+  DROP CONSTRAINT "outcome_operational_authority_shape_check";
+
+ALTER TABLE "outcome_operational_principal_authority"
+  ADD CONSTRAINT "outcome_operational_authority_shape_check" CHECK (
+    "authority_evidence_id" ~ '^reviewer-authority-evidence:[a-f0-9]{64}$'
+    AND "role" IN (
+      'afl_trade_identity_reviewer',
+      'afl_trade_canonical_promoter',
+      'afl_trade_external_identity_reviewer',
+      'afl_trade_model_run_operator',
+      'afl_trade_private_evaluation_operator'
+    )
+    AND "competition" IN ('AFLM','AFLW')
+    AND "valid_from_season" BETWEEN 1897 AND 2200
+    AND "valid_through_season" BETWEEN "valid_from_season" AND 2200
+    AND ("valid_through" IS NULL OR "valid_through" >= "valid_from")
+    AND (
+      ("role" IN (
+          'afl_trade_identity_reviewer',
+          'afl_trade_canonical_promoter',
+          'afl_trade_external_identity_reviewer'
+        )
+        AND "scope_key" = 'public-afl-draft-trade-outcomes')
+      OR
+      ("role" = 'afl_trade_model_run_operator'
+        AND "provider" = 'statly_modeling'
+        AND "capability_id" = 'execute_model_run')
+      OR
+      ("role" = 'afl_trade_private_evaluation_operator'
+        AND "provider" = 'statly_modeling'
+        AND "capability_id" = 'manage_private_trade_evaluation'
+        AND (
+          "scope_key" ~ '^afl-men:[0-9]{4}-trades$'
+          OR "scope_key" = 'afl-trade-history:test-fixture'
+        ))
+    )
+  );
+
+CREATE TABLE "outcome_private_evaluation_authority_snapshot" (
+    "snapshot_id" TEXT NOT NULL,
+    "valuation_scope_key" TEXT NOT NULL,
+    "trade_id" TEXT NOT NULL,
+    "artifact_id" TEXT NOT NULL,
+    "captured_at" TIMESTAMPTZ(3) NOT NULL,
+    "valid_through" TIMESTAMPTZ(3) NOT NULL,
+    "expected_head_status" TEXT NOT NULL,
+    "expected_head_revision" INTEGER NOT NULL,
+    "expected_head_generation_id" TEXT,
+    "content_sha256" CHAR(64) NOT NULL,
+    "content_canonical_json" TEXT NOT NULL,
+    "snapshot_json" JSONB NOT NULL,
+    "registered_at" TIMESTAMPTZ(3) NOT NULL DEFAULT clock_timestamp(),
+
+    CONSTRAINT "outcome_private_evaluation_authority_snapshot_pkey" PRIMARY KEY ("snapshot_id"),
+    CONSTRAINT "outcome_private_evaluation_authority_snapshot_scope_key"
+      UNIQUE ("snapshot_id", "valuation_scope_key", "trade_id"),
+    CONSTRAINT "outcome_private_evaluation_authority_snapshot_artifact_key" UNIQUE ("artifact_id"),
+    CONSTRAINT "outcome_private_evaluation_authority_snapshot_id_check"
+      CHECK ("snapshot_id" ~ '^private-evaluation-authority-snapshot:[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_private_evaluation_authority_snapshot_sha_check"
+      CHECK ("content_sha256" ~ '^[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_private_evaluation_authority_snapshot_window_check"
+      CHECK ("valid_through" > "captured_at"),
+    CONSTRAINT "outcome_private_evaluation_authority_snapshot_head_check"
+      CHECK (
+        ("expected_head_status"='absent' AND "expected_head_revision"=0 AND "expected_head_generation_id" IS NULL)
+        OR ("expected_head_status"='withdrawn' AND "expected_head_revision">0 AND "expected_head_generation_id" IS NULL)
+        OR ("expected_head_status"='active' AND "expected_head_revision">0 AND "expected_head_generation_id" IS NOT NULL)
+      ),
+    CONSTRAINT "outcome_private_evaluation_authority_snapshot_artifact_fkey"
+      FOREIGN KEY ("artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT
+);
+
+CREATE TABLE "outcome_private_evaluation_inspection_receipt" (
+    "inspection_id" TEXT NOT NULL,
+    "snapshot_id" TEXT NOT NULL,
+    "valuation_scope_key" TEXT NOT NULL,
+    "trade_id" TEXT NOT NULL,
+    "artifact_id" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "inspected_at" TIMESTAMPTZ(3) NOT NULL,
+    "valid_through" TIMESTAMPTZ(3) NOT NULL,
+    "expected_head_status" TEXT NOT NULL,
+    "expected_head_revision" INTEGER NOT NULL,
+    "expected_head_generation_id" TEXT,
+    "content_sha256" CHAR(64) NOT NULL,
+    "content_canonical_json" TEXT NOT NULL,
+    "receipt_json" JSONB NOT NULL,
+    "registered_at" TIMESTAMPTZ(3) NOT NULL DEFAULT clock_timestamp(),
+
+    CONSTRAINT "outcome_private_evaluation_inspection_receipt_pkey" PRIMARY KEY ("inspection_id"),
+    CONSTRAINT "outcome_private_evaluation_inspection_receipt_artifact_key" UNIQUE ("artifact_id"),
+    CONSTRAINT "outcome_private_evaluation_inspection_receipt_id_check"
+      CHECK ("inspection_id" ~ '^private-evaluation-inspection:[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_private_evaluation_inspection_receipt_sha_check"
+      CHECK ("content_sha256" ~ '^[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_private_evaluation_inspection_receipt_state_check"
+      CHECK (
+        ("state"='ready' AND "valid_through" IS NOT NULL AND "expected_head_status" IS NOT NULL AND "expected_head_revision" IS NOT NULL)
+        OR ("state"='unavailable' AND "valid_through" IS NOT NULL AND "expected_head_status" IS NOT NULL AND "expected_head_revision" IS NOT NULL)
+      ),
+    CONSTRAINT "outcome_private_evaluation_inspection_receipt_head_check"
+      CHECK (
+        ("expected_head_status"='absent' AND "expected_head_revision"=0 AND "expected_head_generation_id" IS NULL)
+        OR ("expected_head_status"='withdrawn' AND "expected_head_revision">0 AND "expected_head_generation_id" IS NULL)
+        OR ("expected_head_status"='active' AND "expected_head_revision">0 AND "expected_head_generation_id" IS NOT NULL)
+      ),
+    CONSTRAINT "outcome_private_evaluation_inspection_receipt_snapshot_fkey"
+      FOREIGN KEY ("snapshot_id") REFERENCES "outcome_private_evaluation_authority_snapshot"("snapshot_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_private_evaluation_inspection_receipt_artifact_fkey"
+      FOREIGN KEY ("artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT
+);
+
+CREATE TABLE "outcome_private_evaluation_transition_intent" (
+    "transition_intent_id" TEXT NOT NULL,
+    "inspection_id" TEXT NOT NULL,
+    "authority_snapshot_id" TEXT,
+    "operation_id" TEXT NOT NULL,
+    "valuation_scope_key" TEXT NOT NULL,
+    "trade_id" TEXT NOT NULL,
+    "artifact_id" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "expected_head_status" TEXT NOT NULL,
+    "expected_head_revision" INTEGER NOT NULL,
+    "expected_head_generation_id" TEXT,
+    "target_generation_id" TEXT,
+    "requested_at" TIMESTAMPTZ(3) NOT NULL,
+    "expires_at" TIMESTAMPTZ(3) NOT NULL,
+    "content_sha256" CHAR(64) NOT NULL,
+    "content_canonical_json" TEXT NOT NULL,
+    "intent_json" JSONB NOT NULL,
+    "registered_at" TIMESTAMPTZ(3) NOT NULL DEFAULT clock_timestamp(),
+
+    CONSTRAINT "outcome_private_evaluation_transition_intent_pkey" PRIMARY KEY ("transition_intent_id"),
+    CONSTRAINT "outcome_private_evaluation_transition_intent_inspection_key" UNIQUE ("inspection_id"),
+    CONSTRAINT "outcome_private_evaluation_transition_intent_operation_key" UNIQUE ("operation_id"),
+    CONSTRAINT "outcome_private_evaluation_transition_intent_artifact_key" UNIQUE ("artifact_id"),
+    CONSTRAINT "outcome_private_evaluation_transition_intent_id_check"
+      CHECK ("transition_intent_id" ~ '^private-evaluation-transition-intent:[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_private_evaluation_transition_intent_operation_check"
+      CHECK ("operation_id" ~ '^private-evaluation-operation:[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_private_evaluation_transition_intent_action_check"
+      CHECK ("action" IN ('construct_and_activate','withdraw','rollback','recover')),
+    CONSTRAINT "outcome_private_evaluation_transition_intent_window_check"
+      CHECK ("expires_at" > "requested_at"),
+    CONSTRAINT "outcome_private_evaluation_transition_intent_target_check"
+      CHECK (("action"='rollback') = ("target_generation_id" IS NOT NULL)),
+    CONSTRAINT "outcome_private_evaluation_transition_intent_snapshot_check"
+      CHECK (("action"='withdraw') = ("authority_snapshot_id" IS NULL)),
+    CONSTRAINT "outcome_private_evaluation_transition_intent_inspection_fkey"
+      FOREIGN KEY ("inspection_id") REFERENCES "outcome_private_evaluation_inspection_receipt"("inspection_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_private_evaluation_transition_intent_snapshot_fkey"
+      FOREIGN KEY ("authority_snapshot_id", "valuation_scope_key", "trade_id")
+      REFERENCES "outcome_private_evaluation_authority_snapshot"("snapshot_id", "valuation_scope_key", "trade_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_private_evaluation_transition_intent_artifact_fkey"
+      FOREIGN KEY ("artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT
+);
+
+CREATE TABLE "outcome_local_private_trade_evaluation_generation" (
+    "generation_id" TEXT NOT NULL,
+    "valuation_scope_key" TEXT NOT NULL,
+    "trade_id" TEXT NOT NULL,
+    "transition_intent_id" TEXT NOT NULL,
+    "generation_artifact_id" TEXT NOT NULL,
+    "narrative_artifact_id" TEXT NOT NULL,
+    "projection_manifest_artifact_id" TEXT NOT NULL,
+    "generated_at" TIMESTAMPTZ(3) NOT NULL,
+    "content_sha256" CHAR(64) NOT NULL,
+    "content_canonical_json" TEXT NOT NULL,
+    "generation_json" JSONB NOT NULL,
+    "registered_at" TIMESTAMPTZ(3) NOT NULL DEFAULT clock_timestamp(),
+
+    CONSTRAINT "outcome_local_private_trade_evaluation_generation_pkey" PRIMARY KEY ("generation_id"),
+    CONSTRAINT "outcome_local_private_trade_evaluation_generation_scope_key" UNIQUE ("valuation_scope_key", "trade_id", "generation_id"),
+    CONSTRAINT "outcome_local_private_trade_evaluation_generation_intent_key" UNIQUE ("transition_intent_id"),
+    CONSTRAINT "outcome_local_private_trade_evaluation_generation_artifact_key" UNIQUE ("generation_artifact_id"),
+    CONSTRAINT "outcome_local_private_trade_evaluation_generation_id_check"
+      CHECK ("generation_id" ~ '^local-private-trade-evaluation-generation:[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_local_private_trade_evaluation_generation_sha_check"
+      CHECK ("content_sha256" ~ '^[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_local_private_trade_evaluation_generation_intent_fkey"
+      FOREIGN KEY ("transition_intent_id") REFERENCES "outcome_private_evaluation_transition_intent"("transition_intent_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_local_private_trade_evaluation_generation_artifact_fkey"
+      FOREIGN KEY ("generation_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_local_private_trade_evaluation_narrative_artifact_fkey"
+      FOREIGN KEY ("narrative_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_local_private_trade_evaluation_projection_artifact_fkey"
+      FOREIGN KEY ("projection_manifest_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT
+);
+
+ALTER TABLE "outcome_private_evaluation_authority_snapshot"
+  ADD CONSTRAINT "outcome_private_eval_snapshot_expected_gen_fkey"
+  FOREIGN KEY ("valuation_scope_key", "trade_id", "expected_head_generation_id")
+  REFERENCES "outcome_local_private_trade_evaluation_generation"("valuation_scope_key", "trade_id", "generation_id") ON DELETE RESTRICT;
+ALTER TABLE "outcome_private_evaluation_inspection_receipt"
+  ADD CONSTRAINT "outcome_private_eval_inspection_expected_gen_fkey"
+  FOREIGN KEY ("valuation_scope_key", "trade_id", "expected_head_generation_id")
+  REFERENCES "outcome_local_private_trade_evaluation_generation"("valuation_scope_key", "trade_id", "generation_id") ON DELETE RESTRICT;
+ALTER TABLE "outcome_private_evaluation_transition_intent"
+  ADD CONSTRAINT "outcome_private_eval_intent_expected_gen_fkey"
+  FOREIGN KEY ("valuation_scope_key", "trade_id", "expected_head_generation_id")
+  REFERENCES "outcome_local_private_trade_evaluation_generation"("valuation_scope_key", "trade_id", "generation_id") ON DELETE RESTRICT;
+ALTER TABLE "outcome_private_evaluation_transition_intent"
+  ADD CONSTRAINT "outcome_private_eval_intent_target_gen_fkey"
+  FOREIGN KEY ("valuation_scope_key", "trade_id", "target_generation_id")
+  REFERENCES "outcome_local_private_trade_evaluation_generation"("valuation_scope_key", "trade_id", "generation_id") ON DELETE RESTRICT;
+
+CREATE TABLE "outcome_local_private_trade_evaluation_head" (
+    "valuation_scope_key" TEXT NOT NULL,
+    "trade_id" TEXT NOT NULL,
+    "revision" INTEGER NOT NULL,
+    "status" TEXT NOT NULL,
+    "generation_id" TEXT,
+    "last_transition_id" TEXT NOT NULL,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL DEFAULT clock_timestamp(),
+
+    CONSTRAINT "outcome_local_private_trade_evaluation_head_pkey" PRIMARY KEY ("valuation_scope_key", "trade_id"),
+    CONSTRAINT "outcome_local_private_trade_evaluation_head_revision_check" CHECK ("revision">0),
+    CONSTRAINT "outcome_local_private_trade_evaluation_head_state_check"
+      CHECK ((status='active' AND generation_id IS NOT NULL) OR (status IN ('withdrawn') AND generation_id IS NULL)),
+    CONSTRAINT "outcome_local_private_trade_evaluation_head_generation_fkey"
+      FOREIGN KEY ("valuation_scope_key", "trade_id", "generation_id")
+      REFERENCES "outcome_local_private_trade_evaluation_generation"("valuation_scope_key", "trade_id", "generation_id") ON DELETE RESTRICT
+);
+
+CREATE TABLE "outcome_private_evaluation_transition_receipt" (
+    "transition_id" TEXT NOT NULL,
+    "transition_intent_id" TEXT NOT NULL,
+    "operation_id" TEXT NOT NULL,
+    "valuation_scope_key" TEXT NOT NULL,
+    "trade_id" TEXT NOT NULL,
+    "artifact_id" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "from_revision" INTEGER NOT NULL,
+    "from_status" TEXT NOT NULL,
+    "from_generation_id" TEXT,
+    "to_revision" INTEGER NOT NULL,
+    "to_status" TEXT NOT NULL,
+    "to_generation_id" TEXT,
+    "transitioned_at" TIMESTAMPTZ(3) NOT NULL DEFAULT clock_timestamp(),
+    "content_sha256" CHAR(64) NOT NULL,
+    "content_canonical_json" TEXT NOT NULL,
+    "receipt_json" JSONB NOT NULL,
+
+    CONSTRAINT "outcome_private_evaluation_transition_receipt_pkey" PRIMARY KEY ("transition_id"),
+    CONSTRAINT "outcome_private_evaluation_transition_receipt_intent_key" UNIQUE ("transition_intent_id"),
+    CONSTRAINT "outcome_private_evaluation_transition_receipt_operation_key" UNIQUE ("operation_id"),
+    CONSTRAINT "outcome_private_evaluation_transition_receipt_artifact_key" UNIQUE ("artifact_id"),
+    CONSTRAINT "outcome_private_evaluation_transition_receipt_id_check"
+      CHECK ("transition_id" ~ '^private-evaluation-transition:[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_private_evaluation_transition_receipt_action_check"
+      CHECK ("action" IN ('construct_and_activate','withdraw','rollback','recover')),
+    CONSTRAINT "outcome_private_evaluation_transition_receipt_revision_check"
+      CHECK ("from_revision">=0 AND "to_revision"="from_revision"+1),
+    CONSTRAINT "outcome_private_evaluation_transition_receipt_from_state_check"
+      CHECK (("from_status"='absent' AND "from_revision"=0 AND "from_generation_id" IS NULL) OR ("from_status"='withdrawn' AND "from_revision">0 AND "from_generation_id" IS NULL) OR ("from_status"='active' AND "from_revision">0 AND "from_generation_id" IS NOT NULL)),
+    CONSTRAINT "outcome_private_evaluation_transition_receipt_to_state_check"
+      CHECK (("to_status"='withdrawn' AND "to_generation_id" IS NULL) OR ("to_status"='active' AND "to_generation_id" IS NOT NULL)),
+    CONSTRAINT "outcome_private_evaluation_transition_receipt_intent_fkey"
+      FOREIGN KEY ("transition_intent_id") REFERENCES "outcome_private_evaluation_transition_intent"("transition_intent_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_private_evaluation_transition_receipt_artifact_fkey"
+      FOREIGN KEY ("artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_private_eval_receipt_from_gen_fkey"
+      FOREIGN KEY ("valuation_scope_key", "trade_id", "from_generation_id")
+      REFERENCES "outcome_local_private_trade_evaluation_generation"("valuation_scope_key", "trade_id", "generation_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_private_eval_receipt_to_gen_fkey"
+      FOREIGN KEY ("valuation_scope_key", "trade_id", "to_generation_id")
+      REFERENCES "outcome_local_private_trade_evaluation_generation"("valuation_scope_key", "trade_id", "generation_id") ON DELETE RESTRICT
+);
+
+ALTER TABLE "outcome_local_private_trade_evaluation_head"
+  ADD CONSTRAINT "outcome_local_private_trade_evaluation_head_transition_fkey"
+  FOREIGN KEY ("last_transition_id") REFERENCES "outcome_private_evaluation_transition_receipt"("transition_id") ON DELETE RESTRICT;
+
+CREATE TABLE "outcome_private_evaluation_reconstruction_verification" (
+    "verification_id" TEXT NOT NULL,
+    "inspection_id" TEXT NOT NULL,
+    "operation_id" TEXT NOT NULL,
+    "valuation_scope_key" TEXT NOT NULL,
+    "trade_id" TEXT NOT NULL,
+    "generation_id" TEXT NOT NULL,
+    "artifact_id" TEXT NOT NULL,
+    "verified_at" TIMESTAMPTZ(3) NOT NULL,
+    "exact_match" BOOLEAN NOT NULL,
+    "content_sha256" CHAR(64) NOT NULL,
+    "content_canonical_json" TEXT NOT NULL,
+    "verification_json" JSONB NOT NULL,
+    "registered_at" TIMESTAMPTZ(3) NOT NULL DEFAULT clock_timestamp(),
+
+    CONSTRAINT "outcome_private_evaluation_reconstruction_verification_pkey" PRIMARY KEY ("verification_id"),
+    CONSTRAINT "outcome_private_eval_reconstruction_operation_key" UNIQUE ("operation_id"),
+    CONSTRAINT "outcome_private_eval_reconstruction_artifact_key" UNIQUE ("artifact_id"),
+    CONSTRAINT "outcome_private_evaluation_reconstruction_verification_id_check"
+      CHECK ("verification_id" ~ '^private-evaluation-reconstruction-verification:[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_private_eval_reconstruction_operation_check"
+      CHECK ("operation_id" ~ '^private-evaluation-operation:[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_private_eval_reconstruction_sha_check"
+      CHECK ("content_sha256" ~ '^[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_private_eval_reconstruction_match_check"
+      CHECK ("exact_match"=TRUE),
+    CONSTRAINT "outcome_private_eval_reconstruction_inspection_fkey"
+      FOREIGN KEY ("inspection_id") REFERENCES "outcome_private_evaluation_inspection_receipt"("inspection_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_private_eval_reconstruction_artifact_fkey"
+      FOREIGN KEY ("artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_private_eval_reconstruction_generation_fkey"
+      FOREIGN KEY ("valuation_scope_key", "trade_id", "generation_id")
+      REFERENCES "outcome_local_private_trade_evaluation_generation"("valuation_scope_key", "trade_id", "generation_id") ON DELETE RESTRICT
+);
+
+CREATE INDEX "outcome_private_evaluation_snapshot_selector_idx"
+  ON "outcome_private_evaluation_authority_snapshot"("valuation_scope_key", "trade_id", "captured_at");
+CREATE INDEX "outcome_private_evaluation_generation_selector_idx"
+  ON "outcome_local_private_trade_evaluation_generation"("valuation_scope_key", "trade_id", "generated_at");
+CREATE INDEX "outcome_private_evaluation_transition_selector_idx"
+  ON "outcome_private_evaluation_transition_receipt"("valuation_scope_key", "trade_id", "to_revision");
+CREATE INDEX "outcome_private_evaluation_reconstruction_selector_idx"
+  ON "outcome_private_evaluation_reconstruction_verification"("valuation_scope_key", "trade_id", "generation_id", "verified_at");
+
+CREATE OR REPLACE FUNCTION "reject_outcome_private_evaluation_authority_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Private evaluation authority records are append-only';
+END $$;
+
+CREATE TRIGGER "outcome_private_evaluation_snapshot_append_only"
+BEFORE UPDATE OR DELETE ON "outcome_private_evaluation_authority_snapshot"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_evaluation_authority_mutation"();
+CREATE TRIGGER "outcome_private_evaluation_inspection_append_only"
+BEFORE UPDATE OR DELETE ON "outcome_private_evaluation_inspection_receipt"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_evaluation_authority_mutation"();
+CREATE TRIGGER "outcome_private_evaluation_intent_append_only"
+BEFORE UPDATE OR DELETE ON "outcome_private_evaluation_transition_intent"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_evaluation_authority_mutation"();
+
+CREATE OR REPLACE FUNCTION "reject_outcome_private_evaluation_generation_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Private evaluation generations are append-only';
+END $$;
+CREATE TRIGGER "outcome_private_evaluation_generation_append_only"
+BEFORE UPDATE OR DELETE ON "outcome_local_private_trade_evaluation_generation"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_evaluation_generation_mutation"();
+
+CREATE OR REPLACE FUNCTION "reject_outcome_private_evaluation_transition_receipt_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Private evaluation transition receipts are append-only';
+END $$;
+CREATE TRIGGER "outcome_private_evaluation_transition_receipt_append_only"
+BEFORE UPDATE OR DELETE ON "outcome_private_evaluation_transition_receipt"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_evaluation_transition_receipt_mutation"();
+
+CREATE OR REPLACE FUNCTION "reject_outcome_private_eval_reconstruction_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Private evaluation reconstruction verifications are append-only';
+END $$;
+CREATE TRIGGER "outcome_private_eval_reconstruction_append_only"
+BEFORE UPDATE OR DELETE ON "outcome_private_evaluation_reconstruction_verification"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_eval_reconstruction_mutation"();

--- a/prisma/afl-trade-outcomes/migrations/0059_authenticated_prepared_valuation_inputs/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0059_authenticated_prepared_valuation_inputs/migration.sql
@@ -1,0 +1,279 @@
+-- Authenticated prepared calculation inputs. Migration 0048 remains the immutable v1 source-policy
+-- preflight; this migration adds a separately guarded v2 path with exact retained artifact custody.
+
+ALTER TABLE "outcome_prepared_valuation_input_set"
+  DROP CONSTRAINT "outcome_prepared_valuation_input_set_identity_check";
+ALTER TABLE "outcome_prepared_valuation_input_set"
+  ADD CONSTRAINT "outcome_prepared_valuation_input_set_identity_check" CHECK (
+    "prepared_input_set_id" = 'prepared-valuation-input-set:' || "content_sha256" AND
+    "content_sha256" ~ '^[a-f0-9]{64}$' AND
+    "schema_version" IN (
+      'afl-trade-prepared-valuation-input-set/v1',
+      'afl-trade-prepared-valuation-input-set/v2'
+    ) AND
+    "environment" = 'non_production' AND
+    "factual_release_id" ~ '^outcome-release:[a-f0-9]{64}$'
+  );
+
+ALTER TABLE "outcome_prepared_valuation_input_set"
+  DROP CONSTRAINT "outcome_prepared_valuation_input_set_count_check";
+ALTER TABLE "outcome_prepared_valuation_input_set"
+  ADD CONSTRAINT "outcome_prepared_valuation_input_set_count_check" CHECK (
+    "trade_count" > 0 AND
+    "ready_count" >= 0 AND
+    "blocked_count" >= 0 AND
+    "trade_count" = "ready_count" + "blocked_count" AND
+    (
+      ("schema_version"='afl-trade-prepared-valuation-input-set/v1' AND
+       "ready_count"=0 AND "blocked_count">0)
+      OR
+      "schema_version"='afl-trade-prepared-valuation-input-set/v2'
+    )
+  );
+
+ALTER TABLE "outcome_prepared_valuation_input_entry"
+  DROP CONSTRAINT "outcome_prepared_valuation_input_entry_value_check";
+ALTER TABLE "outcome_prepared_valuation_input_entry"
+  ADD CONSTRAINT "outcome_prepared_valuation_input_entry_value_check" CHECK (
+    "ordinal" > 0 AND "state" IN ('ready','blocked') AND jsonb_typeof("entry_json")='object'
+  );
+
+DROP TRIGGER "outcome_prepared_valuation_input_set_validate_insert"
+  ON "outcome_prepared_valuation_input_set";
+CREATE TRIGGER "outcome_prepared_valuation_input_set_validate_insert"
+  BEFORE INSERT ON "outcome_prepared_valuation_input_set"
+  FOR EACH ROW
+  WHEN (NEW."schema_version"='afl-trade-prepared-valuation-input-set/v1')
+  EXECUTE FUNCTION "validate_outcome_prepared_valuation_input_set_insert"();
+
+CREATE FUNCTION "validate_outcome_prepared_valuation_input_v2_artifact"(
+  artifact_ref JSONB,
+  expected_environment "OutcomeEnvironment"
+) RETURNS BOOLEAN AS $$
+DECLARE retained RECORD;
+BEGIN
+  IF jsonb_typeof(artifact_ref)<>'object' OR
+     (SELECT count(*) FROM jsonb_object_keys(artifact_ref))<>6 THEN
+    RETURN FALSE;
+  END IF;
+  SELECT "content_sha256","storage_uri","media_type","byte_length","environment","created_at"
+    INTO retained
+    FROM "outcome_artifact_custody"
+   WHERE "artifact_id"=artifact_ref->>'artifactId'
+   FOR KEY SHARE;
+  RETURN FOUND AND
+    retained."content_sha256"=artifact_ref->>'contentSha256' AND
+    retained."storage_uri"=artifact_ref->>'storageUri' AND
+    retained."media_type"=artifact_ref->>'mediaType' AND
+    retained."byte_length"=(artifact_ref->>'byteLength')::bigint AND
+    retained."environment"=expected_environment AND
+    retained."created_at"=(artifact_ref->>'createdAt')::timestamptz;
+EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+  RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION "validate_outcome_prepared_valuation_input_set_v2_insert"() RETURNS TRIGGER AS $$
+DECLARE
+  content JSONB;
+  release_scope TEXT;
+  release_environment TEXT;
+  release_manifest JSONB;
+  canonical_members JSONB;
+  expected_trade_ids JSONB;
+  release_created_at TIMESTAMPTZ;
+  release_canonical_text TEXT;
+  membership_canonical_text TEXT;
+  release_sha256 TEXT;
+  membership_sha256 TEXT;
+  qualification_report JSONB;
+  qualification_finalized_at TIMESTAMPTZ;
+  qualification_canonical_text TEXT;
+  qualification_sha256 TEXT;
+BEGIN
+  IF NEW."finalized_at" IS NOT NULL THEN
+    RAISE EXCEPTION 'Prepared valuation input v2 must be assembled before finalization';
+  END IF;
+  content:=NEW."prepared_set_json"->'content';
+  SELECT "scope_key","environment","manifest_json","created_at"
+    INTO release_scope,release_environment,release_manifest,release_created_at
+    FROM "outcome_release_manifest"
+   WHERE "release_id"=NEW."factual_release_id" FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Prepared valuation input v2 factual release does not exist';
+  END IF;
+  canonical_members:=release_manifest->'content'->'canonicalMembers';
+  SELECT jsonb_agg(to_jsonb(member->>'canonicalRecordId') ORDER BY member->>'canonicalRecordId')
+    INTO expected_trade_ids
+    FROM jsonb_array_elements(canonical_members) members(member)
+   WHERE member->>'recordKind'='transaction';
+  release_canonical_text:="outcome_afl_trade_canonical_json"(release_manifest);
+  membership_canonical_text:="outcome_afl_trade_canonical_json"(canonical_members);
+  release_sha256:=encode(sha256(convert_to(release_canonical_text,'UTF8')),'hex');
+  membership_sha256:=encode(sha256(convert_to(membership_canonical_text,'UTF8')),'hex');
+
+  SELECT "report_json","finalized_at" INTO qualification_report,qualification_finalized_at
+    FROM "outcome_valuation_source_qualification_report"
+   WHERE "qualification_report_id"=NEW."qualification_report_id" FOR KEY SHARE;
+  qualification_canonical_text:="outcome_afl_trade_canonical_json"(qualification_report);
+  qualification_sha256:=encode(
+    sha256(convert_to(qualification_canonical_text,'UTF8')),'hex'
+  );
+
+  IF NEW."content_canonical_json" IS DISTINCT FROM
+       "outcome_afl_trade_canonical_json"(content) OR
+     NEW."prepared_set_canonical_json" IS DISTINCT FROM
+       "outcome_afl_trade_canonical_json"(NEW."prepared_set_json") OR
+     NEW."content_canonical_json"::jsonb IS DISTINCT FROM content OR
+     NEW."prepared_set_canonical_json"::jsonb IS DISTINCT FROM NEW."prepared_set_json" OR
+     NEW."content_sha256" IS DISTINCT FROM
+       encode(sha256(convert_to(NEW."content_canonical_json",'UTF8')),'hex') OR
+     NEW."prepared_set_json"->>'preparedInputSetId' IS DISTINCT FROM NEW."prepared_input_set_id" OR
+     (SELECT count(*) FROM jsonb_object_keys(NEW."prepared_set_json"))<>2 OR
+     (SELECT count(*) FROM jsonb_object_keys(content))<>22 OR
+     content->>'schemaVersion' IS DISTINCT FROM NEW."schema_version" OR
+     content->>'environment' IS DISTINCT FROM NEW."environment"::text OR
+     content->>'scopeKey' IS DISTINCT FROM NEW."scope_key" OR
+     content->>'factualReleaseScopeKey' IS DISTINCT FROM NEW."factual_release_scope_key" OR
+     content->>'factualReleaseId' IS DISTINCT FROM NEW."factual_release_id" OR
+     content->>'preparationAuthority' IS DISTINCT FROM
+       'authenticated_calculation_evidence_snapshot' OR
+     content->>'qualificationOperation' IS DISTINCT FROM
+       'valuation_model_training_and_derived_feature_creation' OR
+     content->>'qualificationReportId' IS DISTINCT FROM NEW."qualification_report_id" OR
+     content->>'valuationInputBundleId' !~ '^valuation-input-bundle:[a-f0-9]{64}$' OR
+     (content->>'tradeCount')::integer IS DISTINCT FROM NEW."trade_count" OR
+     (content->>'readyCount')::integer IS DISTINCT FROM NEW."ready_count" OR
+     (content->>'blockedCount')::integer IS DISTINCT FROM NEW."blocked_count" OR
+     (content->>'preparedAt')::timestamptz IS DISTINCT FROM NEW."prepared_at" OR
+     content->'publicationEligible' IS DISTINCT FROM 'false'::jsonb OR
+     content->'releaseTradeIds' IS DISTINCT FROM expected_trade_ids OR
+     jsonb_array_length(content->'releaseTradeIds') IS DISTINCT FROM NEW."trade_count" OR
+     jsonb_array_length(content->'entries') IS DISTINCT FROM NEW."trade_count" OR
+     release_scope IS DISTINCT FROM NEW."factual_release_scope_key" OR
+     release_environment IS DISTINCT FROM NEW."environment"::text OR
+     qualification_report IS NULL OR qualification_finalized_at IS NULL OR
+     qualification_report->'content'->>'factualReleaseId' IS DISTINCT FROM
+       NEW."factual_release_id" OR
+     qualification_report->'content'->>'valuationScopeKey' IS DISTINCT FROM NEW."scope_key" OR
+     qualification_report->'content'->>'factualReleaseScopeKey' IS DISTINCT FROM
+       NEW."factual_release_scope_key" OR
+     qualification_report->'content'->'releaseTradeIds' IS DISTINCT FROM
+       content->'releaseTradeIds' OR
+     qualification_report->'content'->'sourceRightsEvidenceRefs' IS DISTINCT FROM
+       content->'sourceQualificationEvidenceRefs' OR
+     qualification_report->'content'->'decision'->>'state' IS DISTINCT FROM
+       'eligible_for_dataset_admission' OR
+     content->'qualificationReportArtifact'->>'artifactId' IS DISTINCT FROM
+       'artifact:'||qualification_sha256 OR
+     content->'qualificationReportArtifact'->>'contentSha256' IS DISTINCT FROM
+       qualification_sha256 OR
+     content->'qualificationReportArtifact'->>'storageUri' IS DISTINCT FROM
+       'artifact://sha256/'||qualification_sha256 OR
+     content->'qualificationReportArtifact'->>'mediaType' IS DISTINCT FROM 'application/json' OR
+     (content->'qualificationReportArtifact'->>'byteLength')::integer IS DISTINCT FROM
+       octet_length(convert_to(qualification_canonical_text,'UTF8')) OR
+     (content->'qualificationReportArtifact'->>'createdAt')::timestamptz IS DISTINCT FROM
+       qualification_finalized_at OR
+     content->'factualReleaseArtifact'->>'artifactId' IS DISTINCT FROM
+       'artifact:'||release_sha256 OR
+     content->'factualReleaseArtifact'->>'contentSha256' IS DISTINCT FROM release_sha256 OR
+     content->'factualReleaseArtifact'->>'storageUri' IS DISTINCT FROM
+       'artifact://sha256/'||release_sha256 OR
+     content->'factualReleaseArtifact'->>'mediaType' IS DISTINCT FROM 'application/json' OR
+     (content->'factualReleaseArtifact'->>'byteLength')::integer IS DISTINCT FROM
+       octet_length(convert_to(release_canonical_text,'UTF8')) OR
+     (content->'factualReleaseArtifact'->>'createdAt')::timestamptz IS DISTINCT FROM
+       release_created_at OR
+     content->'releaseMembershipArtifact'->>'artifactId' IS DISTINCT FROM
+       'artifact:'||membership_sha256 OR
+     content->'releaseMembershipArtifact'->>'contentSha256' IS DISTINCT FROM membership_sha256 OR
+     content->'releaseMembershipArtifact'->>'storageUri' IS DISTINCT FROM
+       'artifact://sha256/'||membership_sha256 OR
+     content->'releaseMembershipArtifact'->>'mediaType' IS DISTINCT FROM 'application/json' OR
+     (content->'releaseMembershipArtifact'->>'byteLength')::integer IS DISTINCT FROM
+       octet_length(convert_to(membership_canonical_text,'UTF8')) OR
+     (content->'releaseMembershipArtifact'->>'createdAt')::timestamptz IS DISTINCT FROM
+       release_created_at OR
+     NOT "validate_outcome_prepared_valuation_input_v2_artifact"(
+       content->'valuationInputBundleArtifact',NEW."environment"
+     ) OR
+     (content->'valuationInputBundleArtifact'->>'createdAt')::timestamptz>NEW."prepared_at" THEN
+    RAISE EXCEPTION 'Prepared valuation input v2 identity, authority, or factual ancestry mismatch';
+  END IF;
+  RETURN NEW;
+EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+  RAISE EXCEPTION 'Prepared valuation input v2 contains invalid typed evidence';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "outcome_prepared_valuation_input_set_v2_validate_insert"
+  BEFORE INSERT ON "outcome_prepared_valuation_input_set"
+  FOR EACH ROW
+  WHEN (NEW."schema_version"='afl-trade-prepared-valuation-input-set/v2')
+  EXECUTE FUNCTION "validate_outcome_prepared_valuation_input_set_v2_insert"();
+
+CREATE FUNCTION "validate_outcome_prepared_valuation_input_entry_v2_insert"() RETURNS TRIGGER AS $$
+DECLARE parent RECORD; blocker JSONB; evidence_ref JSONB;
+BEGIN
+  SELECT "schema_version","environment","prepared_at","finalized_at" INTO parent
+    FROM "outcome_prepared_valuation_input_set"
+   WHERE "prepared_input_set_id"=NEW."prepared_input_set_id" FOR KEY SHARE;
+  IF NOT FOUND OR parent."schema_version"<>'afl-trade-prepared-valuation-input-set/v2' THEN
+    RETURN NEW;
+  END IF;
+  IF parent."finalized_at" IS NOT NULL THEN
+    RAISE EXCEPTION 'Prepared valuation input v2 entry has no open parent set';
+  END IF;
+
+  IF NEW."state"='ready' THEN
+    IF (SELECT count(*) FROM jsonb_object_keys(NEW."entry_json"))<>6 OR
+       NEW."entry_json"->>'calculationInputPackageId' !~
+         '^valuation-calculation-input:[a-f0-9]{64}$' OR
+       NEW."entry_json"->>'inputTraceId' !~
+         '^private-evaluation-input-trace:[a-f0-9]{64}$' OR
+       NEW."entry_json"->'calculationInputArtifact'->>'artifactId'=
+         NEW."entry_json"->'inputTraceArtifact'->>'artifactId' OR
+       NOT "validate_outcome_prepared_valuation_input_v2_artifact"(
+         NEW."entry_json"->'calculationInputArtifact',parent."environment"
+       ) OR
+       NOT "validate_outcome_prepared_valuation_input_v2_artifact"(
+         NEW."entry_json"->'inputTraceArtifact',parent."environment"
+       ) OR
+       (NEW."entry_json"->'calculationInputArtifact'->>'createdAt')::timestamptz>
+         parent."prepared_at" OR
+       (NEW."entry_json"->'inputTraceArtifact'->>'createdAt')::timestamptz>
+         parent."prepared_at" THEN
+      RAISE EXCEPTION 'Prepared valuation input v2 ready evidence is not retained exactly';
+    END IF;
+  ELSE
+    IF (SELECT count(*) FROM jsonb_object_keys(NEW."entry_json"))<>3 OR
+       jsonb_typeof(NEW."entry_json"->'blockers')<>'array' OR
+       jsonb_array_length(NEW."entry_json"->'blockers')=0 THEN
+      RAISE EXCEPTION 'Prepared valuation input v2 blocker shape is invalid';
+    END IF;
+    FOR blocker IN SELECT value FROM jsonb_array_elements(NEW."entry_json"->'blockers') LOOP
+      IF (SELECT count(*) FROM jsonb_object_keys(blocker))<>3 OR
+         jsonb_typeof(blocker->'evidenceRefs')<>'array' OR
+         jsonb_array_length(blocker->'evidenceRefs')=0 THEN
+        RAISE EXCEPTION 'Prepared valuation input v2 blocker evidence is incomplete';
+      END IF;
+      FOR evidence_ref IN SELECT value FROM jsonb_array_elements(blocker->'evidenceRefs') LOOP
+        IF NOT "validate_outcome_prepared_valuation_input_v2_artifact"(
+             evidence_ref,parent."environment"
+           ) OR
+           (evidence_ref->>'createdAt')::timestamptz>parent."prepared_at" THEN
+          RAISE EXCEPTION 'Prepared valuation input v2 blocker evidence is not retained exactly';
+        END IF;
+      END LOOP;
+    END LOOP;
+  END IF;
+  RETURN NEW;
+EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+  RAISE EXCEPTION 'Prepared valuation input v2 entry contains invalid typed evidence';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "outcome_prepared_valuation_input_entry_v2_validate_insert"
+  BEFORE INSERT ON "outcome_prepared_valuation_input_entry"
+  FOR EACH ROW EXECUTE FUNCTION "validate_outcome_prepared_valuation_input_entry_v2_insert"();

--- a/prisma/afl-trade-outcomes/migrations/0060_materialization_manifest_prepared_inputs/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0060_materialization_manifest_prepared_inputs/migration.sql
@@ -1,0 +1,215 @@
+-- Bounded calculation/story replay parents and an explicit current prepared-set pointer.
+-- Migrations 0048 and 0059 remain immutable v1/v2 authority.
+
+ALTER TABLE "outcome_prepared_valuation_input_set"
+  DROP CONSTRAINT "outcome_prepared_valuation_input_set_identity_check";
+ALTER TABLE "outcome_prepared_valuation_input_set"
+  ADD CONSTRAINT "outcome_prepared_valuation_input_set_identity_check" CHECK (
+    "prepared_input_set_id"='prepared-valuation-input-set:'||"content_sha256" AND
+    "content_sha256" ~ '^[a-f0-9]{64}$' AND
+    "schema_version" IN (
+      'afl-trade-prepared-valuation-input-set/v1',
+      'afl-trade-prepared-valuation-input-set/v2',
+      'afl-trade-prepared-valuation-input-set/v3'
+    ) AND "environment"='non_production' AND
+    "factual_release_id" ~ '^outcome-release:[a-f0-9]{64}$'
+  );
+
+ALTER TABLE "outcome_prepared_valuation_input_set"
+  DROP CONSTRAINT "outcome_prepared_valuation_input_set_count_check";
+ALTER TABLE "outcome_prepared_valuation_input_set"
+  ADD CONSTRAINT "outcome_prepared_valuation_input_set_count_check" CHECK (
+    "trade_count">0 AND "ready_count">=0 AND "blocked_count">=0 AND
+    "trade_count"="ready_count"+"blocked_count" AND
+    (("schema_version"='afl-trade-prepared-valuation-input-set/v1' AND
+      "ready_count"=0 AND "blocked_count">0) OR
+     "schema_version" IN (
+       'afl-trade-prepared-valuation-input-set/v2',
+       'afl-trade-prepared-valuation-input-set/v3'
+     ))
+  );
+
+CREATE TABLE "outcome_private_evaluation_materialization_manifest" (
+  "materialization_manifest_id" TEXT PRIMARY KEY,
+  "content_sha256" CHAR(64) NOT NULL,
+  "valuation_scope_key" TEXT NOT NULL,
+  "trade_id" TEXT NOT NULL,
+  "artifact_id" TEXT NOT NULL UNIQUE REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+  "created_at" TIMESTAMPTZ(3) NOT NULL,
+  "content_canonical_json" TEXT NOT NULL,
+  "manifest_canonical_json" TEXT NOT NULL,
+  "manifest_json" JSONB NOT NULL,
+  "registered_at" TIMESTAMPTZ(3) NOT NULL DEFAULT transaction_timestamp(),
+  CONSTRAINT "outcome_private_evaluation_materialization_manifest_identity_check" CHECK (
+    "materialization_manifest_id"='private-evaluation-materialization-manifest:'||"content_sha256" AND
+    "content_sha256" ~ '^[a-f0-9]{64}$' AND jsonb_typeof("manifest_json")='object'
+  )
+);
+
+CREATE INDEX "outcome_private_evaluation_materialization_selector_idx"
+  ON "outcome_private_evaluation_materialization_manifest"(
+    "valuation_scope_key", "trade_id", "created_at"
+  );
+
+CREATE FUNCTION "validate_outcome_private_evaluation_materialization_manifest_insert"()
+RETURNS TRIGGER AS $$
+DECLARE content JSONB; parent_ref JSONB; canonical_manifest TEXT; retained RECORD;
+BEGIN
+  content:=NEW."manifest_json"->'content';
+  canonical_manifest:="outcome_afl_trade_canonical_json"(NEW."manifest_json");
+  SELECT "content_sha256","storage_uri","media_type","byte_length","environment","created_at"
+    INTO retained FROM "outcome_artifact_custody"
+   WHERE "artifact_id"=NEW."artifact_id" FOR KEY SHARE;
+  IF NOT FOUND OR NEW."manifest_json"->>'manifestId'<>NEW."materialization_manifest_id" OR
+     content->>'schemaVersion'<>'private-evaluation-materialization-manifest/v1' OR
+     content->>'environment'<>'non_production' OR content->'publicationEligible'<>'false'::jsonb OR
+     content->'selector'->>'valuationScopeKey'<>NEW."valuation_scope_key" OR
+     content->'selector'->>'tradeId'<>NEW."trade_id" OR
+     (content->>'createdAt')::timestamptz<>NEW."created_at" OR
+     NEW."content_canonical_json"<>"outcome_afl_trade_canonical_json"(content) OR
+     NEW."manifest_canonical_json"<>canonical_manifest OR
+     NEW."content_sha256"<>encode(sha256(convert_to(NEW."content_canonical_json",'UTF8')),'hex') OR
+     retained."content_sha256"<>encode(sha256(convert_to(canonical_manifest,'UTF8')),'hex') OR
+     retained."storage_uri"<>'artifact://sha256/'||retained."content_sha256" OR
+     retained."media_type"<>'application/json' OR
+     retained."byte_length"<>octet_length(convert_to(canonical_manifest,'UTF8')) OR
+     retained."environment"<>'non_production' OR retained."created_at"<>NEW."created_at" THEN
+    RAISE EXCEPTION 'Private evaluation materialization manifest identity or custody mismatch';
+  END IF;
+  FOR parent_ref IN
+    SELECT value FROM jsonb_array_elements(jsonb_build_array(
+      content->'calculationInputArtifact',content->'inputTraceArtifact',
+      content->'explanationPolicyArtifact',content->'lineageGraphArtifact'
+    ) || content->'pickBenchmarks' || content->'playerObservations')
+  LOOP
+    IF parent_ref ? 'artifact' THEN parent_ref:=parent_ref->'artifact'; END IF;
+    IF NOT "validate_outcome_prepared_valuation_input_v2_artifact"(
+      parent_ref,'non_production'::"OutcomeEnvironment"
+    ) OR (parent_ref->>'createdAt')::timestamptz>NEW."created_at" THEN
+      RAISE EXCEPTION 'Private evaluation materialization parent is not retained exactly';
+    END IF;
+  END LOOP;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "outcome_private_evaluation_materialization_manifest_insert_guard"
+BEFORE INSERT ON "outcome_private_evaluation_materialization_manifest"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_evaluation_materialization_manifest_insert"();
+
+CREATE FUNCTION "reject_outcome_private_evaluation_materialization_manifest_mutation"()
+RETURNS TRIGGER AS $$ BEGIN
+  RAISE EXCEPTION 'Private evaluation materialization manifests are append-only';
+END; $$ LANGUAGE plpgsql;
+CREATE TRIGGER "outcome_private_evaluation_materialization_manifest_mutation_guard"
+BEFORE UPDATE OR DELETE ON "outcome_private_evaluation_materialization_manifest"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_evaluation_materialization_manifest_mutation"();
+
+CREATE FUNCTION "validate_outcome_prepared_valuation_input_set_v3_insert"() RETURNS TRIGGER AS $$
+DECLARE content JSONB; expected_trade_ids JSONB;
+BEGIN
+  content:=NEW."prepared_set_json"->'content';
+  SELECT jsonb_agg(to_jsonb(member->>'canonicalRecordId') ORDER BY member->>'canonicalRecordId')
+    INTO expected_trade_ids
+    FROM "outcome_release_manifest" release,
+         jsonb_array_elements(release."manifest_json"->'content'->'canonicalMembers') members(member)
+   WHERE release."release_id"=NEW."factual_release_id" AND member->>'recordKind'='transaction';
+  IF NEW."finalized_at" IS NOT NULL OR expected_trade_ids IS NULL OR
+     NEW."content_canonical_json"<>"outcome_afl_trade_canonical_json"(content) OR
+     NEW."prepared_set_canonical_json"<>"outcome_afl_trade_canonical_json"(NEW."prepared_set_json") OR
+     NEW."content_sha256"<>encode(sha256(convert_to(NEW."content_canonical_json",'UTF8')),'hex') OR
+     content->>'schemaVersion'<>'afl-trade-prepared-valuation-input-set/v3' OR
+     content->>'scopeKey'<>NEW."scope_key" OR content->>'factualReleaseId'<>NEW."factual_release_id" OR
+     content->'releaseTradeIds'<>expected_trade_ids OR
+     jsonb_array_length(content->'entries')<>NEW."trade_count" OR
+     (content->>'readyCount')::integer<>NEW."ready_count" OR
+     (content->>'blockedCount')::integer<>NEW."blocked_count" OR
+     content->>'preparationAuthority'<>'authenticated_calculation_evidence_snapshot' OR
+     NOT "validate_outcome_prepared_valuation_input_v2_artifact"(
+       content->'valuationInputBundleArtifact',NEW."environment"
+     ) THEN
+    RAISE EXCEPTION 'Prepared valuation input v3 identity, release, or custody mismatch';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER "outcome_prepared_valuation_input_set_v3_validate_insert"
+BEFORE INSERT ON "outcome_prepared_valuation_input_set" FOR EACH ROW
+WHEN (NEW."schema_version"='afl-trade-prepared-valuation-input-set/v3')
+EXECUTE FUNCTION "validate_outcome_prepared_valuation_input_set_v3_insert"();
+
+CREATE FUNCTION "validate_outcome_prepared_valuation_input_entry_v3_insert"() RETURNS TRIGGER AS $$
+DECLARE parent RECORD; manifest RECORD; evidence_ref JSONB;
+BEGIN
+  SELECT "schema_version","scope_key","environment","prepared_at","finalized_at" INTO parent
+    FROM "outcome_prepared_valuation_input_set" WHERE "prepared_input_set_id"=NEW."prepared_input_set_id"
+    FOR KEY SHARE;
+  IF NOT FOUND OR parent."schema_version"<>'afl-trade-prepared-valuation-input-set/v3' THEN RETURN NEW; END IF;
+  IF parent."finalized_at" IS NOT NULL THEN RAISE EXCEPTION 'Prepared valuation input v3 has no open parent'; END IF;
+  IF NEW."state"='ready' THEN
+    SELECT "valuation_scope_key","trade_id","artifact_id","created_at" INTO manifest
+      FROM "outcome_private_evaluation_materialization_manifest"
+     WHERE "materialization_manifest_id"=NEW."entry_json"->>'materializationManifestId' FOR KEY SHARE;
+    IF (SELECT count(*) FROM jsonb_object_keys(NEW."entry_json"))<>4 OR NOT FOUND OR
+       manifest."valuation_scope_key"<>parent."scope_key" OR manifest."trade_id"<>NEW."trade_id" OR
+       manifest."artifact_id"<>NEW."entry_json"->'materializationManifestArtifact'->>'artifactId' OR
+       NOT "validate_outcome_prepared_valuation_input_v2_artifact"(
+         NEW."entry_json"->'materializationManifestArtifact',parent."environment"
+       ) OR manifest."created_at">parent."prepared_at" THEN
+      RAISE EXCEPTION 'Prepared valuation input v3 ready manifest is not retained exactly';
+    END IF;
+  ELSE
+    FOR evidence_ref IN
+      SELECT evidence.reference
+        FROM jsonb_array_elements(NEW."entry_json"->'blockers') AS blocker(document)
+        CROSS JOIN LATERAL jsonb_array_elements(blocker.document->'evidenceRefs')
+          AS evidence(reference)
+    LOOP
+      IF NOT "validate_outcome_prepared_valuation_input_v2_artifact"(evidence_ref,parent."environment") THEN
+        RAISE EXCEPTION 'Prepared valuation input v3 blocker evidence is not retained exactly';
+      END IF;
+    END LOOP;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER "outcome_prepared_valuation_input_entry_v3_validate_insert"
+BEFORE INSERT ON "outcome_prepared_valuation_input_entry"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_prepared_valuation_input_entry_v3_insert"();
+
+CREATE TABLE "outcome_current_prepared_valuation_input_set" (
+  "scope_key" TEXT NOT NULL,
+  "prepared_input_set_id" TEXT NOT NULL REFERENCES "outcome_prepared_valuation_input_set"("prepared_input_set_id") ON DELETE RESTRICT,
+  "revision" INTEGER NOT NULL CHECK ("revision">0),
+  "activated_at" TIMESTAMPTZ(3) NOT NULL DEFAULT transaction_timestamp(),
+  PRIMARY KEY ("scope_key")
+);
+
+CREATE FUNCTION "activate_outcome_current_prepared_valuation_input_set"(
+  requested_scope_key TEXT, requested_prepared_input_set_id TEXT, expected_revision INTEGER
+) RETURNS VOID AS $$
+DECLARE current_revision INTEGER; target_is_finalized_v3 BOOLEAN;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended('prepared-input-head:'||requested_scope_key,0));
+  SELECT EXISTS(
+    SELECT 1 FROM "outcome_prepared_valuation_input_set"
+     WHERE prepared_input_set_id=requested_prepared_input_set_id AND scope_key=requested_scope_key
+       AND schema_version='afl-trade-prepared-valuation-input-set/v3' AND finalized_at IS NOT NULL
+  ) INTO target_is_finalized_v3;
+  IF NOT target_is_finalized_v3 THEN
+    RAISE EXCEPTION 'Prepared valuation input head target is not finalized v3 authority';
+  END IF;
+  SELECT revision INTO current_revision FROM "outcome_current_prepared_valuation_input_set"
+   WHERE scope_key=requested_scope_key FOR UPDATE;
+  IF NOT FOUND AND expected_revision=0 THEN
+    INSERT INTO "outcome_current_prepared_valuation_input_set"(scope_key,prepared_input_set_id,revision)
+    VALUES (requested_scope_key,requested_prepared_input_set_id,1);
+  ELSIF current_revision=expected_revision THEN
+    UPDATE "outcome_current_prepared_valuation_input_set" SET
+      prepared_input_set_id=requested_prepared_input_set_id,revision=revision+1,
+      activated_at=transaction_timestamp() WHERE scope_key=requested_scope_key;
+  ELSE
+    RAISE EXCEPTION 'Prepared valuation input heads require compare-and-swap';
+  END IF;
+END;
+$$ LANGUAGE plpgsql;

--- a/prisma/afl-trade-outcomes/migrations/0061_governed_valuation_component_runs/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0061_governed_valuation_component_runs/migration.sql
@@ -1,0 +1,106 @@
+-- Role-aware component runs preserve their native player or pick execution while exposing one
+-- content-addressed model-run identity for private Gate 3 review.
+
+CREATE TABLE "outcome_governed_valuation_component_run" (
+    "run_id" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "native_execution_kind" TEXT NOT NULL,
+    "native_execution_id" TEXT NOT NULL,
+    "artifact_id" TEXT NOT NULL,
+    "native_execution_artifact_id" TEXT NOT NULL,
+    "protocol_id" TEXT NOT NULL,
+    "protocol_artifact_id" TEXT NOT NULL,
+    "dataset_id" TEXT NOT NULL,
+    "dataset_artifact_id" TEXT NOT NULL,
+    "dataset_admission_id" TEXT NOT NULL,
+    "dataset_admission_artifact_id" TEXT NOT NULL,
+    "dataset_admission_gate_ledger_revision" INTEGER NOT NULL,
+    "registered_at" TIMESTAMPTZ(3) NOT NULL,
+    "content_sha256" CHAR(64) NOT NULL,
+    "content_canonical_json" TEXT NOT NULL,
+    "manifest_json" JSONB NOT NULL,
+    "recorded_at" TIMESTAMPTZ(3) NOT NULL DEFAULT clock_timestamp(),
+
+    CONSTRAINT "outcome_governed_valuation_component_run_pkey" PRIMARY KEY ("run_id"),
+    CONSTRAINT "outcome_governed_valuation_component_run_native_key"
+      UNIQUE ("native_execution_kind", "native_execution_id"),
+    CONSTRAINT "outcome_governed_valuation_component_run_artifact_key" UNIQUE ("artifact_id"),
+    CONSTRAINT "outcome_governed_valuation_component_run_id_check"
+      CHECK ("run_id" ~ '^model-run:[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_governed_valuation_component_run_sha_check"
+      CHECK ("content_sha256" ~ '^[a-f0-9]{64}$'),
+    CONSTRAINT "outcome_governed_valuation_component_run_ancestry_check"
+      CHECK (
+        "protocol_id" ~ '^model-protocol:[a-f0-9]{64}$'
+        AND "dataset_id" ~ '^dataset:[a-f0-9]{64}$'
+        AND "dataset_admission_id" ~ '^dataset-admission:[a-f0-9]{64}$'
+        AND "dataset_admission_gate_ledger_revision" > 0
+      ),
+    CONSTRAINT "outcome_governed_valuation_component_run_role_check"
+      CHECK (
+        ("role"='player_contribution_and_availability'
+          AND "native_execution_kind"='admitted_player_model_run'
+          AND "native_execution_id" ~ '^model-run:[a-f0-9]{64}$')
+        OR
+        ("role"='draft_pick_and_future_pick_distribution'
+          AND "native_execution_kind"='pick_pav_model_execution'
+          AND "native_execution_id" ~ '^pick-pav-model-execution:[a-f0-9]{64}$')
+      ),
+    CONSTRAINT "outcome_governed_valuation_component_run_artifact_fkey"
+      FOREIGN KEY ("artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_governed_valuation_component_native_artifact_fkey"
+      FOREIGN KEY ("native_execution_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_governed_valuation_component_protocol_artifact_fkey"
+      FOREIGN KEY ("protocol_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_governed_valuation_component_dataset_artifact_fkey"
+      FOREIGN KEY ("dataset_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_governed_valuation_component_admission_artifact_fkey"
+      FOREIGN KEY ("dataset_admission_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT
+);
+
+CREATE OR REPLACE FUNCTION "validate_outcome_governed_valuation_component_run_insert"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  content JSONB := NEW."manifest_json"->'content';
+BEGIN
+  IF NEW."manifest_json"->>'runId' IS DISTINCT FROM NEW."run_id"
+    OR content->>'schemaVersion' IS DISTINCT FROM 'governed-valuation-component-run/v1'
+    OR content->>'environment' IS DISTINCT FROM 'non_production'
+    OR content->>'role' IS DISTINCT FROM NEW."role"
+    OR content->>'approvalState' IS DISTINCT FROM 'gate_3_review_required'
+    OR content->>'publicationEligible' IS DISTINCT FROM 'false'
+    OR content->'nativeExecution'->>'kind' IS DISTINCT FROM NEW."native_execution_kind"
+    OR content->'nativeExecution'->>'executionId' IS DISTINCT FROM NEW."native_execution_id"
+    OR content->'nativeExecution'->'artifact'->>'artifactId' IS DISTINCT FROM NEW."native_execution_artifact_id"
+    OR content->>'protocolId' IS DISTINCT FROM NEW."protocol_id"
+    OR content->'protocolArtifact'->>'artifactId' IS DISTINCT FROM NEW."protocol_artifact_id"
+    OR content->>'datasetId' IS DISTINCT FROM NEW."dataset_id"
+    OR content->'datasetArtifact'->>'artifactId' IS DISTINCT FROM NEW."dataset_artifact_id"
+    OR content->>'datasetAdmissionId' IS DISTINCT FROM NEW."dataset_admission_id"
+    OR content->'datasetAdmissionArtifact'->>'artifactId' IS DISTINCT FROM NEW."dataset_admission_artifact_id"
+    OR (content->>'datasetAdmissionGateLedgerRevision')::INTEGER IS DISTINCT FROM NEW."dataset_admission_gate_ledger_revision"
+    OR (content->>'registeredAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."registered_at"
+  THEN
+    RAISE EXCEPTION 'Governed valuation component-run columns disagree with manifest JSON';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_governed_valuation_component_run_validate_insert"
+BEFORE INSERT ON "outcome_governed_valuation_component_run"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_governed_valuation_component_run_insert"();
+
+CREATE OR REPLACE FUNCTION "reject_outcome_governed_valuation_component_run_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Governed valuation component runs are append-only';
+END $$;
+
+CREATE TRIGGER "outcome_governed_valuation_component_run_append_only"
+BEFORE UPDATE OR DELETE ON "outcome_governed_valuation_component_run"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_governed_valuation_component_run_mutation"();
+
+CREATE INDEX "outcome_governed_valuation_component_run_role_idx"
+  ON "outcome_governed_valuation_component_run"("role", "registered_at", "run_id");
+CREATE INDEX "outcome_governed_valuation_component_run_ancestry_idx"
+  ON "outcome_governed_valuation_component_run"("dataset_id", "dataset_admission_id", "protocol_id");

--- a/prisma/afl-trade-outcomes/migrations/0062_authenticated_prepared_v3_ancestry/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0062_authenticated_prepared_v3_ancestry/migration.sql
@@ -1,0 +1,145 @@
+-- Authenticate prepared-v3 relational ancestry as strictly as the retained document.
+-- Migration 0060 remains immutable; this forward migration replaces only its v3 insert validator.
+
+CREATE OR REPLACE FUNCTION "validate_outcome_prepared_valuation_input_set_v3_insert"()
+RETURNS TRIGGER AS $$
+DECLARE
+  content JSONB;
+  release_scope TEXT;
+  release_environment TEXT;
+  release_manifest JSONB;
+  canonical_members JSONB;
+  expected_trade_ids JSONB;
+  release_created_at TIMESTAMPTZ;
+  release_canonical_text TEXT;
+  membership_canonical_text TEXT;
+  release_sha256 TEXT;
+  membership_sha256 TEXT;
+  qualification_report JSONB;
+  qualification_finalized_at TIMESTAMPTZ;
+  qualification_canonical_text TEXT;
+  qualification_sha256 TEXT;
+BEGIN
+  IF NEW."finalized_at" IS NOT NULL THEN
+    RAISE EXCEPTION 'Prepared valuation input v3 must be assembled before finalization';
+  END IF;
+
+  content:=NEW."prepared_set_json"->'content';
+  SELECT "scope_key","environment","manifest_json","created_at"
+    INTO release_scope,release_environment,release_manifest,release_created_at
+    FROM "outcome_release_manifest"
+   WHERE "release_id"=NEW."factual_release_id" FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Prepared valuation input v3 factual release does not exist';
+  END IF;
+
+  canonical_members:=release_manifest->'content'->'canonicalMembers';
+  SELECT jsonb_agg(to_jsonb(member->>'canonicalRecordId') ORDER BY member->>'canonicalRecordId')
+    INTO expected_trade_ids
+    FROM jsonb_array_elements(canonical_members) members(member)
+   WHERE member->>'recordKind'='transaction';
+  release_canonical_text:="outcome_afl_trade_canonical_json"(release_manifest);
+  membership_canonical_text:="outcome_afl_trade_canonical_json"(canonical_members);
+  release_sha256:=encode(sha256(convert_to(release_canonical_text,'UTF8')),'hex');
+  membership_sha256:=encode(sha256(convert_to(membership_canonical_text,'UTF8')),'hex');
+
+  SELECT "report_json","finalized_at"
+    INTO qualification_report,qualification_finalized_at
+    FROM "outcome_valuation_source_qualification_report"
+   WHERE "qualification_report_id"=NEW."qualification_report_id" FOR KEY SHARE;
+  qualification_canonical_text:="outcome_afl_trade_canonical_json"(qualification_report);
+  qualification_sha256:=encode(
+    sha256(convert_to(qualification_canonical_text,'UTF8')),'hex'
+  );
+
+  IF NEW."content_canonical_json" IS DISTINCT FROM
+       "outcome_afl_trade_canonical_json"(content) OR
+     NEW."prepared_set_canonical_json" IS DISTINCT FROM
+       "outcome_afl_trade_canonical_json"(NEW."prepared_set_json") OR
+     NEW."content_canonical_json"::jsonb IS DISTINCT FROM content OR
+     NEW."prepared_set_canonical_json"::jsonb IS DISTINCT FROM NEW."prepared_set_json" OR
+     NEW."content_sha256" IS DISTINCT FROM
+       encode(sha256(convert_to(NEW."content_canonical_json",'UTF8')),'hex') OR
+     NEW."prepared_set_json"->>'preparedInputSetId' IS DISTINCT FROM
+       NEW."prepared_input_set_id" OR
+     (SELECT count(*) FROM jsonb_object_keys(NEW."prepared_set_json"))<>2 OR
+     (SELECT count(*) FROM jsonb_object_keys(content))<>22 OR
+     content->>'schemaVersion' IS DISTINCT FROM NEW."schema_version" OR
+     content->>'environment' IS DISTINCT FROM NEW."environment"::text OR
+     content->>'scopeKey' IS DISTINCT FROM NEW."scope_key" OR
+     content->>'factualReleaseScopeKey' IS DISTINCT FROM NEW."factual_release_scope_key" OR
+     content->>'factualReleaseId' IS DISTINCT FROM NEW."factual_release_id" OR
+     content->>'preparationAuthority' IS DISTINCT FROM
+       'authenticated_calculation_evidence_snapshot' OR
+     content->>'qualificationOperation' IS DISTINCT FROM
+       'valuation_model_training_and_derived_feature_creation' OR
+     content->>'qualificationReportId' IS DISTINCT FROM NEW."qualification_report_id" OR
+     content->>'valuationInputBundleId' !~ '^valuation-input-bundle:[a-f0-9]{64}$' OR
+     (content->>'tradeCount')::integer IS DISTINCT FROM NEW."trade_count" OR
+     (content->>'readyCount')::integer IS DISTINCT FROM NEW."ready_count" OR
+     (content->>'blockedCount')::integer IS DISTINCT FROM NEW."blocked_count" OR
+     (content->>'preparedAt')::timestamptz IS DISTINCT FROM NEW."prepared_at" OR
+     content->'publicationEligible' IS DISTINCT FROM 'false'::jsonb OR
+     content->'releaseTradeIds' IS DISTINCT FROM expected_trade_ids OR
+     jsonb_array_length(content->'releaseTradeIds') IS DISTINCT FROM NEW."trade_count" OR
+     jsonb_array_length(content->'entries') IS DISTINCT FROM NEW."trade_count" OR
+     release_scope IS DISTINCT FROM NEW."factual_release_scope_key" OR
+     release_environment IS DISTINCT FROM NEW."environment"::text OR
+     qualification_report IS NULL OR qualification_finalized_at IS NULL OR
+     qualification_report->'content'->>'factualReleaseId' IS DISTINCT FROM
+       NEW."factual_release_id" OR
+     qualification_report->'content'->>'valuationScopeKey' IS DISTINCT FROM
+       NEW."scope_key" OR
+     qualification_report->'content'->>'factualReleaseScopeKey' IS DISTINCT FROM
+       NEW."factual_release_scope_key" OR
+     qualification_report->'content'->'releaseTradeIds' IS DISTINCT FROM
+       content->'releaseTradeIds' OR
+     qualification_report->'content'->'sourceRightsEvidenceRefs' IS DISTINCT FROM
+       content->'sourceQualificationEvidenceRefs' OR
+     qualification_report->'content'->'decision'->>'state' IS DISTINCT FROM
+       'eligible_for_dataset_admission' OR
+     content->'qualificationReportArtifact'->>'artifactId' IS DISTINCT FROM
+       'artifact:'||qualification_sha256 OR
+     content->'qualificationReportArtifact'->>'contentSha256' IS DISTINCT FROM
+       qualification_sha256 OR
+     content->'qualificationReportArtifact'->>'storageUri' IS DISTINCT FROM
+       'artifact://sha256/'||qualification_sha256 OR
+     content->'qualificationReportArtifact'->>'mediaType' IS DISTINCT FROM
+       'application/json' OR
+     (content->'qualificationReportArtifact'->>'byteLength')::integer IS DISTINCT FROM
+       octet_length(convert_to(qualification_canonical_text,'UTF8')) OR
+     (content->'qualificationReportArtifact'->>'createdAt')::timestamptz IS DISTINCT FROM
+       qualification_finalized_at OR
+     content->'factualReleaseArtifact'->>'artifactId' IS DISTINCT FROM
+       'artifact:'||release_sha256 OR
+     content->'factualReleaseArtifact'->>'contentSha256' IS DISTINCT FROM release_sha256 OR
+     content->'factualReleaseArtifact'->>'storageUri' IS DISTINCT FROM
+       'artifact://sha256/'||release_sha256 OR
+     content->'factualReleaseArtifact'->>'mediaType' IS DISTINCT FROM 'application/json' OR
+     (content->'factualReleaseArtifact'->>'byteLength')::integer IS DISTINCT FROM
+       octet_length(convert_to(release_canonical_text,'UTF8')) OR
+     (content->'factualReleaseArtifact'->>'createdAt')::timestamptz IS DISTINCT FROM
+       release_created_at OR
+     content->'releaseMembershipArtifact'->>'artifactId' IS DISTINCT FROM
+       'artifact:'||membership_sha256 OR
+     content->'releaseMembershipArtifact'->>'contentSha256' IS DISTINCT FROM
+       membership_sha256 OR
+     content->'releaseMembershipArtifact'->>'storageUri' IS DISTINCT FROM
+       'artifact://sha256/'||membership_sha256 OR
+     content->'releaseMembershipArtifact'->>'mediaType' IS DISTINCT FROM
+       'application/json' OR
+     (content->'releaseMembershipArtifact'->>'byteLength')::integer IS DISTINCT FROM
+       octet_length(convert_to(membership_canonical_text,'UTF8')) OR
+     (content->'releaseMembershipArtifact'->>'createdAt')::timestamptz IS DISTINCT FROM
+       release_created_at OR
+     NOT "validate_outcome_prepared_valuation_input_v2_artifact"(
+       content->'valuationInputBundleArtifact',NEW."environment"
+     ) OR
+     (content->'valuationInputBundleArtifact'->>'createdAt')::timestamptz>NEW."prepared_at" THEN
+    RAISE EXCEPTION 'Prepared valuation input v3 identity, authority, or factual ancestry mismatch';
+  END IF;
+  RETURN NEW;
+EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+  RAISE EXCEPTION 'Prepared valuation input v3 contains invalid typed evidence';
+END;
+$$ LANGUAGE plpgsql;

--- a/prisma/afl-trade-outcomes/migrations/0063_governed_pick_pav_model_execution/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0063_governed_pick_pav_model_execution/migration.sql
@@ -1,0 +1,163 @@
+-- Governed pick-PAV executions are a separate non-production authority path. The existing
+-- test-fixture execution registry remains unchanged and cannot become Gate 3 eligible.
+
+CREATE TABLE "outcome_governed_pick_pav_model_execution" (
+    "execution_id" TEXT NOT NULL,
+    "observation_set_id" TEXT NOT NULL,
+    "dataset_id" TEXT NOT NULL,
+    "dataset_artifact_id" TEXT NOT NULL,
+    "dataset_admission_id" TEXT NOT NULL,
+    "dataset_admission_artifact_id" TEXT NOT NULL,
+    "dataset_admission_gate_ledger_revision" INTEGER NOT NULL,
+    "protocol_id" TEXT NOT NULL,
+    "protocol_artifact_id" TEXT NOT NULL,
+    "execution_artifact_id" TEXT NOT NULL,
+    "final_test_evaluation_started_at" TIMESTAMPTZ(3) NOT NULL,
+    "completed_at" TIMESTAMPTZ(3) NOT NULL,
+    "content_sha256" CHAR(64) NOT NULL,
+    "content_canonical_json" TEXT NOT NULL,
+    "execution_json" JSONB NOT NULL,
+    "recorded_at" TIMESTAMPTZ(3) NOT NULL DEFAULT clock_timestamp(),
+    "recorded_by" TEXT NOT NULL DEFAULT current_user,
+
+    CONSTRAINT "outcome_governed_pick_pav_model_execution_pkey"
+      PRIMARY KEY ("execution_id"),
+    CONSTRAINT "outcome_governed_pick_pav_model_execution_artifact_key"
+      UNIQUE ("execution_artifact_id"),
+    CONSTRAINT "outcome_governed_pick_pav_model_execution_identity_check"
+      CHECK (
+        "execution_id" ~ '^pick-pav-model-execution:[a-f0-9]{64}$'
+        AND "content_sha256" ~ '^[a-f0-9]{64}$'
+        AND "dataset_id" ~ '^dataset:[a-f0-9]{64}$'
+        AND "dataset_admission_id" ~ '^dataset-admission:[a-f0-9]{64}$'
+        AND "protocol_id" ~ '^model-protocol:[a-f0-9]{64}$'
+        AND "dataset_admission_gate_ledger_revision" > 0
+        AND "completed_at" >= "final_test_evaluation_started_at"
+      ),
+    CONSTRAINT "outcome_governed_pick_pav_model_execution_observation_fkey"
+      FOREIGN KEY ("observation_set_id")
+      REFERENCES "outcome_pick_pav_observation_set"("observation_set_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_governed_pick_pav_model_execution_dataset_fkey"
+      FOREIGN KEY ("dataset_id")
+      REFERENCES "outcome_valuation_dataset_candidate"("dataset_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_governed_pick_pav_model_execution_admission_fkey"
+      FOREIGN KEY ("dataset_admission_id")
+      REFERENCES "outcome_valuation_dataset_admission"("admission_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_governed_pick_pav_model_execution_protocol_fkey"
+      FOREIGN KEY ("protocol_id")
+      REFERENCES "outcome_valuation_model_protocol"("protocol_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_governed_pick_pav_model_execution_artifact_fkey"
+      FOREIGN KEY ("execution_artifact_id")
+      REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_governed_pick_pav_model_execution_dataset_artifact_fkey"
+      FOREIGN KEY ("dataset_artifact_id")
+      REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_governed_pick_exec_admission_artifact_fkey"
+      FOREIGN KEY ("dataset_admission_artifact_id")
+      REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+    CONSTRAINT "outcome_governed_pick_exec_protocol_artifact_fkey"
+      FOREIGN KEY ("protocol_artifact_id")
+      REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT
+);
+
+CREATE OR REPLACE FUNCTION "validate_outcome_governed_pick_pav_model_execution_insert"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  content JSONB := NEW."execution_json"->'content';
+  observation_row RECORD;
+  dataset_row RECORD;
+  admission_row RECORD;
+  protocol_row RECORD;
+BEGIN
+  SELECT * INTO observation_row FROM "outcome_pick_pav_observation_set"
+   WHERE "observation_set_id"=NEW."observation_set_id" FOR SHARE;
+  SELECT * INTO dataset_row FROM "outcome_valuation_dataset_candidate"
+   WHERE "dataset_id"=NEW."dataset_id" FOR SHARE;
+  SELECT * INTO admission_row FROM "outcome_valuation_dataset_admission"
+   WHERE "admission_id"=NEW."dataset_admission_id" FOR SHARE;
+  SELECT * INTO protocol_row FROM "outcome_valuation_model_protocol"
+   WHERE "protocol_id"=NEW."protocol_id" FOR SHARE;
+
+  IF NEW."execution_json"->>'executionId' IS DISTINCT FROM NEW."execution_id"
+    OR NEW."content_sha256" IS DISTINCT FROM
+      substring(NEW."execution_id" FROM length('pick-pav-model-execution:') + 1)
+    OR NEW."content_canonical_json" IS DISTINCT FROM outcome_afl_trade_canonical_json(content)
+    OR NEW."execution_id" IS DISTINCT FROM 'pick-pav-model-execution:' ||
+      encode(sha256(convert_to(NEW."content_canonical_json",'UTF8')),'hex')
+    OR content->>'schemaVersion' IS DISTINCT FROM 'afl-trade-pick-pav-model-execution/v2'
+    OR content->>'environment' IS DISTINCT FROM 'non_production'
+    OR content->>'approvalStatus' IS DISTINCT FROM 'gate_3_review_required'
+    OR content->>'publicationEligible' IS DISTINCT FROM 'false'
+    OR content->>'observationSetId' IS DISTINCT FROM NEW."observation_set_id"
+    OR content->>'datasetId' IS DISTINCT FROM NEW."dataset_id"
+    OR content->'datasetArtifact'->>'artifactId' IS DISTINCT FROM NEW."dataset_artifact_id"
+    OR content->>'datasetAdmissionId' IS DISTINCT FROM NEW."dataset_admission_id"
+    OR content->'datasetAdmissionArtifact'->>'artifactId'
+      IS DISTINCT FROM NEW."dataset_admission_artifact_id"
+    OR (content->>'datasetAdmissionGateLedgerRevision')::INTEGER
+      IS DISTINCT FROM NEW."dataset_admission_gate_ledger_revision"
+    OR content->>'protocolId' IS DISTINCT FROM NEW."protocol_id"
+    OR content->'protocolArtifact'->>'artifactId' IS DISTINCT FROM NEW."protocol_artifact_id"
+    OR (content->>'finalTestEvaluationStartedAt')::TIMESTAMPTZ
+      IS DISTINCT FROM NEW."final_test_evaluation_started_at"
+    OR (content->>'completedAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."completed_at"
+    OR observation_row."status" IS DISTINCT FROM 'finalized'
+    OR observation_row."environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR dataset_row."status" IS DISTINCT FROM 'finalized'
+    OR dataset_row."environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR admission_row."status" IS DISTINCT FROM 'finalized'
+    OR admission_row."environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR admission_row."dataset_id" IS DISTINCT FROM NEW."dataset_id"
+    OR admission_row."gate_ledger_revision"
+      IS DISTINCT FROM NEW."dataset_admission_gate_ledger_revision"
+    OR protocol_row."environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR protocol_row."dataset_id" IS DISTINCT FROM NEW."dataset_id"
+    OR protocol_row."admission_id" IS DISTINCT FROM NEW."dataset_admission_id"
+    OR NEW."dataset_artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+      outcome_afl_trade_canonical_json(dataset_row."dataset_json"),'UTF8')),'hex')
+    OR NEW."dataset_admission_artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+      outcome_afl_trade_canonical_json(admission_row."admission_json"),'UTF8')),'hex')
+    OR NEW."protocol_artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+      outcome_afl_trade_canonical_json(protocol_row."protocol_json"),'UTF8')),'hex')
+    OR observation_row."release_id" IS DISTINCT FROM
+      dataset_row."dataset_json"->'content'->'factualParent'->>'factualReleaseId'
+    OR observation_row."release_id" IS DISTINCT FROM
+      admission_row."admission_json"->'content'->>'factualReleaseId'
+  THEN
+    RAISE EXCEPTION 'Governed pick-PAV execution authority or ancestry mismatch';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_governed_pick_pav_model_execution_validate_insert"
+BEFORE INSERT ON "outcome_governed_pick_pav_model_execution"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_governed_pick_pav_model_execution_insert"();
+
+CREATE OR REPLACE FUNCTION "reject_outcome_governed_pick_pav_model_execution_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Governed pick-PAV model executions are append-only';
+END $$;
+
+CREATE TRIGGER "outcome_governed_pick_pav_model_execution_append_only"
+BEFORE UPDATE OR DELETE ON "outcome_governed_pick_pav_model_execution"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_governed_pick_pav_model_execution_mutation"();
+
+CREATE INDEX "outcome_governed_pick_pav_model_execution_ancestry_idx"
+  ON "outcome_governed_pick_pav_model_execution"
+    ("dataset_id", "dataset_admission_id", "protocol_id", "completed_at");
+
+ALTER TABLE "outcome_governed_valuation_component_run"
+  DROP CONSTRAINT "outcome_governed_valuation_component_run_role_check";
+ALTER TABLE "outcome_governed_valuation_component_run"
+  ADD CONSTRAINT "outcome_governed_valuation_component_run_role_check"
+  CHECK (
+    ("role"='player_contribution_and_availability'
+      AND "native_execution_kind"='admitted_player_model_run'
+      AND "native_execution_id" ~ '^model-run:[a-f0-9]{64}$')
+    OR
+    ("role"='draft_pick_and_future_pick_distribution'
+      AND "native_execution_kind" IN
+        ('pick_pav_model_execution','governed_pick_pav_model_execution')
+      AND "native_execution_id" ~ '^pick-pav-model-execution:[a-f0-9]{64}$')
+  );

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -255,24 +255,42 @@ model OutcomeFactualProjectionItemSet {
 }
 
 model OutcomeArtifactCustody {
-  artifactId                    String                                  @id @map("artifact_id")
-  contentSha256                 String                                  @map("content_sha256") @outcomes.Char(64)
-  storageUri                    String                                  @unique @map("storage_uri")
-  mediaType                     String                                  @map("media_type")
-  byteLength                    BigInt                                  @map("byte_length")
-  artifactClass                 OutcomeArtifactClass                    @map("artifact_class")
-  environment                   OutcomeEnvironment
-  custodyProfileId              String?                                 @map("custody_profile_id")
-  createdAt                     DateTime                                @map("created_at") @outcomes.Timestamptz(3)
-  verifiedAt                    DateTime                                @map("verified_at") @outcomes.Timestamptz(3)
-  custodyJson                   Json                                    @map("custody_json")
-  sourceCaptures                OutcomeSourceCapture[]
-  captureAttemptEvidence        OutcomeSourceCaptureAttempt[]
-  governedEvidence              OutcomeGovernedEvidenceReference[]
-  valuationProjections          OutcomeValuationProjectionManifest[]
-  valuationDatasetArtifacts     OutcomeValuationDatasetArtifactMember[]
-  hpnPavMethods                 OutcomeHpnPavMethod[]
-  workbookTransactionReviewSets OutcomeWorkbookTransactionReviewSet[]
+  artifactId                                   String                                               @id @map("artifact_id")
+  contentSha256                                String                                               @map("content_sha256") @outcomes.Char(64)
+  storageUri                                   String                                               @unique @map("storage_uri")
+  mediaType                                    String                                               @map("media_type")
+  byteLength                                   BigInt                                               @map("byte_length")
+  artifactClass                                OutcomeArtifactClass                                 @map("artifact_class")
+  environment                                  OutcomeEnvironment
+  custodyProfileId                             String?                                              @map("custody_profile_id")
+  createdAt                                    DateTime                                             @map("created_at") @outcomes.Timestamptz(3)
+  verifiedAt                                   DateTime                                             @map("verified_at") @outcomes.Timestamptz(3)
+  custodyJson                                  Json                                                 @map("custody_json")
+  sourceCaptures                               OutcomeSourceCapture[]
+  captureAttemptEvidence                       OutcomeSourceCaptureAttempt[]
+  governedEvidence                             OutcomeGovernedEvidenceReference[]
+  valuationProjections                         OutcomeValuationProjectionManifest[]
+  valuationDatasetArtifacts                    OutcomeValuationDatasetArtifactMember[]
+  hpnPavMethods                                OutcomeHpnPavMethod[]
+  workbookTransactionReviewSets                OutcomeWorkbookTransactionReviewSet[]
+  privateEvaluationAuthoritySnapshots          OutcomePrivateEvaluationAuthoritySnapshot[]          @relation("PrivateEvaluationAuthoritySnapshotArtifact")
+  privateEvaluationMaterializationManifests    OutcomePrivateEvaluationMaterializationManifest[]    @relation("PrivateEvaluationMaterializationManifestArtifact")
+  privateEvaluationInspectionReceipts          OutcomePrivateEvaluationInspectionReceipt[]          @relation("PrivateEvaluationInspectionReceiptArtifact")
+  privateEvaluationTransitionIntents           OutcomePrivateEvaluationTransitionIntent[]           @relation("PrivateEvaluationTransitionIntentArtifact")
+  privateEvaluationGenerationArtifacts         OutcomeLocalPrivateTradeEvaluationGeneration[]       @relation("PrivateEvaluationGenerationArtifact")
+  privateEvaluationNarrativeArtifacts          OutcomeLocalPrivateTradeEvaluationGeneration[]       @relation("PrivateEvaluationNarrativeArtifact")
+  privateEvaluationProjectionManifestArtifacts OutcomeLocalPrivateTradeEvaluationGeneration[]       @relation("PrivateEvaluationProjectionManifestArtifact")
+  privateEvaluationTransitionReceipts          OutcomePrivateEvaluationTransitionReceipt[]          @relation("PrivateEvaluationTransitionReceiptArtifact")
+  privateEvaluationReconstructionVerifications OutcomePrivateEvaluationReconstructionVerification[] @relation("PrivateEvaluationReconstructionVerificationArtifact")
+  governedComponentRunManifests                OutcomeGovernedValuationComponentRun[]                @relation("GovernedValuationComponentRunManifestArtifact")
+  governedComponentRunNativeExecutions         OutcomeGovernedValuationComponentRun[]                @relation("GovernedValuationComponentRunNativeArtifact")
+  governedComponentRunProtocols                OutcomeGovernedValuationComponentRun[]                @relation("GovernedValuationComponentRunProtocolArtifact")
+  governedComponentRunDatasets                 OutcomeGovernedValuationComponentRun[]                @relation("GovernedValuationComponentRunDatasetArtifact")
+  governedComponentRunAdmissions               OutcomeGovernedValuationComponentRun[]                @relation("GovernedValuationComponentRunAdmissionArtifact")
+  governedPickExecutionArtifacts               OutcomeGovernedPickPavModelExecution[]                @relation("GovernedPickExecutionArtifact")
+  governedPickDatasetArtifacts                 OutcomeGovernedPickPavModelExecution[]                @relation("GovernedPickDatasetArtifact")
+  governedPickAdmissionArtifacts               OutcomeGovernedPickPavModelExecution[]                @relation("GovernedPickAdmissionArtifact")
+  governedPickProtocolArtifacts                OutcomeGovernedPickPavModelExecution[]                @relation("GovernedPickProtocolArtifact")
 
   @@unique([artifactClass, contentSha256], map: "outcome_artifact_class_sha256_key")
   @@index([environment, artifactClass, createdAt], map: "outcome_artifact_environment_class_created_idx")
@@ -1734,6 +1752,7 @@ model OutcomePickPavObservationSet {
   draftClasses                OutcomePickPavDraftClass[]
   observations                OutcomePickPavObservation[]
   modelExecutions             OutcomePickPavModelExecution[]
+  governedModelExecutions     OutcomeGovernedPickPavModelExecution[]
 
   @@unique([environment, competition, releaseId, policyId, knowledgeCutoffAt], map: "outcome_pick_pav_observation_set_scope_key")
   @@index([environment, competition, finalizedAt], map: "outcome_pick_pav_observation_set_scope_idx")
@@ -1865,6 +1884,36 @@ model OutcomePickPavModelExecution {
   @@index([environment, competition, completedAt], map: "outcome_pick_pav_model_execution_scope_idx")
   @@index([observationSetId, completedAt], map: "outcome_pick_pav_model_execution_observation_idx")
   @@map("outcome_pick_pav_model_execution")
+}
+
+model OutcomeGovernedPickPavModelExecution {
+  executionId                           String                           @id @map("execution_id") @outcomes.Text
+  observationSetId                      String                           @map("observation_set_id") @outcomes.Text
+  datasetId                             String                           @map("dataset_id") @outcomes.Text
+  datasetArtifactId                     String                           @map("dataset_artifact_id") @outcomes.Text
+  datasetAdmissionId                    String                           @map("dataset_admission_id") @outcomes.Text
+  datasetAdmissionArtifactId            String                           @map("dataset_admission_artifact_id") @outcomes.Text
+  datasetAdmissionGateLedgerRevision    Int                              @map("dataset_admission_gate_ledger_revision")
+  protocolId                            String                           @map("protocol_id") @outcomes.Text
+  protocolArtifactId                    String                           @map("protocol_artifact_id") @outcomes.Text
+  executionArtifactId                   String                           @unique @map("execution_artifact_id") @outcomes.Text
+  finalTestEvaluationStartedAt          DateTime                         @map("final_test_evaluation_started_at") @outcomes.Timestamptz(3)
+  completedAt                           DateTime                         @map("completed_at") @outcomes.Timestamptz(3)
+  contentSha256                         String                           @map("content_sha256") @outcomes.Char(64)
+  contentCanonicalJson                  String                           @map("content_canonical_json") @outcomes.Text
+  executionJson                         Json                             @map("execution_json")
+  recordedAt                            DateTime                         @default(dbgenerated("clock_timestamp()")) @map("recorded_at") @outcomes.Timestamptz(3)
+  recordedBy                            String                           @default(dbgenerated("CURRENT_USER")) @map("recorded_by") @outcomes.Text
+  observationSet                        OutcomePickPavObservationSet     @relation(fields: [observationSetId], references: [observationSetId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_observation_fkey")
+  dataset                               OutcomeValuationDatasetCandidate @relation(fields: [datasetId], references: [datasetId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_dataset_fkey")
+  datasetAdmission                      OutcomeValuationDatasetAdmission @relation(fields: [datasetAdmissionId], references: [admissionId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_admission_fkey")
+  executionArtifact                     OutcomeArtifactCustody           @relation("GovernedPickExecutionArtifact", fields: [executionArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_artifact_fkey")
+  datasetArtifact                       OutcomeArtifactCustody           @relation("GovernedPickDatasetArtifact", fields: [datasetArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_dataset_artifact_fkey")
+  datasetAdmissionArtifact              OutcomeArtifactCustody           @relation("GovernedPickAdmissionArtifact", fields: [datasetAdmissionArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_pick_exec_admission_artifact_fkey")
+  protocolArtifact                      OutcomeArtifactCustody           @relation("GovernedPickProtocolArtifact", fields: [protocolArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_pick_exec_protocol_artifact_fkey")
+
+  @@index([datasetId, datasetAdmissionId, protocolId, completedAt], map: "outcome_governed_pick_pav_model_execution_ancestry_idx")
+  @@map("outcome_governed_pick_pav_model_execution")
 }
 
 model OutcomeProviderIdentityCandidate {
@@ -3829,6 +3878,7 @@ model OutcomeValuationDatasetCandidate {
   playerObservationSets             OutcomeValuationPlayerObservationSet[]
   modelRunIntents                   OutcomeValuationModelRunIntent[]
   modelRunOperationalAuthorizations OutcomeValuationModelRunOperationalAuthorization[]
+  governedPickModelExecutions       OutcomeGovernedPickPavModelExecution[]
 
   @@index([environment, scopeKey, competition, status, createdAt], map: "outcome_valuation_dataset_candidate_scope_idx")
   @@map("outcome_valuation_dataset_candidate")
@@ -3960,6 +4010,7 @@ model OutcomeValuationDatasetAdmission {
   playerObservationSets             OutcomeValuationPlayerObservationSet[]
   modelRunIntents                   OutcomeValuationModelRunIntent[]
   modelRunOperationalAuthorizations OutcomeValuationModelRunOperationalAuthorization[]
+  governedPickModelExecutions       OutcomeGovernedPickPavModelExecution[]
 
   @@unique([datasetId, admittedAt], map: "outcome_valuation_dataset_admission_dataset_time_key")
   @@index([datasetId, status, admittedAt], map: "outcome_valuation_dataset_admission_dataset_idx")
@@ -4345,6 +4396,7 @@ model OutcomePreparedValuationInputSet {
   factualRelease           OutcomeReleaseManifest                    @relation(fields: [factualReleaseId], references: [releaseId], onDelete: Restrict)
   qualificationReport      OutcomeValuationSourceQualificationReport @relation(fields: [qualificationReportId], references: [qualificationReportId], onDelete: Restrict)
   entries                  OutcomePreparedValuationInputEntry[]
+  currentHeads             OutcomeCurrentPreparedValuationInputSet[]
 
   @@index([environment, scopeKey, preparedAt], map: "outcome_prepared_valuation_input_set_scope_idx")
   @@index([factualReleaseId, preparedAt], map: "outcome_prepared_valuation_input_set_release_idx")
@@ -4364,6 +4416,33 @@ model OutcomePreparedValuationInputEntry {
   @@id([preparedInputSetId, ordinal])
   @@unique([preparedInputSetId, tradeId], map: "outcome_prepared_valuation_input_entry_trade_key")
   @@map("outcome_prepared_valuation_input_entry")
+}
+
+model OutcomePrivateEvaluationMaterializationManifest {
+  materializationManifestId String                 @id @map("materialization_manifest_id") @outcomes.Text
+  contentSha256              String                 @map("content_sha256") @outcomes.Char(64)
+  valuationScopeKey          String                 @map("valuation_scope_key") @outcomes.Text
+  tradeId                    String                 @map("trade_id") @outcomes.Text
+  artifactId                 String                 @unique @map("artifact_id") @outcomes.Text
+  createdAt                  DateTime               @map("created_at") @outcomes.Timestamptz(3)
+  contentCanonicalJson       String                 @map("content_canonical_json") @outcomes.Text
+  manifestCanonicalJson      String                 @map("manifest_canonical_json") @outcomes.Text
+  manifestJson               Json                   @map("manifest_json")
+  registeredAt               DateTime               @default(dbgenerated("transaction_timestamp()")) @map("registered_at") @outcomes.Timestamptz(3)
+  artifact                   OutcomeArtifactCustody @relation("PrivateEvaluationMaterializationManifestArtifact", fields: [artifactId], references: [artifactId], onDelete: Restrict)
+
+  @@index([valuationScopeKey, tradeId, createdAt], map: "outcome_private_evaluation_materialization_selector_idx")
+  @@map("outcome_private_evaluation_materialization_manifest")
+}
+
+model OutcomeCurrentPreparedValuationInputSet {
+  scopeKey           String                           @id @map("scope_key") @outcomes.Text
+  preparedInputSetId String                           @map("prepared_input_set_id") @outcomes.Text
+  revision           Int
+  activatedAt        DateTime                         @default(dbgenerated("transaction_timestamp()")) @map("activated_at") @outcomes.Timestamptz(3)
+  preparedInputSet   OutcomePreparedValuationInputSet @relation(fields: [preparedInputSetId], references: [preparedInputSetId], onDelete: Restrict)
+
+  @@map("outcome_current_prepared_valuation_input_set")
 }
 
 model OutcomePrivateValuationEvaluationDecision {
@@ -4836,4 +4915,210 @@ model OutcomeWorkbookTransactionReviewHead {
   @@id([reviewSetId, reviewSubjectId])
   @@index([reviewSetId, outcome, updatedAt], map: "outcome_workbook_transaction_review_head_status_idx")
   @@map("outcome_workbook_transaction_review_head")
+}
+
+model OutcomeGovernedValuationComponentRun {
+  runId                              String                 @id @map("run_id") @outcomes.Text
+  role                               String                 @outcomes.Text
+  nativeExecutionKind                String                 @map("native_execution_kind") @outcomes.Text
+  nativeExecutionId                  String                 @map("native_execution_id") @outcomes.Text
+  artifactId                         String                 @unique @map("artifact_id") @outcomes.Text
+  nativeExecutionArtifactId          String                 @map("native_execution_artifact_id") @outcomes.Text
+  protocolId                         String                 @map("protocol_id") @outcomes.Text
+  protocolArtifactId                 String                 @map("protocol_artifact_id") @outcomes.Text
+  datasetId                          String                 @map("dataset_id") @outcomes.Text
+  datasetArtifactId                  String                 @map("dataset_artifact_id") @outcomes.Text
+  datasetAdmissionId                 String                 @map("dataset_admission_id") @outcomes.Text
+  datasetAdmissionArtifactId         String                 @map("dataset_admission_artifact_id") @outcomes.Text
+  datasetAdmissionGateLedgerRevision Int                    @map("dataset_admission_gate_ledger_revision")
+  registeredAt                       DateTime               @map("registered_at") @outcomes.Timestamptz(3)
+  contentSha256                      String                 @map("content_sha256") @outcomes.Char(64)
+  contentCanonicalJson               String                 @map("content_canonical_json") @outcomes.Text
+  manifestJson                       Json                   @map("manifest_json")
+  recordedAt                         DateTime               @default(dbgenerated("clock_timestamp()")) @map("recorded_at") @outcomes.Timestamptz(3)
+  artifact                           OutcomeArtifactCustody @relation("GovernedValuationComponentRunManifestArtifact", fields: [artifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_run_artifact_fkey")
+  nativeExecutionArtifact            OutcomeArtifactCustody @relation("GovernedValuationComponentRunNativeArtifact", fields: [nativeExecutionArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_native_artifact_fkey")
+  protocolArtifact                   OutcomeArtifactCustody @relation("GovernedValuationComponentRunProtocolArtifact", fields: [protocolArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_protocol_artifact_fkey")
+  datasetArtifact                    OutcomeArtifactCustody @relation("GovernedValuationComponentRunDatasetArtifact", fields: [datasetArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_dataset_artifact_fkey")
+  datasetAdmissionArtifact           OutcomeArtifactCustody @relation("GovernedValuationComponentRunAdmissionArtifact", fields: [datasetAdmissionArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_admission_artifact_fkey")
+
+  @@unique([nativeExecutionKind, nativeExecutionId], map: "outcome_governed_valuation_component_run_native_key")
+  @@index([role, registeredAt, runId], map: "outcome_governed_valuation_component_run_role_idx")
+  @@index([datasetId, datasetAdmissionId, protocolId], map: "outcome_governed_valuation_component_run_ancestry_idx")
+  @@map("outcome_governed_valuation_component_run")
+}
+
+model OutcomePrivateEvaluationAuthoritySnapshot {
+  snapshotId               String                                        @id @map("snapshot_id") @outcomes.Text
+  valuationScopeKey        String                                        @map("valuation_scope_key") @outcomes.Text
+  tradeId                  String                                        @map("trade_id") @outcomes.Text
+  artifactId               String                                        @unique @map("artifact_id") @outcomes.Text
+  capturedAt               DateTime                                      @map("captured_at") @outcomes.Timestamptz(3)
+  validThrough             DateTime                                      @map("valid_through") @outcomes.Timestamptz(3)
+  expectedHeadStatus       String                                        @map("expected_head_status") @outcomes.Text
+  expectedHeadRevision     Int                                           @map("expected_head_revision")
+  expectedHeadGenerationId String?                                       @map("expected_head_generation_id") @outcomes.Text
+  contentSha256            String                                        @map("content_sha256") @outcomes.Char(64)
+  contentCanonicalJson     String                                        @map("content_canonical_json") @outcomes.Text
+  snapshotJson             Json                                          @map("snapshot_json")
+  registeredAt             DateTime                                      @default(dbgenerated("clock_timestamp()")) @map("registered_at") @outcomes.Timestamptz(3)
+  artifact                 OutcomeArtifactCustody                        @relation("PrivateEvaluationAuthoritySnapshotArtifact", fields: [artifactId], references: [artifactId], onDelete: Restrict, map: "outcome_private_evaluation_authority_snapshot_artifact_fkey")
+  expectedHeadGeneration   OutcomeLocalPrivateTradeEvaluationGeneration? @relation("PrivateEvaluationSnapshotExpectedHead", fields: [valuationScopeKey, tradeId, expectedHeadGenerationId], references: [valuationScopeKey, tradeId, generationId], onDelete: Restrict, map: "outcome_private_eval_snapshot_expected_gen_fkey")
+  inspectionReceipts       OutcomePrivateEvaluationInspectionReceipt[]
+  transitionIntents        OutcomePrivateEvaluationTransitionIntent[]
+
+  @@unique([snapshotId, valuationScopeKey, tradeId], map: "outcome_private_evaluation_authority_snapshot_scope_key")
+  @@index([valuationScopeKey, tradeId, capturedAt], map: "outcome_private_evaluation_snapshot_selector_idx")
+  @@map("outcome_private_evaluation_authority_snapshot")
+}
+
+model OutcomePrivateEvaluationInspectionReceipt {
+  inspectionId                String                                               @id @map("inspection_id") @outcomes.Text
+  snapshotId                  String                                               @map("snapshot_id") @outcomes.Text
+  valuationScopeKey           String                                               @map("valuation_scope_key") @outcomes.Text
+  tradeId                     String                                               @map("trade_id") @outcomes.Text
+  artifactId                  String                                               @unique @map("artifact_id") @outcomes.Text
+  state                       String                                               @outcomes.Text
+  inspectedAt                 DateTime                                             @map("inspected_at") @outcomes.Timestamptz(3)
+  validThrough                DateTime                                             @map("valid_through") @outcomes.Timestamptz(3)
+  expectedHeadStatus          String                                               @map("expected_head_status") @outcomes.Text
+  expectedHeadRevision        Int                                                  @map("expected_head_revision")
+  expectedHeadGenerationId    String?                                              @map("expected_head_generation_id") @outcomes.Text
+  contentSha256               String                                               @map("content_sha256") @outcomes.Char(64)
+  contentCanonicalJson        String                                               @map("content_canonical_json") @outcomes.Text
+  receiptJson                 Json                                                 @map("receipt_json")
+  registeredAt                DateTime                                             @default(dbgenerated("clock_timestamp()")) @map("registered_at") @outcomes.Timestamptz(3)
+  snapshot                    OutcomePrivateEvaluationAuthoritySnapshot            @relation(fields: [snapshotId], references: [snapshotId], onDelete: Restrict, map: "outcome_private_evaluation_inspection_receipt_snapshot_fkey")
+  artifact                    OutcomeArtifactCustody                               @relation("PrivateEvaluationInspectionReceiptArtifact", fields: [artifactId], references: [artifactId], onDelete: Restrict, map: "outcome_private_evaluation_inspection_receipt_artifact_fkey")
+  expectedHeadGeneration      OutcomeLocalPrivateTradeEvaluationGeneration?        @relation("PrivateEvaluationInspectionExpectedHead", fields: [valuationScopeKey, tradeId, expectedHeadGenerationId], references: [valuationScopeKey, tradeId, generationId], onDelete: Restrict, map: "outcome_private_eval_inspection_expected_gen_fkey")
+  transitionIntent            OutcomePrivateEvaluationTransitionIntent?
+  reconstructionVerifications OutcomePrivateEvaluationReconstructionVerification[]
+
+  @@map("outcome_private_evaluation_inspection_receipt")
+}
+
+model OutcomePrivateEvaluationTransitionIntent {
+  transitionIntentId       String                                        @id @map("transition_intent_id") @outcomes.Text
+  inspectionId             String                                        @unique @map("inspection_id") @outcomes.Text
+  authoritySnapshotId      String?                                       @map("authority_snapshot_id") @outcomes.Text
+  operationId              String                                        @unique @map("operation_id") @outcomes.Text
+  valuationScopeKey        String                                        @map("valuation_scope_key") @outcomes.Text
+  tradeId                  String                                        @map("trade_id") @outcomes.Text
+  artifactId               String                                        @unique @map("artifact_id") @outcomes.Text
+  action                   String                                        @outcomes.Text
+  expectedHeadStatus       String                                        @map("expected_head_status") @outcomes.Text
+  expectedHeadRevision     Int                                           @map("expected_head_revision")
+  expectedHeadGenerationId String?                                       @map("expected_head_generation_id") @outcomes.Text
+  targetGenerationId       String?                                       @map("target_generation_id") @outcomes.Text
+  requestedAt              DateTime                                      @map("requested_at") @outcomes.Timestamptz(3)
+  expiresAt                DateTime                                      @map("expires_at") @outcomes.Timestamptz(3)
+  contentSha256            String                                        @map("content_sha256") @outcomes.Char(64)
+  contentCanonicalJson     String                                        @map("content_canonical_json") @outcomes.Text
+  intentJson               Json                                          @map("intent_json")
+  registeredAt             DateTime                                      @default(dbgenerated("clock_timestamp()")) @map("registered_at") @outcomes.Timestamptz(3)
+  inspection               OutcomePrivateEvaluationInspectionReceipt     @relation(fields: [inspectionId], references: [inspectionId], onDelete: Restrict, map: "outcome_private_evaluation_transition_intent_inspection_fkey")
+  authoritySnapshot        OutcomePrivateEvaluationAuthoritySnapshot?    @relation(fields: [authoritySnapshotId, valuationScopeKey, tradeId], references: [snapshotId, valuationScopeKey, tradeId], onDelete: Restrict, map: "outcome_private_evaluation_transition_intent_snapshot_fkey")
+  artifact                 OutcomeArtifactCustody                        @relation("PrivateEvaluationTransitionIntentArtifact", fields: [artifactId], references: [artifactId], onDelete: Restrict, map: "outcome_private_evaluation_transition_intent_artifact_fkey")
+  expectedHeadGeneration   OutcomeLocalPrivateTradeEvaluationGeneration? @relation("PrivateEvaluationIntentExpectedHead", fields: [valuationScopeKey, tradeId, expectedHeadGenerationId], references: [valuationScopeKey, tradeId, generationId], onDelete: Restrict, map: "outcome_private_eval_intent_expected_gen_fkey")
+  targetGeneration         OutcomeLocalPrivateTradeEvaluationGeneration? @relation("PrivateEvaluationIntentTarget", fields: [valuationScopeKey, tradeId, targetGenerationId], references: [valuationScopeKey, tradeId, generationId], onDelete: Restrict, map: "outcome_private_eval_intent_target_gen_fkey")
+  generatedGeneration      OutcomeLocalPrivateTradeEvaluationGeneration? @relation("PrivateEvaluationGenerationIntent")
+  transitionReceipt        OutcomePrivateEvaluationTransitionReceipt?
+
+  @@map("outcome_private_evaluation_transition_intent")
+}
+
+model OutcomeLocalPrivateTradeEvaluationGeneration {
+  generationId                 String                                               @id @map("generation_id") @outcomes.Text
+  valuationScopeKey            String                                               @map("valuation_scope_key") @outcomes.Text
+  tradeId                      String                                               @map("trade_id") @outcomes.Text
+  transitionIntentId           String                                               @unique @map("transition_intent_id") @outcomes.Text
+  generationArtifactId         String                                               @unique @map("generation_artifact_id") @outcomes.Text
+  narrativeArtifactId          String                                               @map("narrative_artifact_id") @outcomes.Text
+  projectionManifestArtifactId String                                               @map("projection_manifest_artifact_id") @outcomes.Text
+  generatedAt                  DateTime                                             @map("generated_at") @outcomes.Timestamptz(3)
+  contentSha256                String                                               @map("content_sha256") @outcomes.Char(64)
+  contentCanonicalJson         String                                               @map("content_canonical_json") @outcomes.Text
+  generationJson               Json                                                 @map("generation_json")
+  registeredAt                 DateTime                                             @default(dbgenerated("clock_timestamp()")) @map("registered_at") @outcomes.Timestamptz(3)
+  transitionIntent             OutcomePrivateEvaluationTransitionIntent             @relation("PrivateEvaluationGenerationIntent", fields: [transitionIntentId], references: [transitionIntentId], onDelete: Restrict, map: "outcome_local_private_trade_evaluation_generation_intent_fkey")
+  generationArtifact           OutcomeArtifactCustody                               @relation("PrivateEvaluationGenerationArtifact", fields: [generationArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_local_private_trade_evaluation_generation_artifact_fkey")
+  narrativeArtifact            OutcomeArtifactCustody                               @relation("PrivateEvaluationNarrativeArtifact", fields: [narrativeArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_local_private_trade_evaluation_narrative_artifact_fkey")
+  projectionManifestArtifact   OutcomeArtifactCustody                               @relation("PrivateEvaluationProjectionManifestArtifact", fields: [projectionManifestArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_local_private_trade_evaluation_projection_artifact_fkey")
+  expectedBySnapshots          OutcomePrivateEvaluationAuthoritySnapshot[]          @relation("PrivateEvaluationSnapshotExpectedHead")
+  expectedByInspections        OutcomePrivateEvaluationInspectionReceipt[]          @relation("PrivateEvaluationInspectionExpectedHead")
+  expectedByIntents            OutcomePrivateEvaluationTransitionIntent[]           @relation("PrivateEvaluationIntentExpectedHead")
+  targetedByIntents            OutcomePrivateEvaluationTransitionIntent[]           @relation("PrivateEvaluationIntentTarget")
+  activeHeads                  OutcomeLocalPrivateTradeEvaluationHead[]
+  fromTransitions              OutcomePrivateEvaluationTransitionReceipt[]          @relation("PrivateEvaluationTransitionFromGeneration")
+  toTransitions                OutcomePrivateEvaluationTransitionReceipt[]          @relation("PrivateEvaluationTransitionToGeneration")
+  reconstructionVerifications  OutcomePrivateEvaluationReconstructionVerification[]
+
+  @@unique([valuationScopeKey, tradeId, generationId], map: "outcome_local_private_trade_evaluation_generation_scope_key")
+  @@index([valuationScopeKey, tradeId, generatedAt], map: "outcome_private_evaluation_generation_selector_idx")
+  @@map("outcome_local_private_trade_evaluation_generation")
+}
+
+model OutcomeLocalPrivateTradeEvaluationHead {
+  valuationScopeKey String                                        @map("valuation_scope_key") @outcomes.Text
+  tradeId           String                                        @map("trade_id") @outcomes.Text
+  revision          Int
+  status            String                                        @outcomes.Text
+  generationId      String?                                       @map("generation_id") @outcomes.Text
+  lastTransitionId  String                                        @map("last_transition_id") @outcomes.Text
+  updatedAt         DateTime                                      @default(dbgenerated("clock_timestamp()")) @map("updated_at") @outcomes.Timestamptz(3)
+  generation        OutcomeLocalPrivateTradeEvaluationGeneration? @relation(fields: [valuationScopeKey, tradeId, generationId], references: [valuationScopeKey, tradeId, generationId], onDelete: Restrict, map: "outcome_local_private_trade_evaluation_head_generation_fkey")
+  lastTransition    OutcomePrivateEvaluationTransitionReceipt     @relation(fields: [lastTransitionId], references: [transitionId], onDelete: Restrict, map: "outcome_local_private_trade_evaluation_head_transition_fkey")
+
+  @@id([valuationScopeKey, tradeId])
+  @@map("outcome_local_private_trade_evaluation_head")
+}
+
+model OutcomePrivateEvaluationTransitionReceipt {
+  transitionId         String                                        @id @map("transition_id") @outcomes.Text
+  transitionIntentId   String                                        @unique @map("transition_intent_id") @outcomes.Text
+  operationId          String                                        @unique @map("operation_id") @outcomes.Text
+  valuationScopeKey    String                                        @map("valuation_scope_key") @outcomes.Text
+  tradeId              String                                        @map("trade_id") @outcomes.Text
+  artifactId           String                                        @unique @map("artifact_id") @outcomes.Text
+  action               String                                        @outcomes.Text
+  fromRevision         Int                                           @map("from_revision")
+  fromStatus           String                                        @map("from_status") @outcomes.Text
+  fromGenerationId     String?                                       @map("from_generation_id") @outcomes.Text
+  toRevision           Int                                           @map("to_revision")
+  toStatus             String                                        @map("to_status") @outcomes.Text
+  toGenerationId       String?                                       @map("to_generation_id") @outcomes.Text
+  transitionedAt       DateTime                                      @default(dbgenerated("clock_timestamp()")) @map("transitioned_at") @outcomes.Timestamptz(3)
+  contentSha256        String                                        @map("content_sha256") @outcomes.Char(64)
+  contentCanonicalJson String                                        @map("content_canonical_json") @outcomes.Text
+  receiptJson          Json                                          @map("receipt_json")
+  transitionIntent     OutcomePrivateEvaluationTransitionIntent      @relation(fields: [transitionIntentId], references: [transitionIntentId], onDelete: Restrict, map: "outcome_private_evaluation_transition_receipt_intent_fkey")
+  artifact             OutcomeArtifactCustody                        @relation("PrivateEvaluationTransitionReceiptArtifact", fields: [artifactId], references: [artifactId], onDelete: Restrict, map: "outcome_private_evaluation_transition_receipt_artifact_fkey")
+  fromGeneration       OutcomeLocalPrivateTradeEvaluationGeneration? @relation("PrivateEvaluationTransitionFromGeneration", fields: [valuationScopeKey, tradeId, fromGenerationId], references: [valuationScopeKey, tradeId, generationId], onDelete: Restrict, map: "outcome_private_eval_receipt_from_gen_fkey")
+  toGeneration         OutcomeLocalPrivateTradeEvaluationGeneration? @relation("PrivateEvaluationTransitionToGeneration", fields: [valuationScopeKey, tradeId, toGenerationId], references: [valuationScopeKey, tradeId, generationId], onDelete: Restrict, map: "outcome_private_eval_receipt_to_gen_fkey")
+  currentHeads         OutcomeLocalPrivateTradeEvaluationHead[]
+
+  @@index([valuationScopeKey, tradeId, toRevision], map: "outcome_private_evaluation_transition_selector_idx")
+  @@map("outcome_private_evaluation_transition_receipt")
+}
+
+model OutcomePrivateEvaluationReconstructionVerification {
+  verificationId       String                                       @id @map("verification_id") @outcomes.Text
+  inspectionId         String                                       @map("inspection_id") @outcomes.Text
+  operationId          String                                       @unique(map: "outcome_private_eval_reconstruction_operation_key") @map("operation_id") @outcomes.Text
+  valuationScopeKey    String                                       @map("valuation_scope_key") @outcomes.Text
+  tradeId              String                                       @map("trade_id") @outcomes.Text
+  generationId         String                                       @map("generation_id") @outcomes.Text
+  artifactId           String                                       @unique(map: "outcome_private_eval_reconstruction_artifact_key") @map("artifact_id") @outcomes.Text
+  verifiedAt           DateTime                                     @map("verified_at") @outcomes.Timestamptz(3)
+  exactMatch           Boolean                                      @map("exact_match")
+  contentSha256        String                                       @map("content_sha256") @outcomes.Char(64)
+  contentCanonicalJson String                                       @map("content_canonical_json") @outcomes.Text
+  verificationJson     Json                                         @map("verification_json")
+  registeredAt         DateTime                                     @default(dbgenerated("clock_timestamp()")) @map("registered_at") @outcomes.Timestamptz(3)
+  inspection           OutcomePrivateEvaluationInspectionReceipt    @relation(fields: [inspectionId], references: [inspectionId], onDelete: Restrict, map: "outcome_private_eval_reconstruction_inspection_fkey")
+  generation           OutcomeLocalPrivateTradeEvaluationGeneration @relation(fields: [valuationScopeKey, tradeId, generationId], references: [valuationScopeKey, tradeId, generationId], onDelete: Restrict, map: "outcome_private_eval_reconstruction_generation_fkey")
+  artifact             OutcomeArtifactCustody                       @relation("PrivateEvaluationReconstructionVerificationArtifact", fields: [artifactId], references: [artifactId], onDelete: Restrict, map: "outcome_private_eval_reconstruction_artifact_fkey")
+
+  @@index([valuationScopeKey, tradeId, generationId, verifiedAt], map: "outcome_private_evaluation_reconstruction_selector_idx")
+  @@map("outcome_private_evaluation_reconstruction_verification")
 }

--- a/src/app/api/dev/afl-trade-evaluation/[tradeId]/export/route.ts
+++ b/src/app/api/dev/afl-trade-evaluation/[tradeId]/export/route.ts
@@ -1,0 +1,44 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { logger } from '@/lib/logger';
+import { privateLocalWorkbookReads } from '@/server/aflTradeIntelligence/development/privateLocalWorkbookReads';
+import { parseAflTradePublicRouteParam } from '@/server/aflTradeIntelligence/runtime/publicTradeRouteParam';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const privateHeaders = { 'Cache-Control': 'private, no-store' } as const;
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ tradeId: string }> }
+) {
+  const tradeId = parseAflTradePublicRouteParam((await params).tradeId);
+  if (tradeId === null) {
+    return new NextResponse(null, { status: 400, headers: privateHeaders });
+  }
+
+  try {
+    const result = await privateLocalWorkbookReads.loadExactJsonExport(tradeId);
+    if (result === null || result.state !== 'available') {
+      return new NextResponse(null, { status: 404, headers: privateHeaders });
+    }
+
+    const filenameTradeId = tradeId.replaceAll(/[^a-zA-Z0-9._-]/gu, '-');
+    return new NextResponse(Uint8Array.from(result.bytes).buffer, {
+      status: 200,
+      headers: {
+        ...privateHeaders,
+        'Content-Type': 'application/json',
+        'Content-Disposition': `attachment; filename="${filenameTradeId}-exact-evidence.json"`,
+        'X-Content-Type-Options': 'nosniff',
+        'X-Statly-Generation-Id': result.generationId,
+        'X-Statly-Projection-Manifest-Id': result.projectionManifestId,
+      },
+    });
+  } catch (error) {
+    logger.error('Failed to read authenticated private trade evaluation export', error);
+    return new NextResponse(null, { status: 500, headers: privateHeaders });
+  }
+}

--- a/src/app/dev/afl-trade-evaluation/[tradeId]/page.tsx
+++ b/src/app/dev/afl-trade-evaluation/[tradeId]/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
+import { AflTradePackageEvaluationPanel } from '@/components/draft/AflTradePackageEvaluationPanel';
 import { privateLocalWorkbookReads } from '@/server/aflTradeIntelligence/development/privateLocalWorkbookReads';
+import { decodeGovernedPrivateEvaluationDetailDocument } from '@/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration';
 
 import { LocalValuationReadinessNotice } from '../LocalValuationReadinessNotice';
 import { LocalPrivateReviewedTradeCalculationPanel } from './LocalPrivateReviewedTradeCalculationPanel';
@@ -41,6 +43,19 @@ export default async function LocalWorkbookTradeEvaluationPage({
   );
 
   const { detail } = evaluation;
+  const governedRead = evaluation.governedEvaluation;
+  const governedDocument =
+    governedRead?.state === 'available'
+      ? decodeGovernedPrivateEvaluationDetailDocument(governedRead.bytes)
+      : null;
+  if (
+    governedDocument !== null &&
+    (governedDocument.selector.tradeId !== detail.trade.tradeId ||
+      governedRead?.selector.tradeId !== detail.trade.tradeId ||
+      governedRead.selector.valuationScopeKey !== `afl-men:${detail.trade.year}-trades`)
+  ) {
+    throw new TypeError('The governed evaluation does not belong to this transaction.');
+  }
   const scenario = evaluation.scenario;
   const scenarioDirectionBasis =
     scenario.state === 'ready'
@@ -118,6 +133,66 @@ export default async function LocalWorkbookTradeEvaluationPage({
       {privateCalculation ? (
         <LocalPrivateReviewedTradeCalculationPanel calculation={privateCalculation} />
       ) : null}
+
+      <section
+        aria-labelledby="governed-package-calculation-heading"
+        className="rounded-2xl border border-border bg-card p-5 shadow-sm sm:p-6"
+      >
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="max-w-3xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+              Authenticated retained generation
+            </p>
+            <h2
+              id="governed-package-calculation-heading"
+              className="mt-2 text-xl font-semibold text-foreground"
+            >
+              Automatic governed package calculation
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              The transaction stays intact: every participating club receives one package grade,
+              while each received and surrendered asset explains its exact contribution and later
+              transformation under the same four time views.
+            </p>
+          </div>
+          {governedRead?.state === 'available' ? (
+            <Link
+              href={`/api/dev/afl-trade-evaluation/${encodeURIComponent(
+                detail.trade.tradeId
+              )}/export`}
+              className="inline-flex min-h-11 items-center rounded-md border border-border bg-background px-4 py-2 text-sm font-semibold text-foreground hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Download exact JSON evidence
+            </Link>
+          ) : null}
+        </div>
+
+        {governedDocument !== null && governedRead?.state === 'available' ? (
+          <>
+            <dl className="mt-4 grid gap-3 text-xs text-muted-foreground sm:grid-cols-2">
+              <div className="rounded-lg border border-border bg-muted/30 p-3">
+                <dt className="font-semibold text-foreground">Generation</dt>
+                <dd className="mt-1 break-all font-mono">{governedRead.generationId}</dd>
+              </div>
+              <div className="rounded-lg border border-border bg-muted/30 p-3">
+                <dt className="font-semibold text-foreground">Projection manifest</dt>
+                <dd className="mt-1 break-all font-mono">
+                  {governedRead.projectionManifestId}
+                </dd>
+              </div>
+            </dl>
+            <AflTradePackageEvaluationPanel narrative={governedDocument.narrative} />
+          </>
+        ) : (
+          <p className="mt-4 rounded-lg border border-warning/35 bg-warning/10 px-4 py-3 text-sm text-foreground">
+            Automatic package scores and grades are unavailable: {governedRead?.state ===
+            'unavailable'
+              ? governedRead.reason.replaceAll('_', ' ')
+              : 'no active authenticated generation'}
+            . No fallback score is shown.
+          </p>
+        )}
+      </section>
 
       <section
         aria-labelledby="synthetic-scenario-heading"

--- a/src/components/draft/AflTradePackageEvaluationPanel.tsx
+++ b/src/components/draft/AflTradePackageEvaluationPanel.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { createAflTradeCalculationNarrative } from '@/server/aflTradeIntelligence/valuation/tradeCalculationNarrative';
+
+type Narrative = ReturnType<typeof createAflTradeCalculationNarrative>['content'];
+type View = Narrative['views'][number]['view'];
+type Asset = Narrative['assets'][number];
+type Contribution = Asset['contributions'][number];
+
+const VIEW_LABELS: Record<View, string> = {
+  at_trade: 'At trade',
+  realized: 'Realized',
+  remaining: 'Remaining',
+  current: 'Current',
+};
+
+const VIEW_DEFINITIONS: Record<View, string> = {
+  at_trade: 'The expected package value using evidence available at the transaction cutoff.',
+  realized: 'The observed contribution credited through the evidence cutoff.',
+  remaining: 'The authenticated contribution forecast still ahead.',
+  current: 'Realized contribution plus remaining forecast for the same exchange.',
+};
+
+function formatted(value: number): string {
+  const normalized = Math.abs(value) < 1e-9 ? 0 : value;
+  return Number.isInteger(normalized)
+    ? normalized.toString()
+    : normalized.toFixed(4).replace(/0+$/u, '').replace(/\.$/u, '');
+}
+
+function signed(value: number): string {
+  return `${value >= 0 ? '+' : ''}${formatted(value)}`;
+}
+
+function assetKind(kind: Asset['assetKind']): string {
+  if (kind === 'current_pick') return 'Current pick';
+  if (kind === 'future_pick') return 'Future pick';
+  return 'Player';
+}
+
+function EvidenceFacts({ asset }: { asset: Asset }) {
+  const evidence = asset.modelEvidence;
+  if (evidence.kind === 'pick') {
+    return (
+      <dl className="grid gap-2 sm:grid-cols-2">
+        <div>
+          <dt>Cohort</dt>
+          <dd className="font-semibold text-foreground">
+            {evidence.cohort.observationCount} observations across{' '}
+            {evidence.cohort.draftClassCount} draft classes
+          </dd>
+        </div>
+        <div>
+          <dt>Comparable picks</dt>
+          <dd className="font-semibold text-foreground">
+            Picks {evidence.cohort.minimumSelectionNumber}–
+            {evidence.cohort.maximumSelectionNumber}
+          </dd>
+        </div>
+        <div>
+          <dt>Expected contribution</dt>
+          <dd className="font-semibold text-foreground">
+            {formatted(evidence.expected.contribution)} {evidence.valueUnit}
+          </dd>
+        </div>
+        <div>
+          <dt>Expected games</dt>
+          <dd className="font-semibold text-foreground">
+            {formatted(evidence.expected.games)} over {evidence.fixedHorizonSeasons} seasons
+          </dd>
+        </div>
+      </dl>
+    );
+  }
+  return (
+    <dl className="grid gap-2 sm:grid-cols-2">
+      <div>
+        <dt>Observed games</dt>
+        <dd className="font-semibold text-foreground">
+          {formatted(evidence.totals.gamesPlayed)} across {evidence.seasons.length} seasons
+        </dd>
+      </div>
+      <div>
+        <dt>Observed contribution</dt>
+        <dd className="font-semibold text-foreground">
+          {formatted(evidence.totals.contribution)} fixed_horizon_pav
+        </dd>
+      </div>
+      <div>
+        <dt>Contribution per game</dt>
+        <dd className="font-semibold text-foreground">
+          {evidence.totals.contributionPerGame === null
+            ? 'Unavailable'
+            : formatted(evidence.totals.contributionPerGame)}
+        </dd>
+      </div>
+      <div>
+        <dt>Evidence cutoff</dt>
+        <dd className="font-semibold text-foreground">{evidence.evidenceCutoffAt}</dd>
+      </div>
+    </dl>
+  );
+}
+
+function Lineage({ asset }: { asset: Asset }) {
+  const transformationsByTarget = new Map(
+    asset.lineage.transformations.map((step) => [step.targetAssetId, step])
+  );
+  return (
+    <ol className="space-y-0" aria-label={`${asset.label} transformation lineage`}>
+      {asset.lineage.nodes.map((node, index) => {
+        const transformation = transformationsByTarget.get(node.assetId);
+        return (
+          <li key={node.assetId} className="relative pl-6">
+            {index < asset.lineage.nodes.length - 1 ? (
+              <span
+                aria-hidden="true"
+                className="absolute bottom-0 left-[0.3rem] top-3 w-px bg-border"
+              />
+            ) : null}
+            <span
+              aria-hidden="true"
+              className="absolute left-0 top-2 h-2.5 w-2.5 rounded-full border border-border bg-background"
+            />
+            <p className="pb-4">
+              <span data-lineage-label className="block font-semibold text-foreground">
+                {node.label}
+              </span>
+              <span className="block text-muted-foreground">
+                {transformation === undefined
+                  ? `${assetKind(asset.assetKind)} received`
+                  : `${transformation.kind.replaceAll('_', ' ')} · ${transformation.effectiveAt}`}
+              </span>
+            </p>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function AssetRow({ asset, contribution }: { asset: Asset; contribution: Contribution }) {
+  return (
+    <li className="border-b border-border py-3 last:border-b-0">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="font-semibold text-foreground">{asset.label}</p>
+          <p className="text-xs text-muted-foreground">{assetKind(asset.assetKind)}</p>
+        </div>
+        <span className="shrink-0 font-semibold tabular-nums text-foreground">
+          {signed(contribution.additiveMean)}
+        </span>
+      </div>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">{contribution.story}</p>
+      <details className="mt-1 text-xs text-muted-foreground">
+        <summary className="min-h-10 cursor-pointer py-2 font-semibold text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring">
+          {asset.label} calculation and lineage
+        </summary>
+        <div className="space-y-4 border-t border-border pt-3">
+          <p>{asset.story}</p>
+          <EvidenceFacts asset={asset} />
+          <div>
+            <h5 className="mb-2 font-semibold text-foreground">What this asset became</h5>
+            <Lineage asset={asset} />
+          </div>
+        </div>
+      </details>
+    </li>
+  );
+}
+
+function AssetLedger({
+  label,
+  assetIds,
+  subtotal,
+  assetsById,
+  view,
+}: {
+  label: 'Received' | 'Gave up';
+  assetIds: readonly string[];
+  subtotal: number;
+  assetsById: ReadonlyMap<string, Asset>;
+  view: View;
+}) {
+  return (
+    <section aria-label={`${label} package`}>
+      <h4 className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </h4>
+      <ul className="mt-1">
+        {assetIds.map((assetId) => {
+          const asset = assetsById.get(assetId);
+          const contribution = asset?.contributions.find((candidate) => candidate.view === view);
+          if (asset === undefined || contribution === undefined) return null;
+          return <AssetRow key={assetId} asset={asset} contribution={contribution} />;
+        })}
+      </ul>
+      <p className="mt-2 text-right text-sm font-semibold tabular-nums text-foreground">
+        {label} total {formatted(subtotal)}
+      </p>
+    </section>
+  );
+}
+
+export function AflTradePackageEvaluationPanel({ narrative }: { narrative: Narrative }) {
+  const [selectedView, setSelectedView] = useState<View>(narrative.defaultView);
+  const view = narrative.views.find((candidate) => candidate.view === selectedView);
+  const assetsById = new Map(narrative.assets.map((asset) => [asset.assetId, asset]));
+  if (view === undefined) return null;
+
+  return (
+    <div className="space-y-5">
+      <div className="rounded-xl border border-border bg-background p-4">
+        <label className="grid gap-1 text-sm font-semibold text-foreground sm:hidden">
+          Valuation view
+          <select
+            value={selectedView}
+            onChange={(event) => setSelectedView(event.target.value as View)}
+            className="min-h-11 rounded-md border border-border bg-background px-3 text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {narrative.views.map((candidate) => (
+              <option key={candidate.view} value={candidate.view}>
+                {VIEW_LABELS[candidate.view]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div
+          role="group"
+          aria-label="Trade valuation views"
+          className="hidden grid-cols-4 gap-2 sm:grid"
+        >
+          {narrative.views.map((candidate) => (
+            <button
+              key={candidate.view}
+              type="button"
+              aria-pressed={candidate.view === selectedView}
+              onClick={() => setSelectedView(candidate.view)}
+              className="min-h-11 rounded-md border border-border bg-background px-3 py-2 text-sm font-semibold text-foreground hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-pressed:bg-primary aria-pressed:text-primary-foreground"
+            >
+              {VIEW_LABELS[candidate.view]}
+            </button>
+          ))}
+        </div>
+        <p aria-live="polite" className="mt-3 text-sm leading-6 text-muted-foreground">
+          <span className="font-semibold text-foreground">{VIEW_LABELS[view.view]}:</span>{' '}
+          {VIEW_DEFINITIONS[view.view]}
+        </p>
+      </div>
+
+      <section aria-label={`${VIEW_LABELS[view.view]} club packages`} className="grid gap-4 xl:grid-cols-2">
+        {view.clubs.map((club) => {
+          const gradeLabel =
+            club.grade.grade === null
+              ? `${club.clubName} package grade unavailable`
+              : `${club.clubName} ${club.grade.state} package grade ${club.grade.grade}`;
+          return (
+            <article
+              key={club.aflClubId}
+              aria-label={`${club.clubName} package`}
+              className="overflow-hidden rounded-xl border border-border bg-background"
+            >
+              <header className="flex items-start justify-between gap-3 border-b border-border bg-muted/40 p-4">
+                <div>
+                  <h3 className="text-lg font-semibold text-foreground">{club.clubName}</h3>
+                  <p className="text-xs text-muted-foreground">Complete club package</p>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="text-right">
+                    <span className="block text-xs text-muted-foreground">Package net</span>
+                    <span className="block font-semibold tabular-nums text-foreground">
+                      {signed(club.arithmetic.estimatedAdvantageMean)}
+                    </span>
+                  </span>
+                  <span
+                    aria-label={gradeLabel}
+                    className="inline-flex min-h-11 min-w-12 items-center justify-center rounded-lg border border-border bg-card px-2 text-base font-bold text-foreground"
+                  >
+                    {club.grade.grade ?? '—'}
+                  </span>
+                </div>
+              </header>
+              <div className="grid gap-5 p-4 lg:grid-cols-2">
+                <AssetLedger
+                  label="Received"
+                  assetIds={club.receivedAssetIds}
+                  subtotal={club.arithmetic.receivedMean}
+                  assetsById={assetsById}
+                  view={view.view}
+                />
+                <AssetLedger
+                  label="Gave up"
+                  assetIds={club.givenUpAssetIds}
+                  subtotal={club.arithmetic.givenUpMean}
+                  assetsById={assetsById}
+                  view={view.view}
+                />
+              </div>
+              <footer className="border-t border-border bg-muted/30 p-4">
+                <p className="text-sm font-semibold text-foreground">{club.summary}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Package range {formatted(club.uncertainty.p10)} to{' '}
+                  {formatted(club.uncertainty.p90)} · finish-ahead probability{' '}
+                  {Math.round(club.finishAheadProbability * 100)}%
+                </p>
+              </footer>
+            </article>
+          );
+        })}
+      </section>
+    </div>
+  );
+}

--- a/src/server/aflTradeIntelligence/development/privateLocalWorkbookReads.ts
+++ b/src/server/aflTradeIntelligence/development/privateLocalWorkbookReads.ts
@@ -7,6 +7,12 @@ import type { DraftTradeDetail } from '@/lib/draftTrades/read';
 import { getExplicitAuthenticatedUserIdFromServerContext } from '@/lib/serverAuth';
 
 import { createPgAflOutcomeSqlClient } from '../outcomes/pgOutcomeSqlClient';
+import type {
+  GovernedPrivateEvaluationReadRequest,
+  GovernedPrivateEvaluationReadResult,
+} from '../valuation/governedPrivateEvaluationWorkspace';
+import { createPostgresGovernedPrivateEvaluationWorkspace } from '../valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace';
+import { createLocalAflTradePrivateDerivedArtifactRepository } from './localFileConditionalObjectStore';
 import type { LocalPrivateReviewedTradeCalculation } from './localPrivateReviewedTradeCalculation';
 import { getLocalOutcomesRuntimePool } from './localOutcomesRuntimePool';
 import { assertLocalAflTradeOutcomesRuntimeIdentity } from './localOutcomesRuntimeIdentity';
@@ -26,19 +32,26 @@ import {
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
 const POSTGRES_WAL_LSN_PATTERN = /^[a-f0-9]+\/[a-f0-9]+$/iu;
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
+const GOVERNED_ARTIFACT_REPOSITORY_ID = 'governed-private-evaluation';
+const MAXIMUM_GOVERNED_ARTIFACT_BYTES = 4 * 1024 * 1024;
 
 export interface PrivateLocalWorkbookReadEnvironment extends LocalWorkbookEvaluationEnvironment {
   STATLY_ENABLE_DEV_TOOLS?: string;
   STATLY_LOCAL_OUTCOMES_RUNTIME_NONCE?: string;
+  AFL_TRADE_LOCAL_ARTIFACT_ROOT?: string;
 }
 
 type ArchiveQuery = Parameters<LocalWorkbookEvaluationService['loadArchive']>[0];
 type ArchiveResult = Promise<LocalWorkbookEvaluationArchive | null>;
-type TradeResult = Promise<LocalWorkbookTradeEvaluation | null>;
+export interface PrivateLocalWorkbookTradeEvaluation extends LocalWorkbookTradeEvaluation {
+  governedEvaluation?: GovernedPrivateEvaluationReadResult;
+}
+type TradeResult = Promise<PrivateLocalWorkbookTradeEvaluation | null>;
 
 export interface PrivateLocalWorkbookReads {
   loadArchive(query: ArchiveQuery): ArchiveResult;
   loadTrade(tradeId: string): TradeResult;
+  loadExactJsonExport(tradeId: string): Promise<GovernedPrivateEvaluationReadResult | null>;
 }
 
 export interface PrivateLocalWorkbookReadDependencies {
@@ -56,6 +69,11 @@ export interface PrivateLocalWorkbookReadDependencies {
     detail: DraftTradeDetail,
     workbookSha256: string
   ): Promise<LocalPrivateReviewedTradeCalculation | null>;
+  readGovernedEvaluation?(
+    environment: Readonly<PrivateLocalWorkbookReadEnvironment>,
+    principalId: string,
+    request: GovernedPrivateEvaluationReadRequest
+  ): Promise<GovernedPrivateEvaluationReadResult>;
   environment(): PrivateLocalWorkbookReadEnvironment;
   evaluation: LocalWorkbookEvaluationService;
 }
@@ -70,6 +88,7 @@ function snapshotEnvironment(
     AFL_OUTCOMES_DEV_WORKBOOK_PATH: environment.AFL_OUTCOMES_DEV_WORKBOOK_PATH,
     AFL_OUTCOMES_DEV_WORKBOOK_SHA256: environment.AFL_OUTCOMES_DEV_WORKBOOK_SHA256,
     AFL_OUTCOMES_DATABASE_URL: environment.AFL_OUTCOMES_DATABASE_URL,
+    AFL_TRADE_LOCAL_ARTIFACT_ROOT: environment.AFL_TRADE_LOCAL_ARTIFACT_ROOT,
     STATLY_LOCAL_OUTCOMES_RUNTIME_NONCE: environment.STATLY_LOCAL_OUTCOMES_RUNTIME_NONCE,
   });
 }
@@ -111,6 +130,13 @@ function hasValidRuntimeConfiguration(
   }
 }
 
+function hasValidGovernedArtifactConfiguration(
+  environment: Readonly<PrivateLocalWorkbookReadEnvironment>
+): boolean {
+  const artifactRoot = environment.AFL_TRADE_LOCAL_ARTIFACT_ROOT?.trim();
+  return artifactRoot !== undefined && artifactRoot !== '' && isAbsolute(artifactRoot);
+}
+
 export function createPrivateLocalWorkbookReads(
   dependencies: PrivateLocalWorkbookReadDependencies
 ): PrivateLocalWorkbookReads {
@@ -129,7 +155,10 @@ export function createPrivateLocalWorkbookReads(
     }>
   >();
 
-  async function admit(): Promise<Readonly<PrivateLocalWorkbookReadEnvironment> | null> {
+  async function admit(): Promise<Readonly<{
+    environment: Readonly<PrivateLocalWorkbookReadEnvironment>;
+    principalId: string;
+  }> | null> {
     const environment = snapshotEnvironment(dependencies.environment());
     if (!isEnabled(environment)) return null;
 
@@ -140,7 +169,21 @@ export function createPrivateLocalWorkbookReads(
       throw new Error('Private workbook evaluation runtime configuration is invalid.');
     }
     await dependencies.authenticateRuntime(environment);
-    return environment;
+    return Object.freeze({ environment, principalId: userId });
+  }
+
+  function governedRequest(
+    evaluation: LocalWorkbookTradeEvaluation,
+    document: GovernedPrivateEvaluationReadRequest['document']
+  ): GovernedPrivateEvaluationReadRequest {
+    return {
+      selector: {
+        valuationScopeKey: `afl-men:${evaluation.detail.trade.year}-trades`,
+        tradeId: evaluation.detail.trade.tradeId,
+      },
+      selection: { kind: 'current' },
+      document,
+    };
   }
 
   async function inspectCurrentValuationReadiness(
@@ -196,8 +239,9 @@ export function createPrivateLocalWorkbookReads(
 
   return {
     async loadArchive(query) {
-      const environment = await admit();
-      if (environment === null) return null;
+      const admitted = await admit();
+      if (admitted === null) return null;
+      const { environment } = admitted;
       return dependencies.evaluation.loadArchive(
         query,
         environment,
@@ -206,9 +250,10 @@ export function createPrivateLocalWorkbookReads(
     },
 
     async loadTrade(tradeId) {
-      const environment = await admit();
-      if (environment === null) return null;
-      return dependencies.evaluation.loadTrade(
+      const admitted = await admit();
+      if (admitted === null) return null;
+      const { environment, principalId } = admitted;
+      const evaluation = await dependencies.evaluation.loadTrade(
         tradeId,
         environment,
         (scopeKey) => inspectCurrentValuationReadiness(environment, scopeKey),
@@ -216,6 +261,42 @@ export function createPrivateLocalWorkbookReads(
           ? (detail, workbookSha256) =>
               loadCurrentPrivateCalculation(environment, detail, workbookSha256)
           : undefined
+      );
+      if (evaluation === null || dependencies.readGovernedEvaluation === undefined) {
+        return evaluation;
+      }
+      if (!hasValidGovernedArtifactConfiguration(environment)) {
+        throw new Error('Governed private evaluation artifact configuration is invalid.');
+      }
+      const governedEvaluation = await dependencies.readGovernedEvaluation(
+        environment,
+        principalId,
+        governedRequest(evaluation, { kind: 'detail' })
+      );
+      return { ...evaluation, governedEvaluation };
+    },
+
+    async loadExactJsonExport(tradeId) {
+      const admitted = await admit();
+      if (admitted === null || dependencies.readGovernedEvaluation === undefined) return null;
+      const { environment, principalId } = admitted;
+      if (!hasValidGovernedArtifactConfiguration(environment)) {
+        throw new Error('Governed private evaluation artifact configuration is invalid.');
+      }
+      const evaluation = await dependencies.evaluation.loadTrade(
+        tradeId,
+        environment,
+        (scopeKey) => inspectCurrentValuationReadiness(environment, scopeKey),
+        dependencies.loadPrivateCalculation
+          ? (detail, workbookSha256) =>
+              loadCurrentPrivateCalculation(environment, detail, workbookSha256)
+          : undefined
+      );
+      if (evaluation === null) return null;
+      return dependencies.readGovernedEvaluation(
+        environment,
+        principalId,
+        governedRequest(evaluation, { kind: 'json_export' })
       );
     },
   };
@@ -265,12 +346,37 @@ async function readLocalValuationReadinessGeneration(
   return generation;
 }
 
+async function readAdmittedGovernedEvaluation(
+  environment: Readonly<PrivateLocalWorkbookReadEnvironment>,
+  principalId: string,
+  request: GovernedPrivateEvaluationReadRequest
+): Promise<GovernedPrivateEvaluationReadResult> {
+  const pool = getLocalOutcomesRuntimePool(environment.AFL_OUTCOMES_DATABASE_URL!);
+  if (!hasValidGovernedArtifactConfiguration(environment)) {
+    throw new Error('Governed private evaluation artifact configuration is invalid.');
+  }
+  const artifactRepository = createLocalAflTradePrivateDerivedArtifactRepository({
+    rootDirectory: environment.AFL_TRADE_LOCAL_ARTIFACT_ROOT!.trim(),
+    repositoryId: GOVERNED_ARTIFACT_REPOSITORY_ID,
+    maximumObjectBytes: MAXIMUM_GOVERNED_ARTIFACT_BYTES,
+  });
+  return createPostgresGovernedPrivateEvaluationWorkspace({
+    client: createPgAflOutcomeSqlClient(pool),
+    artifactRepository,
+    maximumArtifactBytes: MAXIMUM_GOVERNED_ARTIFACT_BYTES,
+    principalId,
+    authorizeReader: async ({ principalId: candidatePrincipalId }) =>
+      candidatePrincipalId === principalId && candidatePrincipalId === DEVELOPMENT_AUTH_USER_ID,
+  }).read(request);
+}
+
 export const privateLocalWorkbookReads = createPrivateLocalWorkbookReads({
   authenticate: getExplicitAuthenticatedUserIdFromServerContext,
   authenticateRuntime: authenticateLocalOutcomesRuntime,
   readValuationReadinessGeneration: readLocalValuationReadinessGeneration,
   inspectValuationReadiness: inspectAdmittedLocalValuationReadiness,
   loadPrivateCalculation: loadAdmittedPrivateCalculation,
+  readGovernedEvaluation: readAdmittedGovernedEvaluation,
   environment: () => process.env,
   evaluation: localWorkbookEvaluationService,
 });

--- a/src/server/aflTradeIntelligence/modeling/governedPickPavModelExecution.ts
+++ b/src/server/aflTradeIntelligence/modeling/governedPickPavModelExecution.ts
@@ -1,0 +1,212 @@
+import { z } from 'zod';
+
+import { aflTradeArtifactRefSchema } from '../artifacts/artifactReference';
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '../artifacts/contentAddress';
+import { aflTradePickPavObservationSetSchema } from './pickOutcomeContracts';
+import {
+  aflTradePickPavDistributionBenchmarkConfigSchema,
+  aflTradePickPavDistributionBenchmarkSchema,
+  fitAflTradePickPavDistributionBenchmark,
+} from './pickPavDistributionBenchmark';
+import type { computeAflTradePickPavModelExecutionOutputs } from './pickPavModelExecution';
+import {
+  aflTradePickPavValidationConfigSchema,
+  aflTradePickPavValidationReportSchema,
+  validateAflTradePickPavDistributionBenchmark,
+} from './pickPavDistributionValidation';
+
+const SCHEMA_VERSION = 'afl-trade-pick-pav-model-execution/v2' as const;
+const AUTHORITY_BOUNDARY =
+  'authenticated_non_production_pick_model_candidate_no_gate_3_approval_grade_publication_or_fantasy_ownership' as const;
+const LIMITATION =
+  'This retained non-production execution is eligible for independent Gate 3 review only; it is not an approval, trade grade, or public numerical authority.' as const;
+const instantSchema = z.iso.datetime({ offset: true });
+
+const governedExecutionContentSchema = z
+  .object({
+    schemaVersion: z.literal(SCHEMA_VERSION),
+    authorityBoundary: z.literal(AUTHORITY_BOUNDARY),
+    publicationEligible: z.literal(false),
+    approvalStatus: z.literal('gate_3_review_required'),
+    environment: z.literal('non_production'),
+    competition: z.literal('AFLM'),
+    datasetId: aflTradeContentAddressedIdSchema('dataset'),
+    datasetArtifact: aflTradeArtifactRefSchema,
+    datasetAdmissionId: aflTradeContentAddressedIdSchema('dataset-admission'),
+    datasetAdmissionArtifact: aflTradeArtifactRefSchema,
+    datasetAdmissionGateLedgerRevision: z.number().int().positive(),
+    protocolId: aflTradeContentAddressedIdSchema('model-protocol'),
+    protocolArtifact: aflTradeArtifactRefSchema,
+    observationSetId: aflTradeContentAddressedIdSchema('pick-pav-observation-set'),
+    observationSetSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+    releaseId: aflTradeContentAddressedIdSchema('outcome-release'),
+    policyId: aflTradeContentAddressedIdSchema('pick-pav-policy'),
+    methodId: aflTradeContentAddressedIdSchema('hpn-pav-method'),
+    valueUnit: z.literal('fixed_horizon_pav'),
+    finalTestEvaluationStartedAt: instantSchema,
+    completedAt: instantSchema,
+    observationSet: aflTradePickPavObservationSetSchema,
+    benchmarkConfig: aflTradePickPavDistributionBenchmarkConfigSchema,
+    validationConfig: aflTradePickPavValidationConfigSchema,
+    benchmark: aflTradePickPavDistributionBenchmarkSchema,
+    validationReport: aflTradePickPavValidationReportSchema,
+    limitation: z.literal(LIMITATION),
+  })
+  .strict()
+  .superRefine((execution, context) => {
+    const observationSet = execution.observationSet;
+    if (
+      execution.observationSetId !== observationSet.observationSetId ||
+      execution.observationSetSha256 !== observationSet.content.observationSetSha256 ||
+      observationSet.content.environment !== 'non_production' ||
+      execution.competition !== observationSet.content.competition ||
+      execution.releaseId !== observationSet.content.releaseId ||
+      execution.policyId !== observationSet.content.policy.policyId ||
+      execution.methodId !== observationSet.content.policy.content.methodId ||
+      execution.valueUnit !== observationSet.content.policy.content.outcomeValueUnit
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['observationSet'],
+        message: 'Governed pick execution ancestry must match one non-production observation set.',
+      });
+      return;
+    }
+
+    const evidenceArtifacts = [
+      execution.datasetArtifact,
+      execution.datasetAdmissionArtifact,
+      execution.protocolArtifact,
+    ];
+    if (
+      new Set(evidenceArtifacts.map(({ artifactId }) => artifactId)).size !==
+        evidenceArtifacts.length ||
+      evidenceArtifacts.some(
+        ({ createdAt }) => Date.parse(createdAt) > Date.parse(execution.completedAt)
+      )
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['datasetArtifact'],
+        message: 'Governed pick execution requires distinct authority artifacts retained in time.',
+      });
+      return;
+    }
+
+    const createdAt = Date.parse(observationSet.content.createdAt);
+    const finalTestEvaluationStartedAt = Date.parse(execution.finalTestEvaluationStartedAt);
+    const completedAt = Date.parse(execution.completedAt);
+    if (
+      finalTestEvaluationStartedAt < createdAt ||
+      completedAt < finalTestEvaluationStartedAt ||
+      execution.validationConfig.evaluatedAt !== execution.finalTestEvaluationStartedAt
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['finalTestEvaluationStartedAt'],
+        message: 'Governed final-test evaluation chronology is invalid.',
+      });
+      return;
+    }
+
+    try {
+      const expectedBenchmark = fitAflTradePickPavDistributionBenchmark(
+        observationSet,
+        execution.benchmarkConfig
+      );
+      const expectedReport = validateAflTradePickPavDistributionBenchmark(
+        observationSet,
+        expectedBenchmark,
+        execution.validationConfig
+      );
+      if (
+        canonicalizeAflTradeJson(expectedBenchmark) !==
+          canonicalizeAflTradeJson(execution.benchmark) ||
+        canonicalizeAflTradeJson(expectedReport) !==
+          canonicalizeAflTradeJson(execution.validationReport)
+      ) {
+        context.addIssue({
+          code: 'custom',
+          path: ['benchmark'],
+          message: 'Governed pick execution must retain its exactly re-derived model outputs.',
+        });
+      }
+    } catch (error) {
+      context.addIssue({
+        code: 'custom',
+        path: ['benchmark'],
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Governed pick execution outputs could not be re-derived.',
+      });
+    }
+  });
+
+export const governedAflTradePickPavModelExecutionSchema = z
+  .object({
+    executionId: aflTradeContentAddressedIdSchema('pick-pav-model-execution'),
+    content: governedExecutionContentSchema,
+  })
+  .strict()
+  .superRefine((execution, context) => {
+    addAflTradeContentAddressIssue(
+      'pick-pav-model-execution',
+      execution.executionId,
+      execution.content,
+      context,
+      ['executionId']
+    );
+  });
+
+export type GovernedAflTradePickPavModelExecution = z.infer<
+  typeof governedAflTradePickPavModelExecutionSchema
+>;
+
+export function createGovernedAflTradePickPavModelExecution(input: {
+  readonly outputs: ReturnType<typeof computeAflTradePickPavModelExecutionOutputs>;
+  readonly completedAt: string;
+  readonly authority: Readonly<{
+    datasetId: string;
+    datasetArtifact: z.input<typeof aflTradeArtifactRefSchema>;
+    datasetAdmissionId: string;
+    datasetAdmissionArtifact: z.input<typeof aflTradeArtifactRefSchema>;
+    datasetAdmissionGateLedgerRevision: number;
+    protocolId: string;
+    protocolArtifact: z.input<typeof aflTradeArtifactRefSchema>;
+  }>;
+}): GovernedAflTradePickPavModelExecution {
+  const observationSet = aflTradePickPavObservationSetSchema.parse(input.outputs.observationSet);
+  const content = governedExecutionContentSchema.parse({
+    schemaVersion: SCHEMA_VERSION,
+    authorityBoundary: AUTHORITY_BOUNDARY,
+    publicationEligible: false,
+    approvalStatus: 'gate_3_review_required',
+    environment: 'non_production',
+    competition: observationSet.content.competition,
+    ...input.authority,
+    observationSetId: observationSet.observationSetId,
+    observationSetSha256: observationSet.content.observationSetSha256,
+    releaseId: observationSet.content.releaseId,
+    policyId: observationSet.content.policy.policyId,
+    methodId: observationSet.content.policy.content.methodId,
+    valueUnit: observationSet.content.policy.content.outcomeValueUnit,
+    finalTestEvaluationStartedAt: input.outputs.validationConfig.evaluatedAt,
+    completedAt: input.completedAt,
+    observationSet,
+    benchmarkConfig: input.outputs.benchmarkConfig,
+    validationConfig: input.outputs.validationConfig,
+    benchmark: input.outputs.benchmark,
+    validationReport: input.outputs.validationReport,
+    limitation: LIMITATION,
+  });
+  return governedAflTradePickPavModelExecutionSchema.parse({
+    executionId: createAflTradeContentAddress('pick-pav-model-execution', content),
+    content,
+  });
+}

--- a/src/server/aflTradeIntelligence/modeling/postgresGovernedPickPavModelExecutionRepository.ts
+++ b/src/server/aflTradeIntelligence/modeling/postgresGovernedPickPavModelExecutionRepository.ts
@@ -1,0 +1,276 @@
+import {
+  aflTradeArtifactRefSchema,
+  doesAflTradeArtifactRefMatchBytes,
+  doesAflTradeArtifactRefMatchCanonicalJson,
+  type AflTradeArtifactRef,
+} from '../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../artifacts/contentAddress';
+import type { AflTradeImmutableArtifactRepository } from '../artifacts/immutableArtifactRepository';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../outcomes/postgresOutcomeReleaseRepository';
+import {
+  governedAflTradePickPavModelExecutionSchema,
+  type GovernedAflTradePickPavModelExecution,
+} from './governedPickPavModelExecution';
+
+interface GovernedPickExecutionRow {
+  readonly execution_id: string;
+  readonly observation_set_id: string;
+  readonly dataset_id: string;
+  readonly dataset_artifact_id: string;
+  readonly dataset_admission_id: string;
+  readonly dataset_admission_artifact_id: string;
+  readonly dataset_admission_gate_ledger_revision: number | string;
+  readonly protocol_id: string;
+  readonly protocol_artifact_id: string;
+  readonly execution_artifact_id: string;
+  readonly final_test_evaluation_started_at: Date | string;
+  readonly completed_at: Date | string;
+  readonly content_sha256: string;
+  readonly content_canonical_json: string;
+  readonly execution_json: unknown;
+  readonly artifact_content_sha256: string;
+  readonly artifact_storage_uri: string;
+  readonly artifact_media_type: string;
+  readonly artifact_byte_length: number | string | bigint;
+  readonly artifact_created_at: Date | string;
+}
+
+export interface RetainedGovernedPickPavModelExecution {
+  readonly execution: GovernedAflTradePickPavModelExecution;
+  readonly artifact: AflTradeArtifactRef;
+}
+
+export class GovernedPickPavModelExecutionRepositoryError extends Error {
+  constructor(
+    readonly code: 'NOT_FOUND' | 'INTEGRITY_MISMATCH' | 'REPLAY_CONFLICT',
+    message: string
+  ) {
+    super(message);
+    this.name = 'GovernedPickPavModelExecutionRepositoryError';
+  }
+}
+
+function instant(value: Date | string): string {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(parsed.getTime())) {
+    throw new GovernedPickPavModelExecutionRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'Stored governed pick-execution time is malformed.'
+    );
+  }
+  return parsed.toISOString();
+}
+
+async function authenticatePhysicalEvidence(input: {
+  readonly repository: AflTradeImmutableArtifactRepository;
+  readonly maximumBytes: number;
+  readonly references: readonly AflTradeArtifactRef[];
+}): Promise<void> {
+  for (const reference of input.references) {
+    const loaded = await input.repository.loadExact(reference, input.maximumBytes);
+    if (
+      loaded === null ||
+      canonicalizeAflTradeJson(loaded.reference) !== canonicalizeAflTradeJson(reference) ||
+      !doesAflTradeArtifactRefMatchBytes(loaded.reference, loaded.bytes)
+    ) {
+      throw new GovernedPickPavModelExecutionRepositoryError(
+        'INTEGRITY_MISMATCH',
+        `Governed pick-execution artifact custody failed for ${reference.artifactId}.`
+      );
+    }
+  }
+}
+
+async function loadExactFrom(
+  client: AflOutcomeSqlTransaction,
+  dependencies: {
+    readonly artifactRepository: AflTradeImmutableArtifactRepository;
+    readonly maximumArtifactBytes: number;
+  },
+  executionId: string
+): Promise<RetainedGovernedPickPavModelExecution> {
+  const result = await client.query<GovernedPickExecutionRow>(
+    `SELECT execution.execution_id,execution.observation_set_id,execution.dataset_id,
+       execution.dataset_artifact_id,execution.dataset_admission_id,
+       execution.dataset_admission_artifact_id,
+       execution.dataset_admission_gate_ledger_revision,execution.protocol_id,
+       execution.protocol_artifact_id,execution.execution_artifact_id,
+       execution.final_test_evaluation_started_at,execution.completed_at,
+       execution.content_sha256,execution.content_canonical_json,execution.execution_json,
+       artifact.content_sha256 AS artifact_content_sha256,
+       artifact.storage_uri AS artifact_storage_uri,artifact.media_type AS artifact_media_type,
+       artifact.byte_length AS artifact_byte_length,artifact.created_at AS artifact_created_at
+       FROM outcome_governed_pick_pav_model_execution execution
+       JOIN outcome_artifact_custody artifact
+         ON artifact.artifact_id=execution.execution_artifact_id
+      WHERE execution.execution_id=$1`,
+    [executionId]
+  );
+  if (result.rows.length !== 1 || result.rows[0] === undefined) {
+    throw new GovernedPickPavModelExecutionRepositoryError(
+      'NOT_FOUND',
+      'Governed pick-PAV model execution was not found.'
+    );
+  }
+  const row = result.rows[0];
+  const parsed = governedAflTradePickPavModelExecutionSchema.safeParse(row.execution_json);
+  const artifact = aflTradeArtifactRefSchema.safeParse({
+    artifactId: row.execution_artifact_id,
+    contentSha256: row.artifact_content_sha256,
+    storageUri: row.artifact_storage_uri,
+    mediaType: row.artifact_media_type,
+    byteLength: Number(row.artifact_byte_length),
+    createdAt: instant(row.artifact_created_at),
+  });
+  if (!parsed.success || !artifact.success) {
+    throw new GovernedPickPavModelExecutionRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'Stored governed pick execution or custody metadata is malformed.'
+    );
+  }
+  const execution = parsed.data;
+  const content = execution.content;
+  if (
+    execution.executionId !== executionId ||
+    row.execution_id !== executionId ||
+    row.content_sha256 !== executionId.slice('pick-pav-model-execution:'.length) ||
+    row.observation_set_id !== content.observationSetId ||
+    row.dataset_id !== content.datasetId ||
+    row.dataset_artifact_id !== content.datasetArtifact.artifactId ||
+    row.dataset_admission_id !== content.datasetAdmissionId ||
+    row.dataset_admission_artifact_id !== content.datasetAdmissionArtifact.artifactId ||
+    Number(row.dataset_admission_gate_ledger_revision) !==
+      content.datasetAdmissionGateLedgerRevision ||
+    row.protocol_id !== content.protocolId ||
+    row.protocol_artifact_id !== content.protocolArtifact.artifactId ||
+    instant(row.final_test_evaluation_started_at) !== content.finalTestEvaluationStartedAt ||
+    instant(row.completed_at) !== content.completedAt ||
+    row.content_canonical_json !== canonicalizeAflTradeJson(content) ||
+    artifact.data.createdAt !== content.completedAt ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(artifact.data, execution)
+  ) {
+    throw new GovernedPickPavModelExecutionRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'Stored governed pick-execution columns disagree with immutable ancestry.'
+    );
+  }
+  await authenticatePhysicalEvidence({
+    repository: dependencies.artifactRepository,
+    maximumBytes: dependencies.maximumArtifactBytes,
+    references: [
+      artifact.data,
+      content.datasetArtifact,
+      content.datasetAdmissionArtifact,
+      content.protocolArtifact,
+    ],
+  });
+  return { execution, artifact: artifact.data };
+}
+
+export class PostgresGovernedPickPavModelExecutionRepository {
+  constructor(
+    private readonly dependencies: {
+      readonly client: AflOutcomeSqlClient;
+      readonly artifactRepository: AflTradeImmutableArtifactRepository;
+      readonly maximumArtifactBytes: number;
+    }
+  ) {
+    if (
+      dependencies.artifactRepository.artifactClass !== 'derived_private' ||
+      !Number.isSafeInteger(dependencies.maximumArtifactBytes) ||
+      dependencies.maximumArtifactBytes <= 0
+    ) {
+      throw new TypeError(
+        'Governed pick-execution custody requires bounded private artifact storage.'
+      );
+    }
+  }
+
+  async register(input: {
+    readonly execution: GovernedAflTradePickPavModelExecution;
+    readonly artifact: AflTradeArtifactRef;
+  }): Promise<RetainedGovernedPickPavModelExecution> {
+    const execution = governedAflTradePickPavModelExecutionSchema.parse(input.execution);
+    const artifact = aflTradeArtifactRefSchema.parse(input.artifact);
+    if (
+      artifact.createdAt !== execution.content.completedAt ||
+      !doesAflTradeArtifactRefMatchCanonicalJson(artifact, execution)
+    ) {
+      throw new GovernedPickPavModelExecutionRepositoryError(
+        'INTEGRITY_MISMATCH',
+        'Governed pick-execution artifact does not authenticate the exact execution.'
+      );
+    }
+    await authenticatePhysicalEvidence({
+      repository: this.dependencies.artifactRepository,
+      maximumBytes: this.dependencies.maximumArtifactBytes,
+      references: [
+        artifact,
+        execution.content.datasetArtifact,
+        execution.content.datasetAdmissionArtifact,
+        execution.content.protocolArtifact,
+      ],
+    });
+    return this.dependencies.client.transaction(async (transaction) => {
+      await transaction.query(`SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, [
+        `governed-pick-pav-model-execution:${execution.executionId}`,
+      ]);
+      const existing = await transaction.query(
+        `SELECT 1 FROM outcome_governed_pick_pav_model_execution WHERE execution_id=$1`,
+        [execution.executionId]
+      );
+      if (existing.rowCount) {
+        const replay = await loadExactFrom(
+          transaction,
+          this.dependencies,
+          execution.executionId
+        );
+        if (
+          canonicalizeAflTradeJson(replay) !==
+          canonicalizeAflTradeJson({ execution, artifact })
+        ) {
+          throw new GovernedPickPavModelExecutionRepositoryError(
+            'REPLAY_CONFLICT',
+            'Governed pick-execution replay conflicts with retained evidence.'
+          );
+        }
+        return replay;
+      }
+      const content = execution.content;
+      await transaction.query(
+        `INSERT INTO outcome_governed_pick_pav_model_execution
+          (execution_id,observation_set_id,dataset_id,dataset_artifact_id,
+           dataset_admission_id,dataset_admission_artifact_id,
+           dataset_admission_gate_ledger_revision,protocol_id,protocol_artifact_id,
+           execution_artifact_id,final_test_evaluation_started_at,completed_at,
+           content_sha256,content_canonical_json,execution_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15::jsonb)`,
+        [
+          execution.executionId,
+          content.observationSetId,
+          content.datasetId,
+          content.datasetArtifact.artifactId,
+          content.datasetAdmissionId,
+          content.datasetAdmissionArtifact.artifactId,
+          content.datasetAdmissionGateLedgerRevision,
+          content.protocolId,
+          content.protocolArtifact.artifactId,
+          artifact.artifactId,
+          content.finalTestEvaluationStartedAt,
+          content.completedAt,
+          execution.executionId.slice('pick-pav-model-execution:'.length),
+          canonicalizeAflTradeJson(content),
+          canonicalizeAflTradeJson(execution),
+        ]
+      );
+      return loadExactFrom(transaction, this.dependencies, execution.executionId);
+    });
+  }
+
+  loadExact(executionId: string): Promise<RetainedGovernedPickPavModelExecution> {
+    return loadExactFrom(this.dependencies.client, this.dependencies, executionId);
+  }
+}

--- a/src/server/aflTradeIntelligence/valuation/assetLineageNarrativeEvidence.ts
+++ b/src/server/aflTradeIntelligence/valuation/assetLineageNarrativeEvidence.ts
@@ -1,0 +1,219 @@
+import { buildAflTradeAttributionFrontier } from '../domain/lineageAttribution';
+import {
+  activeAflTradeEdgesBySource,
+  isAflTradeKnownAt,
+  parseAflTradeTime,
+} from '../domain/lineageTemporal';
+import type {
+  AflTradeAssetType,
+  AflTradeLineageEdgeKind,
+  AflTradeLineageGraph,
+  AflTradeTemporalCutoff,
+} from '../domain/lineageTypes';
+import { validateAflTradeLineageGraph } from '../domain/lineageValidation';
+import { createAflTradeLineageGraphId } from './valuationCaseContracts';
+
+export interface AflTradeAssetLineageNarrativeEvidence {
+  readonly lineageGraphId: string;
+  readonly rootAssetId: string;
+  readonly cutoff: AflTradeTemporalCutoff;
+  readonly nodes: readonly Readonly<{
+    assetId: string;
+    assetType: AflTradeAssetType;
+    label: string;
+    depth: number;
+    effectiveFrom: string;
+    evidenceId: string;
+  }>[];
+  readonly transformations: readonly Readonly<{
+    edgeId: string;
+    kind: AflTradeLineageEdgeKind;
+    sourceAssetId: string;
+    targetAssetId: string;
+    sourceLabel: string;
+    targetLabel: string;
+    effectiveAt: string;
+    evidenceId: string;
+    ruleVersion: string;
+  }>[];
+  readonly custodyHistory: readonly Readonly<{
+    custodySpellId: string;
+    assetId: string;
+    aflClubId: string;
+    clubName: string;
+    effectiveFrom: string;
+    effectiveTo: string | null;
+    evidenceId: string;
+  }>[];
+  readonly dispositions: readonly Readonly<{
+    dispositionId: string;
+    kind: 'asset_voided' | 'asset_expired';
+    assetId: string;
+    effectiveAt: string;
+    evidenceId: string;
+    reasonCode: string;
+  }>[];
+  readonly frontierAssetIds: readonly string[];
+}
+
+export interface AflTradeLineageNarrativeDisplayIdentity {
+  readonly assets: readonly Readonly<{ assetId: string; label: string }>[];
+  readonly clubs: readonly Readonly<{ aflClubId: string; clubName: string }>[];
+}
+
+function compareInstants(left: string, right: string): number {
+  return Date.parse(left) - Date.parse(right);
+}
+
+/**
+ * Projects the temporally visible value lineage beneath one authenticated transaction root. The
+ * result is a canonical graph/tree data model for disclosure UI; correction provenance remains out
+ * of the value path.
+ */
+export function deriveAflTradeAssetLineageNarrativeEvidence(
+  graph: AflTradeLineageGraph,
+  rootAssetId: string,
+  cutoff: AflTradeTemporalCutoff,
+  display: AflTradeLineageNarrativeDisplayIdentity
+): AflTradeAssetLineageNarrativeEvidence {
+  const validation = validateAflTradeLineageGraph(graph);
+  if (!validation.valid) {
+    throw new TypeError('Asset narrative evidence requires one valid authenticated lineage graph.');
+  }
+  const effectiveAsOf = parseAflTradeTime(cutoff.effectiveAsOf);
+  const knowledgeCutoffAt = parseAflTradeTime(cutoff.knowledgeCutoffAt);
+  if (effectiveAsOf === null || knowledgeCutoffAt === null) {
+    throw new TypeError('Asset narrative evidence requires an explicit temporal cutoff.');
+  }
+  const assetById = new Map(graph.assets.map((asset) => [asset.assetId, asset]));
+  const assetLabelById = new Map(display.assets.map(({ assetId, label }) => [assetId, label]));
+  const clubNameById = new Map(
+    display.clubs.map(({ aflClubId, clubName }) => [aflClubId, clubName])
+  );
+  if (
+    assetLabelById.size !== display.assets.length ||
+    clubNameById.size !== display.clubs.length ||
+    [...assetLabelById.values(), ...clubNameById.values()].some(
+      (label) => label.trim() === '' || label !== label.trim()
+    )
+  ) {
+    throw new TypeError('Asset narrative evidence requires unique human display identity.');
+  }
+  const root = assetById.get(rootAssetId);
+  if (
+    root === undefined ||
+    parseAflTradeTime(root.effectiveFrom)! > effectiveAsOf ||
+    !isAflTradeKnownAt(root, knowledgeCutoffAt)
+  ) {
+    throw new RangeError('The requested lineage root is not effective and known at the cutoff.');
+  }
+
+  const outgoing = activeAflTradeEdgesBySource(graph.edges, cutoff);
+  const depths = new Map<string, number>([[rootAssetId, 0]]);
+  const traversedEdgeIds = new Set<string>();
+  const queue = [rootAssetId];
+  for (let index = 0; index < queue.length; index += 1) {
+    const sourceAssetId = queue[index]!;
+    const sourceDepth = depths.get(sourceAssetId)!;
+    const edges = [...(outgoing.get(sourceAssetId) ?? [])].sort(
+      (left, right) =>
+        compareInstants(left.effectiveAt, right.effectiveAt) || left.edgeId.localeCompare(right.edgeId)
+    );
+    for (const edge of edges) {
+      traversedEdgeIds.add(edge.edgeId);
+      const nextDepth = sourceDepth + 1;
+      const currentDepth = depths.get(edge.targetAssetId);
+      if (currentDepth === undefined || nextDepth < currentDepth) {
+        depths.set(edge.targetAssetId, nextDepth);
+        queue.push(edge.targetAssetId);
+      }
+    }
+  }
+
+  const nodes = [...depths]
+    .map(([assetId, depth]) => {
+      const asset = assetById.get(assetId)!;
+      const label = assetLabelById.get(assetId);
+      if (label === undefined) {
+        throw new TypeError('Asset narrative evidence is missing human asset identity.');
+      }
+      return {
+        assetId,
+        assetType: asset.assetType,
+        label,
+        depth,
+        effectiveFrom: asset.effectiveFrom,
+        evidenceId: asset.evidenceId,
+      };
+    })
+    .sort(
+      (left, right) =>
+        left.depth - right.depth ||
+        compareInstants(left.effectiveFrom, right.effectiveFrom) ||
+        left.assetId.localeCompare(right.assetId)
+    );
+  const traversedEdges = graph.edges
+    .filter(({ edgeId }) => traversedEdgeIds.has(edgeId))
+    .sort(
+      (left, right) =>
+        depths.get(left.sourceAssetId)! - depths.get(right.sourceAssetId)! ||
+        compareInstants(left.effectiveAt, right.effectiveAt) ||
+        left.edgeId.localeCompare(right.edgeId)
+    );
+  const transformations = traversedEdges.map(
+    ({ knownFrom: _knownFrom, knownTo: _knownTo, ...edge }) => ({
+      ...edge,
+      sourceLabel: assetLabelById.get(edge.sourceAssetId)!,
+      targetLabel: assetLabelById.get(edge.targetAssetId)!,
+    })
+  );
+  const reachableAssetIds = new Set(depths.keys());
+  const custodyHistory = graph.custodySpells
+    .filter(
+      (spell) =>
+        reachableAssetIds.has(spell.assetId) &&
+        parseAflTradeTime(spell.effectiveFrom)! <= effectiveAsOf &&
+        isAflTradeKnownAt(spell, knowledgeCutoffAt)
+    )
+    .sort(
+      (left, right) =>
+        compareInstants(left.effectiveFrom, right.effectiveFrom) ||
+        left.custodySpellId.localeCompare(right.custodySpellId)
+    )
+    .map(({ knownFrom: _knownFrom, knownTo: _knownTo, ...spell }) => {
+      const clubName = clubNameById.get(spell.aflClubId);
+      if (clubName === undefined) {
+        throw new TypeError('Asset narrative evidence is missing human club identity.');
+      }
+      return { ...spell, clubName };
+    });
+  const dispositions = graph.dispositions
+    .filter(
+      (disposition) =>
+        reachableAssetIds.has(disposition.assetId) &&
+        parseAflTradeTime(disposition.effectiveAt)! <= effectiveAsOf &&
+        isAflTradeKnownAt(disposition, knowledgeCutoffAt)
+    )
+    .sort(
+      (left, right) =>
+        compareInstants(left.effectiveAt, right.effectiveAt) ||
+        left.dispositionId.localeCompare(right.dispositionId)
+    )
+    .map(({ knownFrom: _knownFrom, knownTo: _knownTo, ...disposition }) => disposition);
+
+  return {
+    lineageGraphId: createAflTradeLineageGraphId(graph),
+    rootAssetId,
+    cutoff: { ...cutoff },
+    nodes,
+    transformations,
+    custodyHistory,
+    dispositions,
+    frontierAssetIds: buildAflTradeAttributionFrontier(
+      [rootAssetId],
+      traversedEdges,
+      cutoff,
+      graph.dispositions
+    ),
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/calculationNarrativeEvidence.ts
+++ b/src/server/aflTradeIntelligence/valuation/calculationNarrativeEvidence.ts
@@ -1,0 +1,212 @@
+import { z } from 'zod';
+
+import {
+  aflTradePickPavDistributionBenchmarkSchema,
+  type AflTradePickPavDistributionBenchmark,
+} from '../modeling/pickPavDistributionBenchmark';
+import {
+  aflTradePlayerPavObservationSchema,
+  type AflTradePlayerPavObservation,
+} from '../modeling/playerPavObservationContracts';
+
+const selectionNumberSchema = z.number().int().positive().max(500);
+
+export interface AflTradePickCalculationEvidence {
+  readonly kind: 'pick';
+  readonly benchmarkId: string;
+  readonly observationSetId: string;
+  readonly policyId: string;
+  readonly methodId: string;
+  readonly valueUnit: 'fixed_horizon_pav';
+  readonly selectionNumber: number;
+  readonly cohort: Readonly<{
+    minimumSelectionNumber: number;
+    maximumSelectionNumber: number;
+    observationCount: number;
+    draftClassCount: number;
+    sourceSelectionNumbers: readonly number[];
+  }>;
+  readonly expected: Readonly<{
+    contribution: number;
+    games: number;
+  }>;
+  readonly centralRange: Readonly<{
+    contribution: Readonly<{ p10: number; p50: number; p90: number }>;
+    games: Readonly<{ p10: number; p50: number; p90: number }>;
+  }>;
+  readonly outcomeProbabilities: readonly Readonly<{
+    category: string;
+    probability: number;
+  }>[];
+  readonly empiricalSupportObservationIds: readonly string[];
+  readonly fixedHorizonSeasons: number;
+  readonly limitation: string;
+}
+
+interface AflTradePlayerCalculationEvidenceBase {
+  readonly kind: 'player';
+  readonly observationId: string;
+  readonly releaseId: string;
+  readonly playerId: string;
+  readonly acquisitionSpell: AflTradePlayerPavObservation['acquisitionSpell'];
+  readonly predictionSeason: number;
+  readonly evidenceCutoffAt: string;
+  readonly horizon: Readonly<{
+    endsAt: string;
+    requiredSeasons: readonly number[];
+    observedSeasons: readonly number[];
+  }>;
+}
+
+export type AflTradePlayerCalculationEvidence =
+  | (AflTradePlayerCalculationEvidenceBase &
+      Readonly<{
+        state: 'mature_observed' | 'right_censored';
+        seasons: readonly Readonly<{
+          seasonYear: number;
+          gamesPlayed: number;
+          contribution: number;
+          contributionPerGame: number | null;
+          calculationId: string;
+          calculationSha256: string;
+          effectiveThrough: string;
+          sourceObservationIds: readonly string[];
+        }>[];
+        totals: Readonly<{
+          gamesPlayed: number;
+          contribution: number;
+          contributionPerGame: number | null;
+        }>;
+      }>)
+  | (AflTradePlayerCalculationEvidenceBase &
+      Readonly<{
+        state: 'unavailable';
+        reason: Extract<
+          AflTradePlayerPavObservation['outcome'],
+          { state: 'unavailable' }
+        >['reason'];
+        seasons: readonly [];
+        totals: null;
+      }>);
+
+function perGame(contribution: number, gamesPlayed: number): number | null {
+  return gamesPlayed === 0 ? null : contribution / gamesPlayed;
+}
+
+/**
+ * Projects season-by-season receiving-club evidence from one exact player observation. Totals are
+ * re-derived from its sealed season values; unavailable observations never acquire numeric zeros.
+ */
+export function deriveAflTradePlayerCalculationEvidence(
+  unparsedObservation: AflTradePlayerPavObservation
+): AflTradePlayerCalculationEvidence {
+  const observation = aflTradePlayerPavObservationSchema.parse(unparsedObservation);
+  const base: AflTradePlayerCalculationEvidenceBase = {
+    kind: 'player',
+    observationId: observation.observationId,
+    releaseId: observation.releaseId,
+    playerId: observation.playerId,
+    acquisitionSpell: { ...observation.acquisitionSpell },
+    predictionSeason: observation.predictionSeason,
+    evidenceCutoffAt: observation.outcomeObservedAt,
+    horizon: {
+      endsAt: observation.outcomeHorizonEndsAt,
+      requiredSeasons: [...observation.targetCalculationSeasons],
+      observedSeasons: observation.targetValues.map(({ seasonYear }) => seasonYear),
+    },
+  };
+  if (observation.outcome.state === 'unavailable') {
+    return {
+      ...base,
+      state: 'unavailable',
+      reason: observation.outcome.reason,
+      seasons: [],
+      totals: null,
+    };
+  }
+  const seasons = observation.targetValues.map((value) => ({
+    seasonYear: value.seasonYear,
+    gamesPlayed: value.gamesPlayed,
+    contribution: value.totalPav,
+    contributionPerGame: perGame(value.totalPav, value.gamesPlayed),
+    calculationId: value.calculationId,
+    calculationSha256: value.calculationSha256,
+    effectiveThrough: value.effectiveThrough,
+    sourceObservationIds: [...value.sourceRowIds],
+  }));
+  const gamesPlayed = seasons.reduce((sum, season) => sum + season.gamesPlayed, 0);
+  const contribution = seasons.reduce((sum, season) => sum + season.contribution, 0);
+  return {
+    ...base,
+    state: observation.outcome.state,
+    seasons,
+    totals: {
+      gamesPlayed,
+      contribution,
+      contributionPerGame: perGame(contribution, gamesPlayed),
+    },
+  };
+}
+
+/**
+ * Projects the exact empirical support behind one pick estimate. The supplied benchmark is parsed
+ * and content-address authenticated before any reader-facing evidence is returned.
+ */
+export function deriveAflTradePickCalculationEvidence(
+  unparsedBenchmark: AflTradePickPavDistributionBenchmark,
+  unparsedSelectionNumber: number
+): AflTradePickCalculationEvidence {
+  const benchmark = aflTradePickPavDistributionBenchmarkSchema.parse(unparsedBenchmark);
+  const selectionNumber = selectionNumberSchema.parse(unparsedSelectionNumber);
+  const curvePoint = benchmark.content.selectionCurve.find(
+    (candidate) => candidate.selectionNumber === selectionNumber
+  );
+  if (curvePoint === undefined) {
+    throw new RangeError(
+      `Pick ${selectionNumber} is outside the authenticated pick-model support.`
+    );
+  }
+  const block = benchmark.content.distributionBlocks[curvePoint.distributionBlockIndex];
+  if (block === undefined) {
+    throw new TypeError('The authenticated pick curve does not resolve to its empirical cohort.');
+  }
+  const distribution = block.distribution;
+  return {
+    kind: 'pick',
+    benchmarkId: benchmark.benchmarkId,
+    observationSetId: benchmark.content.observationSetId,
+    policyId: benchmark.content.policyId,
+    methodId: benchmark.content.methodId,
+    valueUnit: benchmark.content.valueUnit,
+    selectionNumber,
+    cohort: {
+      minimumSelectionNumber: block.minimumSelectionNumber,
+      maximumSelectionNumber: block.maximumSelectionNumber,
+      observationCount: block.observationCount,
+      draftClassCount: block.draftClassCount,
+      sourceSelectionNumbers: [...block.sourceSelectionNumbers],
+    },
+    expected: {
+      contribution: distribution.expectedContribution,
+      games: distribution.expectedGames,
+    },
+    centralRange: {
+      contribution: {
+        p10: distribution.p10Contribution,
+        p50: distribution.p50Contribution,
+        p90: distribution.p90Contribution,
+      },
+      games: {
+        p10: distribution.p10Games,
+        p50: distribution.p50Games,
+        p90: distribution.p90Games,
+      },
+    },
+    outcomeProbabilities: distribution.outcomeProbabilities.map((outcome) => ({ ...outcome })),
+    empiricalSupportObservationIds: block.empiricalSupport.map(
+      ({ observationId }) => observationId
+    ),
+    fixedHorizonSeasons: benchmark.content.fixedHorizonSeasons,
+    limitation: benchmark.content.limitations[0],
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration.ts
+++ b/src/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration.ts
@@ -1,0 +1,445 @@
+import { z } from 'zod';
+
+import {
+  aflTradeArtifactRefSchema,
+  createAflTradeByteArtifactRef,
+  doesAflTradeArtifactRefMatchBytes,
+  type AflTradeArtifactRef,
+} from '../artifacts/artifactReference';
+import {
+  aflTradeContentAddressedIdSchema,
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '../artifacts/contentAddress';
+import type { createAflTradeCalculationNarrative } from './tradeCalculationNarrative';
+
+type CalculationNarrative = ReturnType<typeof createAflTradeCalculationNarrative>;
+type ReaderDocumentKind = 'archive_summary' | 'detail' | 'reader_api' | 'json_export';
+type RetainedArtifactKind =
+  | 'calculation_narrative'
+  | ReaderDocumentKind
+  | 'projection_manifest'
+  | 'generation';
+
+export interface GovernedPrivateEvaluationSelector {
+  readonly valuationScopeKey: string;
+  readonly tradeId: string;
+}
+
+export interface GovernedPrivateEvaluationRetainedArtifact {
+  readonly kind: RetainedArtifactKind;
+  readonly reference: AflTradeArtifactRef;
+  readonly bytes: Uint8Array;
+}
+
+interface ProjectionManifest {
+  readonly projectionManifestId: string;
+  readonly content: {
+    readonly schemaVersion: 'governed-private-evaluation-projection-manifest/v1';
+    readonly selector: GovernedPrivateEvaluationSelector;
+    readonly narrativeId: string;
+    readonly generatedAt: string;
+    readonly documents: readonly Readonly<{
+      kind: ReaderDocumentKind;
+      artifact: AflTradeArtifactRef;
+    }>[];
+    readonly runtimeHtmlRetention: 'prohibited';
+  };
+}
+
+interface EvaluationGeneration {
+  readonly generationId: string;
+  readonly content: {
+    readonly schemaVersion: 'local-private-trade-evaluation-generation/v1';
+    readonly environment: 'test_fixture';
+    readonly selector: GovernedPrivateEvaluationSelector;
+    readonly transitionIntentId: string;
+    readonly narrativeId: string;
+    readonly narrativeArtifact: AflTradeArtifactRef;
+    readonly projectionManifestId: string;
+    readonly projectionManifestArtifact: AflTradeArtifactRef;
+    readonly generatedAt: string;
+    readonly activationReceipt: 'separate_append_only_transition';
+    readonly publicationProhibited: true;
+  };
+}
+
+export interface GovernedPrivateEvaluationDetailDocument {
+  readonly schemaVersion: 'governed-private-evaluation-detail/v1';
+  readonly selector: GovernedPrivateEvaluationSelector;
+  readonly narrativeId: string;
+  readonly narrative: CalculationNarrative['content'];
+}
+
+export interface GovernedPrivateEvaluationGenerationMaterialization {
+  readonly projectionManifest: ProjectionManifest;
+  readonly generation: EvaluationGeneration;
+  readonly artifacts: GovernedPrivateEvaluationRetainedArtifact[];
+}
+
+const retainedSelectorSchema = z
+  .object({
+    valuationScopeKey: z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,399}$/u),
+    tradeId: z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,399}$/u),
+  })
+  .strict();
+const readerDocumentKindSchema = z.enum([
+  'archive_summary',
+  'detail',
+  'reader_api',
+  'json_export',
+]);
+const retainedGenerationV1Schema = z
+  .object({
+    generationId: aflTradeContentAddressedIdSchema('local-private-trade-evaluation-generation'),
+    content: z
+      .object({
+        schemaVersion: z.literal('local-private-trade-evaluation-generation/v1'),
+        environment: z.literal('test_fixture'),
+        selector: retainedSelectorSchema,
+        transitionIntentId: aflTradeContentAddressedIdSchema(
+          'private-evaluation-transition-intent'
+        ),
+        narrativeId: aflTradeContentAddressedIdSchema('trade-calculation-narrative'),
+        narrativeArtifact: aflTradeArtifactRefSchema,
+        projectionManifestId: aflTradeContentAddressedIdSchema(
+          'private-evaluation-projection-manifest'
+        ),
+        projectionManifestArtifact: aflTradeArtifactRefSchema,
+        generatedAt: z.iso.datetime({ offset: true }),
+        activationReceipt: z.literal('separate_append_only_transition'),
+        publicationProhibited: z.literal(true),
+      })
+      .strict(),
+  })
+  .strict();
+const retainedProjectionManifestV1Schema = z
+  .object({
+    projectionManifestId: aflTradeContentAddressedIdSchema(
+      'private-evaluation-projection-manifest'
+    ),
+    content: z
+      .object({
+        schemaVersion: z.literal('governed-private-evaluation-projection-manifest/v1'),
+        selector: retainedSelectorSchema,
+        narrativeId: aflTradeContentAddressedIdSchema('trade-calculation-narrative'),
+        generatedAt: z.iso.datetime({ offset: true }),
+        documents: z
+          .array(
+            z
+              .object({
+                kind: readerDocumentKindSchema,
+                artifact: aflTradeArtifactRefSchema,
+              })
+              .strict()
+          )
+          .length(4),
+        runtimeHtmlRetention: z.literal('prohibited'),
+      })
+      .strict(),
+  })
+  .strict();
+
+export class UnsupportedGovernedPrivateEvaluationProjectionVersionError extends Error {}
+
+function retainedSchemaVersion(value: unknown): string | null {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return null;
+  const content = (value as { readonly content?: unknown }).content;
+  if (content === null || typeof content !== 'object' || Array.isArray(content)) return null;
+  const schemaVersion = (content as { readonly schemaVersion?: unknown }).schemaVersion;
+  return typeof schemaVersion === 'string' ? schemaVersion : null;
+}
+
+export function parseGovernedPrivateEvaluationGeneration(
+  value: unknown
+): EvaluationGeneration {
+  const version = retainedSchemaVersion(value);
+  if (
+    version !== null &&
+    version !== 'local-private-trade-evaluation-generation/v1'
+  ) {
+    throw new UnsupportedGovernedPrivateEvaluationProjectionVersionError(
+      `Unsupported private evaluation generation version: ${version}`
+    );
+  }
+  return retainedGenerationV1Schema.parse(value) as EvaluationGeneration;
+}
+
+export function parseGovernedPrivateEvaluationProjectionManifest(
+  value: unknown
+): ProjectionManifest {
+  const version = retainedSchemaVersion(value);
+  if (
+    version !== null &&
+    version !== 'governed-private-evaluation-projection-manifest/v1'
+  ) {
+    throw new UnsupportedGovernedPrivateEvaluationProjectionVersionError(
+      `Unsupported private evaluation projection manifest version: ${version}`
+    );
+  }
+  return retainedProjectionManifestV1Schema.parse(value) as ProjectionManifest;
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder('utf-8', { fatal: true });
+const artifactOrder: readonly RetainedArtifactKind[] = [
+  'calculation_narrative',
+  'archive_summary',
+  'detail',
+  'reader_api',
+  'json_export',
+  'projection_manifest',
+  'generation',
+];
+
+function canonicalBytes(value: unknown, terminalNewline = false): Uint8Array {
+  return encoder.encode(`${canonicalizeAflTradeJson(value)}${terminalNewline ? '\n' : ''}`);
+}
+
+function retained(
+  kind: RetainedArtifactKind,
+  bytes: Uint8Array,
+  generatedAt: string
+): GovernedPrivateEvaluationRetainedArtifact {
+  return {
+    kind,
+    bytes: Uint8Array.from(bytes),
+    reference: createAflTradeByteArtifactRef(bytes, 'application/json', generatedAt),
+  };
+}
+
+function same(left: unknown, right: unknown): boolean {
+  return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+}
+
+function validSelector(selector: GovernedPrivateEvaluationSelector): boolean {
+  return (
+    /^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,399}$/u.test(selector.valuationScopeKey) &&
+    /^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,399}$/u.test(selector.tradeId)
+  );
+}
+
+function parseArtifactJson(
+  artifact: GovernedPrivateEvaluationRetainedArtifact,
+  terminalNewline = false
+): unknown {
+  const text = decoder.decode(artifact.bytes);
+  if (terminalNewline !== text.endsWith('\n')) {
+    throw new TypeError('Retained JSON byte framing does not match its document kind.');
+  }
+  return JSON.parse(text);
+}
+
+export function decodeGovernedPrivateEvaluationDetailDocument(
+  bytes: Uint8Array
+): GovernedPrivateEvaluationDetailDocument {
+  try {
+    const text = decoder.decode(bytes);
+    if (text.endsWith('\n')) {
+      throw new TypeError('Detail JSON must use canonical framing without a terminal newline.');
+    }
+    const value = JSON.parse(text) as Partial<GovernedPrivateEvaluationDetailDocument>;
+    if (
+      value === null ||
+      typeof value !== 'object' ||
+      Array.isArray(value) ||
+      canonicalizeAflTradeJson(Object.keys(value).sort()) !==
+        canonicalizeAflTradeJson(['narrative', 'narrativeId', 'schemaVersion', 'selector']) ||
+      value.schemaVersion !== 'governed-private-evaluation-detail/v1' ||
+      value.selector === undefined ||
+      !validSelector(value.selector) ||
+      typeof value.narrativeId !== 'string' ||
+      value.narrative === undefined ||
+      value.narrative.tradeId !== value.selector.tradeId ||
+      value.narrative.publicationProhibited !== true ||
+      canonicalizeAflTradeJson(value.narrative.views.map(({ view }) => view)) !==
+        canonicalizeAflTradeJson(['at_trade', 'realized', 'remaining', 'current']) ||
+      createAflTradeContentAddress('trade-calculation-narrative', value.narrative) !==
+        value.narrativeId
+    ) {
+      throw new TypeError('Private evaluation detail document failed narrative authentication.');
+    }
+    return structuredClone(value) as GovernedPrivateEvaluationDetailDocument;
+  } catch (error) {
+    if (error instanceof TypeError && /detail|narrative/u.test(error.message)) throw error;
+    throw new TypeError('Private evaluation detail document is malformed or unauthenticated.');
+  }
+}
+
+export function createGovernedPrivateEvaluationGeneration(input: {
+  readonly selector: GovernedPrivateEvaluationSelector;
+  readonly transitionIntentId: string;
+  readonly generatedAt: string;
+  readonly narrative: CalculationNarrative;
+}): GovernedPrivateEvaluationGenerationMaterialization {
+  if (
+    !validSelector(input.selector) ||
+    input.selector.tradeId !== input.narrative.content.tradeId ||
+    !/^private-evaluation-transition-intent:[a-f0-9]{64}$/u.test(input.transitionIntentId) ||
+    createAflTradeContentAddress('trade-calculation-narrative', input.narrative.content) !==
+      input.narrative.narrativeId ||
+    input.narrative.content.publicationProhibited !== true
+  ) {
+    throw new TypeError('Private evaluation generation requires one authentic test-fixture narrative.');
+  }
+
+  const current = input.narrative.content.views.find(({ view }) => view === 'current');
+  if (current === undefined) {
+    throw new TypeError('Private evaluation generation requires the synchronized current view.');
+  }
+  const archiveSummary = {
+    schemaVersion: 'governed-private-evaluation-archive-summary/v1' as const,
+    selector: { ...input.selector },
+    narrativeId: input.narrative.narrativeId,
+    valueUnitId: input.narrative.content.valueUnitId,
+    defaultView: input.narrative.content.defaultView,
+    clubs: current.clubs.map((club) => ({
+      aflClubId: club.aflClubId,
+      clubName: club.clubName,
+      receivedAssetIds: [...club.receivedAssetIds],
+      givenUpAssetIds: [...club.givenUpAssetIds],
+      estimatedAdvantageMean: club.arithmetic.estimatedAdvantageMean,
+      grade: { ...club.grade },
+    })),
+  };
+  const detail = {
+    schemaVersion: 'governed-private-evaluation-detail/v1' as const,
+    selector: { ...input.selector },
+    narrativeId: input.narrative.narrativeId,
+    narrative: input.narrative.content,
+  };
+  const readerApi = {
+    schemaVersion: 'governed-private-evaluation-reader-api/v1' as const,
+    selector: { ...input.selector },
+    narrativeId: input.narrative.narrativeId,
+    archiveSummary,
+    detail,
+  };
+  const artifacts = [
+    retained('calculation_narrative', canonicalBytes(input.narrative), input.generatedAt),
+    retained('archive_summary', canonicalBytes(archiveSummary), input.generatedAt),
+    retained('detail', canonicalBytes(detail), input.generatedAt),
+    retained('reader_api', canonicalBytes(readerApi), input.generatedAt),
+    retained('json_export', canonicalBytes(readerApi, true), input.generatedAt),
+  ];
+  const projectionManifestContent: ProjectionManifest['content'] = {
+    schemaVersion: 'governed-private-evaluation-projection-manifest/v1',
+    selector: { ...input.selector },
+    narrativeId: input.narrative.narrativeId,
+    generatedAt: input.generatedAt,
+    documents: artifacts.slice(1).map(({ kind, reference }) => ({
+      kind: kind as ReaderDocumentKind,
+      artifact: reference,
+    })),
+    runtimeHtmlRetention: 'prohibited',
+  };
+  const projectionManifest: ProjectionManifest = {
+    projectionManifestId: createAflTradeContentAddress(
+      'private-evaluation-projection-manifest',
+      projectionManifestContent
+    ),
+    content: projectionManifestContent,
+  };
+  const manifestArtifact = retained(
+    'projection_manifest',
+    canonicalBytes(projectionManifest),
+    input.generatedAt
+  );
+  artifacts.push(manifestArtifact);
+  const generationContent: EvaluationGeneration['content'] = {
+    schemaVersion: 'local-private-trade-evaluation-generation/v1',
+    environment: 'test_fixture',
+    selector: { ...input.selector },
+    transitionIntentId: input.transitionIntentId,
+    narrativeId: input.narrative.narrativeId,
+    narrativeArtifact: artifacts[0]!.reference,
+    projectionManifestId: projectionManifest.projectionManifestId,
+    projectionManifestArtifact: manifestArtifact.reference,
+    generatedAt: input.generatedAt,
+    activationReceipt: 'separate_append_only_transition',
+    publicationProhibited: true,
+  };
+  const generation: EvaluationGeneration = {
+    generationId: createAflTradeContentAddress(
+      'local-private-trade-evaluation-generation',
+      generationContent
+    ),
+    content: generationContent,
+  };
+  artifacts.push(retained('generation', canonicalBytes(generation), input.generatedAt));
+  return { projectionManifest, generation, artifacts };
+}
+
+export function verifyGovernedPrivateEvaluationGeneration(
+  materialization: GovernedPrivateEvaluationGenerationMaterialization
+): boolean {
+  try {
+    const retainedGeneration = parseGovernedPrivateEvaluationGeneration(
+      materialization.generation
+    );
+    const retainedProjectionManifest = parseGovernedPrivateEvaluationProjectionManifest(
+      materialization.projectionManifest
+    );
+    if (
+      materialization.artifacts.length !== artifactOrder.length ||
+      materialization.artifacts.some(
+        (artifact, index) =>
+          artifact.kind !== artifactOrder[index] ||
+          !doesAflTradeArtifactRefMatchBytes(
+            artifact.reference,
+            artifact.bytes,
+            'application/json'
+          )
+      )
+    ) {
+      return false;
+    }
+    const byKind = new Map(materialization.artifacts.map((artifact) => [artifact.kind, artifact]));
+    const narrative = parseArtifactJson(byKind.get('calculation_narrative')!);
+    const archiveSummary = parseArtifactJson(byKind.get('archive_summary')!);
+    const detail = parseArtifactJson(byKind.get('detail')!);
+    const readerApi = parseArtifactJson(byKind.get('reader_api')!);
+    const jsonExport = parseArtifactJson(byKind.get('json_export')!, true);
+    const manifest = parseGovernedPrivateEvaluationProjectionManifest(
+      parseArtifactJson(byKind.get('projection_manifest')!)
+    );
+    const generation = parseGovernedPrivateEvaluationGeneration(
+      parseArtifactJson(byKind.get('generation')!)
+    );
+    const expectedDocuments = (['archive_summary', 'detail', 'reader_api', 'json_export'] as const).map(
+      (kind) => ({ kind, artifact: byKind.get(kind)!.reference })
+    );
+    const narrativeEnvelope = narrative as CalculationNarrative;
+    return (
+      createAflTradeContentAddress('trade-calculation-narrative', narrativeEnvelope.content) ===
+        narrativeEnvelope.narrativeId &&
+      same((detail as { narrative: unknown }).narrative, narrativeEnvelope.content) &&
+      same((readerApi as { archiveSummary: unknown }).archiveSummary, archiveSummary) &&
+      same((readerApi as { detail: unknown }).detail, detail) &&
+      same(readerApi, jsonExport) &&
+      same(manifest, retainedProjectionManifest) &&
+      same(generation, retainedGeneration) &&
+      same(retainedProjectionManifest.content.documents, expectedDocuments) &&
+      createAflTradeContentAddress(
+        'private-evaluation-projection-manifest',
+        retainedProjectionManifest.content
+      ) === retainedProjectionManifest.projectionManifestId &&
+      createAflTradeContentAddress(
+        'local-private-trade-evaluation-generation',
+        retainedGeneration.content
+      ) === retainedGeneration.generationId &&
+      same(
+        retainedGeneration.content.narrativeArtifact,
+        byKind.get('calculation_narrative')!.reference
+      ) &&
+      same(
+        retainedGeneration.content.projectionManifestArtifact,
+        byKind.get('projection_manifest')!.reference
+      ) &&
+      retainedGeneration.content.projectionManifestId ===
+        retainedProjectionManifest.projectionManifestId
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/server/aflTradeIntelligence/valuation/governedPrivateEvaluationWorkspace.ts
+++ b/src/server/aflTradeIntelligence/valuation/governedPrivateEvaluationWorkspace.ts
@@ -1,0 +1,27 @@
+import type {
+  GovernedPrivateEvaluationExecuteRequest,
+  GovernedPrivateEvaluationExecuteResult,
+  GovernedPrivateEvaluationInspectRequest,
+  GovernedPrivateEvaluationInspectResult,
+  GovernedPrivateEvaluationReadRequest,
+  GovernedPrivateEvaluationReadResult,
+} from './internal/governedPrivateEvaluationWorkspaceContracts';
+
+export type {
+  GovernedPrivateEvaluationExecuteRequest,
+  GovernedPrivateEvaluationExecuteResult,
+  GovernedPrivateEvaluationInspectRequest,
+  GovernedPrivateEvaluationInspectResult,
+  GovernedPrivateEvaluationReadRequest,
+  GovernedPrivateEvaluationReadResult,
+};
+
+export interface GovernedPrivateEvaluationWorkspace {
+  inspect(
+    request: GovernedPrivateEvaluationInspectRequest
+  ): Promise<GovernedPrivateEvaluationInspectResult>;
+  execute(
+    request: GovernedPrivateEvaluationExecuteRequest
+  ): Promise<GovernedPrivateEvaluationExecuteResult>;
+  read(request: GovernedPrivateEvaluationReadRequest): Promise<GovernedPrivateEvaluationReadResult>;
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/createGovernedPrivateEvaluationWorkspace.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/createGovernedPrivateEvaluationWorkspace.ts
@@ -1,0 +1,83 @@
+import { doesAflTradeArtifactRefMatchBytes } from '../../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import type { GovernedPrivateEvaluationWorkspace } from '../governedPrivateEvaluationWorkspace';
+import {
+  governedPrivateEvaluationExecuteRequestSchema,
+  governedPrivateEvaluationExecuteResultSchema,
+  governedPrivateEvaluationInspectRequestSchema,
+  governedPrivateEvaluationInspectResultSchema,
+  governedPrivateEvaluationReadRequestSchema,
+  governedPrivateEvaluationReadResultSchema,
+  type GovernedPrivateEvaluationExecuteRequest,
+  type GovernedPrivateEvaluationInspectRequest,
+  type GovernedPrivateEvaluationReadRequest,
+} from './governedPrivateEvaluationWorkspaceContracts';
+
+interface GovernedPrivateEvaluationInternalComposition {
+  readonly inspect: (request: GovernedPrivateEvaluationInspectRequest) => Promise<unknown>;
+  readonly execute: (request: GovernedPrivateEvaluationExecuteRequest) => Promise<unknown>;
+  readonly read: (request: GovernedPrivateEvaluationReadRequest) => Promise<unknown>;
+}
+
+function sameCanonicalJson(left: unknown, right: unknown): boolean {
+  return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+}
+
+export function createGovernedPrivateEvaluationWorkspaceForInternalComposition(
+  composition: GovernedPrivateEvaluationInternalComposition
+): GovernedPrivateEvaluationWorkspace {
+  return {
+    async inspect(unparsedRequest) {
+      const request = governedPrivateEvaluationInspectRequestSchema.parse(unparsedRequest);
+      const result = governedPrivateEvaluationInspectResultSchema.parse(
+        await composition.inspect(request)
+      );
+      if (!sameCanonicalJson(result.selector, request)) {
+        throw new RangeError('The governed private evaluation inspection escaped its selector.');
+      }
+      return result;
+    },
+
+    async execute(unparsedRequest) {
+      const request = governedPrivateEvaluationExecuteRequestSchema.parse(unparsedRequest);
+      const result = governedPrivateEvaluationExecuteResultSchema.parse(
+        await composition.execute(request)
+      );
+      if (result.operationId !== request.operationId) {
+        throw new RangeError('The governed private evaluation execution escaped its operation.');
+      }
+      if (result.inspectionId !== request.inspectionId) {
+        throw new RangeError('The governed private evaluation execution escaped its inspection.');
+      }
+      return result;
+    },
+
+    async read(unparsedRequest) {
+      const request = governedPrivateEvaluationReadRequestSchema.parse(unparsedRequest);
+      const result = governedPrivateEvaluationReadResultSchema.parse(await composition.read(request));
+      if (!sameCanonicalJson(result.selector, request.selector)) {
+        throw new RangeError('The governed private evaluation read escaped its selector.');
+      }
+      if (!sameCanonicalJson(result.selection, request.selection)) {
+        throw new RangeError('The governed private evaluation read escaped its exact selection.');
+      }
+      if (result.document.kind !== request.document.kind) {
+        throw new RangeError('The governed private evaluation read escaped its document selection.');
+      }
+      if (
+        result.state === 'available' &&
+        request.selection.kind === 'generation' &&
+        result.generationId !== request.selection.generationId
+      ) {
+        throw new RangeError('The governed private evaluation read escaped its exact generation.');
+      }
+      if (
+        result.state === 'available' &&
+        !doesAflTradeArtifactRefMatchBytes(result.document.artifact, result.bytes)
+      ) {
+        throw new RangeError('The governed private evaluation read returned unauthenticated bytes.');
+      }
+      return result;
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace.ts
@@ -1,0 +1,70 @@
+import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
+import type { AflOutcomeSqlClient } from '../../outcomes/postgresOutcomeReleaseRepository';
+import { createGovernedPrivateEvaluationWorkspaceForInternalComposition } from './createGovernedPrivateEvaluationWorkspace';
+import { createPostgresGovernedPrivateEvaluationExecutionService } from './postgresGovernedPrivateEvaluationExecutionService';
+import { createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture } from './postgresGovernedPrivateEvaluationCalculationAuthority';
+import { createPostgresGovernedPrivateEvaluationInspectionRepository } from './postgresGovernedPrivateEvaluationInspectionRepository';
+import { createPostgresGovernedPrivateEvaluationLifecycleRepository } from './postgresGovernedPrivateEvaluationLifecycleRepository';
+import { createPostgresGovernedPrivateEvaluationReadRepository } from './postgresGovernedPrivateEvaluationReadRepository';
+import { createPostgresGovernedPrivateEvaluationReconstructionRepository } from './postgresGovernedPrivateEvaluationReconstructionRepository';
+import { createPostgresGovernedPrivateEvaluationStagingRepository } from './postgresGovernedPrivateEvaluationStagingRepository';
+import type { GovernedPrivateEvaluationReadRequest } from './governedPrivateEvaluationWorkspaceContracts';
+
+export function createPostgresGovernedPrivateEvaluationWorkspace(dependencies: {
+  readonly client: AflOutcomeSqlClient;
+  readonly artifactRepository: AflTradeImmutableArtifactRepository;
+  readonly maximumArtifactBytes: number;
+  readonly principalId: string;
+  readonly authorizeReader: (input: {
+    readonly principalId: string;
+    readonly selector: GovernedPrivateEvaluationReadRequest['selector'];
+  }) => Promise<boolean>;
+}) {
+  const staging = createPostgresGovernedPrivateEvaluationStagingRepository({
+    client: dependencies.client,
+    artifactRepository: dependencies.artifactRepository,
+    maximumArtifactBytes: dependencies.maximumArtifactBytes,
+  });
+  const lifecycle = createPostgresGovernedPrivateEvaluationLifecycleRepository({
+    client: dependencies.client,
+    artifactRepository: dependencies.artifactRepository,
+    maximumArtifactBytes: dependencies.maximumArtifactBytes,
+  });
+  const captureCalculationAuthority =
+    createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture({
+      artifactRepository: dependencies.artifactRepository,
+      maximumArtifactBytes: dependencies.maximumArtifactBytes,
+    });
+  const inspection = createPostgresGovernedPrivateEvaluationInspectionRepository({
+    client: dependencies.client,
+    retainArtifact: (artifact) => staging.retainArtifact(artifact),
+    captureCalculationAuthority,
+    validityMilliseconds: 5 * 60 * 1_000,
+  });
+  const read = createPostgresGovernedPrivateEvaluationReadRepository({
+    client: dependencies.client,
+    artifactRepository: dependencies.artifactRepository,
+    maximumArtifactBytes: dependencies.maximumArtifactBytes,
+    principalId: dependencies.principalId,
+    authorizeReader: dependencies.authorizeReader,
+  });
+  const reconstruction = createPostgresGovernedPrivateEvaluationReconstructionRepository({
+    client: dependencies.client,
+    artifactRepository: dependencies.artifactRepository,
+    maximumArtifactBytes: dependencies.maximumArtifactBytes,
+    retainArtifact: (artifact) => staging.retainArtifact(artifact),
+  });
+  const execution = createPostgresGovernedPrivateEvaluationExecutionService({
+    client: dependencies.client,
+    principalId: dependencies.principalId,
+    staging,
+    lifecycle,
+    reconstruction,
+  });
+
+  return createGovernedPrivateEvaluationWorkspaceForInternalComposition({
+    inspect: (request) => inspection.inspect(request),
+    execute: (request) => execution.execute(request),
+    read: (request) => read.read(request),
+  });
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/governedNativeComponentExecution.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedNativeComponentExecution.ts
@@ -1,0 +1,107 @@
+import {
+  doAflTradeArtifactRefsExactlyMatch,
+  doesAflTradeArtifactRefMatchBytes,
+} from '../../artifacts/artifactReference';
+import { aflTradeModelRunManifestV3Schema } from '../../artifacts/modelRunManifest';
+import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
+import { governedAflTradePickPavModelExecutionSchema } from '../../modeling/governedPickPavModelExecution';
+import type { GovernedValuationComponentRunManifest } from './governedValuationComponentRunManifest';
+
+export class GovernedNativeComponentExecutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GovernedNativeComponentExecutionError';
+  }
+}
+
+async function loadNativeDocument(input: {
+  readonly manifest: GovernedValuationComponentRunManifest;
+  readonly artifactRepository: AflTradeImmutableArtifactRepository;
+  readonly maximumArtifactBytes: number;
+}): Promise<unknown> {
+  const reference = input.manifest.content.nativeExecution.artifact;
+  const loaded = await input.artifactRepository.loadExact(
+    reference,
+    input.maximumArtifactBytes
+  );
+  if (
+    loaded === null ||
+    !doAflTradeArtifactRefsExactlyMatch(loaded.reference, reference) ||
+    !doesAflTradeArtifactRefMatchBytes(loaded.reference, loaded.bytes)
+  ) {
+    throw new GovernedNativeComponentExecutionError(
+      'Governed native execution artifact bytes failed exact authentication.'
+    );
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(loaded.bytes));
+  } catch {
+    throw new GovernedNativeComponentExecutionError(
+      'Governed native execution artifact is not canonical JSON.'
+    );
+  }
+}
+
+export async function authenticateGovernedNativeComponentExecution(input: {
+  readonly manifest: GovernedValuationComponentRunManifest;
+  readonly artifactRepository: AflTradeImmutableArtifactRepository;
+  readonly maximumArtifactBytes: number;
+}): Promise<void> {
+  if (
+    input.artifactRepository.artifactClass !== 'derived_private' ||
+    !Number.isSafeInteger(input.maximumArtifactBytes) ||
+    input.maximumArtifactBytes <= 0
+  ) {
+    throw new TypeError('Native component authentication requires bounded private custody.');
+  }
+  const content = input.manifest.content;
+  const document = await loadNativeDocument(input);
+  if (content.nativeExecution.kind === 'admitted_player_model_run') {
+    const parsed = aflTradeModelRunManifestV3Schema.safeParse(document);
+    if (
+      !parsed.success ||
+      parsed.data.runId !== content.nativeExecution.executionId ||
+      parsed.data.content.environment !== 'non_production' ||
+      parsed.data.content.outcome.status !== 'succeeded' ||
+      parsed.data.content.datasetId !== content.datasetId ||
+      parsed.data.content.datasetAdmissionId !== content.datasetAdmissionId ||
+      parsed.data.content.modelProtocolId !== content.protocolId
+    ) {
+      throw new GovernedNativeComponentExecutionError(
+        'Governed player native execution ancestry is invalid or unsuccessful.'
+      );
+    }
+    return;
+  }
+  if (content.nativeExecution.kind !== 'governed_pick_pav_model_execution') {
+    throw new GovernedNativeComponentExecutionError(
+      'Legacy pick fixture executions are not eligible native authority.'
+    );
+  }
+  const parsed = governedAflTradePickPavModelExecutionSchema.safeParse(document);
+  if (
+    !parsed.success ||
+    parsed.data.executionId !== content.nativeExecution.executionId ||
+    parsed.data.content.datasetId !== content.datasetId ||
+    parsed.data.content.datasetAdmissionId !== content.datasetAdmissionId ||
+    parsed.data.content.datasetAdmissionGateLedgerRevision !==
+      content.datasetAdmissionGateLedgerRevision ||
+    parsed.data.content.protocolId !== content.protocolId ||
+    !doAflTradeArtifactRefsExactlyMatch(
+      parsed.data.content.datasetArtifact,
+      content.datasetArtifact
+    ) ||
+    !doAflTradeArtifactRefsExactlyMatch(
+      parsed.data.content.datasetAdmissionArtifact,
+      content.datasetAdmissionArtifact
+    ) ||
+    !doAflTradeArtifactRefsExactlyMatch(
+      parsed.data.content.protocolArtifact,
+      content.protocolArtifact
+    )
+  ) {
+    throw new GovernedNativeComponentExecutionError(
+      'Governed pick native execution ancestry is invalid.'
+    );
+  }
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationAuthoritySnapshot.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationAuthoritySnapshot.ts
@@ -1,0 +1,887 @@
+import { z } from 'zod';
+
+import { aflTradeArtifactRefSchema } from '../../artifacts/artifactReference';
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '../../artifacts/contentAddress';
+import {
+  governedPrivateEvaluationInspectResultSchema,
+  governedPrivateEvaluationSelectorSchema,
+} from './governedPrivateEvaluationWorkspaceContracts';
+
+const LIMITATION =
+  'Private test-fixture inspection only; unavailable calculation authority permits no construction, grade, production use, or publication.' as const;
+const READY_FIXTURE_LIMITATION =
+  'Private synthetic test-fixture authority only; it grants no factual, production, or publication authority.' as const;
+const READY_NON_PRODUCTION_LIMITATION =
+  'Authenticated private non-production calculation authority only; publication and production use remain prohibited.' as const;
+const UNAVAILABLE_NON_PRODUCTION_LIMITATION =
+  'Authenticated private non-production inspection only; unavailable calculation authority permits no construction, grade, production use, or publication.' as const;
+const instantSchema = z.iso.datetime({ offset: true });
+const generationIdSchema = aflTradeContentAddressedIdSchema(
+  'local-private-trade-evaluation-generation'
+);
+const transitionIdSchema = aflTradeContentAddressedIdSchema(
+  'private-evaluation-transition'
+);
+const modelRunIdSchema = aflTradeContentAddressedIdSchema('model-run');
+const componentRoles = [
+  'player_contribution_and_availability',
+  'draft_pick_and_future_pick_distribution',
+] as const;
+
+const headSchema = z
+  .object({
+    status: z.enum(['absent', 'active', 'withdrawn']),
+    revision: z.number().int().nonnegative(),
+    generationId: generationIdSchema.nullable(),
+  })
+  .strict()
+  .superRefine((head, context) => {
+    if (
+      (head.status === 'absent') !== (head.revision === 0) ||
+      (head.status === 'active') !== (head.generationId !== null)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['generationId'],
+        message: 'Authority snapshot lifecycle head is inconsistent.',
+      });
+    }
+  });
+
+const blockerSchema = z
+  .object({
+    code: z.enum([
+      'source_blocked',
+      'insufficient_data',
+      'identity_unresolved',
+      'lineage_unresolved',
+      'model_not_approved',
+      'reconciliation_failed',
+      'engineering_unavailable',
+    ]),
+    message: z.string().trim().min(1).max(2_000),
+  })
+  .strict();
+
+const lifecycleCommonBase = {
+  publicationProhibited: z.literal(true),
+  selector: governedPrivateEvaluationSelectorSchema,
+  capturedAt: instantSchema,
+  validThrough: instantSchema,
+  head: headSchema,
+  lastTransitionId: transitionIdSchema.nullable(),
+};
+
+const fixtureAuthorityCommonBase = {
+  ...lifecycleCommonBase,
+  environment: z.literal('test_fixture'),
+};
+
+const unavailableAuthorityContent = {
+  ...fixtureAuthorityCommonBase,
+  calculationAuthority: z
+    .object({
+      state: z.literal('unavailable'),
+      playerModelRunId: z.null(),
+      pickModelRunId: z.null(),
+    })
+    .strict(),
+  blockers: z.array(blockerSchema).min(1).max(10_000),
+  limitation: z.literal(LIMITATION),
+};
+
+const unavailableNonProductionAuthorityContent = {
+  ...lifecycleCommonBase,
+  environment: z.literal('non_production'),
+  calculationAuthority: z
+    .object({
+      state: z.literal('unavailable'),
+      playerModelRunId: z.null(),
+      pickModelRunId: z.null(),
+    })
+    .strict(),
+  blockers: z.array(blockerSchema).min(1).max(10_000),
+  limitation: z.literal(UNAVAILABLE_NON_PRODUCTION_LIMITATION),
+};
+
+const readyFixtureAuthorityContent = {
+  ...fixtureAuthorityCommonBase,
+  calculationAuthority: z
+    .object({
+      state: z.literal('ready'),
+      playerModelRunId: modelRunIdSchema,
+      pickModelRunId: modelRunIdSchema,
+    })
+    .strict(),
+  blockers: z.tuple([]),
+  limitation: z.literal(READY_FIXTURE_LIMITATION),
+};
+
+const readyComponentSchema = z
+  .object({
+    role: z.enum(componentRoles),
+    runId: modelRunIdSchema,
+    protocolId: aflTradeContentAddressedIdSchema('model-protocol'),
+    datasetId: aflTradeContentAddressedIdSchema('dataset'),
+    datasetAdmissionId: aflTradeContentAddressedIdSchema('dataset-admission'),
+    datasetAdmissionGateLedgerRevision: z.number().int().positive(),
+    gate3DecisionId: aflTradeContentAddressedIdSchema('gate-decision'),
+    gate3DecisionVersion: z.number().int().positive(),
+  })
+  .strict();
+
+const readyCalculationAuthoritySchema = z
+  .object({
+    state: z.literal('ready'),
+    preparedInputSetId: aflTradeContentAddressedIdSchema('prepared-valuation-input-set'),
+    preparedInputSetArtifact: aflTradeArtifactRefSchema,
+    factualReleaseId: aflTradeContentAddressedIdSchema('outcome-release'),
+    valuationInputBundleId: aflTradeContentAddressedIdSchema('valuation-input-bundle'),
+    valuationInputBundleArtifact: aflTradeArtifactRefSchema,
+    calculationInputPackageId: aflTradeContentAddressedIdSchema(
+      'valuation-calculation-input'
+    ),
+    calculationInputArtifact: aflTradeArtifactRefSchema,
+    inputTraceId: aflTradeContentAddressedIdSchema('private-evaluation-input-trace'),
+    inputTraceArtifact: aflTradeArtifactRefSchema,
+    gateLedgerRevision: z.number().int().positive(),
+    components: z.array(readyComponentSchema).length(componentRoles.length),
+  })
+  .strict()
+  .superRefine((authority, context) => {
+    if (
+      canonicalizeAflTradeJson(authority.components.map(({ role }) => role)) !==
+      canonicalizeAflTradeJson(componentRoles)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['components'],
+        message: 'Calculation-authority components must use canonical roles.',
+      });
+    }
+    for (const field of [
+      'runId',
+      'protocolId',
+      'datasetId',
+      'datasetAdmissionId',
+      'gate3DecisionId',
+    ] as const) {
+      if (new Set(authority.components.map((component) => component[field])).size !== 2) {
+        context.addIssue({
+          code: 'custom',
+          path: ['components'],
+          message: `Calculation-authority component ${field} values must be distinct.`,
+        });
+      }
+    }
+    if (
+      authority.components.some(
+        ({ datasetAdmissionGateLedgerRevision }) =>
+          datasetAdmissionGateLedgerRevision > authority.gateLedgerRevision
+      )
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['gateLedgerRevision'],
+        message: 'Gate ledger head cannot predate an admitted component.',
+      });
+    }
+    const artifactIds = [
+      authority.preparedInputSetArtifact.artifactId,
+      authority.valuationInputBundleArtifact.artifactId,
+      authority.calculationInputArtifact.artifactId,
+      authority.inputTraceArtifact.artifactId,
+    ];
+    if (new Set(artifactIds).size !== artifactIds.length) {
+      context.addIssue({
+        code: 'custom',
+        path: ['preparedInputSetArtifact'],
+        message: 'Calculation-authority documents require distinct retained bytes.',
+      });
+    }
+  });
+
+const readyCalculationAuthorityV3Schema = z
+  .object({
+    state: z.literal('ready'),
+    preparedInputHeadRevision: z.number().int().positive(),
+    preparedInputSetId: aflTradeContentAddressedIdSchema('prepared-valuation-input-set'),
+    factualRegistryRevision: z.number().int().positive(),
+    factualReleaseId: aflTradeContentAddressedIdSchema('outcome-release'),
+    activeFactualReleaseRevision: z.number().int().positive(),
+    privateValuationDecisionId: aflTradeContentAddressedIdSchema(
+      'private-valuation-evaluation-decision'
+    ),
+    privateValuationDecisionRevision: z.number().int().positive(),
+    materializationManifestId: aflTradeContentAddressedIdSchema(
+      'private-evaluation-materialization-manifest'
+    ),
+    materializationManifestArtifact: aflTradeArtifactRefSchema,
+    valuationInputBundleId: aflTradeContentAddressedIdSchema('valuation-input-bundle'),
+    valuationInputBundleArtifact: aflTradeArtifactRefSchema,
+    gateLedgerRevision: z.number().int().positive(),
+    components: z.array(readyComponentSchema).length(componentRoles.length),
+  })
+  .strict()
+  .superRefine((authority, context) => {
+    if (
+      canonicalizeAflTradeJson(authority.components.map(({ role }) => role)) !==
+      canonicalizeAflTradeJson(componentRoles)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['components'],
+        message: 'Calculation-authority components must use canonical roles.',
+      });
+    }
+    for (const field of [
+      'runId',
+      'protocolId',
+      'datasetId',
+      'datasetAdmissionId',
+      'gate3DecisionId',
+    ] as const) {
+      if (new Set(authority.components.map((component) => component[field])).size !== 2) {
+        context.addIssue({
+          code: 'custom',
+          path: ['components'],
+          message: `Calculation-authority component ${field} values must be distinct.`,
+        });
+      }
+    }
+    if (
+      authority.components.some(
+        ({ datasetAdmissionGateLedgerRevision }) =>
+          datasetAdmissionGateLedgerRevision > authority.gateLedgerRevision
+      )
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['gateLedgerRevision'],
+        message: 'Gate ledger head cannot predate an admitted component.',
+      });
+    }
+    if (
+      authority.materializationManifestArtifact.artifactId ===
+      authority.valuationInputBundleArtifact.artifactId
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['materializationManifestArtifact'],
+        message: 'Calculation-authority documents require distinct retained bytes.',
+      });
+    }
+  });
+
+const readyNonProductionAuthorityContent = {
+  ...lifecycleCommonBase,
+  environment: z.literal('non_production'),
+  calculationAuthority: readyCalculationAuthoritySchema,
+  blockers: z.tuple([]),
+  limitation: z.literal(READY_NON_PRODUCTION_LIMITATION),
+};
+
+const readyNonProductionAuthorityV3Content = {
+  ...lifecycleCommonBase,
+  environment: z.literal('non_production'),
+  calculationAuthority: readyCalculationAuthorityV3Schema,
+  blockers: z.tuple([]),
+  limitation: z.literal(READY_NON_PRODUCTION_LIMITATION),
+};
+
+function addAuthorityIssues(
+  value: {
+    capturedAt: string;
+    validThrough: string;
+    head: z.output<typeof headSchema>;
+    lastTransitionId: string | null;
+    blockers: readonly z.output<typeof blockerSchema>[];
+  },
+  context: z.RefinementCtx
+): void {
+  const window = Date.parse(value.validThrough) - Date.parse(value.capturedAt);
+  if (window <= 0 || window > 15 * 60 * 1_000) {
+    context.addIssue({
+      code: 'custom',
+      path: ['validThrough'],
+      message: 'Authority snapshot requires one positive short trusted-time window.',
+    });
+  }
+  if ((value.head.status === 'absent') !== (value.lastTransitionId === null)) {
+    context.addIssue({
+      code: 'custom',
+      path: ['lastTransitionId'],
+      message: 'Authority snapshot predecessor does not match its lifecycle head.',
+    });
+  }
+  const sorted = [...value.blockers].sort(
+    (left, right) => left.code.localeCompare(right.code) || left.message.localeCompare(right.message)
+  );
+  if (canonicalizeAflTradeJson(sorted) !== canonicalizeAflTradeJson(value.blockers)) {
+    context.addIssue({
+      code: 'custom',
+      path: ['blockers'],
+      message: 'Authority snapshot blockers must use canonical ordering.',
+    });
+  }
+}
+
+const unavailableSnapshotContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-authority-snapshot/v1'),
+    ...unavailableAuthorityContent,
+  })
+  .strict()
+  .superRefine(addAuthorityIssues);
+
+const readyFixtureSnapshotContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-authority-snapshot/v1'),
+    ...readyFixtureAuthorityContent,
+  })
+  .strict()
+  .superRefine(addAuthorityIssues);
+
+const readyNonProductionSnapshotContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-authority-snapshot/v2'),
+    ...readyNonProductionAuthorityContent,
+  })
+  .strict()
+  .superRefine((value, context) => {
+    addAuthorityIssues(value, context);
+    if (
+      [
+        value.calculationAuthority.preparedInputSetArtifact,
+        value.calculationAuthority.valuationInputBundleArtifact,
+        value.calculationAuthority.calculationInputArtifact,
+        value.calculationAuthority.inputTraceArtifact,
+      ].some(({ createdAt }) => Date.parse(createdAt) > Date.parse(value.capturedAt))
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['calculationAuthority'],
+        message: 'Calculation-authority artifacts must exist before snapshot capture.',
+      });
+    }
+  });
+
+const unavailableNonProductionSnapshotContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-authority-snapshot/v3'),
+    ...unavailableNonProductionAuthorityContent,
+  })
+  .strict()
+  .superRefine(addAuthorityIssues);
+
+const readyNonProductionSnapshotContentV3Schema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-authority-snapshot/v3'),
+    ...readyNonProductionAuthorityV3Content,
+  })
+  .strict()
+  .superRefine((value, context) => {
+    addAuthorityIssues(value, context);
+    if (
+      [
+        value.calculationAuthority.materializationManifestArtifact,
+        value.calculationAuthority.valuationInputBundleArtifact,
+      ].some(({ createdAt }) => Date.parse(createdAt) > Date.parse(value.capturedAt))
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['calculationAuthority'],
+        message: 'Calculation-authority artifacts must exist before snapshot capture.',
+      });
+    }
+  });
+
+const snapshotContentSchema = z.union([
+  unavailableSnapshotContentSchema,
+  readyFixtureSnapshotContentSchema,
+  readyNonProductionSnapshotContentSchema,
+  unavailableNonProductionSnapshotContentSchema,
+  readyNonProductionSnapshotContentV3Schema,
+]);
+
+const snapshotSchema = z
+  .object({
+    snapshotId: aflTradeContentAddressedIdSchema('private-evaluation-authority-snapshot'),
+    content: snapshotContentSchema,
+  })
+  .strict()
+  .superRefine((snapshot, context) => {
+    addAflTradeContentAddressIssue(
+      'private-evaluation-authority-snapshot',
+      snapshot.snapshotId,
+      snapshot.content,
+      context,
+      ['snapshotId']
+    );
+  });
+
+const unavailableInspectionContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-inspection/v1'),
+    snapshotId: aflTradeContentAddressedIdSchema('private-evaluation-authority-snapshot'),
+    state: z.literal('unavailable'),
+    ...unavailableAuthorityContent,
+  })
+  .strict()
+  .superRefine(addAuthorityIssues);
+
+const readyFixtureInspectionContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-inspection/v1'),
+    snapshotId: aflTradeContentAddressedIdSchema('private-evaluation-authority-snapshot'),
+    state: z.literal('ready'),
+    ...readyFixtureAuthorityContent,
+  })
+  .strict()
+  .superRefine(addAuthorityIssues);
+
+const readyNonProductionInspectionContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-inspection/v2'),
+    snapshotId: aflTradeContentAddressedIdSchema('private-evaluation-authority-snapshot'),
+    state: z.literal('ready'),
+    ...readyNonProductionAuthorityContent,
+  })
+  .strict()
+  .superRefine((value, context) => {
+    addAuthorityIssues(value, context);
+    if (
+      [
+        value.calculationAuthority.preparedInputSetArtifact,
+        value.calculationAuthority.valuationInputBundleArtifact,
+        value.calculationAuthority.calculationInputArtifact,
+        value.calculationAuthority.inputTraceArtifact,
+      ].some(({ createdAt }) => Date.parse(createdAt) > Date.parse(value.capturedAt))
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['calculationAuthority'],
+        message: 'Calculation-authority artifacts must exist before inspection.',
+      });
+    }
+  });
+
+const unavailableNonProductionInspectionContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-inspection/v3'),
+    snapshotId: aflTradeContentAddressedIdSchema('private-evaluation-authority-snapshot'),
+    state: z.literal('unavailable'),
+    ...unavailableNonProductionAuthorityContent,
+  })
+  .strict()
+  .superRefine(addAuthorityIssues);
+
+const readyNonProductionInspectionContentV3Schema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-inspection/v3'),
+    snapshotId: aflTradeContentAddressedIdSchema('private-evaluation-authority-snapshot'),
+    state: z.literal('ready'),
+    ...readyNonProductionAuthorityV3Content,
+  })
+  .strict()
+  .superRefine((value, context) => {
+    addAuthorityIssues(value, context);
+    if (
+      [
+        value.calculationAuthority.materializationManifestArtifact,
+        value.calculationAuthority.valuationInputBundleArtifact,
+      ].some(({ createdAt }) => Date.parse(createdAt) > Date.parse(value.capturedAt))
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['calculationAuthority'],
+        message: 'Calculation-authority artifacts must exist before inspection.',
+      });
+    }
+  });
+
+const inspectionContentSchema = z.union([
+  unavailableInspectionContentSchema,
+  readyFixtureInspectionContentSchema,
+  readyNonProductionInspectionContentSchema,
+  unavailableNonProductionInspectionContentSchema,
+  readyNonProductionInspectionContentV3Schema,
+]);
+
+const inspectionSchema = z
+  .object({
+    inspectionId: aflTradeContentAddressedIdSchema('private-evaluation-inspection'),
+    content: inspectionContentSchema,
+  })
+  .strict()
+  .superRefine((inspection, context) => {
+    addAflTradeContentAddressIssue(
+      'private-evaluation-inspection',
+      inspection.inspectionId,
+      inspection.content,
+      context,
+      ['inspectionId']
+    );
+  });
+
+const retainedSchema = z
+  .object({ snapshot: snapshotSchema, inspection: inspectionSchema })
+  .strict()
+  .superRefine((retained, context) => {
+    const { snapshotId: _snapshotId, schemaVersion: _snapshotVersion, ...snapshotCommon } = {
+      snapshotId: retained.snapshot.snapshotId,
+      ...retained.snapshot.content,
+    };
+    const { snapshotId, state: _state, schemaVersion: _inspectionVersion, ...inspectionCommon } =
+      retained.inspection.content;
+    if (
+      snapshotId !== retained.snapshot.snapshotId ||
+      canonicalizeAflTradeJson(snapshotCommon) !== canonicalizeAflTradeJson(inspectionCommon)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['inspection'],
+        message: 'Authority inspection does not authenticate its exact snapshot.',
+      });
+    }
+  });
+
+type CreationInput = Readonly<{
+  selector: z.input<typeof governedPrivateEvaluationSelectorSchema>;
+  capturedAt: string;
+  validThrough: string;
+  head: z.input<typeof headSchema>;
+  lastTransitionId: string | null;
+  blockers: readonly z.input<typeof blockerSchema>[];
+}>;
+
+type ReadyFixtureCreationInput = Readonly<{
+  selector: z.input<typeof governedPrivateEvaluationSelectorSchema>;
+  capturedAt: string;
+  validThrough: string;
+  head: z.input<typeof headSchema>;
+  lastTransitionId: string | null;
+  playerModelRunId: string;
+  pickModelRunId: string;
+}>;
+
+type ReadyCreationInput = Readonly<{
+  selector: z.input<typeof governedPrivateEvaluationSelectorSchema>;
+  capturedAt: string;
+  validThrough: string;
+  head: z.input<typeof headSchema>;
+  lastTransitionId: string | null;
+  preparedInputSetId: string;
+  preparedInputSetArtifact: z.input<typeof aflTradeArtifactRefSchema>;
+  factualReleaseId: string;
+  valuationInputBundleId: string;
+  valuationInputBundleArtifact: z.input<typeof aflTradeArtifactRefSchema>;
+  calculationInputPackageId: string;
+  calculationInputArtifact: z.input<typeof aflTradeArtifactRefSchema>;
+  inputTraceId: string;
+  inputTraceArtifact: z.input<typeof aflTradeArtifactRefSchema>;
+  gateLedgerRevision: number;
+  components: readonly z.input<typeof readyComponentSchema>[];
+}>;
+
+type ReadyV3CreationInput = Readonly<{
+  selector: z.input<typeof governedPrivateEvaluationSelectorSchema>;
+  capturedAt: string;
+  validThrough: string;
+  head: z.input<typeof headSchema>;
+  lastTransitionId: string | null;
+  preparedInputHeadRevision: number;
+  preparedInputSetId: string;
+  factualRegistryRevision: number;
+  factualReleaseId: string;
+  activeFactualReleaseRevision: number;
+  privateValuationDecisionId: string;
+  privateValuationDecisionRevision: number;
+  materializationManifestId: string;
+  materializationManifestArtifact: z.input<typeof aflTradeArtifactRefSchema>;
+  valuationInputBundleId: string;
+  valuationInputBundleArtifact: z.input<typeof aflTradeArtifactRefSchema>;
+  gateLedgerRevision: number;
+  components: readonly z.input<typeof readyComponentSchema>[];
+}>;
+
+function resultOf(retained: z.output<typeof retainedSchema>) {
+  return governedPrivateEvaluationInspectResultSchema.parse({
+    state: retained.inspection.content.state,
+    selector: retained.inspection.content.selector,
+    inspectionId: retained.inspection.inspectionId,
+    validThrough: retained.inspection.content.validThrough,
+    head: retained.inspection.content.head,
+    blockers: retained.inspection.content.blockers,
+  });
+}
+
+export function authenticateGovernedPrivateEvaluationAuthorityInspection(
+  input: unknown
+) {
+  const retainedInput = input as { snapshot?: unknown; inspection?: unknown };
+  const retained = retainedSchema.parse({
+    snapshot: retainedInput?.snapshot,
+    inspection: retainedInput?.inspection,
+  });
+  return { ...retained, result: resultOf(retained) };
+}
+
+export function createUnavailableGovernedPrivateEvaluationAuthorityInspection(
+  input: CreationInput
+) {
+  const common = {
+    environment: 'test_fixture' as const,
+    publicationProhibited: true as const,
+    selector: input.selector,
+    capturedAt: input.capturedAt,
+    validThrough: input.validThrough,
+    head: input.head,
+    lastTransitionId: input.lastTransitionId,
+    calculationAuthority: {
+      state: 'unavailable' as const,
+      playerModelRunId: null,
+      pickModelRunId: null,
+    },
+    blockers: [...input.blockers].sort(
+      (left, right) => left.code.localeCompare(right.code) || left.message.localeCompare(right.message)
+    ),
+    limitation: LIMITATION,
+  };
+  const snapshotContent = snapshotContentSchema.parse({
+    schemaVersion: 'private-evaluation-authority-snapshot/v1',
+    ...common,
+  });
+  const snapshot = snapshotSchema.parse({
+    snapshotId: createAflTradeContentAddress(
+      'private-evaluation-authority-snapshot',
+      snapshotContent
+    ),
+    content: snapshotContent,
+  });
+  const inspectionContent = inspectionContentSchema.parse({
+    schemaVersion: 'private-evaluation-inspection/v1',
+    snapshotId: snapshot.snapshotId,
+    state: 'unavailable',
+    ...common,
+  });
+  const inspection = inspectionSchema.parse({
+    inspectionId: createAflTradeContentAddress(
+      'private-evaluation-inspection',
+      inspectionContent
+    ),
+    content: inspectionContent,
+  });
+  return authenticateGovernedPrivateEvaluationAuthorityInspection({ snapshot, inspection });
+}
+
+export function createUnavailableNonProductionGovernedPrivateEvaluationAuthorityInspection(
+  input: CreationInput
+) {
+  const common = {
+    environment: 'non_production' as const,
+    publicationProhibited: true as const,
+    selector: input.selector,
+    capturedAt: input.capturedAt,
+    validThrough: input.validThrough,
+    head: input.head,
+    lastTransitionId: input.lastTransitionId,
+    calculationAuthority: {
+      state: 'unavailable' as const,
+      playerModelRunId: null,
+      pickModelRunId: null,
+    },
+    blockers: [...input.blockers].sort(
+      (left, right) => left.code.localeCompare(right.code) || left.message.localeCompare(right.message)
+    ),
+    limitation: UNAVAILABLE_NON_PRODUCTION_LIMITATION,
+  };
+  const snapshotContent = unavailableNonProductionSnapshotContentSchema.parse({
+    schemaVersion: 'private-evaluation-authority-snapshot/v3',
+    ...common,
+  });
+  const snapshot = snapshotSchema.parse({
+    snapshotId: createAflTradeContentAddress(
+      'private-evaluation-authority-snapshot',
+      snapshotContent
+    ),
+    content: snapshotContent,
+  });
+  const inspectionContent = unavailableNonProductionInspectionContentSchema.parse({
+    schemaVersion: 'private-evaluation-inspection/v3',
+    snapshotId: snapshot.snapshotId,
+    state: 'unavailable',
+    ...common,
+  });
+  const inspection = inspectionSchema.parse({
+    inspectionId: createAflTradeContentAddress(
+      'private-evaluation-inspection',
+      inspectionContent
+    ),
+    content: inspectionContent,
+  });
+  return authenticateGovernedPrivateEvaluationAuthorityInspection({ snapshot, inspection });
+}
+
+export function createReadyFixtureGovernedPrivateEvaluationAuthorityInspection(
+  input: ReadyFixtureCreationInput
+) {
+  const common = {
+    environment: 'test_fixture' as const,
+    publicationProhibited: true as const,
+    selector: input.selector,
+    capturedAt: input.capturedAt,
+    validThrough: input.validThrough,
+    head: input.head,
+    lastTransitionId: input.lastTransitionId,
+    calculationAuthority: {
+      state: 'ready' as const,
+      playerModelRunId: input.playerModelRunId,
+      pickModelRunId: input.pickModelRunId,
+    },
+    blockers: [] as const,
+    limitation: READY_FIXTURE_LIMITATION,
+  };
+  const snapshotContent = readyFixtureSnapshotContentSchema.parse({
+    schemaVersion: 'private-evaluation-authority-snapshot/v1',
+    ...common,
+  });
+  const snapshot = snapshotSchema.parse({
+    snapshotId: createAflTradeContentAddress(
+      'private-evaluation-authority-snapshot',
+      snapshotContent
+    ),
+    content: snapshotContent,
+  });
+  const inspectionContent = readyFixtureInspectionContentSchema.parse({
+    schemaVersion: 'private-evaluation-inspection/v1',
+    snapshotId: snapshot.snapshotId,
+    state: 'ready',
+    ...common,
+  });
+  const inspection = inspectionSchema.parse({
+    inspectionId: createAflTradeContentAddress(
+      'private-evaluation-inspection',
+      inspectionContent
+    ),
+    content: inspectionContent,
+  });
+  return authenticateGovernedPrivateEvaluationAuthorityInspection({ snapshot, inspection });
+}
+
+export function createReadyGovernedPrivateEvaluationAuthorityInspection(
+  input: ReadyCreationInput
+) {
+  const common = {
+    environment: 'non_production' as const,
+    publicationProhibited: true as const,
+    selector: input.selector,
+    capturedAt: input.capturedAt,
+    validThrough: input.validThrough,
+    head: input.head,
+    lastTransitionId: input.lastTransitionId,
+    calculationAuthority: {
+      state: 'ready' as const,
+      preparedInputSetId: input.preparedInputSetId,
+      preparedInputSetArtifact: input.preparedInputSetArtifact,
+      factualReleaseId: input.factualReleaseId,
+      valuationInputBundleId: input.valuationInputBundleId,
+      valuationInputBundleArtifact: input.valuationInputBundleArtifact,
+      calculationInputPackageId: input.calculationInputPackageId,
+      calculationInputArtifact: input.calculationInputArtifact,
+      inputTraceId: input.inputTraceId,
+      inputTraceArtifact: input.inputTraceArtifact,
+      gateLedgerRevision: input.gateLedgerRevision,
+      components: input.components,
+    },
+    blockers: [] as const,
+    limitation: READY_NON_PRODUCTION_LIMITATION,
+  };
+  const snapshotContent = readyNonProductionSnapshotContentSchema.parse({
+    schemaVersion: 'private-evaluation-authority-snapshot/v2',
+    ...common,
+  });
+  const snapshot = snapshotSchema.parse({
+    snapshotId: createAflTradeContentAddress(
+      'private-evaluation-authority-snapshot',
+      snapshotContent
+    ),
+    content: snapshotContent,
+  });
+  const inspectionContent = readyNonProductionInspectionContentSchema.parse({
+    schemaVersion: 'private-evaluation-inspection/v2',
+    snapshotId: snapshot.snapshotId,
+    state: 'ready',
+    ...common,
+  });
+  const inspection = inspectionSchema.parse({
+    inspectionId: createAflTradeContentAddress(
+      'private-evaluation-inspection',
+      inspectionContent
+    ),
+    content: inspectionContent,
+  });
+  return authenticateGovernedPrivateEvaluationAuthorityInspection({ snapshot, inspection });
+}
+
+export function createReadyGovernedPrivateEvaluationAuthorityInspectionV3(
+  input: ReadyV3CreationInput
+) {
+  const common = {
+    environment: 'non_production' as const,
+    publicationProhibited: true as const,
+    selector: input.selector,
+    capturedAt: input.capturedAt,
+    validThrough: input.validThrough,
+    head: input.head,
+    lastTransitionId: input.lastTransitionId,
+    calculationAuthority: {
+      state: 'ready' as const,
+      preparedInputHeadRevision: input.preparedInputHeadRevision,
+      preparedInputSetId: input.preparedInputSetId,
+      factualRegistryRevision: input.factualRegistryRevision,
+      factualReleaseId: input.factualReleaseId,
+      activeFactualReleaseRevision: input.activeFactualReleaseRevision,
+      privateValuationDecisionId: input.privateValuationDecisionId,
+      privateValuationDecisionRevision: input.privateValuationDecisionRevision,
+      materializationManifestId: input.materializationManifestId,
+      materializationManifestArtifact: input.materializationManifestArtifact,
+      valuationInputBundleId: input.valuationInputBundleId,
+      valuationInputBundleArtifact: input.valuationInputBundleArtifact,
+      gateLedgerRevision: input.gateLedgerRevision,
+      components: input.components,
+    },
+    blockers: [] as const,
+    limitation: READY_NON_PRODUCTION_LIMITATION,
+  };
+  const snapshotContent = readyNonProductionSnapshotContentV3Schema.parse({
+    schemaVersion: 'private-evaluation-authority-snapshot/v3',
+    ...common,
+  });
+  const snapshot = snapshotSchema.parse({
+    snapshotId: createAflTradeContentAddress(
+      'private-evaluation-authority-snapshot',
+      snapshotContent
+    ),
+    content: snapshotContent,
+  });
+  const inspectionContent = readyNonProductionInspectionContentV3Schema.parse({
+    schemaVersion: 'private-evaluation-inspection/v3',
+    snapshotId: snapshot.snapshotId,
+    state: 'ready',
+    ...common,
+  });
+  const inspection = inspectionSchema.parse({
+    inspectionId: createAflTradeContentAddress(
+      'private-evaluation-inspection',
+      inspectionContent
+    ),
+    content: inspectionContent,
+  });
+  return authenticateGovernedPrivateEvaluationAuthorityInspection({ snapshot, inspection });
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationExplanationPolicy.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationExplanationPolicy.ts
@@ -1,0 +1,96 @@
+import { z } from 'zod';
+
+import { AFL_TRADE_VALUATION_VIEWS } from '@/types/aflTradeIntelligence';
+
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  createAflTradeContentAddress,
+} from '../../artifacts/contentAddress';
+
+export const GOVERNED_PRIVATE_EVALUATION_EXPLANATION_POLICY_SCHEMA_VERSION =
+  'private-evaluation-explanation-policy/v1' as const;
+
+const LIMITATION =
+  'Private calculation explanation policy only; not model, grade, publication, or activation authority.' as const;
+
+const publicIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(200)
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9._:-]*$/);
+
+const practicalEquivalenceBandSchema = z
+  .object({
+    view: z.enum(AFL_TRADE_VALUATION_VIEWS),
+    maximumDifference: z.number().finite().nonnegative(),
+  })
+  .strict();
+
+export const governedPrivateEvaluationExplanationPolicyContentSchema = z
+  .object({
+    schemaVersion: z.literal(GOVERNED_PRIVATE_EVALUATION_EXPLANATION_POLICY_SCHEMA_VERSION),
+    environment: z.literal('non_production'),
+    valueUnitId: publicIdSchema,
+    selectedLayer: z.enum(['gross', 'listSpotAdjusted', 'scarcityAdjusted']),
+    practicalEquivalence: z
+      .object({
+        basis: z.string().trim().min(1).max(500),
+        bandByView: z.array(practicalEquivalenceBandSchema).length(
+          AFL_TRADE_VALUATION_VIEWS.length
+        ),
+      })
+      .strict(),
+    createdAt: z.iso.datetime({ offset: true }),
+    publicationEligible: z.literal(false),
+    limitation: z.literal(LIMITATION),
+  })
+  .strict()
+  .superRefine((content, context) => {
+    content.practicalEquivalence.bandByView.forEach((band, index) => {
+      if (band.view !== AFL_TRADE_VALUATION_VIEWS[index]) {
+        context.addIssue({
+          code: 'custom',
+          path: ['practicalEquivalence', 'bandByView', index, 'view'],
+          message: 'Practical-equivalence bands must use canonical four-view order.',
+        });
+      }
+    });
+  });
+
+export const governedPrivateEvaluationExplanationPolicySchema = z
+  .object({
+    policyId: aflTradeContentAddressedIdSchema('private-evaluation-explanation-policy'),
+    content: governedPrivateEvaluationExplanationPolicyContentSchema,
+  })
+  .strict()
+  .superRefine((policy, context) => {
+    addAflTradeContentAddressIssue(
+      'private-evaluation-explanation-policy',
+      policy.policyId,
+      policy.content,
+      context,
+      ['policyId']
+    );
+  });
+
+export type GovernedPrivateEvaluationExplanationPolicyContent = z.infer<
+  typeof governedPrivateEvaluationExplanationPolicyContentSchema
+>;
+export type GovernedPrivateEvaluationExplanationPolicy = z.infer<
+  typeof governedPrivateEvaluationExplanationPolicySchema
+>;
+
+export function createGovernedPrivateEvaluationExplanationPolicy(
+  input: GovernedPrivateEvaluationExplanationPolicyContent
+): GovernedPrivateEvaluationExplanationPolicy {
+  const content = governedPrivateEvaluationExplanationPolicyContentSchema.parse(input);
+  return governedPrivateEvaluationExplanationPolicySchema.parse({
+    policyId: createAflTradeContentAddress(
+      'private-evaluation-explanation-policy',
+      content
+    ),
+    content,
+  });
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationExplanationSource.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationExplanationSource.ts
@@ -1,0 +1,68 @@
+import { AFL_TRADE_VALUATION_VIEWS } from '@/types/aflTradeIntelligence';
+
+import {
+  governedPrivateEvaluationExplanationPolicySchema,
+  type GovernedPrivateEvaluationExplanationPolicy,
+} from './governedPrivateEvaluationExplanationPolicy';
+import {
+  governedPrivateEvaluationInputTraceSchema,
+  type GovernedPrivateEvaluationInputTrace,
+} from './governedPrivateEvaluationInputTrace';
+import { deriveGovernedPrivateEvaluationTransaction } from './governedPrivateEvaluationTransaction';
+
+export interface GovernedPrivateEvaluationExplanationSource {
+  readonly authority: {
+    readonly kind: 'authenticated_non_production';
+    readonly inputTraceId: string;
+    readonly explanationPolicyId: string;
+    readonly publicationProhibited: true;
+  };
+  readonly selector: GovernedPrivateEvaluationInputTrace['content']['selector'];
+  readonly effectiveAt: string;
+  readonly valueUnitId: string;
+  readonly selectedLayer: GovernedPrivateEvaluationExplanationPolicy['content']['selectedLayer'];
+  readonly practicalEquivalence: {
+    readonly basis: string;
+    readonly bandByView: Record<(typeof AFL_TRADE_VALUATION_VIEWS)[number], number>;
+  };
+  readonly clubs: ReturnType<typeof deriveGovernedPrivateEvaluationTransaction>['clubs'];
+  readonly transfers: ReturnType<typeof deriveGovernedPrivateEvaluationTransaction>['transfers'];
+}
+
+export function authenticateGovernedPrivateEvaluationExplanationSource(input: {
+  trace: unknown;
+  policy: unknown;
+}): GovernedPrivateEvaluationExplanationSource {
+  const trace = governedPrivateEvaluationInputTraceSchema.parse(input.trace);
+  const policy = governedPrivateEvaluationExplanationPolicySchema.parse(input.policy);
+  if (trace.content.environment !== 'non_production') {
+    throw new TypeError('A private non-production explanation policy requires a non-production input trace.');
+  }
+  if (Date.parse(policy.content.createdAt) > Date.parse(trace.content.derivedAt)) {
+    throw new TypeError('The explanation policy must exist before the authenticated input trace derivation.');
+  }
+  const transaction = deriveGovernedPrivateEvaluationTransaction(trace);
+  return {
+    authority: {
+      kind: 'authenticated_non_production',
+      inputTraceId: trace.inputTraceId,
+      explanationPolicyId: policy.policyId,
+      publicationProhibited: true,
+    },
+    selector: trace.content.selector,
+    effectiveAt: transaction.effectiveAt,
+    valueUnitId: policy.content.valueUnitId,
+    selectedLayer: policy.content.selectedLayer,
+    practicalEquivalence: {
+      basis: policy.content.practicalEquivalence.basis,
+      bandByView: Object.fromEntries(
+        policy.content.practicalEquivalence.bandByView.map(({ view, maximumDifference }) => [
+          view,
+          maximumDifference,
+        ])
+      ) as Record<(typeof AFL_TRADE_VALUATION_VIEWS)[number], number>,
+    },
+    clubs: transaction.clubs,
+    transfers: transaction.transfers,
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationInputTrace.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationInputTrace.ts
@@ -1,0 +1,467 @@
+import { z } from 'zod';
+
+import { aflTradeArtifactRefSchema } from '../../artifacts/artifactReference';
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '../../artifacts/contentAddress';
+import { governedPrivateEvaluationSelectorSchema } from './governedPrivateEvaluationWorkspaceContracts';
+
+const instantSchema = z.iso.datetime({ offset: true });
+const publicIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(200)
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9._:-]*$/);
+const displayLabelSchema = z.string().trim().min(1).max(240);
+const componentRoles = [
+  'player_contribution_and_availability',
+  'draft_pick_and_future_pick_distribution',
+] as const;
+const pickAssetKinds = ['current_pick_entitlement', 'future_pick_entitlement'] as const;
+
+const componentSchema = z
+  .object({
+    role: z.enum(componentRoles),
+    runId: aflTradeContentAddressedIdSchema('model-run'),
+    protocolId: aflTradeContentAddressedIdSchema('model-protocol'),
+    datasetId: aflTradeContentAddressedIdSchema('dataset'),
+    datasetAdmissionId: aflTradeContentAddressedIdSchema('dataset-admission'),
+    gate3DecisionId: aflTradeContentAddressedIdSchema('gate-decision'),
+    evidence: z
+      .object({
+        runManifest: aflTradeArtifactRefSchema,
+        protocol: aflTradeArtifactRefSchema,
+        datasetAdmission: aflTradeArtifactRefSchema,
+        gate3Decision: aflTradeArtifactRefSchema,
+      })
+      .strict(),
+  })
+  .strict();
+
+const transferSchema = z
+  .object({
+    transferId: publicIdSchema,
+    assetId: publicIdSchema,
+    assetKind: z.enum(['player', ...pickAssetKinds]),
+    fromClubId: publicIdSchema,
+    toClubId: publicIdSchema,
+    displayLabel: displayLabelSchema,
+    evidenceRef: aflTradeArtifactRefSchema,
+  })
+  .strict();
+
+const seasonSchema = z
+  .object({
+    season: z.number().int().min(1897).max(2200),
+    status: z.enum(['complete', 'current_complete', 'right_censored']),
+    startsAt: instantSchema,
+    endsAt: instantSchema,
+    evidenceRef: aflTradeArtifactRefSchema,
+  })
+  .strict()
+  .superRefine((season, context) => {
+    if (Date.parse(season.endsAt) <= Date.parse(season.startsAt)) {
+      context.addIssue({ code: 'custom', message: 'Season end must follow season start.' });
+    }
+  });
+
+const acquisitionSpellSchema = z
+  .object({
+    spellVersionId: publicIdSchema,
+    clubId: publicIdSchema,
+    clubName: displayLabelSchema,
+    joinedAt: instantSchema,
+    departedAt: instantSchema.nullable(),
+    evidenceRef: aflTradeArtifactRefSchema,
+  })
+  .strict()
+  .superRefine((spell, context) => {
+    if (spell.departedAt !== null && Date.parse(spell.departedAt) <= Date.parse(spell.joinedAt)) {
+      context.addIssue({ code: 'custom', message: 'Acquisition-spell departure must follow joining.' });
+    }
+  });
+
+const requiredSeasonSchema = z
+  .object({
+    season: z.number().int().min(1897).max(2200),
+    status: z.enum(['complete', 'current_complete', 'right_censored']),
+    evidenceRef: aflTradeArtifactRefSchema,
+  })
+  .strict();
+
+const playerHorizonSchema = z
+  .object({
+    assetId: publicIdSchema,
+    playerId: publicIdSchema,
+    playerName: displayLabelSchema,
+    playerObservationId: aflTradeContentAddressedIdSchema('player-pav-observation'),
+    playerObservationArtifact: aflTradeArtifactRefSchema,
+    receivingClubId: publicIdSchema,
+    acquisitionSpells: z.array(acquisitionSpellSchema).min(1).max(20),
+    requiredSeasons: z.array(requiredSeasonSchema).min(1).max(40),
+  })
+  .strict();
+
+const custodySchema = z
+  .object({
+    ordinal: z.number().int().nonnegative().max(100),
+    clubId: publicIdSchema,
+    clubName: displayLabelSchema,
+    heldFrom: instantSchema,
+    heldThrough: instantSchema.nullable(),
+    evidenceRef: aflTradeArtifactRefSchema,
+  })
+  .strict()
+  .superRefine((custody, context) => {
+    if (
+      custody.heldThrough !== null &&
+      Date.parse(custody.heldThrough) <= Date.parse(custody.heldFrom)
+    ) {
+      context.addIssue({ code: 'custom', message: 'Pick custody must have a positive interval.' });
+    }
+  });
+
+const lineageAssetLabelSchema = z
+  .object({
+    assetId: publicIdSchema,
+    displayLabel: displayLabelSchema,
+  })
+  .strict();
+
+const transformationSchema = z
+  .object({
+    ordinal: z.number().int().nonnegative().max(100),
+    kind: z.enum(['renumbered', 'selected_player', 'split', 'merged']),
+    fromAssetIds: z.array(publicIdSchema).min(1).max(20),
+    toAssetIds: z.array(publicIdSchema).min(1).max(20),
+    effectiveAt: instantSchema,
+    economicAllocationDecisionId: aflTradeContentAddressedIdSchema(
+      'economic-allocation-decision'
+    ).nullable(),
+    assetLabels: z.array(lineageAssetLabelSchema).min(1).max(40),
+    evidenceRef: aflTradeArtifactRefSchema,
+  })
+  .strict()
+  .superRefine((transformation, context) => {
+    const needsAllocation = transformation.kind === 'split' || transformation.kind === 'merged';
+    if (needsAllocation !== (transformation.economicAllocationDecisionId !== null)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['economicAllocationDecisionId'],
+        message:
+          'Split or merged transformations require one approved economic-allocation decision.',
+      });
+    }
+    for (const field of ['fromAssetIds', 'toAssetIds'] as const) {
+      const ids = transformation[field];
+      if (new Set(ids).size !== ids.length || ids.some((id, index) => index > 0 && ids[index - 1]! > id)) {
+        context.addIssue({
+          code: 'custom',
+          path: [field],
+          message: 'Transformation assets must be unique and canonically ordered.',
+        });
+      }
+    }
+    const expectedLabelIds = [...new Set([
+      ...transformation.fromAssetIds,
+      ...transformation.toAssetIds,
+    ])].sort();
+    const actualLabelIds = transformation.assetLabels.map(({ assetId }) => assetId);
+    if (!canonicalIds(actualLabelIds) || !exactJson(actualLabelIds, expectedLabelIds)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['assetLabels'],
+        message: 'Transformation labels must exactly cover its complete lineage frontier.',
+      });
+    }
+  });
+
+const pickLineageSchema = z
+  .object({
+    rootAssetId: publicIdSchema,
+    pickIdentityId: publicIdSchema,
+    pickIdentityLabel: displayLabelSchema,
+    receivingClubId: publicIdSchema,
+    pickObservationSetId: aflTradeContentAddressedIdSchema('pick-pav-observation-set'),
+    pickModelExecutionId: aflTradeContentAddressedIdSchema('pick-pav-model-execution'),
+    pickBenchmarkId: aflTradeContentAddressedIdSchema('pick-pav-benchmark'),
+    pickBenchmarkArtifact: aflTradeArtifactRefSchema,
+    resolvedSelectionNumber: z.number().int().positive().max(500).nullable(),
+    custody: z.array(custodySchema).min(1).max(100),
+    transformations: z.array(transformationSchema).max(100),
+  })
+  .strict();
+
+export const GOVERNED_PRIVATE_EVALUATION_INPUT_TRACE_SCHEMA_VERSION =
+  'private-evaluation-input-trace/v1' as const;
+const LIMITATION =
+  'Authenticated calculation-input trace only; contains no caller-supplied values, grades, publication approval, or activation authority.' as const;
+
+function canonicalIds(values: readonly string[]): boolean {
+  return (
+    new Set(values).size === values.length &&
+    values.every((value, index) => index === 0 || values[index - 1]! < value)
+  );
+}
+
+function exactJson(left: unknown, right: unknown): boolean {
+  return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+}
+
+export const governedPrivateEvaluationInputTraceContentSchema = z
+  .object({
+    schemaVersion: z.literal(GOVERNED_PRIVATE_EVALUATION_INPUT_TRACE_SCHEMA_VERSION),
+    environment: z.enum(['non_production', 'production']),
+    selector: governedPrivateEvaluationSelectorSchema,
+    factualReleaseId: aflTradeContentAddressedIdSchema('outcome-release'),
+    valuationInputBundleId: aflTradeContentAddressedIdSchema('valuation-input-bundle'),
+    components: z.array(componentSchema).length(componentRoles.length),
+    transaction: z
+      .object({
+        effectiveAt: instantSchema,
+        clubs: z
+          .array(
+            z
+              .object({
+                aflClubId: publicIdSchema,
+                clubName: displayLabelSchema,
+              })
+              .strict()
+          )
+          .min(2)
+          .max(4),
+        transfers: z.array(transferSchema).min(2).max(100),
+      })
+      .strict(),
+    seasonUniverse: z.array(seasonSchema).min(1).max(40),
+    playerHorizons: z.array(playerHorizonSchema).max(100),
+    pickLineages: z.array(pickLineageSchema).max(100),
+    derivedAt: instantSchema,
+    publicationEligible: z.literal(false),
+    limitation: z.literal(LIMITATION),
+  })
+  .strict()
+  .superRefine((trace, context) => {
+    const componentRoleValues = trace.components.map(({ role }) => role);
+    if (!exactJson(componentRoleValues, componentRoles)) {
+      context.addIssue({ code: 'custom', message: 'Model components must use canonical roles.' });
+    }
+    for (const field of [
+      'runId',
+      'protocolId',
+      'datasetId',
+      'datasetAdmissionId',
+      'gate3DecisionId',
+    ] as const) {
+      if (new Set(trace.components.map((component) => component[field])).size !== componentRoles.length) {
+        context.addIssue({ code: 'custom', message: `Model component ${field} values must be distinct.` });
+      }
+    }
+
+    const transferIds = trace.transaction.transfers.map(({ transferId }) => transferId);
+    const transferAssetIds = trace.transaction.transfers.map(({ assetId }) => assetId);
+    const participatingClubIds = [
+      ...new Set(
+        trace.transaction.transfers.flatMap(({ fromClubId, toClubId }) => [
+          fromClubId,
+          toClubId,
+        ])
+      ),
+    ].sort();
+    const transactionClubIds = trace.transaction.clubs.map(({ aflClubId }) => aflClubId);
+    if (
+      !canonicalIds(transactionClubIds) ||
+      !canonicalIds(transferIds) ||
+      !canonicalIds(transferAssetIds) ||
+      !exactJson(transactionClubIds, participatingClubIds) ||
+      trace.transaction.transfers.some(({ fromClubId, toClubId }) => fromClubId === toClubId)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['transaction'],
+        message: 'Transaction clubs must equal the exact clubs participating in directed transfers.',
+      });
+    }
+
+    const seasons = trace.seasonUniverse.map(({ season }) => String(season));
+    const currentSeasons = trace.seasonUniverse.filter(({ status }) => status !== 'complete');
+    const firstPostTradeSeason = new Date(trace.transaction.effectiveAt).getUTCFullYear() + 1;
+    if (
+      !canonicalIds(seasons) ||
+      currentSeasons.length !== 1 ||
+      trace.seasonUniverse.at(-1)?.status === 'complete' ||
+      trace.seasonUniverse.some(
+        ({ season, startsAt, endsAt }, index) =>
+          season !== firstPostTradeSeason + index ||
+          startsAt.slice(0, 4) !== String(season) ||
+          endsAt.slice(0, 4) !== String(season)
+      )
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['seasonUniverse'],
+        message:
+          'Season universe must contain every consecutive post-trade season through the current cutoff.',
+      });
+    }
+
+    const transfersByAsset = new Map(
+      trace.transaction.transfers.map((transfer) => [transfer.assetId, transfer])
+    );
+    const clubNames = new Map<string, string>();
+    const clubIdentities = [
+      ...trace.transaction.clubs.map(({ aflClubId, clubName }) => ({
+        clubId: aflClubId,
+        clubName,
+      })),
+      ...trace.playerHorizons.flatMap(({ acquisitionSpells }) => acquisitionSpells),
+      ...trace.pickLineages.flatMap(({ custody }) => custody),
+    ];
+    for (const { clubId, clubName } of clubIdentities) {
+      const existingName = clubNames.get(clubId);
+      if (existingName !== undefined && existingName !== clubName) {
+        context.addIssue({
+          code: 'custom',
+          path: ['transaction', 'clubs'],
+          message: 'One authenticated club identity cannot use conflicting display names.',
+        });
+      }
+      clubNames.set(clubId, clubName);
+    }
+    const playerAssetIds = trace.transaction.transfers
+      .filter(({ assetKind }) => assetKind === 'player')
+      .map(({ assetId }) => assetId)
+      .sort();
+    const tracedPlayerIds = trace.playerHorizons.map(({ assetId }) => assetId);
+    const pickAssetIds = trace.transaction.transfers
+      .filter(({ assetKind }) => pickAssetKinds.includes(assetKind as (typeof pickAssetKinds)[number]))
+      .map(({ assetId }) => assetId)
+      .sort();
+    const tracedPickIds = trace.pickLineages.map(({ rootAssetId }) => rootAssetId);
+    if (!canonicalIds(tracedPlayerIds) || !exactJson(playerAssetIds, tracedPlayerIds)) {
+      context.addIssue({ code: 'custom', message: 'Every player transfer requires one exact player horizon.' });
+    }
+    if (!canonicalIds(tracedPickIds) || !exactJson(pickAssetIds, tracedPickIds)) {
+      context.addIssue({ code: 'custom', message: 'Every pick transfer requires one exact pick lineage.' });
+    }
+
+    for (const horizon of trace.playerHorizons) {
+      const transfer = transfersByAsset.get(horizon.assetId);
+      const spells = [...horizon.acquisitionSpells].sort((left, right) =>
+        left.joinedAt.localeCompare(right.joinedAt)
+      );
+      const receivingSpell = spells.find(({ clubId }) => clubId === horizon.receivingClubId);
+      const expectedSeasons = receivingSpell === undefined ? [] : trace.seasonUniverse
+        .filter((season) =>
+          Date.parse(season.startsAt) >= Math.max(
+            Date.parse(trace.transaction.effectiveAt),
+            Date.parse(receivingSpell.joinedAt)
+          ) &&
+          (receivingSpell.departedAt === null ||
+            Date.parse(season.startsAt) < Date.parse(receivingSpell.departedAt))
+        )
+        .map(({ season, status }) => ({ season, status }));
+      const actualSeasons = horizon.requiredSeasons.map(({ season, status }) => ({ season, status }));
+      if (
+        transfer?.assetKind !== 'player' ||
+        transfer.toClubId !== horizon.receivingClubId ||
+        transfer.displayLabel !== horizon.playerName ||
+        receivingSpell === undefined ||
+        !exactJson(actualSeasons, expectedSeasons)
+      ) {
+        context.addIssue({
+          code: 'custom',
+          path: ['playerHorizons'],
+          message: 'Player horizon must contain every applicable season from the authenticated universe.',
+        });
+      }
+    }
+
+    for (const lineage of trace.pickLineages) {
+      const transfer = transfersByAsset.get(lineage.rootAssetId);
+      const custodyContinuous = lineage.custody.every((entry, index) =>
+        entry.ordinal === index &&
+        (index === 0
+          ? entry.clubId === lineage.receivingClubId && entry.heldFrom === trace.transaction.effectiveAt
+          : lineage.custody[index - 1]!.heldThrough === entry.heldFrom) &&
+        (index < lineage.custody.length - 1 ? entry.heldThrough !== null : entry.heldThrough === null)
+      );
+      let frontier = [lineage.rootAssetId];
+      const transformationChain = lineage.transformations.every((transformation, index) => {
+        const valid =
+          transformation.ordinal === index &&
+          exactJson(transformation.fromAssetIds, frontier) &&
+          Date.parse(transformation.effectiveAt) >= Date.parse(trace.transaction.effectiveAt);
+        frontier = transformation.toAssetIds;
+        return valid;
+      });
+      if (
+        transfer === undefined ||
+        transfer.assetKind === 'player' ||
+        transfer.toClubId !== lineage.receivingClubId ||
+        !custodyContinuous ||
+        !transformationChain
+      ) {
+        context.addIssue({
+          code: 'custom',
+          path: ['pickLineages'],
+          message: 'Pick lineage must preserve exact identity, continuous custody, and ordered transformations.',
+        });
+      }
+    }
+
+    const createdAtValues = [
+      ...trace.components.flatMap(({ evidence }) => Object.values(evidence).map(({ createdAt }) => createdAt)),
+      ...trace.transaction.transfers.map(({ evidenceRef }) => evidenceRef.createdAt),
+      ...trace.seasonUniverse.map(({ evidenceRef }) => evidenceRef.createdAt),
+      ...trace.playerHorizons.flatMap(
+        ({ playerObservationArtifact, acquisitionSpells, requiredSeasons }) => [
+          playerObservationArtifact.createdAt,
+          ...acquisitionSpells.map(({ evidenceRef }) => evidenceRef.createdAt),
+          ...requiredSeasons.map(({ evidenceRef }) => evidenceRef.createdAt),
+        ]
+      ),
+      ...trace.pickLineages.flatMap(({ pickBenchmarkArtifact, custody, transformations }) => [
+        pickBenchmarkArtifact.createdAt,
+        ...custody.map(({ evidenceRef }) => evidenceRef.createdAt),
+        ...transformations.map(({ evidenceRef }) => evidenceRef.createdAt),
+      ]),
+    ];
+    if (createdAtValues.some((createdAt) => Date.parse(createdAt) > Date.parse(trace.derivedAt))) {
+      context.addIssue({ code: 'custom', message: 'Input-trace evidence must exist before derivation.' });
+    }
+  });
+
+export const governedPrivateEvaluationInputTraceSchema = z
+  .object({
+    inputTraceId: aflTradeContentAddressedIdSchema('private-evaluation-input-trace'),
+    content: governedPrivateEvaluationInputTraceContentSchema,
+  })
+  .strict()
+  .superRefine((trace, context) => {
+    addAflTradeContentAddressIssue(
+      'private-evaluation-input-trace',
+      trace.inputTraceId,
+      trace.content,
+      context,
+      ['inputTraceId']
+    );
+  });
+
+export type GovernedPrivateEvaluationInputTrace = z.infer<
+  typeof governedPrivateEvaluationInputTraceSchema
+>;
+
+export function createGovernedPrivateEvaluationInputTrace(
+  input: z.input<typeof governedPrivateEvaluationInputTraceContentSchema>
+): GovernedPrivateEvaluationInputTrace {
+  const content = governedPrivateEvaluationInputTraceContentSchema.parse(input);
+  return governedPrivateEvaluationInputTraceSchema.parse({
+    inputTraceId: createAflTradeContentAddress('private-evaluation-input-trace', content),
+    content,
+  });
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle.ts
@@ -1,0 +1,278 @@
+import { z } from 'zod';
+
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  createAflTradeContentAddress,
+} from '../../artifacts/contentAddress';
+import { governedPrivateEvaluationSelectorSchema } from './governedPrivateEvaluationWorkspaceContracts';
+
+const LIMITATION =
+  'Private test-fixture lifecycle evidence only; it grants no factual, model, production, or publication authority.' as const;
+const instantSchema = z.iso.datetime({ offset: true });
+const generationIdSchema = aflTradeContentAddressedIdSchema(
+  'local-private-trade-evaluation-generation'
+);
+const transitionIdSchema = aflTradeContentAddressedIdSchema(
+  'private-evaluation-transition'
+);
+
+const lifecycleHeadSchema = z
+  .object({
+    status: z.enum(['absent', 'active', 'withdrawn']),
+    revision: z.number().int().nonnegative(),
+    generationId: generationIdSchema.nullable(),
+  })
+  .strict()
+  .superRefine((head, context) => {
+    if ((head.status === 'active') !== (head.generationId !== null)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['generationId'],
+        message: 'Only an active lifecycle head may identify a generation.',
+      });
+    }
+    if ((head.status === 'absent') !== (head.revision === 0)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['revision'],
+        message: 'Only an absent lifecycle head may have revision zero.',
+      });
+    }
+  });
+
+const transitionActionSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('construct_and_activate') }).strict(),
+  z
+    .object({
+      kind: z.literal('withdraw'),
+      reason: z.string().trim().min(1).max(2_000),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('rollback'),
+      targetGenerationId: generationIdSchema,
+    })
+    .strict(),
+  z.object({ kind: z.literal('recover') }).strict(),
+]);
+
+const transitionIntentContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-transition-intent/v1'),
+    environment: z.literal('test_fixture'),
+    publicationProhibited: z.literal(true),
+    selector: governedPrivateEvaluationSelectorSchema,
+    inspectionId: aflTradeContentAddressedIdSchema('private-evaluation-inspection'),
+    authoritySnapshotId: aflTradeContentAddressedIdSchema(
+      'private-evaluation-authority-snapshot'
+    ).nullable(),
+    operationId: aflTradeContentAddressedIdSchema('private-evaluation-operation'),
+    action: transitionActionSchema,
+    expectedHead: lifecycleHeadSchema,
+    review: z
+      .object({
+        principalId: z.string().trim().min(1).max(400),
+        rationale: z.string().trim().min(1).max(2_000),
+      })
+      .strict(),
+    requestedAt: instantSchema,
+    expiresAt: instantSchema,
+    limitation: z.literal(LIMITATION),
+  })
+  .strict()
+  .superRefine((intent, context) => {
+    const requiresAuthority = intent.action.kind !== 'withdraw';
+    if (requiresAuthority !== (intent.authoritySnapshotId !== null)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['authoritySnapshotId'],
+        message: 'Activating transitions require retained authority; withdrawal must not relabel it.',
+      });
+    }
+    if (Date.parse(intent.expiresAt) <= Date.parse(intent.requestedAt)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['expiresAt'],
+        message: 'A transition intent must have a positive trusted-time validity window.',
+      });
+    }
+    if (intent.action.kind === 'withdraw' && intent.expectedHead.status !== 'active') {
+      context.addIssue({
+        code: 'custom',
+        path: ['expectedHead'],
+        message: 'Withdrawal requires one exact active head.',
+      });
+    }
+    if (
+      intent.action.kind === 'rollback' &&
+      (intent.expectedHead.status !== 'active' ||
+        intent.expectedHead.generationId === intent.action.targetGenerationId)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['action'],
+        message: 'Rollback requires a different generation from one exact active head.',
+      });
+    }
+    if (intent.action.kind === 'recover' && intent.expectedHead.status !== 'withdrawn') {
+      context.addIssue({
+        code: 'custom',
+        path: ['expectedHead'],
+        message: 'Recovery requires one exact withdrawn head.',
+      });
+    }
+  });
+
+export const governedPrivateEvaluationTransitionIntentSchema = z
+  .object({
+    transitionIntentId: aflTradeContentAddressedIdSchema(
+      'private-evaluation-transition-intent'
+    ),
+    content: transitionIntentContentSchema,
+  })
+  .strict()
+  .superRefine((intent, context) => {
+    addAflTradeContentAddressIssue(
+      'private-evaluation-transition-intent',
+      intent.transitionIntentId,
+      intent.content,
+      context,
+      ['transitionIntentId']
+    );
+  });
+
+export type GovernedPrivateEvaluationTransitionIntent = z.infer<
+  typeof governedPrivateEvaluationTransitionIntentSchema
+>;
+
+export function createGovernedPrivateEvaluationTransitionIntent(
+  input: Omit<
+    z.input<typeof transitionIntentContentSchema>,
+    'schemaVersion' | 'environment' | 'publicationProhibited' | 'limitation'
+  >
+): GovernedPrivateEvaluationTransitionIntent {
+  const content = transitionIntentContentSchema.parse({
+    schemaVersion: 'private-evaluation-transition-intent/v1',
+    environment: 'test_fixture',
+    publicationProhibited: true,
+    ...input,
+    limitation: LIMITATION,
+  });
+  return governedPrivateEvaluationTransitionIntentSchema.parse({
+    transitionIntentId: createAflTradeContentAddress(
+      'private-evaluation-transition-intent',
+      content
+    ),
+    content,
+  });
+}
+
+const transitionReceiptContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-transition-receipt/v1'),
+    environment: z.literal('test_fixture'),
+    publicationProhibited: z.literal(true),
+    intent: governedPrivateEvaluationTransitionIntentSchema,
+    selector: governedPrivateEvaluationSelectorSchema,
+    action: transitionActionSchema,
+    previousTransitionId: transitionIdSchema.nullable(),
+    fromHead: lifecycleHeadSchema,
+    toHead: lifecycleHeadSchema,
+    transitionedAt: instantSchema,
+    limitation: z.literal(LIMITATION),
+  })
+  .strict()
+  .superRefine((receipt, context) => {
+    const intent = receipt.intent.content;
+    const inWindow =
+      Date.parse(receipt.transitionedAt) >= Date.parse(intent.requestedAt) &&
+      Date.parse(receipt.transitionedAt) <= Date.parse(intent.expiresAt);
+    if (
+      receipt.selector.valuationScopeKey !== intent.selector.valuationScopeKey ||
+      receipt.selector.tradeId !== intent.selector.tradeId ||
+      receipt.action.kind !== intent.action.kind ||
+      receipt.fromHead.status !== intent.expectedHead.status ||
+      receipt.fromHead.revision !== intent.expectedHead.revision ||
+      receipt.fromHead.generationId !== intent.expectedHead.generationId ||
+      receipt.toHead.revision !== receipt.fromHead.revision + 1 ||
+      (receipt.fromHead.status === 'absent') !== (receipt.previousTransitionId === null) ||
+      !inWindow
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['toHead'],
+        message: 'A transition receipt must bind its intent, exact predecessor, next revision, and validity window.',
+      });
+    }
+    if (
+      (receipt.action.kind === 'withdraw' && receipt.toHead.status !== 'withdrawn') ||
+      (receipt.action.kind !== 'withdraw' && receipt.toHead.status !== 'active') ||
+      (receipt.action.kind === 'rollback' &&
+        receipt.toHead.generationId !== receipt.action.targetGenerationId)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['toHead'],
+        message: 'The resulting head does not match the authenticated lifecycle action.',
+      });
+    }
+  });
+
+export const governedPrivateEvaluationTransitionReceiptSchema = z
+  .object({
+    transitionId: transitionIdSchema,
+    content: transitionReceiptContentSchema,
+  })
+  .strict()
+  .superRefine((receipt, context) => {
+    addAflTradeContentAddressIssue(
+      'private-evaluation-transition',
+      receipt.transitionId,
+      receipt.content,
+      context,
+      ['transitionId']
+    );
+  });
+
+export type GovernedPrivateEvaluationTransitionReceipt = z.infer<
+  typeof governedPrivateEvaluationTransitionReceiptSchema
+>;
+
+export function createGovernedPrivateEvaluationTransitionReceipt(input: {
+  readonly intent: GovernedPrivateEvaluationTransitionIntent;
+  readonly previousTransitionId: string | null;
+  readonly toGenerationId: string | null;
+  readonly transitionedAt: string;
+}): GovernedPrivateEvaluationTransitionReceipt {
+  const intent = governedPrivateEvaluationTransitionIntentSchema.parse(input.intent);
+  const action = intent.content.action;
+  if (
+    (action.kind === 'withdraw') !== (input.toGenerationId === null) ||
+    (action.kind === 'rollback' && input.toGenerationId !== action.targetGenerationId)
+  ) {
+    throw new TypeError('The lifecycle result generation does not match its authenticated action.');
+  }
+  const content = transitionReceiptContentSchema.parse({
+    schemaVersion: 'private-evaluation-transition-receipt/v1',
+    environment: 'test_fixture',
+    publicationProhibited: true,
+    intent,
+    selector: intent.content.selector,
+    action,
+    previousTransitionId: input.previousTransitionId,
+    fromHead: intent.content.expectedHead,
+    toHead: {
+      status: action.kind === 'withdraw' ? 'withdrawn' : 'active',
+      revision: intent.content.expectedHead.revision + 1,
+      generationId: input.toGenerationId,
+    },
+    transitionedAt: input.transitionedAt,
+    limitation: LIMITATION,
+  });
+  return governedPrivateEvaluationTransitionReceiptSchema.parse({
+    transitionId: createAflTradeContentAddress('private-evaluation-transition', content),
+    content,
+  });
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationMaterializationManifest.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationMaterializationManifest.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod';
+
+import { aflTradeArtifactRefSchema } from '../../artifacts/artifactReference';
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '../../artifacts/contentAddress';
+import { governedPrivateEvaluationSelectorSchema } from './governedPrivateEvaluationWorkspaceContracts';
+
+const LIMITATION =
+  'Private materialization inputs only; not model, grade, activation, production, or publication authority.' as const;
+const instantSchema = z.iso.datetime({ offset: true });
+
+const pickBenchmarkSchema = z
+  .object({
+    benchmarkId: aflTradeContentAddressedIdSchema('pick-pav-benchmark'),
+    artifact: aflTradeArtifactRefSchema,
+  })
+  .strict();
+
+const playerObservationSchema = z
+  .object({
+    observationId: aflTradeContentAddressedIdSchema('player-pav-observation'),
+    artifact: aflTradeArtifactRefSchema,
+  })
+  .strict();
+
+export const governedPrivateEvaluationMaterializationManifestContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-materialization-manifest/v1'),
+    environment: z.literal('non_production'),
+    selector: governedPrivateEvaluationSelectorSchema,
+    calculationInputPackageId: aflTradeContentAddressedIdSchema(
+      'valuation-calculation-input'
+    ),
+    calculationInputArtifact: aflTradeArtifactRefSchema,
+    inputTraceId: aflTradeContentAddressedIdSchema('private-evaluation-input-trace'),
+    inputTraceArtifact: aflTradeArtifactRefSchema,
+    explanationPolicyId: aflTradeContentAddressedIdSchema(
+      'private-evaluation-explanation-policy'
+    ),
+    explanationPolicyArtifact: aflTradeArtifactRefSchema,
+    lineageGraphId: aflTradeContentAddressedIdSchema('lineage-graph'),
+    lineageGraphArtifact: aflTradeArtifactRefSchema,
+    pickBenchmarks: z.array(pickBenchmarkSchema).max(100),
+    playerObservations: z.array(playerObservationSchema).max(100),
+    createdAt: instantSchema,
+    publicationEligible: z.literal(false),
+    limitation: z.literal(LIMITATION),
+  })
+  .strict()
+  .superRefine((manifest, context) => {
+    for (const [path, ids] of [
+      ['pickBenchmarks', manifest.pickBenchmarks.map(({ benchmarkId }) => benchmarkId)],
+      [
+        'playerObservations',
+        manifest.playerObservations.map(({ observationId }) => observationId),
+      ],
+    ] as const) {
+      const canonical = [...ids].sort();
+      if (new Set(ids).size !== ids.length || !exactJson(ids, canonical)) {
+        context.addIssue({
+          code: 'custom',
+          path: [path],
+          message: 'Materialization evidence must be unique and canonically ordered.',
+        });
+      }
+    }
+    const artifacts = [
+      manifest.calculationInputArtifact,
+      manifest.inputTraceArtifact,
+      manifest.explanationPolicyArtifact,
+      manifest.lineageGraphArtifact,
+      ...manifest.pickBenchmarks.map(({ artifact }) => artifact),
+      ...manifest.playerObservations.map(({ artifact }) => artifact),
+    ];
+    if (new Set(artifacts.map(({ artifactId }) => artifactId)).size !== artifacts.length) {
+      context.addIssue({
+        code: 'custom',
+        path: ['calculationInputArtifact'],
+        message: 'Materialization manifest parents require distinct retained bytes.',
+      });
+    }
+    if (artifacts.some(({ createdAt }) => Date.parse(createdAt) > Date.parse(manifest.createdAt))) {
+      context.addIssue({
+        code: 'custom',
+        path: ['createdAt'],
+        message: 'Every materialization parent must exist before the manifest is created.',
+      });
+    }
+  });
+
+export const governedPrivateEvaluationMaterializationManifestSchema = z
+  .object({
+    manifestId: aflTradeContentAddressedIdSchema(
+      'private-evaluation-materialization-manifest'
+    ),
+    content: governedPrivateEvaluationMaterializationManifestContentSchema,
+  })
+  .strict()
+  .superRefine((manifest, context) => {
+    addAflTradeContentAddressIssue(
+      'private-evaluation-materialization-manifest',
+      manifest.manifestId,
+      manifest.content,
+      context,
+      ['manifestId']
+    );
+  });
+
+function exactJson(left: unknown, right: unknown): boolean {
+  return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+}
+
+export type GovernedPrivateEvaluationMaterializationManifest = z.infer<
+  typeof governedPrivateEvaluationMaterializationManifestSchema
+>;
+
+export function createGovernedPrivateEvaluationMaterializationManifest(
+  input: z.input<typeof governedPrivateEvaluationMaterializationManifestContentSchema>
+): GovernedPrivateEvaluationMaterializationManifest {
+  const content = governedPrivateEvaluationMaterializationManifestContentSchema.parse(input);
+  return governedPrivateEvaluationMaterializationManifestSchema.parse({
+    manifestId: createAflTradeContentAddress(
+      'private-evaluation-materialization-manifest',
+      content
+    ),
+    content,
+  });
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationMaterializer.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationMaterializer.ts
@@ -1,0 +1,400 @@
+import { doesAflTradeArtifactRefMatchCanonicalJson } from '../../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import type { AflTradeLineageGraph } from '../../domain/lineageTypes';
+import {
+  aflTradePickPavDistributionBenchmarkSchema,
+  type AflTradePickPavDistributionBenchmark,
+} from '../../modeling/pickPavDistributionBenchmark';
+import {
+  aflTradePlayerPavObservationSchema,
+  type AflTradePlayerPavObservation,
+} from '../../modeling/playerPavObservationContracts';
+import { deriveAflTradeAssetLineageNarrativeEvidence } from '../assetLineageNarrativeEvidence';
+import {
+  deriveAflTradePickCalculationEvidence,
+  deriveAflTradePlayerCalculationEvidence,
+} from '../calculationNarrativeEvidence';
+import { createAflTradeCalculationNarrative } from '../tradeCalculationNarrative';
+import {
+  createGovernedAflTradeValuationExplanation,
+  type AflTradeValuationExplanationDocument,
+} from '../tradeValuationExplanation';
+import {
+  aflTradeValuationCalculationInputPackageSchema,
+  type AflTradeValuationCalculationInputPackage,
+} from '../valuationCalculationInputPackage';
+import { createAflTradeLineageGraphId } from '../valuationCaseContracts';
+import {
+  governedPrivateEvaluationExplanationPolicySchema,
+  type GovernedPrivateEvaluationExplanationPolicy,
+} from './governedPrivateEvaluationExplanationPolicy';
+import {
+  governedPrivateEvaluationInputTraceSchema,
+  type GovernedPrivateEvaluationInputTrace,
+} from './governedPrivateEvaluationInputTrace';
+import {
+  governedPrivateEvaluationMaterializationManifestSchema,
+  type GovernedPrivateEvaluationMaterializationManifest,
+} from './governedPrivateEvaluationMaterializationManifest';
+
+export type GovernedPrivateEvaluationMaterializationBlockerCode =
+  | 'incomplete_numeric_evidence'
+  | 'pick_benchmark_missing'
+  | 'pick_model_support_unavailable'
+  | 'pick_selection_unresolved'
+  | 'player_evidence_missing'
+  | 'player_evidence_unavailable';
+
+export interface GovernedPrivateEvaluationMaterializationBlocker {
+  readonly code: GovernedPrivateEvaluationMaterializationBlockerCode;
+  readonly assetId: string | null;
+  readonly message: string;
+}
+
+export interface MaterializeGovernedPrivateEvaluationInput {
+  readonly trace: GovernedPrivateEvaluationInputTrace;
+  readonly explanationPolicy: GovernedPrivateEvaluationExplanationPolicy;
+  readonly calculationInputPackage: AflTradeValuationCalculationInputPackage;
+  readonly pickBenchmarks: readonly AflTradePickPavDistributionBenchmark[];
+  readonly playerObservations: readonly AflTradePlayerPavObservation[];
+  readonly lineageGraph: AflTradeLineageGraph;
+}
+
+export interface ReplayGovernedPrivateEvaluationMaterializationInput
+  extends MaterializeGovernedPrivateEvaluationInput {
+  readonly materializationManifest: GovernedPrivateEvaluationMaterializationManifest;
+}
+
+export type GovernedPrivateEvaluationMaterializationResult =
+  | Readonly<{
+      state: 'ready';
+      explanation: AflTradeValuationExplanationDocument;
+      narrative: ReturnType<typeof createAflTradeCalculationNarrative>;
+      publicationEligible: false;
+    }>
+  | Readonly<{
+      state: 'unavailable';
+      tradeId: string;
+      blockers: readonly GovernedPrivateEvaluationMaterializationBlocker[];
+    }>;
+
+type MaterializedEvidence = Parameters<
+  typeof createAflTradeCalculationNarrative
+>[0]['assets'][number];
+
+function exactJson(left: unknown, right: unknown): boolean {
+  return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+}
+
+function uniqueById<T>(
+  values: readonly T[],
+  idOf: (value: T) => string,
+  label: string
+): Map<string, T> {
+  const result = new Map<string, T>();
+  for (const value of values) {
+    const id = idOf(value);
+    if (result.has(id)) {
+      throw new TypeError(`Governed materialization received duplicate ${label} identity.`);
+    }
+    result.set(id, value);
+  }
+  return result;
+}
+
+function addDisplayIdentity(
+  identities: Map<string, string>,
+  id: string,
+  label: string,
+  kind: 'asset' | 'club'
+): void {
+  const known = identities.get(id);
+  if (known !== undefined && known !== label) {
+    throw new TypeError(`Governed materialization found conflicting ${kind} display identity.`);
+  }
+  identities.set(id, label);
+}
+
+function displayIdentity(trace: GovernedPrivateEvaluationInputTrace) {
+  const assets = new Map<string, string>();
+  const clubs = new Map<string, string>();
+  for (const { assetId, displayLabel } of trace.content.transaction.transfers) {
+    addDisplayIdentity(assets, assetId, displayLabel, 'asset');
+  }
+  for (const { assetId, playerName, acquisitionSpells } of trace.content.playerHorizons) {
+    addDisplayIdentity(assets, assetId, playerName, 'asset');
+    for (const spell of acquisitionSpells) {
+      addDisplayIdentity(clubs, spell.clubId, spell.clubName, 'club');
+    }
+  }
+  for (const lineage of trace.content.pickLineages) {
+    addDisplayIdentity(assets, lineage.rootAssetId, lineage.pickIdentityLabel, 'asset');
+    for (const transformation of lineage.transformations) {
+      for (const label of transformation.assetLabels) {
+        addDisplayIdentity(assets, label.assetId, label.displayLabel, 'asset');
+      }
+    }
+    for (const custody of lineage.custody) {
+      addDisplayIdentity(clubs, custody.clubId, custody.clubName, 'club');
+    }
+  }
+  for (const club of trace.content.transaction.clubs) {
+    addDisplayIdentity(clubs, club.aflClubId, club.clubName, 'club');
+  }
+  return {
+    assets: [...assets].map(([assetId, label]) => ({ assetId, label })),
+    clubs: [...clubs].map(([aflClubId, clubName]) => ({ aflClubId, clubName })),
+  };
+}
+
+function assertPlayerAncestry(
+  trace: GovernedPrivateEvaluationInputTrace,
+  horizon: GovernedPrivateEvaluationInputTrace['content']['playerHorizons'][number],
+  observation: AflTradePlayerPavObservation
+): void {
+  const spell = horizon.acquisitionSpells.find(
+    ({ spellVersionId }) => spellVersionId === observation.acquisitionSpell.spellVersionId
+  );
+  const requiredSeasons = horizon.requiredSeasons.map(({ season }) => season);
+  const observedDeparture = observation.acquisitionSpell.effectiveThrough;
+  const tracedDeparture = spell?.departedAt?.slice(0, 10) ?? null;
+  if (
+    observation.observationId !== horizon.playerObservationId ||
+    observation.releaseId !== trace.content.factualReleaseId ||
+    observation.playerId !== horizon.playerId ||
+    observation.acquisitionSpell.clubId !== horizon.receivingClubId ||
+    spell === undefined ||
+    observation.acquisitionSpell.effectiveFrom !== spell.joinedAt.slice(0, 10) ||
+    observedDeparture !== tracedDeparture ||
+    !exactJson(observation.targetCalculationSeasons, requiredSeasons) ||
+    Date.parse(observation.outcomeObservedAt) > Date.parse(trace.content.derivedAt) ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(horizon.playerObservationArtifact, observation)
+  ) {
+    throw new TypeError(
+      'Governed materialization player evidence does not match its exact release, horizon, spell, or retained artifact.'
+    );
+  }
+}
+
+function unavailable(
+  tradeId: string,
+  blockers: readonly GovernedPrivateEvaluationMaterializationBlocker[]
+): GovernedPrivateEvaluationMaterializationResult {
+  return { state: 'unavailable', tradeId, blockers };
+}
+
+/**
+ * Authenticates retained calculation parents, derives all model and lineage evidence, then creates
+ * one complete four-view explanation and reader narrative. It never accepts caller-supplied values,
+ * stories, or grades, and it never returns a partially materialized calculation.
+ */
+export function materializeGovernedPrivateEvaluation(
+  input: MaterializeGovernedPrivateEvaluationInput
+): GovernedPrivateEvaluationMaterializationResult {
+  const trace = governedPrivateEvaluationInputTraceSchema.parse(input.trace);
+  const explanationPolicy = governedPrivateEvaluationExplanationPolicySchema.parse(
+    input.explanationPolicy
+  );
+  const calculationInputPackage = aflTradeValuationCalculationInputPackageSchema.parse(
+    input.calculationInputPackage
+  );
+  const pickBenchmarks = input.pickBenchmarks.map((benchmark) =>
+    aflTradePickPavDistributionBenchmarkSchema.parse(benchmark)
+  );
+  const playerObservations = input.playerObservations.map((observation) =>
+    aflTradePlayerPavObservationSchema.parse(observation)
+  );
+  const benchmarkById = uniqueById(
+    pickBenchmarks,
+    ({ benchmarkId }) => benchmarkId,
+    'pick benchmark'
+  );
+  const playerObservationById = uniqueById(
+    playerObservations,
+    ({ observationId }) => observationId,
+    'player observation'
+  );
+  const tradeId = trace.content.selector.tradeId;
+
+  if (
+    createAflTradeLineageGraphId(input.lineageGraph) !==
+    calculationInputPackage.content.valuationCase.content.lineageGraphId
+  ) {
+    throw new TypeError(
+      'Governed materialization lineage graph does not match the calculation input package.'
+    );
+  }
+
+  const blockers: GovernedPrivateEvaluationMaterializationBlocker[] = [];
+  const modelEvidence = new Map<
+    string,
+    MaterializedEvidence['modelEvidence']
+  >();
+  for (const horizon of trace.content.playerHorizons) {
+    const observation = playerObservationById.get(horizon.playerObservationId);
+    if (observation === undefined) {
+      blockers.push({
+        code: 'player_evidence_missing',
+        assetId: horizon.assetId,
+        message: `${horizon.playerName} has no retained authenticated player observation.`,
+      });
+      continue;
+    }
+    assertPlayerAncestry(trace, horizon, observation);
+    const evidence = deriveAflTradePlayerCalculationEvidence(observation);
+    if (evidence.state === 'unavailable') {
+      blockers.push({
+        code: 'player_evidence_unavailable',
+        assetId: horizon.assetId,
+        message: `${horizon.playerName} evidence is unavailable (${evidence.reason}).`,
+      });
+      continue;
+    }
+    modelEvidence.set(horizon.assetId, evidence);
+  }
+  for (const lineage of trace.content.pickLineages) {
+    if (lineage.resolvedSelectionNumber === null) {
+      blockers.push({
+        code: 'pick_selection_unresolved',
+        assetId: lineage.rootAssetId,
+        message: `${lineage.pickIdentityLabel} has no authenticated resolved selection number.`,
+      });
+      continue;
+    }
+    const benchmark = benchmarkById.get(lineage.pickBenchmarkId);
+    if (benchmark === undefined) {
+      blockers.push({
+        code: 'pick_benchmark_missing',
+        assetId: lineage.rootAssetId,
+        message: `${lineage.pickIdentityLabel} has no retained authenticated pick benchmark.`,
+      });
+      continue;
+    }
+    if (
+      benchmark.content.observationSetId !== lineage.pickObservationSetId ||
+      benchmark.content.valueUnit !==
+        calculationInputPackage.content.valuationCase.content.valueUnitId ||
+      !doesAflTradeArtifactRefMatchCanonicalJson(lineage.pickBenchmarkArtifact, benchmark)
+    ) {
+      throw new TypeError(
+        'Governed materialization pick evidence does not match its observation set, value unit, or retained artifact.'
+      );
+    }
+    try {
+      modelEvidence.set(
+        lineage.rootAssetId,
+        deriveAflTradePickCalculationEvidence(benchmark, lineage.resolvedSelectionNumber)
+      );
+    } catch (error) {
+      if (!(error instanceof RangeError)) throw error;
+      blockers.push({
+        code: 'pick_model_support_unavailable',
+        assetId: lineage.rootAssetId,
+        message: `${lineage.pickIdentityLabel} is outside the authenticated pick-model support.`,
+      });
+    }
+  }
+  if (blockers.length > 0) return unavailable(tradeId, blockers);
+
+  const currentContext = calculationInputPackage.content.valuationCase.content.viewContexts.find(
+    ({ view }) => view === 'current'
+  )!;
+  const display = displayIdentity(trace);
+  const evidencePackages: MaterializedEvidence[] = trace.content.transaction.transfers.map(
+    ({ assetId }) => {
+      const evidence = modelEvidence.get(assetId);
+      if (evidence === undefined) {
+        throw new TypeError('Governed materialization is missing evidence for a transaction root.');
+      }
+      return {
+        assetId,
+        modelEvidence: evidence,
+        lineage: deriveAflTradeAssetLineageNarrativeEvidence(
+          input.lineageGraph,
+          assetId,
+          {
+            effectiveAsOf: currentContext.effectiveAt,
+            knowledgeCutoffAt: currentContext.knowledgeCutoffAt,
+          },
+          display
+        ),
+      };
+    }
+  );
+  const explanationResult = createGovernedAflTradeValuationExplanation({
+    trace,
+    explanationPolicy,
+    calculationInputPackage,
+  });
+  if (explanationResult.state === 'unavailable') {
+    return unavailable(tradeId, [
+      {
+        code: 'incomplete_numeric_evidence',
+        assetId: null,
+        message: explanationResult.explanation,
+      },
+    ]);
+  }
+  const narrative = createAflTradeCalculationNarrative({
+    explanation: explanationResult.document,
+    assets: evidencePackages,
+  });
+  return {
+    state: 'ready',
+    explanation: explanationResult.document,
+    narrative,
+    publicationEligible: false,
+  };
+}
+
+/** Authenticates the bounded retained-parent manifest before replaying deterministic materialization. */
+export function replayGovernedPrivateEvaluationMaterialization(
+  input: ReplayGovernedPrivateEvaluationMaterializationInput
+): GovernedPrivateEvaluationMaterializationResult {
+  const manifest = governedPrivateEvaluationMaterializationManifestSchema.parse(
+    input.materializationManifest
+  );
+  const content = manifest.content;
+  const pickBenchmarks = [...input.pickBenchmarks].sort((left, right) =>
+    left.benchmarkId.localeCompare(right.benchmarkId)
+  );
+  const playerObservations = [...input.playerObservations].sort((left, right) =>
+    left.observationId.localeCompare(right.observationId)
+  );
+  const pickParents = content.pickBenchmarks;
+  const playerParents = content.playerObservations;
+  if (
+    !exactJson(content.selector, input.trace.content.selector) ||
+    content.calculationInputPackageId !== input.calculationInputPackage.calculationInputPackageId ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(
+      content.calculationInputArtifact,
+      input.calculationInputPackage
+    ) ||
+    content.inputTraceId !== input.trace.inputTraceId ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(content.inputTraceArtifact, input.trace) ||
+    content.explanationPolicyId !== input.explanationPolicy.policyId ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(
+      content.explanationPolicyArtifact,
+      input.explanationPolicy
+    ) ||
+    content.lineageGraphId !== createAflTradeLineageGraphId(input.lineageGraph) ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(content.lineageGraphArtifact, input.lineageGraph) ||
+    pickParents.length !== pickBenchmarks.length ||
+    pickParents.some(
+      (parent, index) =>
+        parent.benchmarkId !== pickBenchmarks[index]?.benchmarkId ||
+        !doesAflTradeArtifactRefMatchCanonicalJson(parent.artifact, pickBenchmarks[index])
+    ) ||
+    playerParents.length !== playerObservations.length ||
+    playerParents.some(
+      (parent, index) =>
+        parent.observationId !== playerObservations[index]?.observationId ||
+        !doesAflTradeArtifactRefMatchCanonicalJson(parent.artifact, playerObservations[index])
+    )
+  ) {
+    throw new TypeError(
+      'Governed materialization replay does not match its exact retained-parent manifest.'
+    );
+  }
+  return materializeGovernedPrivateEvaluation(input);
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationTransaction.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationTransaction.ts
@@ -1,0 +1,74 @@
+import {
+  governedPrivateEvaluationInputTraceSchema,
+  type GovernedPrivateEvaluationInputTrace,
+} from './governedPrivateEvaluationInputTrace';
+
+type ExplanationAssetKind = 'player' | 'current_pick' | 'future_pick';
+
+export interface GovernedPrivateEvaluationDirectedTransfer {
+  readonly transferId: string;
+  readonly assetId: string;
+  readonly assetKind: ExplanationAssetKind;
+  readonly fromClubId: string;
+  readonly toClubId: string;
+  readonly displayLabel: string;
+  readonly directionBasis: 'archive_recorded_transfer';
+}
+
+export interface GovernedPrivateEvaluationClubBank {
+  readonly aflClubId: string;
+  readonly clubName: string;
+  readonly receivedAssetIds: readonly string[];
+  readonly givenUpAssetIds: readonly string[];
+}
+
+function explanationAssetKind(
+  value: GovernedPrivateEvaluationInputTrace['content']['transaction']['transfers'][number]['assetKind']
+): ExplanationAssetKind {
+  if (value === 'current_pick_entitlement') return 'current_pick';
+  if (value === 'future_pick_entitlement') return 'future_pick';
+  return 'player';
+}
+
+export function deriveGovernedPrivateEvaluationTransaction(unparsedTrace: unknown) {
+  const trace = governedPrivateEvaluationInputTraceSchema.parse(unparsedTrace);
+  const transfers: readonly GovernedPrivateEvaluationDirectedTransfer[] =
+    trace.content.transaction.transfers.map((transfer) => ({
+      transferId: transfer.transferId,
+      assetId: transfer.assetId,
+      assetKind: explanationAssetKind(transfer.assetKind),
+      fromClubId: transfer.fromClubId,
+      toClubId: transfer.toClubId,
+      displayLabel: transfer.displayLabel,
+      directionBasis: 'archive_recorded_transfer',
+    }));
+  const clubs: readonly GovernedPrivateEvaluationClubBank[] =
+    trace.content.transaction.clubs.map((club) => ({
+      aflClubId: club.aflClubId,
+      clubName: club.clubName,
+      receivedAssetIds: transfers
+        .filter(({ toClubId }) => toClubId === club.aflClubId)
+        .map(({ assetId }) => assetId)
+        .sort(),
+      givenUpAssetIds: transfers
+        .filter(({ fromClubId }) => fromClubId === club.aflClubId)
+        .map(({ assetId }) => assetId)
+        .sort(),
+    }));
+  if (
+    clubs.some(
+      ({ receivedAssetIds, givenUpAssetIds }) =>
+        receivedAssetIds.length === 0 || givenUpAssetIds.length === 0
+    )
+  ) {
+    throw new TypeError(
+      'A complete governed transaction requires every club to receive and give up an asset.'
+    );
+  }
+  return {
+    selector: trace.content.selector,
+    effectiveAt: trace.content.transaction.effectiveAt,
+    clubs,
+    transfers,
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationWorkspaceContracts.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationWorkspaceContracts.ts
@@ -1,0 +1,305 @@
+import { z } from 'zod';
+
+import { aflTradeArtifactRefSchema } from '../../artifacts/artifactReference';
+import { aflTradeContentAddressedIdSchema } from '../../artifacts/contentAddress';
+
+const scopedIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(400)
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9._:/-]*$/u);
+const instantSchema = z.iso.datetime({ offset: true });
+
+const inspectionIdSchema = aflTradeContentAddressedIdSchema('private-evaluation-inspection');
+const operationIdSchema = aflTradeContentAddressedIdSchema('private-evaluation-operation');
+const generationIdSchema = aflTradeContentAddressedIdSchema(
+  'local-private-trade-evaluation-generation'
+);
+const projectionManifestIdSchema = aflTradeContentAddressedIdSchema(
+  'private-evaluation-projection-manifest'
+);
+
+export const governedPrivateEvaluationSelectorSchema = z
+  .object({
+    valuationScopeKey: scopedIdSchema,
+    tradeId: scopedIdSchema,
+  })
+  .strict();
+
+const blockerSchema = z
+  .object({
+    code: z.enum([
+      'source_blocked',
+      'insufficient_data',
+      'identity_unresolved',
+      'lineage_unresolved',
+      'model_not_approved',
+      'reconciliation_failed',
+      'engineering_unavailable',
+    ]),
+    message: z.string().trim().min(1).max(2_000),
+  })
+  .strict();
+
+const lifecycleHeadSchema = z
+  .object({
+    status: z.enum(['absent', 'active', 'withdrawn']),
+    revision: z.number().int().nonnegative(),
+    generationId: generationIdSchema.nullable(),
+  })
+  .strict()
+  .superRefine((head, context) => {
+    if ((head.status === 'active') !== (head.generationId !== null)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['generationId'],
+        message: 'Only an active lifecycle head may identify a current generation.',
+      });
+    }
+    if (head.status === 'absent' && head.revision !== 0) {
+      context.addIssue({
+        code: 'custom',
+        path: ['revision'],
+        message: 'An absent lifecycle head must begin at revision zero.',
+      });
+    }
+    if (head.status !== 'absent' && head.revision === 0) {
+      context.addIssue({
+        code: 'custom',
+        path: ['revision'],
+        message: 'An active or withdrawn lifecycle head must follow a committed transition.',
+      });
+    }
+  });
+
+export const governedPrivateEvaluationInspectRequestSchema =
+  governedPrivateEvaluationSelectorSchema;
+
+export const governedPrivateEvaluationInspectResultSchema = z.discriminatedUnion('state', [
+  z
+    .object({
+      state: z.literal('ready'),
+      selector: governedPrivateEvaluationSelectorSchema,
+      inspectionId: inspectionIdSchema,
+      validThrough: instantSchema,
+      head: lifecycleHeadSchema,
+      blockers: z.tuple([]),
+    })
+    .strict(),
+  z
+    .object({
+      state: z.literal('unavailable'),
+      selector: governedPrivateEvaluationSelectorSchema,
+      inspectionId: inspectionIdSchema,
+      validThrough: instantSchema,
+      head: lifecycleHeadSchema,
+      blockers: z.array(blockerSchema).min(1).max(10_000),
+    })
+    .strict(),
+]);
+
+const executionReviewSchema = z
+  .object({
+    rationale: z.string().trim().min(1).max(2_000),
+  })
+  .strict();
+
+const executionActionSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('construct_and_activate') }).strict(),
+  z.object({ kind: z.literal('recover') }).strict(),
+  z
+    .object({
+      kind: z.literal('withdraw'),
+      reason: z.string().trim().min(1).max(2_000),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('rollback'),
+      targetGenerationId: generationIdSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('verify_reconstruction'),
+      generationId: generationIdSchema,
+    })
+    .strict(),
+]);
+
+export const governedPrivateEvaluationExecuteRequestSchema = z
+  .object({
+    inspectionId: inspectionIdSchema,
+    operationId: operationIdSchema,
+    action: executionActionSchema,
+    review: executionReviewSchema,
+  })
+  .strict();
+
+const executionResultBase = {
+  selector: governedPrivateEvaluationSelectorSchema,
+  inspectionId: inspectionIdSchema,
+  operationId: operationIdSchema,
+};
+
+export const governedPrivateEvaluationExecuteResultSchema = z.discriminatedUnion('state', [
+  z
+    .object({
+      state: z.literal('activated'),
+      ...executionResultBase,
+      generationId: generationIdSchema,
+      head: lifecycleHeadSchema,
+    })
+    .strict(),
+  z
+    .object({
+      state: z.literal('withdrawn'),
+      ...executionResultBase,
+      head: lifecycleHeadSchema,
+    })
+    .strict(),
+  z
+    .object({
+      state: z.literal('rolled_back'),
+      ...executionResultBase,
+      generationId: generationIdSchema,
+      head: lifecycleHeadSchema,
+    })
+    .strict(),
+  z
+    .object({
+      state: z.literal('recovered'),
+      ...executionResultBase,
+      generationId: generationIdSchema,
+      head: lifecycleHeadSchema,
+    })
+    .strict(),
+  z
+    .object({
+      state: z.literal('reconstruction_verified'),
+      ...executionResultBase,
+      generationId: generationIdSchema,
+      exactMatch: z.literal(true),
+    })
+    .strict(),
+  z
+    .object({
+      state: z.literal('unavailable'),
+      ...executionResultBase,
+      blockers: z.array(blockerSchema).min(1).max(10_000),
+    })
+    .strict(),
+  z
+    .object({
+      state: z.literal('conflict'),
+      ...executionResultBase,
+      message: z.string().trim().min(1).max(2_000),
+    })
+    .strict(),
+  z
+    .object({
+      state: z.literal('invalid_transition'),
+      ...executionResultBase,
+      message: z.string().trim().min(1).max(2_000),
+    })
+    .strict(),
+  z
+    .object({
+      state: z.literal('not_found'),
+      ...executionResultBase,
+      resource: z.enum(['inspection', 'generation']),
+    })
+    .strict(),
+]);
+
+const readSelectionSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('current') }).strict(),
+  z.object({ kind: z.literal('generation'), generationId: generationIdSchema }).strict(),
+]);
+const readDocumentSchema = z
+  .object({
+    kind: z.enum(['archive_summary', 'detail', 'reader_api', 'json_export']),
+  })
+  .strict();
+const readArtifactBytesSchema = z.custom<Uint8Array>(
+  (value) =>
+    ArrayBuffer.isView(value) &&
+    Object.prototype.toString.call(value) === '[object Uint8Array]' &&
+    'length' in value &&
+    typeof value.length === 'number' &&
+    value.byteLength === value.length,
+  'Authenticated projection bytes must be a Uint8Array.'
+);
+const readLifecycleSchema = z
+  .object({
+    status: z.enum(['active', 'withdrawn', 'superseded']),
+    current: z.boolean(),
+  })
+  .strict()
+  .superRefine((lifecycle, context) => {
+    if ((lifecycle.status === 'active') !== lifecycle.current) {
+      context.addIssue({
+        code: 'custom',
+        path: ['current'],
+        message: 'Only the active generation may be labelled current.',
+      });
+    }
+  });
+
+export const governedPrivateEvaluationReadRequestSchema = z
+  .object({
+    selector: governedPrivateEvaluationSelectorSchema,
+    selection: readSelectionSchema,
+    document: readDocumentSchema,
+  })
+  .strict();
+
+export const governedPrivateEvaluationReadResultSchema = z.discriminatedUnion('state', [
+  z
+    .object({
+      state: z.literal('available'),
+      selector: governedPrivateEvaluationSelectorSchema,
+      selection: readSelectionSchema,
+      generationId: generationIdSchema,
+      projectionManifestId: projectionManifestIdSchema,
+      lifecycle: readLifecycleSchema,
+      document: readDocumentSchema.extend({ artifact: aflTradeArtifactRefSchema }).strict(),
+      bytes: readArtifactBytesSchema,
+    })
+    .strict(),
+  z
+    .object({
+      state: z.literal('unavailable'),
+      selector: governedPrivateEvaluationSelectorSchema,
+      selection: readSelectionSchema,
+      document: readDocumentSchema,
+      reason: z.enum([
+        'not_found',
+        'withdrawn',
+        'projection_unavailable',
+        'authentication_failed',
+        'reconstruction_mismatch',
+      ]),
+    })
+    .strict(),
+]);
+
+export type GovernedPrivateEvaluationInspectRequest = z.infer<
+  typeof governedPrivateEvaluationInspectRequestSchema
+>;
+export type GovernedPrivateEvaluationInspectResult = z.infer<
+  typeof governedPrivateEvaluationInspectResultSchema
+>;
+export type GovernedPrivateEvaluationExecuteRequest = z.infer<
+  typeof governedPrivateEvaluationExecuteRequestSchema
+>;
+export type GovernedPrivateEvaluationExecuteResult = z.infer<
+  typeof governedPrivateEvaluationExecuteResultSchema
+>;
+export type GovernedPrivateEvaluationReadRequest = z.infer<
+  typeof governedPrivateEvaluationReadRequestSchema
+>;
+export type GovernedPrivateEvaluationReadResult = z.infer<
+  typeof governedPrivateEvaluationReadResultSchema
+>;

--- a/src/server/aflTradeIntelligence/valuation/internal/governedReadyComponentAuthority.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedReadyComponentAuthority.ts
@@ -1,0 +1,157 @@
+import {
+  doAflTradeArtifactRefsExactlyMatch,
+  doesAflTradeArtifactRefMatchCanonicalJson,
+  type AflTradeArtifactRef,
+} from '../../artifacts/artifactReference';
+import {
+  aflTradeGateDecisionRecordSchema,
+  type AflTradeGateDecisionRecord,
+} from '../../governance/gateDecisionTypes';
+import type { GovernedPrivateEvaluationInputTrace } from './governedPrivateEvaluationInputTrace';
+import type { RetainedGovernedValuationComponentRun } from './postgresGovernedValuationComponentRunRepository';
+
+type TraceComponent = GovernedPrivateEvaluationInputTrace['content']['components'][number];
+
+export type GovernedReadyComponentAuthority = Readonly<{
+  role: TraceComponent['role'];
+  runId: string;
+  protocolId: string;
+  datasetId: string;
+  datasetAdmissionId: string;
+  datasetAdmissionGateLedgerRevision: number;
+  gate3DecisionId: string;
+  gate3DecisionVersion: number;
+}>;
+
+export class GovernedReadyComponentAuthorityError extends Error {
+  constructor(
+    readonly code: 'ANCESTRY_MISMATCH' | 'NOT_CURRENT' | 'NOT_APPROVED' | 'EXPIRED',
+    message: string
+  ) {
+    super(message);
+    this.name = 'GovernedReadyComponentAuthorityError';
+  }
+}
+
+function requireExactAncestry(input: {
+  readonly traceComponent: TraceComponent;
+  readonly run: RetainedGovernedValuationComponentRun;
+  readonly gate3Decision: AflTradeGateDecisionRecord;
+  readonly gate3DecisionArtifact: AflTradeArtifactRef;
+}): void {
+  const trace = input.traceComponent;
+  const run = input.run;
+  const content = run.manifest.content;
+  const nativeExecutionIsEligible =
+    trace.role === 'player_contribution_and_availability'
+      ? content.nativeExecution.kind === 'admitted_player_model_run'
+      : content.nativeExecution.kind === 'governed_pick_pav_model_execution';
+  if (
+    !nativeExecutionIsEligible ||
+    trace.role !== content.role ||
+    trace.runId !== run.manifest.runId ||
+    trace.protocolId !== content.protocolId ||
+    trace.datasetId !== content.datasetId ||
+    trace.datasetAdmissionId !== content.datasetAdmissionId ||
+    trace.gate3DecisionId !== input.gate3Decision.decisionId ||
+    !doAflTradeArtifactRefsExactlyMatch(trace.evidence.runManifest, run.artifact) ||
+    !doAflTradeArtifactRefsExactlyMatch(trace.evidence.protocol, content.protocolArtifact) ||
+    !doAflTradeArtifactRefsExactlyMatch(
+      trace.evidence.datasetAdmission,
+      content.datasetAdmissionArtifact
+    ) ||
+    !doAflTradeArtifactRefsExactlyMatch(
+      trace.evidence.gate3Decision,
+      input.gate3DecisionArtifact
+    ) ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(
+      input.gate3DecisionArtifact,
+      input.gate3Decision
+    )
+  ) {
+    throw new GovernedReadyComponentAuthorityError(
+      'ANCESTRY_MISMATCH',
+      'Component trace, governed native execution eligibility, or Gate 3 evidence ancestry disagrees.'
+    );
+  }
+}
+
+function requireCurrentGate3(input: {
+  readonly runId: string;
+  readonly decision: AflTradeGateDecisionRecord;
+  readonly isCurrent: boolean;
+  readonly capturedAt: string;
+}): void {
+  const decision = input.decision.content;
+  if (!input.isCurrent) {
+    throw new GovernedReadyComponentAuthorityError(
+      'NOT_CURRENT',
+      'Gate 3 component authority is not the current decision.'
+    );
+  }
+  if (
+    decision.gate !== 'gate_3_model_validity' ||
+    decision.environment !== 'non_production' ||
+    decision.state !== 'approved' ||
+    decision.authorityKind !== 'external_human_record' ||
+    decision.effectiveAt === null ||
+    decision.revalidateAt === null ||
+    !decision.affectedArtifacts.some(
+      ({ kind, artifactId }) => kind === 'model_run' && artifactId === input.runId
+    )
+  ) {
+    throw new GovernedReadyComponentAuthorityError(
+      'NOT_APPROVED',
+      'Ready component authority requires an external human Gate 3 approval for the exact run.'
+    );
+  }
+  if (
+    Date.parse(decision.effectiveAt) > Date.parse(input.capturedAt) ||
+    Date.parse(decision.revalidateAt) <= Date.parse(input.capturedAt)
+  ) {
+    throw new GovernedReadyComponentAuthorityError(
+      'EXPIRED',
+      'Gate 3 component authority is outside its current revalidation window.'
+    );
+  }
+}
+
+export function authenticateGovernedReadyComponentAuthority(input: {
+  readonly traceComponent: TraceComponent;
+  readonly run: RetainedGovernedValuationComponentRun;
+  readonly gate3Decision: unknown;
+  readonly gate3DecisionArtifact: AflTradeArtifactRef;
+  readonly gate3IsCurrent: boolean;
+  readonly gateLedgerRevision: number;
+  readonly capturedAt: string;
+}): GovernedReadyComponentAuthority {
+  const gate3Decision = aflTradeGateDecisionRecordSchema.parse(input.gate3Decision);
+  requireExactAncestry({ ...input, gate3Decision });
+  requireCurrentGate3({
+    runId: input.run.manifest.runId,
+    decision: gate3Decision,
+    isCurrent: input.gate3IsCurrent,
+    capturedAt: input.capturedAt,
+  });
+  const admissionRevision = input.run.manifest.content.datasetAdmissionGateLedgerRevision;
+  if (
+    !Number.isSafeInteger(input.gateLedgerRevision) ||
+    input.gateLedgerRevision <= 0 ||
+    admissionRevision > input.gateLedgerRevision
+  ) {
+    throw new GovernedReadyComponentAuthorityError(
+      'NOT_CURRENT',
+      'Component dataset admission cannot postdate the observed Gate ledger head.'
+    );
+  }
+  return {
+    role: input.traceComponent.role,
+    runId: input.traceComponent.runId,
+    protocolId: input.traceComponent.protocolId,
+    datasetId: input.traceComponent.datasetId,
+    datasetAdmissionId: input.traceComponent.datasetAdmissionId,
+    datasetAdmissionGateLedgerRevision: admissionRevision,
+    gate3DecisionId: gate3Decision.decisionId,
+    gate3DecisionVersion: gate3Decision.content.version,
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest.ts
@@ -1,0 +1,138 @@
+import { z } from 'zod';
+
+import { aflTradeArtifactRefSchema } from '../../artifacts/artifactReference';
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  createAflTradeContentAddress,
+} from '../../artifacts/contentAddress';
+
+const SCHEMA_VERSION = 'governed-valuation-component-run/v1' as const;
+const LIMITATION =
+  'Authenticated non-production component-run candidate only; Gate 3 approval, grades, production use, and publication remain prohibited.' as const;
+const instantSchema = z.iso.datetime({ offset: true });
+
+const nativeExecutionSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('admitted_player_model_run'),
+      executionId: aflTradeContentAddressedIdSchema('model-run'),
+      artifact: aflTradeArtifactRefSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('pick_pav_model_execution'),
+      executionId: aflTradeContentAddressedIdSchema('pick-pav-model-execution'),
+      artifact: aflTradeArtifactRefSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('governed_pick_pav_model_execution'),
+      executionId: aflTradeContentAddressedIdSchema('pick-pav-model-execution'),
+      artifact: aflTradeArtifactRefSchema,
+    })
+    .strict(),
+]);
+
+export const governedValuationComponentRunManifestContentSchema = z
+  .object({
+    schemaVersion: z.literal(SCHEMA_VERSION),
+    environment: z.literal('non_production'),
+    role: z.enum([
+      'player_contribution_and_availability',
+      'draft_pick_and_future_pick_distribution',
+    ]),
+    nativeExecution: nativeExecutionSchema,
+    protocolId: aflTradeContentAddressedIdSchema('model-protocol'),
+    protocolArtifact: aflTradeArtifactRefSchema,
+    datasetId: aflTradeContentAddressedIdSchema('dataset'),
+    datasetArtifact: aflTradeArtifactRefSchema,
+    datasetAdmissionId: aflTradeContentAddressedIdSchema('dataset-admission'),
+    datasetAdmissionArtifact: aflTradeArtifactRefSchema,
+    datasetAdmissionGateLedgerRevision: z.number().int().positive(),
+    registeredAt: instantSchema,
+    approvalState: z.literal('gate_3_review_required'),
+    publicationEligible: z.literal(false),
+    limitation: z.literal(LIMITATION),
+  })
+  .strict()
+  .superRefine((manifest, context) => {
+    const roleMatchesNativeExecution =
+      manifest.role === 'player_contribution_and_availability'
+        ? manifest.nativeExecution.kind === 'admitted_player_model_run'
+        : manifest.nativeExecution.kind === 'pick_pav_model_execution' ||
+          manifest.nativeExecution.kind === 'governed_pick_pav_model_execution';
+    if (!roleMatchesNativeExecution) {
+      context.addIssue({
+        code: 'custom',
+        path: ['nativeExecution'],
+        message: 'Component role and native execution kind must agree.',
+      });
+    }
+
+    const artifacts = [
+      manifest.nativeExecution.artifact,
+      manifest.protocolArtifact,
+      manifest.datasetArtifact,
+      manifest.datasetAdmissionArtifact,
+    ];
+    if (new Set(artifacts.map(({ artifactId }) => artifactId)).size !== artifacts.length) {
+      context.addIssue({
+        code: 'custom',
+        path: ['nativeExecution'],
+        message: 'Component-run evidence requires distinct retained artifacts.',
+      });
+    }
+    if (
+      artifacts.some(({ createdAt }) => Date.parse(createdAt) > Date.parse(manifest.registeredAt))
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['registeredAt'],
+        message: 'Every component-run evidence artifact must exist before registration.',
+      });
+    }
+  });
+
+export const governedValuationComponentRunManifestSchema = z
+  .object({
+    runId: aflTradeContentAddressedIdSchema('model-run'),
+    content: governedValuationComponentRunManifestContentSchema,
+  })
+  .strict()
+  .superRefine((manifest, context) => {
+    addAflTradeContentAddressIssue('model-run', manifest.runId, manifest.content, context, [
+      'runId',
+    ]);
+  });
+
+export type GovernedValuationComponentRunManifest = z.infer<
+  typeof governedValuationComponentRunManifestSchema
+>;
+
+export function createGovernedValuationComponentRunManifest(
+  input: Omit<
+    z.input<typeof governedValuationComponentRunManifestContentSchema>,
+    'schemaVersion' | 'approvalState' | 'publicationEligible' | 'limitation'
+  >
+): GovernedValuationComponentRunManifest {
+  const content = governedValuationComponentRunManifestContentSchema.parse({
+    schemaVersion: SCHEMA_VERSION,
+    ...input,
+    approvalState: 'gate_3_review_required',
+    publicationEligible: false,
+    limitation: LIMITATION,
+  });
+  return governedValuationComponentRunManifestSchema.parse({
+    runId: createAflTradeContentAddress('model-run', content),
+    content,
+  });
+}
+
+export function authenticateGovernedValuationComponentRunManifest(
+  input: unknown
+): GovernedValuationComponentRunManifest {
+  return governedValuationComponentRunManifestSchema.parse(input);
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationCalculationAuthority.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationCalculationAuthority.ts
@@ -1,0 +1,291 @@
+import {
+  doAflTradeArtifactRefsExactlyMatch,
+  doesAflTradeArtifactRefMatchBytes,
+  doesAflTradeArtifactRefMatchCanonicalJson,
+  type AflTradeArtifactRef,
+} from '../../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import { aflTradeValuationInputBundleSchema } from '../../artifacts/valuationInputBundle';
+import {
+  verifyAflTradeArtifactReadback,
+  type AflTradeImmutableArtifactRepository,
+} from '../../artifacts/immutableArtifactRepository';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../../outcomes/postgresOutcomeReleaseRepository';
+import { loadCurrentAflTradePreparedValuationInputTradeFromTransaction } from '../postgresPreparedValuationInputSetStore';
+import { aflTradeValuationCalculationInputPackageSchema } from '../valuationCalculationInputPackage';
+import { governedPrivateEvaluationInputTraceSchema } from './governedPrivateEvaluationInputTrace';
+import { capturePostgresGovernedPrivateEvaluationCurrentAuthority } from './postgresGovernedPrivateEvaluationCurrentAuthority';
+import type { GovernedPrivateEvaluationCapturedCalculationAuthority } from './postgresGovernedPrivateEvaluationInspectionRepository';
+import { PostgresGovernedPrivateEvaluationMaterializationManifestRepository } from './postgresGovernedPrivateEvaluationMaterializationManifestRepository';
+
+const BLOCKER_MESSAGES = {
+  source_blocked: 'The current factual source authority blocks this calculation.',
+  model_not_approved: 'The required model component has not received current external Gate 3 approval.',
+  insufficient_data: 'The prepared evidence is insufficient for this calculation.',
+  identity_unresolved: 'A required trade or asset identity remains unresolved.',
+  lineage_unresolved: 'A required asset lineage remains unresolved.',
+  unsupported_trade: 'This trade shape is not yet supported by the authenticated calculation path.',
+  component_output_unavailable: 'A required governed model output is unavailable.',
+  policy_unavailable: 'A required calculation policy is unavailable.',
+  temporal_evidence_unavailable: 'Required season or cutoff evidence is unavailable.',
+} as const;
+
+type CapturedBlocker = Extract<
+  GovernedPrivateEvaluationCapturedCalculationAuthority,
+  { state: 'unavailable' }
+>['blockers'][number];
+
+function inspectionBlocker(
+  blocker: {
+    readonly code: keyof typeof BLOCKER_MESSAGES;
+    readonly subject: { readonly kind: string; readonly id: string };
+  }
+): CapturedBlocker {
+  const code =
+    blocker.code === 'component_output_unavailable'
+      ? 'model_not_approved'
+      : blocker.code === 'policy_unavailable' ||
+          blocker.code === 'temporal_evidence_unavailable' ||
+          blocker.code === 'unsupported_trade'
+        ? 'insufficient_data'
+        : blocker.code;
+  return {
+    code,
+    message: `${BLOCKER_MESSAGES[blocker.code]} (${blocker.subject.kind}:${blocker.subject.id})`,
+  };
+}
+
+function transactionClient(transaction: AflOutcomeSqlTransaction): AflOutcomeSqlClient {
+  return {
+    query: transaction.query.bind(transaction),
+    transaction: async (work) => work(transaction),
+  };
+}
+
+async function loadJsonArtifact(input: {
+  readonly repository: AflTradeImmutableArtifactRepository;
+  readonly reference: AflTradeArtifactRef;
+  readonly maximumBytes: number;
+}): Promise<unknown> {
+  const loaded = await input.repository.loadExact(input.reference, input.maximumBytes);
+  if (
+    loaded === null ||
+    !doAflTradeArtifactRefsExactlyMatch(loaded.reference, input.reference) ||
+    !doesAflTradeArtifactRefMatchBytes(loaded.reference, loaded.bytes)
+  ) {
+    throw new TypeError('Retained calculation artifact failed exact byte authentication.');
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(loaded.bytes));
+  } catch {
+    throw new TypeError('Retained calculation artifact is not valid JSON.');
+  }
+}
+
+export function createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture(
+  dependencies: {
+    readonly artifactRepository: AflTradeImmutableArtifactRepository;
+    readonly maximumArtifactBytes: number;
+  }
+) {
+  if (
+    dependencies.artifactRepository.artifactClass !== 'derived_private' ||
+    !Number.isSafeInteger(dependencies.maximumArtifactBytes) ||
+    dependencies.maximumArtifactBytes <= 0
+  ) {
+    throw new TypeError('Calculation-authority capture requires bounded private artifact custody.');
+  }
+  return async function capture(input: {
+    readonly transaction: Parameters<
+      typeof loadCurrentAflTradePreparedValuationInputTradeFromTransaction
+    >[0];
+    readonly selector: { readonly valuationScopeKey: string; readonly tradeId: string };
+    readonly capturedAt: string;
+  }): Promise<GovernedPrivateEvaluationCapturedCalculationAuthority> {
+    const current = await loadCurrentAflTradePreparedValuationInputTradeFromTransaction(
+      input.transaction,
+      { scopeKey: input.selector.valuationScopeKey, tradeId: input.selector.tradeId }
+    );
+    if (current === null) {
+      return {
+        state: 'unavailable',
+        blockers: [
+          {
+            code: 'insufficient_data',
+            message: 'No current authenticated v3 prepared calculation inputs cover this trade.',
+          },
+        ],
+      };
+    }
+    const prepared = current.preparedInputSet.content;
+    if (prepared.schemaVersion !== 'afl-trade-prepared-valuation-input-set/v3') {
+      throw new TypeError('Current calculation authority is not an authenticated v3 prepared set.');
+    }
+    const entry = prepared.entries.find(({ tradeId }) => tradeId === input.selector.tradeId);
+    if (entry === undefined) {
+      throw new TypeError('Authenticated prepared authority omitted its selected trade.');
+    }
+    if (entry.state === 'blocked') {
+      return {
+        state: 'unavailable',
+        blockers: entry.blockers.map(inspectionBlocker),
+      };
+    }
+    const materialization =
+      await new PostgresGovernedPrivateEvaluationMaterializationManifestRepository(
+        transactionClient(input.transaction)
+      ).loadExact(entry.materializationManifestId);
+    if (
+      materialization.manifest.manifestId !== entry.materializationManifestId ||
+      !doAflTradeArtifactRefsExactlyMatch(
+        materialization.artifact,
+        entry.materializationManifestArtifact
+      ) ||
+      materialization.manifest.content.selector.valuationScopeKey !==
+        input.selector.valuationScopeKey ||
+      materialization.manifest.content.selector.tradeId !== input.selector.tradeId
+    ) {
+      throw new TypeError(
+        'Prepared calculation authority disagrees with its exact retained materialization manifest.'
+      );
+    }
+    await verifyAflTradeArtifactReadback(
+      dependencies.artifactRepository,
+      materialization.artifact,
+      input.capturedAt,
+      dependencies.maximumArtifactBytes
+    );
+    const manifest = materialization.manifest.content;
+    const parentArtifacts = [
+      prepared.factualReleaseArtifact,
+      prepared.releaseMembershipArtifact,
+      prepared.qualificationReportArtifact,
+      ...prepared.sourceQualificationEvidenceRefs,
+      prepared.valuationInputBundleArtifact,
+      manifest.calculationInputArtifact,
+      manifest.inputTraceArtifact,
+      manifest.explanationPolicyArtifact,
+      manifest.lineageGraphArtifact,
+      ...manifest.pickBenchmarks.map(({ artifact }) => artifact),
+      ...manifest.playerObservations.map(({ artifact }) => artifact),
+    ];
+    for (const artifact of parentArtifacts) {
+      await verifyAflTradeArtifactReadback(
+        dependencies.artifactRepository,
+        artifact,
+        input.capturedAt,
+        dependencies.maximumArtifactBytes
+      );
+    }
+    const valuationInputBundle = aflTradeValuationInputBundleSchema.safeParse(
+      await loadJsonArtifact({
+        repository: dependencies.artifactRepository,
+        reference: prepared.valuationInputBundleArtifact,
+        maximumBytes: dependencies.maximumArtifactBytes,
+      })
+    );
+    if (!valuationInputBundle.success) {
+      throw new TypeError(
+        'Retained valuation input bundle failed exact contract authentication.'
+      );
+    }
+    const bundle = valuationInputBundle.data;
+    const nestedBundleArtifacts = [
+      bundle.content.packagePolicy.listSpotPolicyArtifact,
+      bundle.content.packagePolicy.scarcityPolicyArtifact,
+      bundle.content.packagePolicy.roleCongestionPolicyArtifact,
+      bundle.content.simulation.lowReturnDefinitionArtifact,
+      bundle.content.simulation.eliteOutcomeDefinitionArtifact,
+      bundle.content.simulation.practicalEquivalenceDefinitionArtifact,
+      bundle.content.explanationPolicyArtifact,
+    ];
+    for (const artifact of nestedBundleArtifacts) {
+      await verifyAflTradeArtifactReadback(
+        dependencies.artifactRepository,
+        artifact,
+        input.capturedAt,
+        dependencies.maximumArtifactBytes
+      );
+    }
+    const inputTrace = governedPrivateEvaluationInputTraceSchema.safeParse(
+      await loadJsonArtifact({
+        repository: dependencies.artifactRepository,
+        reference: manifest.inputTraceArtifact,
+        maximumBytes: dependencies.maximumArtifactBytes,
+      })
+    );
+    const calculationInput = aflTradeValuationCalculationInputPackageSchema.safeParse(
+      await loadJsonArtifact({
+        repository: dependencies.artifactRepository,
+        reference: manifest.calculationInputArtifact,
+        maximumBytes: dependencies.maximumArtifactBytes,
+      })
+    );
+    if (!inputTrace.success || !calculationInput.success) {
+      throw new TypeError('Retained calculation trace or package failed exact authentication.');
+    }
+    const trace = inputTrace.data;
+    const calculation = calculationInput.data;
+    const bundleComponents = bundle.content.components.map(
+      ({ role, runId, protocolId, datasetId, gate3DecisionId }) => ({
+        role,
+        runId,
+        protocolId,
+        datasetId,
+        gate3DecisionId,
+      })
+    );
+    const traceComponents = trace.content.components.map(
+      ({ role, runId, protocolId, datasetId, gate3DecisionId }) => ({
+        role,
+        runId,
+        protocolId,
+        datasetId,
+        gate3DecisionId,
+      })
+    );
+    if (
+      bundle.valuationInputBundleId !== prepared.valuationInputBundleId ||
+      bundle.content.scopeKey !== input.selector.valuationScopeKey ||
+      trace.inputTraceId !== manifest.inputTraceId ||
+      !doesAflTradeArtifactRefMatchCanonicalJson(manifest.inputTraceArtifact, trace) ||
+      trace.content.selector.valuationScopeKey !== input.selector.valuationScopeKey ||
+      trace.content.selector.tradeId !== input.selector.tradeId ||
+      trace.content.factualReleaseId !== prepared.factualReleaseId ||
+      trace.content.valuationInputBundleId !== bundle.valuationInputBundleId ||
+      canonicalizeAflTradeJson(traceComponents) !==
+        canonicalizeAflTradeJson(bundleComponents) ||
+      calculation.calculationInputPackageId !== manifest.calculationInputPackageId ||
+      !doesAflTradeArtifactRefMatchCanonicalJson(
+        manifest.calculationInputArtifact,
+        calculation
+      ) ||
+      calculation.content.tradeId !== input.selector.tradeId ||
+      calculation.content.valuationInputBundleId !== bundle.valuationInputBundleId ||
+      calculation.content.authority.kind !== 'authenticated_non_production' ||
+      calculation.content.authority.inputTraceId !== trace.inputTraceId
+    ) {
+      throw new TypeError(
+        'Retained prepared inputs, bundle, trace, and calculation package do not share exact ancestry.'
+      );
+    }
+    return capturePostgresGovernedPrivateEvaluationCurrentAuthority({
+      transaction: input.transaction,
+      selector: input.selector,
+      capturedAt: input.capturedAt,
+      prepared,
+      trace,
+      materializationManifestId: materialization.manifest.manifestId,
+      materializationManifestArtifact: materialization.artifact,
+      valuationInputBundleId: bundle.valuationInputBundleId,
+      valuationInputBundleArtifact: prepared.valuationInputBundleArtifact,
+      preparedInputHeadRevision: current.head.revision,
+      preparedInputSetId: current.head.preparedInputSetId,
+      artifactRepository: dependencies.artifactRepository,
+      maximumArtifactBytes: dependencies.maximumArtifactBytes,
+    });
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationComponentAuthority.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationComponentAuthority.ts
@@ -1,0 +1,202 @@
+import {
+  doAflTradeArtifactRefsExactlyMatch,
+  doesAflTradeArtifactRefMatchBytes,
+  doesAflTradeArtifactRefMatchCanonicalJson,
+} from '../../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
+import { aflTradeGateDecisionRecordSchema } from '../../governance/gateDecisionTypes';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../../outcomes/postgresOutcomeReleaseRepository';
+import { authenticateGovernedNativeComponentExecution } from './governedNativeComponentExecution';
+import type { GovernedPrivateEvaluationInputTrace } from './governedPrivateEvaluationInputTrace';
+import {
+  authenticateGovernedReadyComponentAuthority,
+  GovernedReadyComponentAuthorityError,
+  type GovernedReadyComponentAuthority,
+} from './governedReadyComponentAuthority';
+import {
+  GovernedValuationComponentRunRepositoryError,
+  PostgresGovernedValuationComponentRunRepository,
+} from './postgresGovernedValuationComponentRunRepository';
+
+interface GateHeadRow {
+  readonly revision: number | string;
+}
+
+interface GateDecisionRow {
+  readonly decision_id: string;
+  readonly gate: string;
+  readonly decision_key: string;
+  readonly version: number | string;
+  readonly environment: string;
+  readonly decision_json: unknown;
+  readonly is_current: boolean;
+}
+
+type Unavailable = Readonly<{
+  state: 'unavailable';
+  blockers: readonly Readonly<{
+    code: 'model_not_approved';
+    message: string;
+  }>[];
+}>;
+
+const unavailable = (): Unavailable => ({
+  state: 'unavailable',
+  blockers: [
+    {
+      code: 'model_not_approved',
+      message: 'Current external Gate 3 approval is unavailable for both governed model components.',
+    },
+  ],
+});
+
+function transactionClient(transaction: AflOutcomeSqlTransaction): AflOutcomeSqlClient {
+  return {
+    query: transaction.query.bind(transaction),
+    transaction: async (work) => work(transaction),
+  };
+}
+
+async function loadGate3(input: {
+  transaction: AflOutcomeSqlTransaction;
+  decisionId: string;
+  artifactRepository: AflTradeImmutableArtifactRepository;
+  maximumArtifactBytes: number;
+  artifact: GovernedPrivateEvaluationInputTrace['content']['components'][number]['evidence']['gate3Decision'];
+}) {
+  const result = await input.transaction.query<GateDecisionRow>(
+    `SELECT decision.decision_id,decision.gate,decision.decision_key,decision.version,
+       decision.environment::text AS environment,decision.decision_json,
+       NOT EXISTS (
+         SELECT 1 FROM outcome_gate_decision successor
+          WHERE successor.gate=decision.gate
+            AND successor.environment=decision.environment
+            AND successor.decision_key=decision.decision_key
+            AND successor.version>decision.version
+       ) AS is_current
+       FROM outcome_gate_decision decision WHERE decision.decision_id=$1`,
+    [input.decisionId]
+  );
+  if (result.rows.length === 0) return null;
+  const row = result.rows[0];
+  if (result.rows.length !== 1 || row === undefined) {
+    throw new TypeError('Gate 3 decision identity is ambiguous.');
+  }
+  const parsed = aflTradeGateDecisionRecordSchema.safeParse(row.decision_json);
+  if (
+    !parsed.success ||
+    parsed.data.decisionId !== row.decision_id ||
+    parsed.data.content.gate !== row.gate ||
+    parsed.data.content.decisionKey !== row.decision_key ||
+    parsed.data.content.version !== Number(row.version) ||
+    parsed.data.content.environment !== row.environment
+  ) {
+    throw new TypeError('Stored Gate 3 decision failed exact SQL authentication.');
+  }
+  const loaded = await input.artifactRepository.loadExact(
+    input.artifact,
+    input.maximumArtifactBytes
+  );
+  if (
+    loaded === null ||
+    !doAflTradeArtifactRefsExactlyMatch(loaded.reference, input.artifact) ||
+    !doesAflTradeArtifactRefMatchBytes(loaded.reference, loaded.bytes)
+  ) {
+    throw new TypeError('Gate 3 retained decision bytes failed exact authentication.');
+  }
+  let physical: unknown;
+  try {
+    physical = JSON.parse(new TextDecoder().decode(loaded.bytes));
+  } catch {
+    throw new TypeError('Gate 3 retained decision bytes are not valid JSON.');
+  }
+  if (
+    canonicalizeAflTradeJson(physical) !== canonicalizeAflTradeJson(parsed.data) ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(input.artifact, parsed.data)
+  ) {
+    throw new TypeError('Gate 3 SQL and retained object evidence disagree.');
+  }
+  return { decision: parsed.data, artifact: input.artifact, isCurrent: row.is_current };
+}
+
+export async function loadCurrentGovernedComponentAuthority(input: {
+  transaction: AflOutcomeSqlTransaction;
+  trace: GovernedPrivateEvaluationInputTrace;
+  capturedAt: string;
+  artifactRepository: AflTradeImmutableArtifactRepository;
+  maximumArtifactBytes: number;
+}): Promise<
+  | Unavailable
+  | Readonly<{
+      state: 'ready';
+      gateLedgerRevision: number;
+      components: readonly GovernedReadyComponentAuthority[];
+    }>
+> {
+  const head = await input.transaction.query<GateHeadRow>(
+    `SELECT revision FROM outcome_gate_ledger_head WHERE singleton_id=1`
+  );
+  const gateLedgerRevision = Number(head.rows[0]?.revision);
+  if (
+    head.rows.length !== 1 ||
+    !Number.isSafeInteger(gateLedgerRevision) ||
+    gateLedgerRevision < 0
+  ) {
+    throw new TypeError('Gate ledger head is unavailable or malformed.');
+  }
+  if (gateLedgerRevision === 0) return unavailable();
+  const repository = new PostgresGovernedValuationComponentRunRepository({
+    client: transactionClient(input.transaction),
+    artifactRepository: input.artifactRepository,
+    maximumArtifactBytes: input.maximumArtifactBytes,
+  });
+  const components: GovernedReadyComponentAuthority[] = [];
+  for (const traceComponent of input.trace.content.components) {
+    let run;
+    try {
+      run = await repository.loadExact(traceComponent.runId);
+      await authenticateGovernedNativeComponentExecution({
+        manifest: run.manifest,
+        artifactRepository: input.artifactRepository,
+        maximumArtifactBytes: input.maximumArtifactBytes,
+      });
+    } catch (error) {
+      if (
+        error instanceof GovernedValuationComponentRunRepositoryError &&
+        error.code === 'NOT_FOUND'
+      ) {
+        return unavailable();
+      }
+      throw error;
+    }
+    const gate3 = await loadGate3({
+      transaction: input.transaction,
+      decisionId: traceComponent.gate3DecisionId,
+      artifactRepository: input.artifactRepository,
+      maximumArtifactBytes: input.maximumArtifactBytes,
+      artifact: traceComponent.evidence.gate3Decision,
+    });
+    if (gate3 === null) return unavailable();
+    try {
+      components.push(
+        authenticateGovernedReadyComponentAuthority({
+          traceComponent,
+          run,
+          gate3Decision: gate3.decision,
+          gate3DecisionArtifact: gate3.artifact,
+          gate3IsCurrent: gate3.isCurrent,
+          gateLedgerRevision,
+          capturedAt: input.capturedAt,
+        })
+      );
+    } catch (error) {
+      if (error instanceof GovernedReadyComponentAuthorityError) return unavailable();
+      throw error;
+    }
+  }
+  return { state: 'ready', gateLedgerRevision, components };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationCurrentAuthority.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationCurrentAuthority.ts
@@ -1,0 +1,255 @@
+import {
+  doAflTradeArtifactRefsExactlyMatch,
+  type AflTradeArtifactRef,
+} from '../../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
+import {
+  authenticateAflDraftTradeOutcomeReleaseRegistry,
+  type AflDraftTradeOutcomeReleaseRegistry,
+} from '../../outcomes/outcomeReleaseState';
+import type { AflOutcomeSqlTransaction } from '../../outcomes/postgresOutcomeReleaseRepository';
+import {
+  parseAflTradePrivateValuationEvaluationDecision,
+  type AflTradePrivateValuationEvaluationDecision,
+} from '../privateValuationEvaluationDecision';
+import type { GovernedPrivateEvaluationInputTrace } from './governedPrivateEvaluationInputTrace';
+import type { GovernedPrivateEvaluationCapturedCalculationAuthority } from './postgresGovernedPrivateEvaluationInspectionRepository';
+import { loadCurrentGovernedComponentAuthority } from './postgresGovernedPrivateEvaluationComponentAuthority';
+
+export { loadCurrentGovernedComponentAuthority } from './postgresGovernedPrivateEvaluationComponentAuthority';
+
+interface FactualHeadRow {
+  readonly revision: number | string;
+  readonly last_event_id: string | null;
+  readonly registry_json: unknown;
+  readonly active_release_id: string | null;
+  readonly active_revision: number | string | null;
+  readonly activated_at: Date | string | null;
+}
+
+interface PrivateDecisionRow {
+  readonly head_revision: number | string;
+  readonly head_decision_id: string;
+  readonly head_status: 'authorized' | 'withdrawn';
+  readonly decision_id: string;
+  readonly valuation_scope_key: string;
+  readonly factual_release_scope_key: string;
+  readonly factual_release_id: string;
+  readonly decision_status: 'authorized' | 'withdrawn';
+  readonly decision_revision: number | string;
+  readonly decision_json: unknown;
+}
+
+type CurrentAuthorityInput = Readonly<{
+  transaction: AflOutcomeSqlTransaction;
+  selector: { valuationScopeKey: string; tradeId: string };
+  capturedAt: string;
+  prepared: {
+    factualReleaseScopeKey: string;
+    factualReleaseId: string;
+    factualReleaseArtifact: AflTradeArtifactRef;
+    releaseMembershipArtifact: AflTradeArtifactRef;
+    sourceQualificationEvidenceRefs: readonly AflTradeArtifactRef[];
+  };
+  trace: GovernedPrivateEvaluationInputTrace;
+  materializationManifestId: string;
+  materializationManifestArtifact: AflTradeArtifactRef;
+  valuationInputBundleId: string;
+  valuationInputBundleArtifact: AflTradeArtifactRef;
+  preparedInputHeadRevision: number;
+  preparedInputSetId: string;
+  artifactRepository: AflTradeImmutableArtifactRepository;
+  maximumArtifactBytes: number;
+}>;
+
+function instant(value: Date | string): string {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(parsed.getTime())) {
+    throw new TypeError('Current factual authority contains malformed database time.');
+  }
+  return parsed.toISOString();
+}
+
+function authenticateRegistry(value: unknown): AflDraftTradeOutcomeReleaseRegistry {
+  return authenticateAflDraftTradeOutcomeReleaseRegistry(
+    structuredClone(value) as AflDraftTradeOutcomeReleaseRegistry
+  );
+}
+
+type PreparedFactualAuthority = CurrentAuthorityInput['prepared'] & {
+  readonly valuationScopeKey: string;
+};
+
+export async function loadCurrentPrivateValuationDecision(
+  transaction: AflOutcomeSqlTransaction,
+  prepared: PreparedFactualAuthority
+): Promise<
+  | { readonly state: 'ready'; readonly decision: AflTradePrivateValuationEvaluationDecision }
+  | Extract<GovernedPrivateEvaluationCapturedCalculationAuthority, { state: 'unavailable' }>
+> {
+  const result = await transaction.query<PrivateDecisionRow>(
+    `SELECT head.revision AS head_revision,head.decision_id AS head_decision_id,
+       head.status AS head_status,decision.decision_id,decision.valuation_scope_key,
+       decision.factual_release_scope_key,decision.factual_release_id,
+       decision.status AS decision_status,decision.revision AS decision_revision,
+       decision.decision_json
+       FROM outcome_private_valuation_evaluation_head head
+       JOIN outcome_private_valuation_evaluation_decision decision
+         ON decision.decision_id=head.decision_id
+      WHERE head.valuation_scope_key=$1 AND head.factual_release_id=$2`,
+    [prepared.valuationScopeKey, prepared.factualReleaseId]
+  );
+  if (result.rows.length === 0) {
+    return {
+      state: 'unavailable',
+      blockers: [
+        {
+          code: 'source_blocked',
+          message: 'No current authorized private derived-calculation decision covers this release.',
+        },
+      ],
+    };
+  }
+  const row = result.rows[0];
+  if (result.rows.length !== 1 || row === undefined) {
+    throw new TypeError('The private valuation decision head is ambiguous.');
+  }
+  const decision = parseAflTradePrivateValuationEvaluationDecision(row.decision_json);
+  const headRevision = Number(row.head_revision);
+  const decisionRevision = Number(row.decision_revision);
+  if (
+    decision.decisionId !== row.decision_id ||
+    row.head_decision_id !== row.decision_id ||
+    headRevision !== decisionRevision ||
+    decision.content.revision !== decisionRevision ||
+    decision.content.valuationScopeKey !== row.valuation_scope_key ||
+    decision.content.factualReleaseScopeKey !== row.factual_release_scope_key ||
+    decision.content.factualReleaseId !== row.factual_release_id ||
+    decision.content.status !== row.decision_status ||
+    row.head_status !== row.decision_status ||
+    row.valuation_scope_key !== prepared.valuationScopeKey ||
+    row.factual_release_scope_key !== prepared.factualReleaseScopeKey ||
+    row.factual_release_id !== prepared.factualReleaseId ||
+    !doAflTradeArtifactRefsExactlyMatch(
+      decision.content.factualReleaseArtifact,
+      prepared.factualReleaseArtifact
+    ) ||
+    !doAflTradeArtifactRefsExactlyMatch(
+      decision.content.releaseMembershipArtifact,
+      prepared.releaseMembershipArtifact
+    ) ||
+    canonicalizeAflTradeJson(decision.content.sourceRightsEvidenceRefs) !==
+      canonicalizeAflTradeJson(prepared.sourceQualificationEvidenceRefs)
+  ) {
+    throw new TypeError('The private valuation head disagrees with exact prepared ancestry.');
+  }
+  if (decision.content.status !== 'authorized') {
+    return {
+      state: 'unavailable',
+      blockers: [
+        {
+          code: 'source_blocked',
+          message: 'No current authorized private derived-calculation decision covers this release.',
+        },
+      ],
+    };
+  }
+  return { state: 'ready', decision };
+}
+
+export async function capturePostgresGovernedPrivateEvaluationCurrentAuthority(
+  input: CurrentAuthorityInput
+): Promise<GovernedPrivateEvaluationCapturedCalculationAuthority> {
+  const result = await input.transaction.query<FactualHeadRow>(
+    `SELECT head.revision,head.last_event_id,head.registry_json,
+       active.release_id AS active_release_id,active.revision AS active_revision,
+       active.activated_at
+       FROM outcome_registry_head head
+       LEFT JOIN outcome_active_release active ON active.scope_key=$1
+      WHERE head.singleton_id=1`,
+    [input.prepared.factualReleaseScopeKey]
+  );
+  const row = result.rows[0];
+  if (result.rows.length !== 1 || row === undefined) {
+    throw new TypeError('The factual registry head is unavailable or ambiguous.');
+  }
+  const registry = authenticateRegistry(row.registry_json);
+  const revision = Number(row.revision);
+  if (
+    !Number.isSafeInteger(revision) ||
+    revision < 0 ||
+    registry.revision !== revision ||
+    (registry.events.at(-1)?.eventId ?? null) !== row.last_event_id
+  ) {
+    throw new TypeError('The factual registry head disagrees with its authenticated bytes.');
+  }
+  const pointer = registry.activeByScope[input.prepared.factualReleaseScopeKey];
+  if (pointer === undefined) {
+    if (
+      row.active_release_id !== null ||
+      row.active_revision !== null ||
+      row.activated_at !== null
+    ) {
+      throw new TypeError('The active factual projection disagrees with the registry head.');
+    }
+    return {
+      state: 'unavailable',
+      blockers: [
+        {
+          code: 'source_blocked',
+          message: 'The exact prepared factual release is not the current active release.',
+        },
+      ],
+    };
+  }
+  const activeRevision = Number(row.active_revision);
+  if (
+    row.active_release_id !== pointer.releaseId ||
+    activeRevision !== pointer.revision ||
+    row.activated_at === null ||
+    instant(row.activated_at) !== pointer.activatedAt
+  ) {
+    throw new TypeError('The active factual projection disagrees with the registry head.');
+  }
+  if (pointer.releaseId !== input.prepared.factualReleaseId) {
+    return {
+      state: 'unavailable',
+      blockers: [
+        {
+          code: 'source_blocked',
+          message: 'The exact prepared factual release is not the current active release.',
+        },
+      ],
+    };
+  }
+  const privateAuthority = await loadCurrentPrivateValuationDecision(input.transaction, {
+    ...input.prepared,
+    valuationScopeKey: input.selector.valuationScopeKey,
+  });
+  if (privateAuthority.state === 'unavailable') return privateAuthority;
+  const componentAuthority = await loadCurrentGovernedComponentAuthority({
+    transaction: input.transaction,
+    trace: input.trace,
+    capturedAt: input.capturedAt,
+    artifactRepository: input.artifactRepository,
+    maximumArtifactBytes: input.maximumArtifactBytes,
+  });
+  if (componentAuthority.state === 'unavailable') return componentAuthority;
+  return {
+    state: 'ready',
+    preparedInputHeadRevision: input.preparedInputHeadRevision,
+    preparedInputSetId: input.preparedInputSetId,
+    factualRegistryRevision: revision,
+    factualReleaseId: input.prepared.factualReleaseId,
+    activeFactualReleaseRevision: pointer.revision,
+    privateValuationDecisionId: privateAuthority.decision.decisionId,
+    privateValuationDecisionRevision: privateAuthority.decision.content.revision,
+    materializationManifestId: input.materializationManifestId,
+    materializationManifestArtifact: input.materializationManifestArtifact,
+    valuationInputBundleId: input.valuationInputBundleId,
+    valuationInputBundleArtifact: input.valuationInputBundleArtifact,
+    gateLedgerRevision: componentAuthority.gateLedgerRevision,
+    components: componentAuthority.components,
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationExecutionService.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationExecutionService.ts
@@ -1,0 +1,394 @@
+import {
+  createAflTradeCanonicalJsonArtifactRef,
+  type AflTradeArtifactRef,
+} from '../../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import type { AflOutcomeSqlClient } from '../../outcomes/postgresOutcomeReleaseRepository';
+import { authenticateGovernedPrivateEvaluationAuthorityInspection } from './governedPrivateEvaluationAuthoritySnapshot';
+import {
+  createGovernedPrivateEvaluationTransitionIntent,
+  createGovernedPrivateEvaluationTransitionReceipt,
+  governedPrivateEvaluationTransitionReceiptSchema,
+  type GovernedPrivateEvaluationTransitionIntent,
+  type GovernedPrivateEvaluationTransitionReceipt,
+} from './governedPrivateEvaluationLifecycle';
+import {
+  governedPrivateEvaluationExecuteRequestSchema,
+  governedPrivateEvaluationExecuteResultSchema,
+  type GovernedPrivateEvaluationExecuteRequest,
+} from './governedPrivateEvaluationWorkspaceContracts';
+
+interface InspectionRow {
+  readonly receipt_json: unknown;
+  readonly snapshot_json: unknown;
+}
+
+interface ExistingRow {
+  readonly receipt_json: unknown;
+}
+
+interface TrustedTimeRow {
+  readonly trusted_at: Date | string;
+}
+
+interface WithdrawalRow {
+  readonly from_generation_id: string | null;
+}
+
+interface OperatorAuthorityRow {
+  readonly authority_evidence_id: string;
+}
+
+interface StagingDependency {
+  stage(input: {
+    readonly intent: GovernedPrivateEvaluationTransitionIntent;
+    readonly intentArtifact: AflTradeArtifactRef;
+  }): Promise<unknown>;
+  retainArtifact(input: {
+    readonly reference: AflTradeArtifactRef;
+    readonly bytes: Uint8Array;
+  }): Promise<AflTradeArtifactRef>;
+}
+
+interface LifecycleDependency {
+  commit(input: {
+    readonly receipt: GovernedPrivateEvaluationTransitionReceipt;
+    readonly receiptArtifact: AflTradeArtifactRef;
+  }): Promise<
+    | {
+        readonly state: 'committed' | 'replayed';
+        readonly head: GovernedPrivateEvaluationTransitionReceipt['content']['toHead'];
+        readonly transitionId: string;
+      }
+    | {
+        readonly state: 'conflict';
+        readonly expectedHead: GovernedPrivateEvaluationTransitionReceipt['content']['fromHead'];
+        readonly actualHead: GovernedPrivateEvaluationTransitionReceipt['content']['fromHead'];
+      }
+  >;
+}
+
+interface ReconstructionDependency {
+  verify(input: {
+    readonly selector: { readonly valuationScopeKey: string; readonly tradeId: string };
+    readonly inspectionId: string;
+    readonly operationId: string;
+    readonly generationId: string;
+  }): Promise<{ readonly generationId: string; readonly exactMatch: true }>;
+}
+
+function same(left: unknown, right: unknown): boolean {
+  return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+}
+
+function parseTime(value: Date | string): string {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(parsed.getTime())) {
+    throw new TypeError('Private evaluation execution requires trusted PostgreSQL time.');
+  }
+  return parsed.toISOString();
+}
+
+function transitionResult(
+  receipt: GovernedPrivateEvaluationTransitionReceipt,
+  operationId: string
+) {
+  const base = {
+    selector: receipt.content.selector,
+    inspectionId: receipt.content.intent.content.inspectionId,
+    operationId,
+  };
+  if (receipt.content.action.kind === 'withdraw') {
+    return governedPrivateEvaluationExecuteResultSchema.parse({
+      state: 'withdrawn',
+      ...base,
+      head: receipt.content.toHead,
+    });
+  }
+  const state =
+    receipt.content.action.kind === 'rollback'
+      ? 'rolled_back'
+      : receipt.content.action.kind === 'recover'
+        ? 'recovered'
+        : 'activated';
+  return governedPrivateEvaluationExecuteResultSchema.parse({
+    state,
+    ...base,
+    generationId: receipt.content.toHead.generationId,
+    head: receipt.content.toHead,
+  });
+}
+
+async function resolveRecoveryGeneration(input: {
+  readonly client: AflOutcomeSqlClient;
+  readonly selector: { readonly valuationScopeKey: string; readonly tradeId: string };
+  readonly withdrawnRevision: number;
+  readonly withdrawalTransitionId: string | null;
+}): Promise<string | null> {
+  if (input.withdrawalTransitionId === null) return null;
+  const result = await input.client.query<WithdrawalRow>(
+    `SELECT from_generation_id
+       FROM outcome_private_evaluation_transition_receipt
+      WHERE transition_id=$1 AND valuation_scope_key=$2 AND trade_id=$3
+        AND action='withdraw' AND to_status='withdrawn' AND to_revision=$4`,
+    [
+      input.withdrawalTransitionId,
+      input.selector.valuationScopeKey,
+      input.selector.tradeId,
+      input.withdrawnRevision,
+    ]
+  );
+  if (result.rows.length !== 1) return null;
+  return result.rows[0]?.from_generation_id ?? null;
+}
+
+async function requireCurrentOperatorAuthority(input: {
+  readonly client: AflOutcomeSqlClient;
+  readonly principalId: string;
+  readonly selector: { readonly valuationScopeKey: string; readonly tradeId: string };
+  readonly authorizedAt: string;
+}): Promise<void> {
+  const result = await input.client.query<OperatorAuthorityRow>(
+    `SELECT authority.authority_evidence_id
+       FROM outcome_operational_principal_authority authority
+       JOIN outcome_governed_evidence_reference evidence
+         ON evidence.reference_id=authority.authority_evidence_id
+       JOIN outcome_review_decision approval
+         ON approval.decision_id=evidence.approval_decision_id
+      WHERE authority.principal_ref=$1
+        AND authority.role='afl_trade_private_evaluation_operator'
+        AND authority.scope_key=$2
+        AND authority.provider='statly_modeling'
+        AND authority.capability_id='manage_private_trade_evaluation'
+        AND authority.competition='AFLM'
+        AND authority.valid_from<=$3::timestamptz
+        AND (authority.valid_through IS NULL OR authority.valid_through>$3::timestamptz)
+        AND evidence.environment='test_fixture'::"OutcomeEnvironment"
+        AND evidence.status='approved'::"OutcomeRecordStatus"
+        AND approval.decision='approved'
+        AND NOT EXISTS (SELECT 1 FROM outcome_review_decision successor
+                         WHERE successor.supersedes_decision_id=approval.decision_id)
+      FOR SHARE OF authority,evidence,approval`,
+    [input.principalId, input.selector.valuationScopeKey, input.authorizedAt]
+  );
+  if (
+    result.rows.length !== 1 ||
+    !result.rows[0]?.authority_evidence_id.startsWith('reviewer-authority-evidence:')
+  ) {
+    throw new TypeError(
+      'Private evaluation execution requires current governed operator authority for the exact scope.'
+    );
+  }
+}
+
+export function createPostgresGovernedPrivateEvaluationExecutionService(dependencies: {
+  readonly client: AflOutcomeSqlClient;
+  readonly principalId: string;
+  readonly staging: StagingDependency;
+  readonly lifecycle: LifecycleDependency;
+  readonly reconstruction: ReconstructionDependency;
+}) {
+  if (dependencies.principalId.trim() === '' || dependencies.principalId.length > 400) {
+    throw new TypeError('Private evaluation execution requires an authenticated principal.');
+  }
+  return {
+    async execute(unparsedRequest: GovernedPrivateEvaluationExecuteRequest) {
+      const request = governedPrivateEvaluationExecuteRequestSchema.parse(unparsedRequest);
+      const existing = await dependencies.client.query<ExistingRow>(
+        `SELECT receipt_json
+           FROM outcome_private_evaluation_transition_receipt
+          WHERE operation_id=$1`,
+        [request.operationId]
+      );
+      if (existing.rows.length > 1) {
+        throw new TypeError('Private evaluation operation identity is not unique.');
+      }
+      if (existing.rows[0] !== undefined) {
+        const receipt = governedPrivateEvaluationTransitionReceiptSchema.parse(
+          existing.rows[0].receipt_json
+        );
+        const intent = receipt.content.intent.content;
+        if (
+          intent.inspectionId !== request.inspectionId ||
+          intent.operationId !== request.operationId ||
+          intent.review.principalId !== dependencies.principalId ||
+          intent.review.rationale !== request.review.rationale ||
+          !same(intent.action, request.action)
+        ) {
+          throw new TypeError('Private evaluation operation replay conflicts with its request.');
+        }
+        return transitionResult(receipt, request.operationId);
+      }
+      const inspectionResult = await dependencies.client.query<InspectionRow>(
+        `SELECT ir.receipt_json,snapshot.snapshot_json
+           FROM outcome_private_evaluation_inspection_receipt ir
+           JOIN outcome_private_evaluation_authority_snapshot snapshot
+             ON snapshot.snapshot_id=ir.snapshot_id
+            AND snapshot.valuation_scope_key=ir.valuation_scope_key
+            AND snapshot.trade_id=ir.trade_id
+          WHERE ir.inspection_id=$1`,
+        [request.inspectionId]
+      );
+      if (inspectionResult.rows.length !== 1) {
+        throw new TypeError('Private evaluation execution requires one retained inspection.');
+      }
+      const row = inspectionResult.rows[0]!;
+      const retained = authenticateGovernedPrivateEvaluationAuthorityInspection({
+        snapshot: row.snapshot_json,
+        inspection: row.receipt_json,
+      });
+      const trusted = await dependencies.client.query<TrustedTimeRow>(
+        `SELECT date_trunc('milliseconds',transaction_timestamp()) AS trusted_at`
+      );
+      if (trusted.rows.length !== 1 || trusted.rows[0] === undefined) {
+        throw new TypeError('Private evaluation execution could not establish trusted time.');
+      }
+      const requestedAt = parseTime(trusted.rows[0].trusted_at);
+      if (Date.parse(requestedAt) > Date.parse(retained.result.validThrough)) {
+        return governedPrivateEvaluationExecuteResultSchema.parse({
+          state: 'invalid_transition',
+          selector: retained.result.selector,
+          inspectionId: request.inspectionId,
+          operationId: request.operationId,
+          message: 'The retained inspection has expired; inspect again.',
+        });
+      }
+      await requireCurrentOperatorAuthority({
+        client: dependencies.client,
+        principalId: dependencies.principalId,
+        selector: retained.result.selector,
+        authorizedAt: requestedAt,
+      });
+      const base = {
+        selector: retained.result.selector,
+        inspectionId: request.inspectionId,
+        operationId: request.operationId,
+      };
+      if (request.action.kind === 'verify_reconstruction') {
+        const verification = await dependencies.reconstruction.verify({
+          selector: retained.result.selector,
+          inspectionId: request.inspectionId,
+          operationId: request.operationId,
+          generationId: request.action.generationId,
+        });
+        return governedPrivateEvaluationExecuteResultSchema.parse({
+          state: 'reconstruction_verified',
+          ...base,
+          generationId: verification.generationId,
+          exactMatch: verification.exactMatch,
+        });
+      }
+      if (request.action.kind === 'construct_and_activate') {
+        return governedPrivateEvaluationExecuteResultSchema.parse({
+          state: 'unavailable',
+          ...base,
+          blockers: retained.result.blockers,
+        });
+      }
+      if (
+        (request.action.kind === 'rollback' || request.action.kind === 'recover') &&
+        retained.result.state !== 'ready'
+      ) {
+        return governedPrivateEvaluationExecuteResultSchema.parse({
+          state: 'invalid_transition',
+          ...base,
+          message: 'Rollback and recovery require exact ready calculation authority.',
+        });
+      }
+      if (
+        request.action.kind === 'withdraw' &&
+        retained.result.head.status !== 'active'
+      ) {
+        return governedPrivateEvaluationExecuteResultSchema.parse({
+          state: 'invalid_transition',
+          ...base,
+          message: 'Withdrawal requires one exact active generation.',
+        });
+      }
+      if (
+        request.action.kind === 'rollback' &&
+        (retained.result.head.status !== 'active' ||
+          retained.result.head.generationId === request.action.targetGenerationId)
+      ) {
+        return governedPrivateEvaluationExecuteResultSchema.parse({
+          state: 'invalid_transition',
+          ...base,
+          message: 'Rollback requires a different retained generation from one exact active head.',
+        });
+      }
+      if (request.action.kind === 'recover' && retained.result.head.status !== 'withdrawn') {
+        return governedPrivateEvaluationExecuteResultSchema.parse({
+          state: 'invalid_transition',
+          ...base,
+          message: 'Recovery requires one exact withdrawn head.',
+        });
+      }
+      const targetGenerationId =
+        request.action.kind === 'rollback'
+          ? request.action.targetGenerationId
+          : request.action.kind === 'recover'
+            ? await resolveRecoveryGeneration({
+                client: dependencies.client,
+                selector: retained.result.selector,
+                withdrawnRevision: retained.result.head.revision,
+                withdrawalTransitionId: retained.inspection.content.lastTransitionId,
+              })
+            : null;
+      if (
+        (request.action.kind === 'rollback' || request.action.kind === 'recover') &&
+        targetGenerationId === null
+      ) {
+        return governedPrivateEvaluationExecuteResultSchema.parse({
+          state: 'invalid_transition',
+          ...base,
+          message: 'The exact lifecycle target generation could not be authenticated.',
+        });
+      }
+      if (targetGenerationId !== null) {
+        await dependencies.reconstruction.verify({
+          selector: retained.result.selector,
+          inspectionId: request.inspectionId,
+          operationId: request.operationId,
+          generationId: targetGenerationId,
+        });
+      }
+      const intent = createGovernedPrivateEvaluationTransitionIntent({
+        selector: retained.result.selector,
+        inspectionId: request.inspectionId,
+        authoritySnapshotId:
+          request.action.kind === 'withdraw' ? null : retained.snapshot.snapshotId,
+        operationId: request.operationId,
+        action: request.action,
+        expectedHead: retained.result.head,
+        review: {
+          principalId: dependencies.principalId,
+          rationale: request.review.rationale,
+        },
+        requestedAt,
+        expiresAt: retained.result.validThrough,
+      });
+      const intentArtifact = createAflTradeCanonicalJsonArtifactRef(intent, requestedAt);
+      await dependencies.staging.stage({ intent, intentArtifact });
+      const receipt = createGovernedPrivateEvaluationTransitionReceipt({
+        intent,
+        previousTransitionId: retained.inspection.content.lastTransitionId,
+        toGenerationId: targetGenerationId,
+        transitionedAt: requestedAt,
+      });
+      const receiptArtifact = createAflTradeCanonicalJsonArtifactRef(receipt, requestedAt);
+      await dependencies.staging.retainArtifact({
+        reference: receiptArtifact,
+        bytes: new TextEncoder().encode(canonicalizeAflTradeJson(receipt)),
+      });
+      const committed = await dependencies.lifecycle.commit({ receipt, receiptArtifact });
+      if (committed.state === 'conflict') {
+        return governedPrivateEvaluationExecuteResultSchema.parse({
+          state: 'conflict',
+          ...base,
+          message: 'The lifecycle head changed after inspection; inspect again.',
+        });
+      }
+      return transitionResult(receipt, request.operationId);
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationExecutionService.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationExecutionService.ts
@@ -8,6 +8,7 @@ import { authenticateGovernedPrivateEvaluationAuthorityInspection } from './gove
 import {
   createGovernedPrivateEvaluationTransitionIntent,
   createGovernedPrivateEvaluationTransitionReceipt,
+  governedPrivateEvaluationTransitionIntentSchema,
   governedPrivateEvaluationTransitionReceiptSchema,
   type GovernedPrivateEvaluationTransitionIntent,
   type GovernedPrivateEvaluationTransitionReceipt,
@@ -25,6 +26,10 @@ interface InspectionRow {
 
 interface ExistingRow {
   readonly receipt_json: unknown;
+}
+
+interface ExistingIntentRow {
+  readonly intent_json: unknown;
 }
 
 interface TrustedTimeRow {
@@ -79,6 +84,20 @@ interface ReconstructionDependency {
 
 function same(left: unknown, right: unknown): boolean {
   return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+}
+
+function doesIntentMatchRequest(
+  intent: GovernedPrivateEvaluationTransitionIntent['content'],
+  request: GovernedPrivateEvaluationExecuteRequest,
+  principalId: string
+): boolean {
+  return (
+    intent.inspectionId === request.inspectionId &&
+    intent.operationId === request.operationId &&
+    intent.review.principalId === principalId &&
+    intent.review.rationale === request.review.rationale &&
+    same(intent.action, request.action)
+  );
 }
 
 function parseTime(value: Date | string): string {
@@ -208,16 +227,31 @@ export function createPostgresGovernedPrivateEvaluationExecutionService(dependen
           existing.rows[0].receipt_json
         );
         const intent = receipt.content.intent.content;
-        if (
-          intent.inspectionId !== request.inspectionId ||
-          intent.operationId !== request.operationId ||
-          intent.review.principalId !== dependencies.principalId ||
-          intent.review.rationale !== request.review.rationale ||
-          !same(intent.action, request.action)
-        ) {
+        if (!doesIntentMatchRequest(intent, request, dependencies.principalId)) {
           throw new TypeError('Private evaluation operation replay conflicts with its request.');
         }
         return transitionResult(receipt, request.operationId);
+      }
+      const stagedResult = await dependencies.client.query<ExistingIntentRow>(
+        `SELECT intent_json
+           FROM outcome_private_evaluation_transition_intent
+          WHERE operation_id=$1`,
+        [request.operationId]
+      );
+      if (stagedResult.rows.length > 1) {
+        throw new TypeError('Private evaluation staged operation identity is not unique.');
+      }
+      const stagedIntent =
+        stagedResult.rows[0] === undefined
+          ? null
+          : governedPrivateEvaluationTransitionIntentSchema.parse(
+              stagedResult.rows[0].intent_json
+            );
+      if (
+        stagedIntent !== null &&
+        !doesIntentMatchRequest(stagedIntent.content, request, dependencies.principalId)
+      ) {
+        throw new TypeError('Private evaluation staged operation conflicts with its request.');
       }
       const inspectionResult = await dependencies.client.query<InspectionRow>(
         `SELECT ir.receipt_json,snapshot.snapshot_json
@@ -243,8 +277,8 @@ export function createPostgresGovernedPrivateEvaluationExecutionService(dependen
       if (trusted.rows.length !== 1 || trusted.rows[0] === undefined) {
         throw new TypeError('Private evaluation execution could not establish trusted time.');
       }
-      const requestedAt = parseTime(trusted.rows[0].trusted_at);
-      if (Date.parse(requestedAt) > Date.parse(retained.result.validThrough)) {
+      const trustedAt = parseTime(trusted.rows[0].trusted_at);
+      if (Date.parse(trustedAt) > Date.parse(retained.result.validThrough)) {
         return governedPrivateEvaluationExecuteResultSchema.parse({
           state: 'invalid_transition',
           selector: retained.result.selector,
@@ -257,7 +291,7 @@ export function createPostgresGovernedPrivateEvaluationExecutionService(dependen
         client: dependencies.client,
         principalId: dependencies.principalId,
         selector: retained.result.selector,
-        authorizedAt: requestedAt,
+        authorizedAt: trustedAt,
       });
       const base = {
         selector: retained.result.selector,
@@ -352,30 +386,49 @@ export function createPostgresGovernedPrivateEvaluationExecutionService(dependen
           generationId: targetGenerationId,
         });
       }
-      const intent = createGovernedPrivateEvaluationTransitionIntent({
-        selector: retained.result.selector,
-        inspectionId: request.inspectionId,
-        authoritySnapshotId:
-          request.action.kind === 'withdraw' ? null : retained.snapshot.snapshotId,
-        operationId: request.operationId,
-        action: request.action,
-        expectedHead: retained.result.head,
-        review: {
-          principalId: dependencies.principalId,
-          rationale: request.review.rationale,
-        },
-        requestedAt,
-        expiresAt: retained.result.validThrough,
-      });
-      const intentArtifact = createAflTradeCanonicalJsonArtifactRef(intent, requestedAt);
-      await dependencies.staging.stage({ intent, intentArtifact });
+      const authoritySnapshotId =
+        request.action.kind === 'withdraw' ? null : retained.snapshot.snapshotId;
+      if (
+        stagedIntent !== null &&
+        (!same(stagedIntent.content.selector, retained.result.selector) ||
+          stagedIntent.content.authoritySnapshotId !== authoritySnapshotId ||
+          !same(stagedIntent.content.expectedHead, retained.result.head) ||
+          stagedIntent.content.expiresAt !== retained.result.validThrough)
+      ) {
+        throw new TypeError(
+          'Private evaluation staged operation conflicts with its authenticated inspection.'
+        );
+      }
+      const intent =
+        stagedIntent ??
+        createGovernedPrivateEvaluationTransitionIntent({
+          selector: retained.result.selector,
+          inspectionId: request.inspectionId,
+          authoritySnapshotId,
+          operationId: request.operationId,
+          action: request.action,
+          expectedHead: retained.result.head,
+          review: {
+            principalId: dependencies.principalId,
+            rationale: request.review.rationale,
+          },
+          requestedAt: trustedAt,
+          expiresAt: retained.result.validThrough,
+        });
+      if (stagedIntent === null) {
+        const intentArtifact = createAflTradeCanonicalJsonArtifactRef(intent, trustedAt);
+        await dependencies.staging.stage({ intent, intentArtifact });
+      }
       const receipt = createGovernedPrivateEvaluationTransitionReceipt({
         intent,
         previousTransitionId: retained.inspection.content.lastTransitionId,
         toGenerationId: targetGenerationId,
-        transitionedAt: requestedAt,
+        transitionedAt: intent.content.requestedAt,
       });
-      const receiptArtifact = createAflTradeCanonicalJsonArtifactRef(receipt, requestedAt);
+      const receiptArtifact = createAflTradeCanonicalJsonArtifactRef(
+        receipt,
+        intent.content.requestedAt
+      );
       await dependencies.staging.retainArtifact({
         reference: receiptArtifact,
         bytes: new TextEncoder().encode(canonicalizeAflTradeJson(receipt)),

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationInspectionRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationInspectionRepository.ts
@@ -1,0 +1,291 @@
+import {
+  createAflTradeCanonicalJsonArtifactRef,
+  doesAflTradeArtifactRefMatchCanonicalJson,
+  type AflTradeArtifactRef,
+} from '../../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../../outcomes/postgresOutcomeReleaseRepository';
+import {
+  createReadyGovernedPrivateEvaluationAuthorityInspectionV3,
+  createUnavailableNonProductionGovernedPrivateEvaluationAuthorityInspection,
+} from './governedPrivateEvaluationAuthoritySnapshot';
+import type { GovernedReadyComponentAuthority } from './governedReadyComponentAuthority';
+import {
+  governedPrivateEvaluationInspectRequestSchema,
+  type GovernedPrivateEvaluationInspectRequest,
+} from './governedPrivateEvaluationWorkspaceContracts';
+
+interface TrustedTimeRow {
+  readonly trusted_at: Date | string;
+}
+
+interface HeadRow {
+  readonly status: 'active' | 'withdrawn';
+  readonly revision: number | string;
+  readonly generation_id: string | null;
+  readonly last_transition_id: string;
+}
+
+type Head = Readonly<{
+  status: 'absent' | 'active' | 'withdrawn';
+  revision: number;
+  generationId: string | null;
+}>;
+
+type InspectionBlocker = Readonly<{
+  code:
+    | 'source_blocked'
+    | 'insufficient_data'
+    | 'identity_unresolved'
+    | 'lineage_unresolved'
+    | 'model_not_approved'
+    | 'reconciliation_failed'
+    | 'engineering_unavailable';
+  message: string;
+}>;
+
+export type GovernedPrivateEvaluationCapturedCalculationAuthority =
+  | Readonly<{ state: 'unavailable'; blockers: readonly InspectionBlocker[] }>
+  | Readonly<{
+      state: 'ready';
+      preparedInputHeadRevision: number;
+      preparedInputSetId: string;
+      factualRegistryRevision: number;
+      factualReleaseId: string;
+      activeFactualReleaseRevision: number;
+      privateValuationDecisionId: string;
+      privateValuationDecisionRevision: number;
+      materializationManifestId: string;
+      materializationManifestArtifact: AflTradeArtifactRef;
+      valuationInputBundleId: string;
+      valuationInputBundleArtifact: AflTradeArtifactRef;
+      gateLedgerRevision: number;
+      components: readonly GovernedReadyComponentAuthority[];
+    }>;
+
+type RetainedInspection =
+  | ReturnType<
+      typeof createUnavailableNonProductionGovernedPrivateEvaluationAuthorityInspection
+    >
+  | ReturnType<typeof createReadyGovernedPrivateEvaluationAuthorityInspectionV3>;
+
+function parseTime(value: Date | string): string {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(parsed.getTime())) {
+    throw new TypeError('Private evaluation inspection requires trusted PostgreSQL time.');
+  }
+  return parsed.toISOString();
+}
+
+async function capture(
+  client: AflOutcomeSqlClient,
+  selector: GovernedPrivateEvaluationInspectRequest,
+  captureCalculationAuthority: (input: {
+    readonly transaction: AflOutcomeSqlTransaction;
+    readonly selector: GovernedPrivateEvaluationInspectRequest;
+    readonly capturedAt: string;
+  }) => Promise<GovernedPrivateEvaluationCapturedCalculationAuthority>
+): Promise<{
+  capturedAt: string;
+  head: Head;
+  lastTransitionId: string | null;
+  calculationAuthority: GovernedPrivateEvaluationCapturedCalculationAuthority;
+}> {
+  return client.transaction(async (transaction) => {
+    await transaction.query(`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ`);
+    const trusted = await transaction.query<TrustedTimeRow>(
+      `SELECT date_trunc('milliseconds',transaction_timestamp()) AS trusted_at`
+    );
+    if (trusted.rows.length !== 1 || trusted.rows[0] === undefined) {
+      throw new TypeError('Private evaluation inspection could not establish trusted time.');
+    }
+    const headResult = await transaction.query<HeadRow>(
+      `SELECT status,revision,generation_id,last_transition_id
+         FROM outcome_local_private_trade_evaluation_head
+        WHERE valuation_scope_key=$1 AND trade_id=$2`,
+      [selector.valuationScopeKey, selector.tradeId]
+    );
+    let head: Head;
+    let lastTransitionId: string | null;
+    if (headResult.rows.length === 0) {
+      head = { status: 'absent', revision: 0, generationId: null };
+      lastTransitionId = null;
+    } else {
+      const row = headResult.rows[0];
+      const revision = Number(row?.revision);
+      if (
+        headResult.rows.length !== 1 ||
+        row === undefined ||
+        !Number.isSafeInteger(revision) ||
+        revision <= 0 ||
+        (row.status === 'active') !== (row.generation_id !== null)
+      ) {
+        throw new TypeError('Private evaluation inspection found a malformed composite head.');
+      }
+      head = { status: row.status, revision, generationId: row.generation_id };
+      lastTransitionId = row.last_transition_id;
+    }
+    const capturedAt = parseTime(trusted.rows[0].trusted_at);
+    return {
+      capturedAt,
+      head,
+      lastTransitionId,
+      calculationAuthority: await captureCalculationAuthority({
+        transaction,
+        selector,
+        capturedAt,
+      }),
+    };
+  });
+}
+
+async function insertRetainedInspection(
+  transaction: AflOutcomeSqlTransaction,
+  retained: RetainedInspection,
+  snapshotArtifact: AflTradeArtifactRef,
+  inspectionArtifact: AflTradeArtifactRef
+): Promise<void> {
+  const snapshot = retained.snapshot;
+  const inspection = retained.inspection;
+  const selector = snapshot.content.selector;
+  const snapshotInsert = await transaction.query(
+    `INSERT INTO outcome_private_evaluation_authority_snapshot
+      (snapshot_id,valuation_scope_key,trade_id,artifact_id,captured_at,valid_through,
+       expected_head_status,expected_head_revision,expected_head_generation_id,
+       content_sha256,content_canonical_json,snapshot_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
+    [
+      snapshot.snapshotId,
+      selector.valuationScopeKey,
+      selector.tradeId,
+      snapshotArtifact.artifactId,
+      snapshot.content.capturedAt,
+      snapshot.content.validThrough,
+      snapshot.content.head.status,
+      snapshot.content.head.revision,
+      snapshot.content.head.generationId,
+      snapshot.snapshotId.slice('private-evaluation-authority-snapshot:'.length),
+      canonicalizeAflTradeJson(snapshot.content),
+      canonicalizeAflTradeJson(snapshot),
+    ]
+  );
+  const inspectionInsert = await transaction.query(
+    `INSERT INTO outcome_private_evaluation_inspection_receipt
+      (inspection_id,snapshot_id,valuation_scope_key,trade_id,artifact_id,state,
+       inspected_at,valid_through,expected_head_status,expected_head_revision,
+       expected_head_generation_id,content_sha256,content_canonical_json,receipt_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14::jsonb)`,
+    [
+      inspection.inspectionId,
+      snapshot.snapshotId,
+      selector.valuationScopeKey,
+      selector.tradeId,
+      inspectionArtifact.artifactId,
+      inspection.content.state,
+      inspection.content.capturedAt,
+      inspection.content.validThrough,
+      inspection.content.head.status,
+      inspection.content.head.revision,
+      inspection.content.head.generationId,
+      inspection.inspectionId.slice('private-evaluation-inspection:'.length),
+      canonicalizeAflTradeJson(inspection.content),
+      canonicalizeAflTradeJson(inspection),
+    ]
+  );
+  if (snapshotInsert.rowCount !== 1 || inspectionInsert.rowCount !== 1) {
+    throw new TypeError('Private evaluation inspection was not persisted exactly once.');
+  }
+}
+
+export function createPostgresGovernedPrivateEvaluationInspectionRepository(dependencies: {
+  readonly client: AflOutcomeSqlClient;
+  readonly retainArtifact: (artifact: {
+    readonly reference: AflTradeArtifactRef;
+    readonly bytes: Uint8Array;
+  }) => Promise<AflTradeArtifactRef>;
+  readonly captureCalculationAuthority?: (input: {
+    readonly transaction: AflOutcomeSqlTransaction;
+    readonly selector: GovernedPrivateEvaluationInspectRequest;
+    readonly capturedAt: string;
+  }) => Promise<GovernedPrivateEvaluationCapturedCalculationAuthority>;
+  readonly validityMilliseconds: number;
+}) {
+  if (
+    !Number.isSafeInteger(dependencies.validityMilliseconds) ||
+    dependencies.validityMilliseconds <= 0 ||
+    dependencies.validityMilliseconds > 15 * 60 * 1_000
+  ) {
+    throw new TypeError('Private evaluation inspection requires a short validity window.');
+  }
+  return {
+    async inspect(unparsedRequest: GovernedPrivateEvaluationInspectRequest) {
+      const selector = governedPrivateEvaluationInspectRequestSchema.parse(unparsedRequest);
+      const capturedState = await capture(
+        dependencies.client,
+        selector,
+        dependencies.captureCalculationAuthority ??
+          (async () => ({
+            state: 'unavailable' as const,
+            blockers: [
+              {
+                code: 'model_not_approved' as const,
+                message:
+                  'Externally approved player and pick model runs are not both available for this trade.',
+              },
+            ],
+          }))
+      );
+      const common = {
+        selector,
+        capturedAt: capturedState.capturedAt,
+        validThrough: new Date(
+          Date.parse(capturedState.capturedAt) + dependencies.validityMilliseconds
+        ).toISOString(),
+        head: capturedState.head,
+        lastTransitionId: capturedState.lastTransitionId,
+      };
+      const retained =
+        capturedState.calculationAuthority.state === 'ready'
+          ? createReadyGovernedPrivateEvaluationAuthorityInspectionV3({
+              ...common,
+              ...capturedState.calculationAuthority,
+            })
+          : createUnavailableNonProductionGovernedPrivateEvaluationAuthorityInspection({
+              ...common,
+              blockers: capturedState.calculationAuthority.blockers,
+            });
+      const artifacts = [retained.snapshot, retained.inspection].map((document) => ({
+        document,
+        bytes: new TextEncoder().encode(canonicalizeAflTradeJson(document)),
+        reference: createAflTradeCanonicalJsonArtifactRef(
+          document,
+          capturedState.capturedAt
+        ),
+      }));
+      for (const artifact of artifacts) {
+        const retainedReference = await dependencies.retainArtifact({
+          reference: artifact.reference,
+          bytes: artifact.bytes,
+        });
+        if (
+          retainedReference.artifactId !== artifact.reference.artifactId ||
+          !doesAflTradeArtifactRefMatchCanonicalJson(retainedReference, artifact.document)
+        ) {
+          throw new TypeError('Private evaluation inspection artifact retention failed.');
+        }
+      }
+      await dependencies.client.transaction((transaction) =>
+        insertRetainedInspection(
+          transaction,
+          retained,
+          artifacts[0]!.reference,
+          artifacts[1]!.reference
+        )
+      );
+      return retained.result;
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationLifecycleRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationLifecycleRepository.ts
@@ -1,0 +1,568 @@
+import {
+  aflTradeArtifactRefSchema,
+  doAflTradeArtifactRefsExactlyMatch,
+  doesAflTradeArtifactRefMatchBytes,
+  doesAflTradeArtifactRefMatchCanonicalJson,
+  type AflTradeArtifactRef,
+} from '../../artifacts/artifactReference';
+import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
+import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../../outcomes/postgresOutcomeReleaseRepository';
+import {
+  governedPrivateEvaluationTransitionReceiptSchema,
+  type GovernedPrivateEvaluationTransitionReceipt,
+} from './governedPrivateEvaluationLifecycle';
+import { authenticateGovernedPrivateEvaluationAuthorityInspection } from './governedPrivateEvaluationAuthoritySnapshot';
+
+interface HeadRow {
+  readonly status: 'active' | 'withdrawn';
+  readonly revision: number | string;
+  readonly generation_id: string | null;
+  readonly last_transition_id: string;
+}
+
+interface ExistingReceiptRow {
+  readonly receipt_json: unknown;
+  readonly artifact_id: string;
+}
+
+interface TrustedTimeRow {
+  readonly trusted_at: Date | string;
+}
+
+interface OperatorAuthorityRow {
+  readonly authority_evidence_id: string;
+}
+
+interface StoredAuthorityRow {
+  readonly intent_json: unknown;
+  readonly authority_snapshot_id: string | null;
+  readonly inspection_snapshot_id: string;
+  readonly inspection_state: 'ready' | 'unavailable';
+  readonly inspection_valid_through: Date | string;
+  readonly inspection_head_status: 'absent' | 'active' | 'withdrawn';
+  readonly inspection_head_revision: number | string;
+  readonly inspection_head_generation_id: string | null;
+  readonly snapshot_id: string | null;
+  readonly snapshot_valid_through: Date | string | null;
+  readonly snapshot_head_status: 'absent' | 'active' | 'withdrawn' | null;
+  readonly snapshot_head_revision: number | string | null;
+  readonly snapshot_head_generation_id: string | null;
+  readonly snapshot_json: unknown;
+  readonly inspection_json: unknown;
+  readonly snapshot_artifact_id: string;
+  readonly snapshot_artifact_sha256: string;
+  readonly snapshot_artifact_storage_uri: string;
+  readonly snapshot_artifact_media_type: string;
+  readonly snapshot_artifact_byte_length: number | string | bigint;
+  readonly snapshot_artifact_created_at: Date | string;
+  readonly inspection_artifact_id: string;
+  readonly inspection_artifact_sha256: string;
+  readonly inspection_artifact_storage_uri: string;
+  readonly inspection_artifact_media_type: string;
+  readonly inspection_artifact_byte_length: number | string | bigint;
+  readonly inspection_artifact_created_at: Date | string;
+}
+
+type LifecycleHead = GovernedPrivateEvaluationTransitionReceipt['content']['toHead'];
+
+export type GovernedPrivateEvaluationLifecycleCommitResult =
+  | {
+      readonly state: 'committed' | 'replayed';
+      readonly head: LifecycleHead;
+      readonly transitionId: string;
+    }
+  | {
+      readonly state: 'conflict';
+      readonly expectedHead: LifecycleHead;
+      readonly actualHead: LifecycleHead;
+    };
+
+function same(left: unknown, right: unknown): boolean {
+  return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+}
+
+function parseTime(value: Date | string): number {
+  const parsed = value instanceof Date ? value.getTime() : Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw new TypeError('The lifecycle repository requires trusted PostgreSQL time.');
+  }
+  return parsed;
+}
+
+function sameHead(left: LifecycleHead, right: LifecycleHead): boolean {
+  return (
+    left.status === right.status &&
+    left.revision === right.revision &&
+    left.generationId === right.generationId
+  );
+}
+
+async function loadHeadForUpdate(
+  transaction: AflOutcomeSqlTransaction,
+  selector: { readonly valuationScopeKey: string; readonly tradeId: string }
+): Promise<{ readonly head: LifecycleHead; readonly lastTransitionId: string | null }> {
+  await transaction.query(`SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, [
+    `governed-private-evaluation-head:${canonicalizeAflTradeJson(selector)}`,
+  ]);
+  const result = await transaction.query<HeadRow>(
+    `SELECT status,revision,generation_id,last_transition_id
+       FROM outcome_local_private_trade_evaluation_head
+      WHERE valuation_scope_key=$1 AND trade_id=$2
+      FOR UPDATE`,
+    [selector.valuationScopeKey, selector.tradeId]
+  );
+  if (result.rows.length === 0) {
+    return {
+      head: { status: 'absent', revision: 0, generationId: null },
+      lastTransitionId: null,
+    };
+  }
+  const row = result.rows[0];
+  const revision = Number(row?.revision);
+  if (
+    result.rows.length !== 1 ||
+    row === undefined ||
+    !Number.isSafeInteger(revision) ||
+    revision <= 0 ||
+    (row.status === 'active') !== (row.generation_id !== null)
+  ) {
+    throw new TypeError('The composite private evaluation lifecycle head is malformed.');
+  }
+  return {
+    head: {
+      status: row.status,
+      revision,
+      generationId: row.generation_id,
+    },
+    lastTransitionId: row.last_transition_id,
+  };
+}
+
+async function proveResultGeneration(
+  transaction: AflOutcomeSqlTransaction,
+  receipt: GovernedPrivateEvaluationTransitionReceipt
+): Promise<void> {
+  const { action, selector, toHead, fromHead, previousTransitionId, intent } = receipt.content;
+  if (action.kind === 'withdraw') return;
+  const generationId = toHead.generationId!;
+  if (action.kind === 'recover') {
+    const withdrawal = await transaction.query<{ from_generation_id: string | null }>(
+      `SELECT from_generation_id
+         FROM outcome_private_evaluation_transition_receipt
+        WHERE valuation_scope_key=$1 AND trade_id=$2 AND to_revision=$3
+          AND transition_id=$4 AND action='withdraw' AND to_status='withdrawn'
+        FOR KEY SHARE`,
+      [selector.valuationScopeKey, selector.tradeId, fromHead.revision, previousTransitionId]
+    );
+    if (
+      withdrawal.rows.length !== 1 ||
+      withdrawal.rows[0]?.from_generation_id !== generationId
+    ) {
+      throw new TypeError('Recovery requires the exact generation removed by the current withdrawal.');
+    }
+  }
+  if (action.kind === 'rollback') {
+    const priorActivation = await transaction.query(
+      `SELECT transition_id
+         FROM outcome_private_evaluation_transition_receipt
+        WHERE valuation_scope_key=$1 AND trade_id=$2 AND to_generation_id=$3
+          AND action IN ('construct_and_activate','rollback','recover')
+        LIMIT 1 FOR KEY SHARE`,
+      [selector.valuationScopeKey, selector.tradeId, generationId]
+    );
+    if (priorActivation.rows.length !== 1) {
+      throw new TypeError('Rollback requires a generation previously activated for this selector.');
+    }
+  }
+  const generation = await transaction.query<{ generation_id: string }>(
+    `SELECT generation_id
+       FROM outcome_local_private_trade_evaluation_generation
+      WHERE valuation_scope_key=$1 AND trade_id=$2 AND generation_id=$3
+        AND ($4<>'construct_and_activate' OR transition_intent_id=$5)
+      FOR KEY SHARE`,
+    [
+      selector.valuationScopeKey,
+      selector.tradeId,
+      generationId,
+      action.kind,
+      intent.transitionIntentId,
+    ]
+  );
+  if (generation.rows.length !== 1) {
+    throw new TypeError('The lifecycle result generation is absent or escaped its transition intent.');
+  }
+}
+
+function rowHead(
+  status: StoredAuthorityRow['inspection_head_status'],
+  revision: number | string,
+  generationId: string | null
+): LifecycleHead {
+  return { status, revision: Number(revision), generationId };
+}
+
+function artifactReference(
+  row: StoredAuthorityRow,
+  kind: 'snapshot' | 'inspection'
+): AflTradeArtifactRef {
+  const byteLength = Number(row[`${kind}_artifact_byte_length`]);
+  const createdAtValue = row[`${kind}_artifact_created_at`];
+  const createdAt =
+    createdAtValue instanceof Date
+      ? createdAtValue.toISOString()
+      : new Date(createdAtValue).toISOString();
+  return aflTradeArtifactRefSchema.parse({
+    artifactId: row[`${kind}_artifact_id`],
+    contentSha256: row[`${kind}_artifact_sha256`],
+    storageUri: row[`${kind}_artifact_storage_uri`],
+    mediaType: row[`${kind}_artifact_media_type`],
+    byteLength,
+    createdAt,
+  });
+}
+
+async function authenticateStoredAuthorityArtifacts(input: {
+  readonly row: StoredAuthorityRow;
+  readonly artifactRepository: AflTradeImmutableArtifactRepository;
+  readonly maximumArtifactBytes: number;
+}) {
+  const snapshotReference = artifactReference(input.row, 'snapshot');
+  const inspectionReference = artifactReference(input.row, 'inspection');
+  const [snapshotArtifact, inspectionArtifact] = await Promise.all([
+    input.artifactRepository.loadExact(snapshotReference, input.maximumArtifactBytes),
+    input.artifactRepository.loadExact(inspectionReference, input.maximumArtifactBytes),
+  ]);
+  if (
+    snapshotArtifact === null ||
+    inspectionArtifact === null ||
+    !doAflTradeArtifactRefsExactlyMatch(snapshotReference, snapshotArtifact.reference) ||
+    !doAflTradeArtifactRefsExactlyMatch(inspectionReference, inspectionArtifact.reference) ||
+    !doesAflTradeArtifactRefMatchBytes(snapshotArtifact.reference, snapshotArtifact.bytes) ||
+    !doesAflTradeArtifactRefMatchBytes(inspectionArtifact.reference, inspectionArtifact.bytes) ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(snapshotReference, input.row.snapshot_json) ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(inspectionReference, input.row.inspection_json)
+  ) {
+    throw new TypeError('The lifecycle transition lacks exact retained authority bytes.');
+  }
+  let snapshotFromBytes: unknown;
+  let inspectionFromBytes: unknown;
+  try {
+    snapshotFromBytes = JSON.parse(
+      new TextDecoder('utf-8', { fatal: true }).decode(snapshotArtifact.bytes)
+    );
+    inspectionFromBytes = JSON.parse(
+      new TextDecoder('utf-8', { fatal: true }).decode(inspectionArtifact.bytes)
+    );
+  } catch {
+    throw new TypeError('The lifecycle retained authority bytes are not exact JSON.');
+  }
+  const retained = authenticateGovernedPrivateEvaluationAuthorityInspection({
+    snapshot: snapshotFromBytes,
+    inspection: inspectionFromBytes,
+  });
+  if (
+    !same(retained.snapshot, input.row.snapshot_json) ||
+    !same(retained.inspection, input.row.inspection_json)
+  ) {
+    throw new TypeError('The lifecycle relational authority differs from its retained bytes.');
+  }
+  return retained;
+}
+
+async function proveStoredAuthority(
+  transaction: AflOutcomeSqlTransaction,
+  receipt: GovernedPrivateEvaluationTransitionReceipt,
+  artifactRepository: AflTradeImmutableArtifactRepository,
+  maximumArtifactBytes: number
+): Promise<void> {
+  const content = receipt.content;
+  const intent = content.intent.content;
+  const result = await transaction.query<StoredAuthorityRow>(
+    `SELECT ti.intent_json,ti.authority_snapshot_id,
+            ir.snapshot_id AS inspection_snapshot_id,ir.state AS inspection_state,
+            ir.valid_through AS inspection_valid_through,
+            ir.expected_head_status AS inspection_head_status,
+            ir.expected_head_revision AS inspection_head_revision,
+            ir.expected_head_generation_id AS inspection_head_generation_id,
+            authority.snapshot_id,authority.valid_through AS snapshot_valid_through,
+            authority.expected_head_status AS snapshot_head_status,
+            authority.expected_head_revision AS snapshot_head_revision,
+            authority.expected_head_generation_id AS snapshot_head_generation_id,
+            authority.snapshot_json,ir.receipt_json AS inspection_json,
+            snapshot_artifact.artifact_id AS snapshot_artifact_id,
+            snapshot_artifact.content_sha256 AS snapshot_artifact_sha256,
+            snapshot_artifact.storage_uri AS snapshot_artifact_storage_uri,
+            snapshot_artifact.media_type AS snapshot_artifact_media_type,
+            snapshot_artifact.byte_length AS snapshot_artifact_byte_length,
+            snapshot_artifact.created_at AS snapshot_artifact_created_at,
+            inspection_artifact.artifact_id AS inspection_artifact_id,
+            inspection_artifact.content_sha256 AS inspection_artifact_sha256,
+            inspection_artifact.storage_uri AS inspection_artifact_storage_uri,
+            inspection_artifact.media_type AS inspection_artifact_media_type,
+            inspection_artifact.byte_length AS inspection_artifact_byte_length,
+            inspection_artifact.created_at AS inspection_artifact_created_at
+       FROM outcome_private_evaluation_transition_intent ti
+       JOIN outcome_private_evaluation_inspection_receipt ir
+         ON ir.inspection_id=ti.inspection_id
+        AND ir.valuation_scope_key=ti.valuation_scope_key AND ir.trade_id=ti.trade_id
+       JOIN outcome_private_evaluation_authority_snapshot authority
+         ON authority.snapshot_id=ir.snapshot_id
+        AND authority.valuation_scope_key=ir.valuation_scope_key
+        AND authority.trade_id=ir.trade_id
+       JOIN outcome_artifact_custody snapshot_artifact
+         ON snapshot_artifact.artifact_id=authority.artifact_id
+       JOIN outcome_artifact_custody inspection_artifact
+         ON inspection_artifact.artifact_id=ir.artifact_id
+      WHERE ti.transition_intent_id=$1 AND ti.valuation_scope_key=$2 AND ti.trade_id=$3`,
+    [content.intent.transitionIntentId, content.selector.valuationScopeKey, content.selector.tradeId]
+  );
+  const row = result.rows[0];
+  const requiresCalculationAuthority = content.action.kind !== 'withdraw';
+  const requiresSnapshotEvidence = content.action.kind !== 'withdraw';
+  const inspectionHead =
+    row === undefined
+      ? null
+      : rowHead(
+          row.inspection_head_status,
+          row.inspection_head_revision,
+          row.inspection_head_generation_id
+        );
+  const snapshotHead =
+    row?.snapshot_head_status === null || row?.snapshot_head_revision === null
+      ? null
+      : rowHead(
+          row.snapshot_head_status,
+          row.snapshot_head_revision,
+          row.snapshot_head_generation_id
+        );
+  if (
+    result.rows.length !== 1 ||
+    row === undefined ||
+    !same(row.intent_json, content.intent) ||
+    row.authority_snapshot_id !== intent.authoritySnapshotId ||
+    (requiresCalculationAuthority
+      ? row.inspection_state !== 'ready'
+      : !['ready', 'unavailable'].includes(row.inspection_state)) ||
+    parseTime(row.inspection_valid_through) < parseTime(content.transitionedAt) ||
+    inspectionHead === null ||
+    !sameHead(inspectionHead, content.fromHead) ||
+    (requiresSnapshotEvidence &&
+      (row.snapshot_id !== intent.authoritySnapshotId ||
+        row.inspection_snapshot_id !== intent.authoritySnapshotId ||
+        row.snapshot_valid_through === null ||
+        parseTime(row.snapshot_valid_through) < parseTime(content.transitionedAt) ||
+        snapshotHead === null ||
+        !sameHead(snapshotHead, content.fromHead)))
+  ) {
+    throw new TypeError('The lifecycle transition lacks exact stored snapshot authority.');
+  }
+  const retained = await authenticateStoredAuthorityArtifacts({
+    row,
+    artifactRepository,
+    maximumArtifactBytes,
+  });
+  if (
+    !same(retained.result.selector, content.selector) ||
+    retained.inspection.content.lastTransitionId !== content.previousTransitionId ||
+    retained.result.state !== row.inspection_state ||
+    !sameHead(retained.result.head, inspectionHead) ||
+    parseTime(retained.result.validThrough) !== parseTime(row.inspection_valid_through) ||
+    retained.snapshot.snapshotId !== row.snapshot_id ||
+    snapshotHead === null ||
+    !sameHead(retained.snapshot.content.head, snapshotHead) ||
+    row.snapshot_valid_through === null ||
+    parseTime(retained.snapshot.content.validThrough) !== parseTime(row.snapshot_valid_through)
+  ) {
+    throw new TypeError(
+      'The lifecycle relational authority differs from its authenticated retained authority.'
+    );
+  }
+}
+
+async function proveCurrentOperatorAuthority(
+  transaction: AflOutcomeSqlTransaction,
+  receipt: GovernedPrivateEvaluationTransitionReceipt
+): Promise<void> {
+  const content = receipt.content;
+  const result = await transaction.query<OperatorAuthorityRow>(
+    `SELECT authority.authority_evidence_id
+       FROM outcome_operational_principal_authority authority
+       JOIN outcome_governed_evidence_reference evidence
+         ON evidence.reference_id=authority.authority_evidence_id
+       JOIN outcome_review_decision approval
+         ON approval.decision_id=evidence.approval_decision_id
+      WHERE authority.principal_ref=$1
+        AND authority.role='afl_trade_private_evaluation_operator'
+        AND authority.scope_key=$2
+        AND authority.provider='statly_modeling'
+        AND authority.capability_id='manage_private_trade_evaluation'
+        AND authority.competition='AFLM'
+        AND authority.valid_from<=transaction_timestamp()
+        AND (authority.valid_through IS NULL OR authority.valid_through>transaction_timestamp())
+        AND authority.valid_from<=$3::timestamptz
+        AND (authority.valid_through IS NULL OR authority.valid_through>$3::timestamptz)
+        AND evidence.environment='test_fixture'::"OutcomeEnvironment"
+        AND evidence.status='approved'::"OutcomeRecordStatus"
+        AND approval.decision='approved'
+        AND NOT EXISTS (SELECT 1 FROM outcome_review_decision successor
+                         WHERE successor.supersedes_decision_id=approval.decision_id)
+      FOR SHARE OF authority,evidence,approval`,
+    [
+      content.intent.content.review.principalId,
+      content.selector.valuationScopeKey,
+      content.transitionedAt,
+    ]
+  );
+  if (
+    result.rows.length !== 1 ||
+    !result.rows[0]?.authority_evidence_id.startsWith('reviewer-authority-evidence:')
+  ) {
+    throw new TypeError(
+      'The lifecycle transition lacks current governed operator authority for the exact scope.'
+    );
+  }
+}
+
+async function insertReceiptAndCasHead(
+  transaction: AflOutcomeSqlTransaction,
+  receipt: GovernedPrivateEvaluationTransitionReceipt,
+  artifact: AflTradeArtifactRef
+): Promise<void> {
+  const content = receipt.content;
+  const intent = content.intent.content;
+  await transaction.query(
+    `INSERT INTO outcome_private_evaluation_transition_receipt
+      (transition_id,transition_intent_id,operation_id,valuation_scope_key,trade_id,
+       artifact_id,action,from_revision,from_status,from_generation_id,to_revision,
+       to_status,to_generation_id,transitioned_at,content_sha256,content_canonical_json,receipt_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17::jsonb)`,
+    [
+      receipt.transitionId,
+      content.intent.transitionIntentId,
+      intent.operationId,
+      content.selector.valuationScopeKey,
+      content.selector.tradeId,
+      artifact.artifactId,
+      content.action.kind,
+      content.fromHead.revision,
+      content.fromHead.status,
+      content.fromHead.generationId,
+      content.toHead.revision,
+      content.toHead.status,
+      content.toHead.generationId,
+      content.transitionedAt,
+      receipt.transitionId.slice('private-evaluation-transition:'.length),
+      canonicalizeAflTradeJson(content),
+      canonicalizeAflTradeJson(receipt),
+    ]
+  );
+  const head = await transaction.query(
+    `INSERT INTO outcome_local_private_trade_evaluation_head
+      (valuation_scope_key,trade_id,revision,status,generation_id,last_transition_id,updated_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7)
+     ON CONFLICT (valuation_scope_key,trade_id) DO UPDATE
+       SET revision=EXCLUDED.revision,status=EXCLUDED.status,
+           generation_id=EXCLUDED.generation_id,last_transition_id=EXCLUDED.last_transition_id,
+           updated_at=EXCLUDED.updated_at
+     WHERE outcome_local_private_trade_evaluation_head.revision=$8
+       AND outcome_local_private_trade_evaluation_head.status=$9
+       AND outcome_local_private_trade_evaluation_head.generation_id IS NOT DISTINCT FROM $10`,
+    [
+      content.selector.valuationScopeKey,
+      content.selector.tradeId,
+      content.toHead.revision,
+      content.toHead.status,
+      content.toHead.generationId,
+      receipt.transitionId,
+      content.transitionedAt,
+      content.fromHead.revision,
+      content.fromHead.status,
+      content.fromHead.generationId,
+    ]
+  );
+  if (head.rowCount !== 1) {
+    throw new TypeError('The lifecycle head changed after its serializable composite lock.');
+  }
+}
+
+export function createPostgresGovernedPrivateEvaluationLifecycleRepository(dependencies: {
+  readonly client: AflOutcomeSqlClient;
+  readonly artifactRepository: AflTradeImmutableArtifactRepository;
+  readonly maximumArtifactBytes: number;
+}) {
+  if (
+    dependencies.artifactRepository.artifactClass !== 'derived_private' ||
+    !Number.isSafeInteger(dependencies.maximumArtifactBytes) ||
+    dependencies.maximumArtifactBytes <= 0
+  ) {
+    throw new TypeError('Lifecycle commits require bounded private artifact custody.');
+  }
+  return {
+    async commit(input: {
+      readonly receipt: GovernedPrivateEvaluationTransitionReceipt;
+      readonly receiptArtifact: AflTradeArtifactRef;
+    }): Promise<GovernedPrivateEvaluationLifecycleCommitResult> {
+      const receipt = governedPrivateEvaluationTransitionReceiptSchema.parse(input.receipt);
+      const artifact = aflTradeArtifactRefSchema.parse(input.receiptArtifact);
+      if (!doesAflTradeArtifactRefMatchCanonicalJson(artifact, receipt)) {
+        throw new TypeError('The lifecycle receipt artifact does not authenticate its exact JSON.');
+      }
+      return dependencies.client.transaction(async (transaction) => {
+        await transaction.query(`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`);
+        const existing = await transaction.query<ExistingReceiptRow>(
+          `SELECT receipt_json,artifact_id
+             FROM outcome_private_evaluation_transition_receipt
+            WHERE operation_id=$1 FOR KEY SHARE`,
+          [receipt.content.intent.content.operationId]
+        );
+        if (existing.rows.length > 0) {
+          if (
+            existing.rows.length !== 1 ||
+            !same(existing.rows[0]?.receipt_json, receipt) ||
+            existing.rows[0]?.artifact_id !== artifact.artifactId
+          ) {
+            throw new TypeError('The lifecycle operation replay conflicts with retained evidence.');
+          }
+          return { state: 'replayed', head: receipt.content.toHead, transitionId: receipt.transitionId };
+        }
+        const trusted = await transaction.query<TrustedTimeRow>(
+          `SELECT date_trunc('milliseconds',transaction_timestamp()) AS trusted_at`
+        );
+        if (
+          trusted.rows.length !== 1 ||
+          trusted.rows[0] === undefined ||
+          parseTime(trusted.rows[0].trusted_at) < parseTime(receipt.content.transitionedAt) ||
+          parseTime(trusted.rows[0].trusted_at) >
+            parseTime(receipt.content.intent.content.expiresAt)
+        ) {
+          throw new TypeError('The lifecycle transition is future-dated or its authority expired.');
+        }
+        const current = await loadHeadForUpdate(transaction, receipt.content.selector);
+        if (
+          !sameHead(current.head, receipt.content.fromHead) ||
+          current.lastTransitionId !== receipt.content.previousTransitionId
+        ) {
+          return {
+            state: 'conflict',
+            expectedHead: receipt.content.fromHead,
+            actualHead: current.head,
+          };
+        }
+        await proveStoredAuthority(
+          transaction,
+          receipt,
+          dependencies.artifactRepository,
+          dependencies.maximumArtifactBytes
+        );
+        await proveCurrentOperatorAuthority(transaction, receipt);
+        await proveResultGeneration(transaction, receipt);
+        await insertReceiptAndCasHead(transaction, receipt, artifact);
+        return { state: 'committed', head: receipt.content.toHead, transitionId: receipt.transitionId };
+      });
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationMaterializationManifestRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationMaterializationManifestRepository.ts
@@ -1,0 +1,189 @@
+import {
+  aflTradeArtifactRefSchema,
+  doesAflTradeArtifactRefMatchCanonicalJson,
+  type AflTradeArtifactRef,
+} from '../../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../../outcomes/postgresOutcomeReleaseRepository';
+import {
+  governedPrivateEvaluationMaterializationManifestSchema,
+  type GovernedPrivateEvaluationMaterializationManifest,
+} from './governedPrivateEvaluationMaterializationManifest';
+
+interface MaterializationManifestRow {
+  readonly materialization_manifest_id: string;
+  readonly content_sha256: string;
+  readonly valuation_scope_key: string;
+  readonly trade_id: string;
+  readonly created_at: Date | string;
+  readonly content_canonical_json: string;
+  readonly manifest_canonical_json: string;
+  readonly manifest_json: unknown;
+  readonly artifact_id: string;
+  readonly artifact_content_sha256: string;
+  readonly storage_uri: string;
+  readonly media_type: string;
+  readonly byte_length: string | number | bigint;
+  readonly artifact_created_at: Date | string;
+  readonly artifact_environment: string;
+  readonly artifact_class: string;
+}
+
+export interface RetainedGovernedPrivateEvaluationMaterializationManifest {
+  readonly manifest: GovernedPrivateEvaluationMaterializationManifest;
+  readonly artifact: AflTradeArtifactRef;
+}
+
+export class GovernedPrivateEvaluationMaterializationManifestRepositoryError extends Error {
+  constructor(
+    readonly code: 'NOT_FOUND' | 'INTEGRITY_MISMATCH' | 'REPLAY_CONFLICT',
+    message: string
+  ) {
+    super(message);
+    this.name = 'GovernedPrivateEvaluationMaterializationManifestRepositoryError';
+  }
+}
+
+function instant(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function digestFromManifestId(manifestId: string): string {
+  return manifestId.slice('private-evaluation-materialization-manifest:'.length);
+}
+
+async function loadExactFrom(
+  client: AflOutcomeSqlTransaction,
+  manifestId: string
+): Promise<RetainedGovernedPrivateEvaluationMaterializationManifest> {
+  const result = await client.query<MaterializationManifestRow>(
+    `SELECT manifest.materialization_manifest_id,manifest.content_sha256,
+       manifest.valuation_scope_key,manifest.trade_id,manifest.created_at,
+       manifest.content_canonical_json,manifest.manifest_canonical_json,manifest.manifest_json,
+       artifact.artifact_id,artifact.content_sha256 AS artifact_content_sha256,
+       artifact.storage_uri,artifact.media_type,artifact.byte_length,
+       artifact.created_at AS artifact_created_at,artifact.environment::text AS artifact_environment,
+       artifact.artifact_class::text AS artifact_class
+      FROM outcome_private_evaluation_materialization_manifest manifest
+      JOIN outcome_artifact_custody artifact ON artifact.artifact_id=manifest.artifact_id
+     WHERE manifest.materialization_manifest_id=$1`,
+    [manifestId]
+  );
+  const row = result.rows[0];
+  if (!row) {
+    throw new GovernedPrivateEvaluationMaterializationManifestRepositoryError(
+      'NOT_FOUND',
+      'Private evaluation materialization manifest was not found.'
+    );
+  }
+
+  const parsedManifest = governedPrivateEvaluationMaterializationManifestSchema.safeParse(
+    row.manifest_json
+  );
+  const parsedArtifact = aflTradeArtifactRefSchema.safeParse({
+    artifactId: row.artifact_id,
+    contentSha256: row.artifact_content_sha256,
+    storageUri: row.storage_uri,
+    mediaType: row.media_type,
+    byteLength: Number(row.byte_length),
+    createdAt: instant(row.artifact_created_at),
+  });
+  if (!parsedManifest.success || !parsedArtifact.success) {
+    throw new GovernedPrivateEvaluationMaterializationManifestRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'Stored materialization manifest or artifact custody is malformed.'
+    );
+  }
+  const manifest = parsedManifest.data;
+  const artifact = parsedArtifact.data;
+  if (
+    manifest.manifestId !== manifestId ||
+    row.materialization_manifest_id !== manifestId ||
+    row.content_sha256 !== digestFromManifestId(manifestId) ||
+    row.valuation_scope_key !== manifest.content.selector.valuationScopeKey ||
+    row.trade_id !== manifest.content.selector.tradeId ||
+    instant(row.created_at) !== manifest.content.createdAt ||
+    row.content_canonical_json !== canonicalizeAflTradeJson(manifest.content) ||
+    row.manifest_canonical_json !== canonicalizeAflTradeJson(manifest) ||
+    row.artifact_environment !== 'non_production' ||
+    row.artifact_class !== 'derived_private' ||
+    artifact.createdAt !== manifest.content.createdAt ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(artifact, manifest)
+  ) {
+    throw new GovernedPrivateEvaluationMaterializationManifestRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'Stored materialization manifest disagrees with its immutable identity or custody.'
+    );
+  }
+  return { manifest, artifact };
+}
+
+export class PostgresGovernedPrivateEvaluationMaterializationManifestRepository {
+  constructor(private readonly client: AflOutcomeSqlClient) {}
+
+  async register(input: {
+    readonly manifest: GovernedPrivateEvaluationMaterializationManifest;
+    readonly artifact: AflTradeArtifactRef;
+  }): Promise<RetainedGovernedPrivateEvaluationMaterializationManifest> {
+    const manifest = governedPrivateEvaluationMaterializationManifestSchema.parse(input.manifest);
+    const artifact = aflTradeArtifactRefSchema.parse(input.artifact);
+    if (
+      artifact.createdAt !== manifest.content.createdAt ||
+      !doesAflTradeArtifactRefMatchCanonicalJson(artifact, manifest)
+    ) {
+      throw new GovernedPrivateEvaluationMaterializationManifestRepositoryError(
+        'INTEGRITY_MISMATCH',
+        'Materialization manifest artifact does not authenticate the exact manifest bytes.'
+      );
+    }
+    return this.client.transaction(async (transaction) => {
+      await transaction.query(`SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, [
+        `private-evaluation-materialization-manifest:${manifest.manifestId}`,
+      ]);
+      const existing = await transaction.query(
+        `SELECT 1 FROM outcome_private_evaluation_materialization_manifest
+          WHERE materialization_manifest_id=$1`,
+        [manifest.manifestId]
+      );
+      if (existing.rowCount) {
+        const replay = await loadExactFrom(transaction, manifest.manifestId);
+        if (
+          canonicalizeAflTradeJson(replay) !== canonicalizeAflTradeJson({ manifest, artifact })
+        ) {
+          throw new GovernedPrivateEvaluationMaterializationManifestRepositoryError(
+            'REPLAY_CONFLICT',
+            'Materialization manifest replay conflicts with retained evidence.'
+          );
+        }
+        return replay;
+      }
+      await transaction.query(
+        `INSERT INTO outcome_private_evaluation_materialization_manifest
+          (materialization_manifest_id,content_sha256,valuation_scope_key,trade_id,artifact_id,
+           created_at,content_canonical_json,manifest_canonical_json,manifest_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb)`,
+        [
+          manifest.manifestId,
+          digestFromManifestId(manifest.manifestId),
+          manifest.content.selector.valuationScopeKey,
+          manifest.content.selector.tradeId,
+          artifact.artifactId,
+          manifest.content.createdAt,
+          canonicalizeAflTradeJson(manifest.content),
+          canonicalizeAflTradeJson(manifest),
+          canonicalizeAflTradeJson(manifest),
+        ]
+      );
+      return loadExactFrom(transaction, manifest.manifestId);
+    });
+  }
+
+  loadExact(
+    manifestId: string
+  ): Promise<RetainedGovernedPrivateEvaluationMaterializationManifest> {
+    return loadExactFrom(this.client, manifestId);
+  }
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationReadRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationReadRepository.ts
@@ -1,0 +1,288 @@
+import {
+  aflTradeArtifactRefSchema,
+  createAflTradeCanonicalJsonArtifactRef,
+  doAflTradeArtifactRefsExactlyMatch,
+  doesAflTradeArtifactRefMatchBytes,
+  type AflTradeArtifactRef,
+} from '../../artifacts/artifactReference';
+import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
+import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import type { AflOutcomeSqlClient } from '../../outcomes/postgresOutcomeReleaseRepository';
+import {
+  parseGovernedPrivateEvaluationGeneration,
+  parseGovernedPrivateEvaluationProjectionManifest,
+  UnsupportedGovernedPrivateEvaluationProjectionVersionError,
+  verifyGovernedPrivateEvaluationGeneration,
+  type GovernedPrivateEvaluationGenerationMaterialization,
+  type GovernedPrivateEvaluationRetainedArtifact,
+} from '../governedPrivateEvaluationGeneration';
+import {
+  governedPrivateEvaluationReadRequestSchema,
+  governedPrivateEvaluationReadResultSchema,
+  type GovernedPrivateEvaluationReadRequest,
+  type GovernedPrivateEvaluationReadResult,
+} from './governedPrivateEvaluationWorkspaceContracts';
+
+interface CurrentRow {
+  readonly status: 'active' | 'withdrawn';
+  readonly generation_json: unknown | null;
+}
+
+interface GenerationRow {
+  readonly generation_json: unknown;
+  readonly head_status: 'active' | 'withdrawn' | null;
+  readonly head_generation_id: string | null;
+  readonly last_action: 'construct_and_activate' | 'withdraw' | 'rollback' | 'recover' | null;
+  readonly last_from_generation_id: string | null;
+}
+
+type DocumentKind = GovernedPrivateEvaluationReadRequest['document']['kind'];
+
+class ProjectionUnavailableError extends Error {}
+
+function same(left: unknown, right: unknown): boolean {
+  return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+}
+
+function parseJson(bytes: Uint8Array): unknown {
+  return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+}
+
+async function loadExact(
+  repository: AflTradeImmutableArtifactRepository,
+  reference: AflTradeArtifactRef,
+  maximumBytes: number
+): Promise<Uint8Array> {
+  const retained = await repository.loadExact(reference, maximumBytes);
+  if (retained === null) throw new ProjectionUnavailableError();
+  if (
+    !doAflTradeArtifactRefsExactlyMatch(reference, retained.reference) ||
+    !doesAflTradeArtifactRefMatchBytes(retained.reference, retained.bytes)
+  ) {
+    throw new TypeError('Retained private projection bytes failed exact authentication.');
+  }
+  return retained.bytes;
+}
+
+export async function loadAuthenticatedGovernedPrivateEvaluationMaterialization(input: {
+  readonly generationJson: unknown;
+  readonly artifactRepository: AflTradeImmutableArtifactRepository;
+  readonly maximumArtifactBytes: number;
+}): Promise<GovernedPrivateEvaluationGenerationMaterialization> {
+  const generation = parseGovernedPrivateEvaluationGeneration(input.generationJson);
+  const generationContent = generation?.content;
+  if (
+    typeof generation?.generationId !== 'string' ||
+    typeof generationContent?.generatedAt !== 'string' ||
+    generationContent.narrativeArtifact === undefined ||
+    generationContent.projectionManifestArtifact === undefined
+  ) {
+    throw new TypeError('The retained private evaluation generation is malformed.');
+  }
+  const narrativeReference = aflTradeArtifactRefSchema.parse(
+    generationContent.narrativeArtifact
+  );
+  const manifestReference = aflTradeArtifactRefSchema.parse(
+    generationContent.projectionManifestArtifact
+  );
+  const generationReference = createAflTradeCanonicalJsonArtifactRef(
+    generation,
+    generationContent.generatedAt
+  );
+  const narrativeBytes = await loadExact(
+    input.artifactRepository,
+    narrativeReference,
+    input.maximumArtifactBytes
+  );
+  const manifestBytes = await loadExact(
+    input.artifactRepository,
+    manifestReference,
+    input.maximumArtifactBytes
+  );
+  const generationBytes = await loadExact(
+    input.artifactRepository,
+    generationReference,
+    input.maximumArtifactBytes
+  );
+  const projectionManifest = parseGovernedPrivateEvaluationProjectionManifest(
+    parseJson(manifestBytes)
+  );
+  if (
+    projectionManifest?.content?.documents === undefined ||
+    !Array.isArray(projectionManifest.content.documents)
+  ) {
+    throw new TypeError('The retained private evaluation projection manifest is malformed.');
+  }
+  const documentArtifacts: GovernedPrivateEvaluationRetainedArtifact[] = [];
+  for (const document of projectionManifest.content.documents) {
+    const reference = aflTradeArtifactRefSchema.parse(document.artifact);
+    documentArtifacts.push({
+      kind: document.kind,
+      reference,
+      bytes: await loadExact(
+        input.artifactRepository,
+        reference,
+        input.maximumArtifactBytes
+      ),
+    });
+  }
+  const materialization: GovernedPrivateEvaluationGenerationMaterialization = {
+    generation,
+    projectionManifest,
+    artifacts: [
+      { kind: 'calculation_narrative', reference: narrativeReference, bytes: narrativeBytes },
+      ...documentArtifacts,
+      { kind: 'projection_manifest', reference: manifestReference, bytes: manifestBytes },
+      { kind: 'generation', reference: generationReference, bytes: generationBytes },
+    ],
+  };
+  if (!verifyGovernedPrivateEvaluationGeneration(materialization)) {
+    throw new TypeError('The retained private evaluation generation failed reconstruction.');
+  }
+  return materialization;
+}
+
+function unavailable(
+  request: GovernedPrivateEvaluationReadRequest,
+  reason: Extract<GovernedPrivateEvaluationReadResult, { state: 'unavailable' }>['reason']
+): GovernedPrivateEvaluationReadResult {
+  return governedPrivateEvaluationReadResultSchema.parse({
+    state: 'unavailable',
+    selector: request.selector,
+    selection: request.selection,
+    document: request.document,
+    reason,
+  });
+}
+
+export function createPostgresGovernedPrivateEvaluationReadRepository(dependencies: {
+  readonly client: AflOutcomeSqlClient;
+  readonly artifactRepository: AflTradeImmutableArtifactRepository;
+  readonly maximumArtifactBytes: number;
+  readonly principalId: string;
+  readonly authorizeReader: (input: {
+    readonly principalId: string;
+    readonly selector: GovernedPrivateEvaluationReadRequest['selector'];
+  }) => Promise<boolean>;
+}) {
+  if (
+    dependencies.artifactRepository.artifactClass !== 'derived_private' ||
+    !Number.isSafeInteger(dependencies.maximumArtifactBytes) ||
+    dependencies.maximumArtifactBytes <= 0 ||
+    dependencies.principalId.trim() === '' ||
+    dependencies.principalId.length > 400
+  ) {
+    throw new TypeError(
+      'Private evaluation reads require authenticated reader identity and bounded private artifact custody.'
+    );
+  }
+  return {
+    async read(unparsedRequest: GovernedPrivateEvaluationReadRequest) {
+      const request = governedPrivateEvaluationReadRequestSchema.parse(unparsedRequest);
+      const authorized = await dependencies.authorizeReader({
+        principalId: dependencies.principalId,
+        selector: request.selector,
+      });
+      if (!authorized) return unavailable(request, 'not_found');
+      let generationJson: unknown;
+      let lifecycle: {
+        readonly status: 'active' | 'withdrawn' | 'superseded';
+        readonly current: boolean;
+      };
+      if (request.selection.kind === 'current') {
+        const result = await dependencies.client.query<CurrentRow>(
+          `SELECT h.status,g.generation_json
+             FROM outcome_local_private_trade_evaluation_head h
+             LEFT JOIN outcome_local_private_trade_evaluation_generation g
+               ON g.valuation_scope_key=h.valuation_scope_key AND g.trade_id=h.trade_id
+              AND g.generation_id=h.generation_id
+            WHERE h.valuation_scope_key=$1 AND h.trade_id=$2`,
+          [request.selector.valuationScopeKey, request.selector.tradeId]
+        );
+        if (result.rows.length === 0) return unavailable(request, 'not_found');
+        if (result.rows.length !== 1) return unavailable(request, 'authentication_failed');
+        const row = result.rows[0]!;
+        if (row.status === 'withdrawn') return unavailable(request, 'withdrawn');
+        if (row.status !== 'active' || row.generation_json === null) {
+          return unavailable(request, 'authentication_failed');
+        }
+        generationJson = row.generation_json;
+        lifecycle = { status: 'active', current: true };
+      } else {
+        const result = await dependencies.client.query<GenerationRow>(
+          `SELECT g.generation_json,h.status AS head_status,
+                  h.generation_id AS head_generation_id,
+                  last.action AS last_action,
+                  last.from_generation_id AS last_from_generation_id
+             FROM outcome_local_private_trade_evaluation_generation g
+             LEFT JOIN outcome_local_private_trade_evaluation_head h
+               ON h.valuation_scope_key=g.valuation_scope_key AND h.trade_id=g.trade_id
+             LEFT JOIN outcome_private_evaluation_transition_receipt last
+               ON last.transition_id=h.last_transition_id
+            WHERE g.valuation_scope_key=$1 AND g.trade_id=$2 AND g.generation_id=$3
+              AND EXISTS (
+                SELECT 1 FROM outcome_private_evaluation_transition_receipt activated
+                 WHERE activated.valuation_scope_key=g.valuation_scope_key
+                   AND activated.trade_id=g.trade_id
+                   AND activated.to_generation_id=g.generation_id
+                   AND activated.action IN ('construct_and_activate','rollback','recover')
+              )`,
+          [
+            request.selector.valuationScopeKey,
+            request.selector.tradeId,
+            request.selection.generationId,
+          ]
+        );
+        if (result.rows.length === 0) return unavailable(request, 'not_found');
+        if (result.rows.length !== 1) return unavailable(request, 'authentication_failed');
+        const row = result.rows[0]!;
+        generationJson = row.generation_json;
+        lifecycle =
+          row.head_status === 'active' &&
+          row.head_generation_id === request.selection.generationId
+            ? { status: 'active', current: true }
+            : row.head_status === 'withdrawn' &&
+                row.last_action === 'withdraw' &&
+                row.last_from_generation_id === request.selection.generationId
+              ? { status: 'withdrawn', current: false }
+              : { status: 'superseded', current: false };
+      }
+      try {
+        const materialization = await loadAuthenticatedGovernedPrivateEvaluationMaterialization({
+          generationJson,
+          artifactRepository: dependencies.artifactRepository,
+          maximumArtifactBytes: dependencies.maximumArtifactBytes,
+        });
+        if (
+          !same(materialization.generation.content.selector, request.selector) ||
+          (request.selection.kind === 'generation' &&
+            materialization.generation.generationId !== request.selection.generationId)
+        ) {
+          return unavailable(request, 'authentication_failed');
+        }
+        const document = materialization.artifacts.find(
+          (artifact) => artifact.kind === (request.document.kind as DocumentKind)
+        );
+        if (document === undefined) return unavailable(request, 'projection_unavailable');
+        return governedPrivateEvaluationReadResultSchema.parse({
+          state: 'available',
+          selector: request.selector,
+          selection: request.selection,
+          generationId: materialization.generation.generationId,
+          projectionManifestId: materialization.projectionManifest.projectionManifestId,
+          lifecycle,
+          document: { kind: request.document.kind, artifact: document.reference },
+          bytes: document.bytes,
+        });
+      } catch (error) {
+        return unavailable(
+          request,
+          error instanceof ProjectionUnavailableError ||
+            error instanceof UnsupportedGovernedPrivateEvaluationProjectionVersionError
+            ? 'projection_unavailable'
+            : 'authentication_failed'
+        );
+      }
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationReconstructionRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationReconstructionRepository.ts
@@ -1,0 +1,262 @@
+import { z } from 'zod';
+
+import {
+  createAflTradeCanonicalJsonArtifactRef,
+  doesAflTradeArtifactRefMatchCanonicalJson,
+  type AflTradeArtifactRef,
+} from '../../artifacts/artifactReference';
+import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
+import {
+  aflTradeContentAddressedIdSchema,
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '../../artifacts/contentAddress';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../../outcomes/postgresOutcomeReleaseRepository';
+import { governedPrivateEvaluationSelectorSchema } from './governedPrivateEvaluationWorkspaceContracts';
+import { loadAuthenticatedGovernedPrivateEvaluationMaterialization } from './postgresGovernedPrivateEvaluationReadRepository';
+
+const requestSchema = z
+  .object({
+    selector: governedPrivateEvaluationSelectorSchema,
+    inspectionId: aflTradeContentAddressedIdSchema('private-evaluation-inspection'),
+    operationId: aflTradeContentAddressedIdSchema('private-evaluation-operation'),
+    generationId: aflTradeContentAddressedIdSchema(
+      'local-private-trade-evaluation-generation'
+    ),
+  })
+  .strict();
+
+interface GenerationRow {
+  readonly generation_json: unknown;
+}
+
+interface TrustedTimeRow {
+  readonly trusted_at: Date | string;
+}
+
+interface ExistingRow {
+  readonly verification_json: unknown;
+  readonly artifact_id: string;
+}
+
+interface InspectionRow {
+  readonly inspection_id: string;
+}
+
+function same(left: unknown, right: unknown): boolean {
+  return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+}
+
+async function trustedNow(client: AflOutcomeSqlClient): Promise<string> {
+  const result = await client.query<TrustedTimeRow>(
+    `SELECT date_trunc('milliseconds',clock_timestamp()) AS trusted_at`
+  );
+  const value = result.rows[0]?.trusted_at;
+  const parsed = value instanceof Date ? value : new Date(value ?? Number.NaN);
+  if (result.rows.length !== 1 || !Number.isFinite(parsed.getTime())) {
+    throw new TypeError('Reconstruction verification requires trusted PostgreSQL time.');
+  }
+  return parsed.toISOString();
+}
+
+async function findExisting(
+  client: AflOutcomeSqlClient | AflOutcomeSqlTransaction,
+  operationId: string
+): Promise<ExistingRow | null> {
+  const result = await client.query<ExistingRow>(
+    `SELECT verification_json,artifact_id
+       FROM outcome_private_evaluation_reconstruction_verification
+      WHERE operation_id=$1`,
+    [operationId]
+  );
+  if (result.rows.length > 1) {
+    throw new TypeError('Reconstruction operation identity is not unique.');
+  }
+  return result.rows[0] ?? null;
+}
+
+function replayExisting(
+  existing: ExistingRow,
+  request: z.output<typeof requestSchema>
+) {
+  const verification = structuredClone(existing.verification_json) as {
+    readonly verificationId?: string;
+    readonly content?: {
+      readonly selector?: unknown;
+      readonly inspectionId?: string;
+      readonly operationId?: string;
+      readonly generationId?: string;
+      readonly verifiedAt?: string;
+      readonly exactMatch?: boolean;
+    };
+  };
+  const content = verification.content;
+  if (
+    typeof verification.verificationId !== 'string' ||
+    typeof content?.verifiedAt !== 'string' ||
+    content.inspectionId !== request.inspectionId ||
+    content.operationId !== request.operationId ||
+    content.generationId !== request.generationId ||
+    content.exactMatch !== true ||
+    !same(content.selector, request.selector) ||
+    createAflTradeContentAddress(
+      'private-evaluation-reconstruction-verification',
+      content
+    ) !== verification.verificationId ||
+    createAflTradeCanonicalJsonArtifactRef(verification, content.verifiedAt).artifactId !==
+      existing.artifact_id
+  ) {
+    throw new TypeError('Reconstruction operation replay conflicts with retained evidence.');
+  }
+  return {
+    state: 'replayed' as const,
+    verificationId: verification.verificationId,
+    generationId: content.generationId,
+    exactMatch: true as const,
+    verifiedAt: content.verifiedAt,
+    verification,
+  };
+}
+
+export function createPostgresGovernedPrivateEvaluationReconstructionRepository(dependencies: {
+  readonly client: AflOutcomeSqlClient;
+  readonly artifactRepository: AflTradeImmutableArtifactRepository;
+  readonly maximumArtifactBytes: number;
+  readonly retainArtifact: (artifact: {
+    readonly reference: AflTradeArtifactRef;
+    readonly bytes: Uint8Array;
+  }) => Promise<AflTradeArtifactRef>;
+}) {
+  if (
+    dependencies.artifactRepository.artifactClass !== 'derived_private' ||
+    !Number.isSafeInteger(dependencies.maximumArtifactBytes) ||
+    dependencies.maximumArtifactBytes <= 0
+  ) {
+    throw new TypeError('Reconstruction verification requires bounded private artifact custody.');
+  }
+  return {
+    async verify(unparsedRequest: z.input<typeof requestSchema>) {
+      const request = requestSchema.parse(unparsedRequest);
+      const generationResult = await dependencies.client.query<GenerationRow>(
+        `SELECT generation_json
+           FROM outcome_local_private_trade_evaluation_generation
+          WHERE valuation_scope_key=$1 AND trade_id=$2 AND generation_id=$3`,
+        [request.selector.valuationScopeKey, request.selector.tradeId, request.generationId]
+      );
+      if (generationResult.rows.length !== 1) {
+        throw new TypeError('Reconstruction requires one exact retained generation.');
+      }
+      const materialization = await loadAuthenticatedGovernedPrivateEvaluationMaterialization({
+        generationJson: generationResult.rows[0]!.generation_json,
+        artifactRepository: dependencies.artifactRepository,
+        maximumArtifactBytes: dependencies.maximumArtifactBytes,
+      });
+      if (
+        materialization.generation.generationId !== request.generationId ||
+        !same(materialization.generation.content.selector, request.selector)
+      ) {
+        throw new TypeError('Reconstruction escaped its composite generation selector.');
+      }
+      const priorOperation = await findExisting(dependencies.client, request.operationId);
+      if (priorOperation !== null) return replayExisting(priorOperation, request);
+      const verifiedAt = await trustedNow(dependencies.client);
+      const content = {
+        schemaVersion: 'private-evaluation-reconstruction-verification/v1' as const,
+        environment: 'test_fixture' as const,
+        publicationProhibited: true as const,
+        selector: request.selector,
+        inspectionId: request.inspectionId,
+        operationId: request.operationId,
+        generationId: request.generationId,
+        projectionManifestId: materialization.projectionManifest.projectionManifestId,
+        verifiedAt,
+        exactMatch: true as const,
+        artifacts: materialization.artifacts.map(({ kind, reference }) => ({
+          kind,
+          artifact: reference,
+        })),
+        limitation:
+          'Private test-fixture reconstruction only; it grants no factual, model, production, or publication authority.' as const,
+      };
+      const verification = {
+        verificationId: createAflTradeContentAddress(
+          'private-evaluation-reconstruction-verification',
+          content
+        ),
+        content,
+      };
+      const artifact = createAflTradeCanonicalJsonArtifactRef(verification, verifiedAt);
+      const bytes = new TextEncoder().encode(canonicalizeAflTradeJson(verification));
+      const retained = await dependencies.retainArtifact({ reference: artifact, bytes });
+      if (
+        retained.artifactId !== artifact.artifactId ||
+        !doesAflTradeArtifactRefMatchCanonicalJson(retained, verification)
+      ) {
+        throw new TypeError('Reconstruction verification bytes were not retained exactly.');
+      }
+      return dependencies.client.transaction(async (transaction) => {
+        const replay = await findExisting(transaction, request.operationId);
+        if (replay !== null) return replayExisting(replay, request);
+        const inspection = await transaction.query<InspectionRow>(
+          `SELECT inspection_id
+             FROM outcome_private_evaluation_inspection_receipt
+            WHERE inspection_id=$1 AND valuation_scope_key=$2 AND trade_id=$3
+              AND state IN ('ready','unavailable') AND valid_through >= $4
+            FOR KEY SHARE`,
+          [
+            request.inspectionId,
+            request.selector.valuationScopeKey,
+            request.selector.tradeId,
+            verifiedAt,
+          ]
+        );
+        const generationStillExists = await transaction.query(
+          `SELECT generation_id
+             FROM outcome_local_private_trade_evaluation_generation
+            WHERE valuation_scope_key=$1 AND trade_id=$2 AND generation_id=$3
+            FOR KEY SHARE`,
+          [request.selector.valuationScopeKey, request.selector.tradeId, request.generationId]
+        );
+        if (inspection.rows.length !== 1 || generationStillExists.rows.length !== 1) {
+          throw new TypeError('Reconstruction inspection or generation authority is stale.');
+        }
+        const inserted = await transaction.query(
+          `INSERT INTO outcome_private_evaluation_reconstruction_verification
+            (verification_id,inspection_id,operation_id,valuation_scope_key,trade_id,
+             generation_id,artifact_id,verified_at,exact_match,content_sha256,
+             content_canonical_json,verification_json)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,TRUE,$9,$10,$11::jsonb)`,
+          [
+            verification.verificationId,
+            request.inspectionId,
+            request.operationId,
+            request.selector.valuationScopeKey,
+            request.selector.tradeId,
+            request.generationId,
+            artifact.artifactId,
+            verifiedAt,
+            verification.verificationId.slice(
+              'private-evaluation-reconstruction-verification:'.length
+            ),
+            canonicalizeAflTradeJson(content),
+            canonicalizeAflTradeJson(verification),
+          ]
+        );
+        if (inserted.rowCount !== 1) {
+          throw new TypeError('Reconstruction verification was not persisted exactly once.');
+        }
+        return {
+          state: 'verified' as const,
+          verificationId: verification.verificationId,
+          generationId: request.generationId,
+          exactMatch: true as const,
+          verifiedAt,
+          verification,
+        };
+      });
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationStagingRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationStagingRepository.ts
@@ -1,0 +1,326 @@
+import {
+  aflTradeArtifactRefSchema,
+  doAflTradeArtifactRefsExactlyMatch,
+  doesAflTradeArtifactRefMatchBytes,
+  doesAflTradeArtifactRefMatchCanonicalJson,
+  type AflTradeArtifactRef,
+} from '../../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../../outcomes/postgresOutcomeReleaseRepository';
+import {
+  verifyGovernedPrivateEvaluationGeneration,
+  type GovernedPrivateEvaluationGenerationMaterialization,
+  type GovernedPrivateEvaluationRetainedArtifact,
+} from '../governedPrivateEvaluationGeneration';
+import {
+  governedPrivateEvaluationTransitionIntentSchema,
+  type GovernedPrivateEvaluationTransitionIntent,
+} from './governedPrivateEvaluationLifecycle';
+
+interface CustodyRow {
+  readonly artifact_id: string;
+  readonly content_sha256: string;
+  readonly storage_uri: string;
+  readonly media_type: string;
+  readonly byte_length: number | string | bigint;
+}
+
+interface IntentRow {
+  readonly intent_json: unknown;
+  readonly artifact_id: string;
+}
+
+interface GenerationRow {
+  readonly generation_json: unknown;
+  readonly generation_artifact_id: string;
+}
+
+interface TrustedTimeRow {
+  readonly trusted_at: Date | string;
+}
+
+function same(left: unknown, right: unknown): boolean {
+  return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+}
+
+function canonicalBytes(value: unknown): Uint8Array {
+  return new TextEncoder().encode(canonicalizeAflTradeJson(value));
+}
+
+async function loadTrustedTime(transaction: AflOutcomeSqlTransaction): Promise<string> {
+  const result = await transaction.query<TrustedTimeRow>(
+    `SELECT date_trunc('milliseconds',transaction_timestamp()) AS trusted_at`
+  );
+  const value = result.rows[0]?.trusted_at;
+  const parsed = value instanceof Date ? value : new Date(value ?? Number.NaN);
+  if (result.rows.length !== 1 || !Number.isFinite(parsed.getTime())) {
+    throw new TypeError('Private evaluation staging requires trusted PostgreSQL time.');
+  }
+  return parsed.toISOString();
+}
+
+async function retainExact(
+  repository: AflTradeImmutableArtifactRepository,
+  maximumBytes: number,
+  artifact: { readonly reference: AflTradeArtifactRef; readonly bytes: Uint8Array }
+): Promise<void> {
+  await repository.putIfAbsent(artifact.reference, artifact.bytes);
+  const retained = await repository.loadExact(artifact.reference, maximumBytes);
+  if (
+    retained === null ||
+    !doAflTradeArtifactRefsExactlyMatch(retained.reference, artifact.reference) ||
+    !doesAflTradeArtifactRefMatchBytes(retained.reference, retained.bytes) ||
+    retained.bytes.byteLength !== artifact.bytes.byteLength ||
+    retained.bytes.some((byte, index) => byte !== artifact.bytes[index])
+  ) {
+    throw new TypeError('Private evaluation staging failed exact artifact readback.');
+  }
+}
+
+async function registerCustody(
+  transaction: AflOutcomeSqlTransaction,
+  reference: AflTradeArtifactRef,
+  verifiedAt: string,
+  custody: {
+    readonly environment: 'test_fixture' | 'non_production';
+    readonly repositoryAssurance:
+      | 'fixture_memory'
+      | 'fixture_filesystem'
+      | 'local_non_production_filesystem';
+  }
+): Promise<void> {
+  await transaction.query(
+    `INSERT INTO outcome_artifact_custody
+      (artifact_id,content_sha256,storage_uri,media_type,byte_length,artifact_class,
+       environment,created_at,verified_at,custody_json)
+     VALUES ($1,$2,$3,$4,$5,'derived_private',$6,$7,$8,$9::jsonb)
+     ON CONFLICT (artifact_id) DO NOTHING`,
+    [
+      reference.artifactId,
+      reference.contentSha256,
+      reference.storageUri,
+      reference.mediaType,
+      reference.byteLength,
+      custody.environment,
+      reference.createdAt,
+      verifiedAt,
+      canonicalizeAflTradeJson({
+        schemaVersion: 'governed-private-evaluation-artifact-custody/v1',
+        environment: custody.environment,
+        repositoryAssurance: custody.repositoryAssurance,
+        publicationProhibited: true,
+        reference,
+      }),
+    ]
+  );
+  const retained = await transaction.query<CustodyRow>(
+    `SELECT artifact_id,content_sha256,storage_uri,media_type,byte_length
+       FROM outcome_artifact_custody
+      WHERE artifact_id=$1 FOR KEY SHARE`,
+    [reference.artifactId]
+  );
+  const row = retained.rows[0];
+  if (
+    retained.rows.length !== 1 ||
+    row === undefined ||
+    row.artifact_id !== reference.artifactId ||
+    row.content_sha256 !== reference.contentSha256 ||
+    row.storage_uri !== reference.storageUri ||
+    row.media_type !== reference.mediaType ||
+    String(row.byte_length) !== String(reference.byteLength)
+  ) {
+    throw new TypeError('Private evaluation artifact custody replay conflicts.');
+  }
+}
+
+async function insertIntent(
+  transaction: AflOutcomeSqlTransaction,
+  intent: GovernedPrivateEvaluationTransitionIntent,
+  artifact: AflTradeArtifactRef
+): Promise<void> {
+  const content = intent.content;
+  await transaction.query(
+    `INSERT INTO outcome_private_evaluation_transition_intent
+      (transition_intent_id,inspection_id,authority_snapshot_id,operation_id,valuation_scope_key,trade_id,
+       artifact_id,action,expected_head_status,expected_head_revision,
+       expected_head_generation_id,target_generation_id,requested_at,expires_at,
+       content_sha256,content_canonical_json,intent_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17::jsonb)
+     ON CONFLICT (transition_intent_id) DO NOTHING`,
+    [
+      intent.transitionIntentId,
+      content.inspectionId,
+      content.authoritySnapshotId,
+      content.operationId,
+      content.selector.valuationScopeKey,
+      content.selector.tradeId,
+      artifact.artifactId,
+      content.action.kind,
+      content.expectedHead.status,
+      content.expectedHead.revision,
+      content.expectedHead.generationId,
+      content.action.kind === 'rollback' ? content.action.targetGenerationId : null,
+      content.requestedAt,
+      content.expiresAt,
+      intent.transitionIntentId.slice('private-evaluation-transition-intent:'.length),
+      canonicalizeAflTradeJson(content),
+      canonicalizeAflTradeJson(intent),
+    ]
+  );
+  const retained = await transaction.query<IntentRow>(
+    `SELECT intent_json,artifact_id
+       FROM outcome_private_evaluation_transition_intent
+      WHERE transition_intent_id=$1 FOR KEY SHARE`,
+    [intent.transitionIntentId]
+  );
+  if (
+    retained.rows.length !== 1 ||
+    !same(retained.rows[0]?.intent_json, intent) ||
+    retained.rows[0]?.artifact_id !== artifact.artifactId
+  ) {
+    throw new TypeError('Private evaluation transition intent replay conflicts.');
+  }
+}
+
+async function insertGeneration(
+  transaction: AflOutcomeSqlTransaction,
+  materialization: GovernedPrivateEvaluationGenerationMaterialization
+): Promise<void> {
+  const generation = materialization.generation;
+  const byKind = new Map(materialization.artifacts.map((artifact) => [artifact.kind, artifact]));
+  const generationArtifact = byKind.get('generation')!;
+  const narrativeArtifact = byKind.get('calculation_narrative')!;
+  const manifestArtifact = byKind.get('projection_manifest')!;
+  await transaction.query(
+    `INSERT INTO outcome_local_private_trade_evaluation_generation
+      (generation_id,valuation_scope_key,trade_id,transition_intent_id,
+       generation_artifact_id,narrative_artifact_id,projection_manifest_artifact_id,
+       generated_at,content_sha256,content_canonical_json,generation_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb)
+     ON CONFLICT (generation_id) DO NOTHING`,
+    [
+      generation.generationId,
+      generation.content.selector.valuationScopeKey,
+      generation.content.selector.tradeId,
+      generation.content.transitionIntentId,
+      generationArtifact.reference.artifactId,
+      narrativeArtifact.reference.artifactId,
+      manifestArtifact.reference.artifactId,
+      generation.content.generatedAt,
+      generation.generationId.slice('local-private-trade-evaluation-generation:'.length),
+      canonicalizeAflTradeJson(generation.content),
+      canonicalizeAflTradeJson(generation),
+    ]
+  );
+  const retained = await transaction.query<GenerationRow>(
+    `SELECT generation_json,generation_artifact_id
+       FROM outcome_local_private_trade_evaluation_generation
+      WHERE generation_id=$1 FOR KEY SHARE`,
+    [generation.generationId]
+  );
+  if (
+    retained.rows.length !== 1 ||
+    !same(retained.rows[0]?.generation_json, generation) ||
+    retained.rows[0]?.generation_artifact_id !== generationArtifact.reference.artifactId
+  ) {
+    throw new TypeError('Private evaluation dormant generation replay conflicts.');
+  }
+}
+
+export function createPostgresGovernedPrivateEvaluationStagingRepository(dependencies: {
+  readonly client: AflOutcomeSqlClient;
+  readonly artifactRepository: AflTradeImmutableArtifactRepository;
+  readonly maximumArtifactBytes: number;
+}) {
+  const repositoryAssurance = dependencies.artifactRepository.assurance;
+  if (repositoryAssurance === 'durable_object_storage') {
+    throw new TypeError('Private evaluation staging requires private local custody.');
+  }
+  if (
+    dependencies.artifactRepository.artifactClass !== 'derived_private' ||
+    !Number.isSafeInteger(dependencies.maximumArtifactBytes) ||
+    dependencies.maximumArtifactBytes <= 0
+  ) {
+    throw new TypeError('Private evaluation staging requires bounded private fixture custody.');
+  }
+  const custody = {
+    environment:
+      dependencies.artifactRepository.assurance === 'local_non_production_filesystem'
+        ? ('non_production' as const)
+        : ('test_fixture' as const),
+    repositoryAssurance,
+  };
+  return {
+    async retainArtifact(input: {
+      readonly reference: AflTradeArtifactRef;
+      readonly bytes: Uint8Array;
+    }): Promise<AflTradeArtifactRef> {
+      const reference = aflTradeArtifactRefSchema.parse(input.reference);
+      await retainExact(dependencies.artifactRepository, dependencies.maximumArtifactBytes, {
+        reference,
+        bytes: input.bytes,
+      });
+      await dependencies.client.transaction(async (transaction) => {
+        const verifiedAt = await loadTrustedTime(transaction);
+        await registerCustody(transaction, reference, verifiedAt, custody);
+      });
+      return reference;
+    },
+
+    async stage(input: {
+      readonly intent: GovernedPrivateEvaluationTransitionIntent;
+      readonly intentArtifact: AflTradeArtifactRef;
+      readonly materialization?: GovernedPrivateEvaluationGenerationMaterialization;
+    }) {
+      const intent = governedPrivateEvaluationTransitionIntentSchema.parse(input.intent);
+      const intentArtifact = aflTradeArtifactRefSchema.parse(input.intentArtifact);
+      const constructing = intent.content.action.kind === 'construct_and_activate';
+      if (
+        constructing !== (input.materialization !== undefined) ||
+        (input.materialization !== undefined &&
+          (!verifyGovernedPrivateEvaluationGeneration(input.materialization) ||
+            input.materialization.generation.content.transitionIntentId !==
+              intent.transitionIntentId ||
+            !same(input.materialization.generation.content.selector, intent.content.selector)))
+      ) {
+        throw new TypeError('Construction staging requires one complete verified generation.');
+      }
+      if (!doesAflTradeArtifactRefMatchCanonicalJson(intentArtifact, intent)) {
+        throw new TypeError('The transition intent artifact does not authenticate its exact JSON.');
+      }
+      const intentRetained = {
+        reference: intentArtifact,
+        bytes: canonicalBytes(intent),
+      };
+      const retained: readonly (
+        | typeof intentRetained
+        | GovernedPrivateEvaluationRetainedArtifact
+      )[] = [intentRetained, ...(input.materialization?.artifacts ?? [])];
+      for (const artifact of retained) {
+        await retainExact(
+          dependencies.artifactRepository,
+          dependencies.maximumArtifactBytes,
+          artifact
+        );
+      }
+      return dependencies.client.transaction(async (transaction) => {
+        const verifiedAt = await loadTrustedTime(transaction);
+        for (const artifact of retained) {
+          await registerCustody(transaction, artifact.reference, verifiedAt, custody);
+        }
+        await insertIntent(transaction, intent, intentArtifact);
+        if (input.materialization !== undefined) {
+          await insertGeneration(transaction, input.materialization);
+        }
+        return {
+          transitionIntentId: intent.transitionIntentId,
+          generationId: input.materialization?.generation.generationId ?? null,
+        };
+      });
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationComponentRunRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationComponentRunRepository.ts
@@ -1,0 +1,275 @@
+import {
+  aflTradeArtifactRefSchema,
+  doesAflTradeArtifactRefMatchBytes,
+  doesAflTradeArtifactRefMatchCanonicalJson,
+  type AflTradeArtifactRef,
+} from '../../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../../outcomes/postgresOutcomeReleaseRepository';
+import {
+  governedValuationComponentRunManifestSchema,
+  type GovernedValuationComponentRunManifest,
+} from './governedValuationComponentRunManifest';
+
+interface ComponentRunRow {
+  readonly run_id: string;
+  readonly role: string;
+  readonly native_execution_kind: string;
+  readonly native_execution_id: string;
+  readonly artifact_id: string;
+  readonly native_execution_artifact_id: string;
+  readonly protocol_id: string;
+  readonly protocol_artifact_id: string;
+  readonly dataset_id: string;
+  readonly dataset_artifact_id: string;
+  readonly dataset_admission_id: string;
+  readonly dataset_admission_artifact_id: string;
+  readonly dataset_admission_gate_ledger_revision: number | string;
+  readonly registered_at: Date | string;
+  readonly content_sha256: string;
+  readonly content_canonical_json: string;
+  readonly manifest_json: unknown;
+  readonly artifact_content_sha256: string;
+  readonly artifact_storage_uri: string;
+  readonly artifact_media_type: string;
+  readonly artifact_byte_length: number | string | bigint;
+  readonly artifact_created_at: Date | string;
+}
+
+export interface RetainedGovernedValuationComponentRun {
+  readonly manifest: GovernedValuationComponentRunManifest;
+  readonly artifact: AflTradeArtifactRef;
+}
+
+export class GovernedValuationComponentRunRepositoryError extends Error {
+  constructor(
+    readonly code: 'NOT_FOUND' | 'INTEGRITY_MISMATCH' | 'REPLAY_CONFLICT',
+    message: string
+  ) {
+    super(message);
+    this.name = 'GovernedValuationComponentRunRepositoryError';
+  }
+}
+
+function instant(value: Date | string): string {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(parsed.getTime())) {
+    throw new GovernedValuationComponentRunRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'Stored component-run time is malformed.'
+    );
+  }
+  return parsed.toISOString();
+}
+
+async function loadPhysicalEvidence(input: {
+  readonly repository: AflTradeImmutableArtifactRepository;
+  readonly maximumBytes: number;
+  readonly references: readonly AflTradeArtifactRef[];
+}): Promise<void> {
+  for (const reference of input.references) {
+    const loaded = await input.repository.loadExact(reference, input.maximumBytes);
+    if (
+      loaded === null ||
+      canonicalizeAflTradeJson(loaded.reference) !== canonicalizeAflTradeJson(reference) ||
+      !doesAflTradeArtifactRefMatchBytes(loaded.reference, loaded.bytes)
+    ) {
+      throw new GovernedValuationComponentRunRepositoryError(
+        'INTEGRITY_MISMATCH',
+        `Component-run artifact custody failed for ${reference.artifactId}.`
+      );
+    }
+  }
+}
+
+async function loadExactFrom(
+  client: AflOutcomeSqlTransaction,
+  dependencies: {
+    readonly artifactRepository: AflTradeImmutableArtifactRepository;
+    readonly maximumArtifactBytes: number;
+  },
+  runId: string
+): Promise<RetainedGovernedValuationComponentRun> {
+  const result = await client.query<ComponentRunRow>(
+    `SELECT run.run_id,run.role,run.native_execution_kind,run.native_execution_id,
+       run.artifact_id,run.native_execution_artifact_id,run.protocol_id,
+       run.protocol_artifact_id,run.dataset_id,run.dataset_artifact_id,
+       run.dataset_admission_id,run.dataset_admission_artifact_id,
+       run.dataset_admission_gate_ledger_revision,run.registered_at,run.content_sha256,
+       run.content_canonical_json,run.manifest_json,
+       artifact.content_sha256 AS artifact_content_sha256,
+       artifact.storage_uri AS artifact_storage_uri,artifact.media_type AS artifact_media_type,
+       artifact.byte_length AS artifact_byte_length,artifact.created_at AS artifact_created_at
+       FROM outcome_governed_valuation_component_run run
+       JOIN outcome_artifact_custody artifact ON artifact.artifact_id=run.artifact_id
+      WHERE run.run_id=$1`,
+    [runId]
+  );
+  if (result.rows.length !== 1 || result.rows[0] === undefined) {
+    throw new GovernedValuationComponentRunRepositoryError(
+      'NOT_FOUND',
+      'Governed valuation component run was not found.'
+    );
+  }
+  const row = result.rows[0];
+  const parsed = governedValuationComponentRunManifestSchema.safeParse(row.manifest_json);
+  const artifact = aflTradeArtifactRefSchema.safeParse({
+    artifactId: row.artifact_id,
+    contentSha256: row.artifact_content_sha256,
+    storageUri: row.artifact_storage_uri,
+    mediaType: row.artifact_media_type,
+    byteLength: Number(row.artifact_byte_length),
+    createdAt: instant(row.artifact_created_at),
+  });
+  if (!parsed.success || !artifact.success) {
+    throw new GovernedValuationComponentRunRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'Stored component-run manifest or custody metadata is malformed.'
+    );
+  }
+  const manifest = parsed.data;
+  const content = manifest.content;
+  const admissionRevision = Number(row.dataset_admission_gate_ledger_revision);
+  if (
+    manifest.runId !== runId ||
+    row.run_id !== runId ||
+    row.content_sha256 !== runId.slice('model-run:'.length) ||
+    row.role !== content.role ||
+    row.native_execution_kind !== content.nativeExecution.kind ||
+    row.native_execution_id !== content.nativeExecution.executionId ||
+    row.native_execution_artifact_id !== content.nativeExecution.artifact.artifactId ||
+    row.protocol_id !== content.protocolId ||
+    row.protocol_artifact_id !== content.protocolArtifact.artifactId ||
+    row.dataset_id !== content.datasetId ||
+    row.dataset_artifact_id !== content.datasetArtifact.artifactId ||
+    row.dataset_admission_id !== content.datasetAdmissionId ||
+    row.dataset_admission_artifact_id !== content.datasetAdmissionArtifact.artifactId ||
+    admissionRevision !== content.datasetAdmissionGateLedgerRevision ||
+    instant(row.registered_at) !== content.registeredAt ||
+    row.content_canonical_json !== canonicalizeAflTradeJson(content) ||
+    artifact.data.createdAt !== content.registeredAt ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(artifact.data, manifest)
+  ) {
+    throw new GovernedValuationComponentRunRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'Stored component-run columns disagree with immutable ancestry.'
+    );
+  }
+  await loadPhysicalEvidence({
+    repository: dependencies.artifactRepository,
+    maximumBytes: dependencies.maximumArtifactBytes,
+    references: [
+      artifact.data,
+      content.nativeExecution.artifact,
+      content.protocolArtifact,
+      content.datasetArtifact,
+      content.datasetAdmissionArtifact,
+    ],
+  });
+  return { manifest, artifact: artifact.data };
+}
+
+export class PostgresGovernedValuationComponentRunRepository {
+  constructor(
+    private readonly dependencies: {
+      readonly client: AflOutcomeSqlClient;
+      readonly artifactRepository: AflTradeImmutableArtifactRepository;
+      readonly maximumArtifactBytes: number;
+    }
+  ) {
+    if (
+      dependencies.artifactRepository.artifactClass !== 'derived_private' ||
+      !Number.isSafeInteger(dependencies.maximumArtifactBytes) ||
+      dependencies.maximumArtifactBytes <= 0
+    ) {
+      throw new TypeError('Component-run custody requires bounded private artifact storage.');
+    }
+  }
+
+  async register(input: {
+    readonly manifest: GovernedValuationComponentRunManifest;
+    readonly artifact: AflTradeArtifactRef;
+  }): Promise<RetainedGovernedValuationComponentRun> {
+    const manifest = governedValuationComponentRunManifestSchema.parse(input.manifest);
+    const artifact = aflTradeArtifactRefSchema.parse(input.artifact);
+    if (
+      artifact.createdAt !== manifest.content.registeredAt ||
+      !doesAflTradeArtifactRefMatchCanonicalJson(artifact, manifest)
+    ) {
+      throw new GovernedValuationComponentRunRepositoryError(
+        'INTEGRITY_MISMATCH',
+        'Component-run artifact does not authenticate the exact manifest.'
+      );
+    }
+    await loadPhysicalEvidence({
+      repository: this.dependencies.artifactRepository,
+      maximumBytes: this.dependencies.maximumArtifactBytes,
+      references: [
+        artifact,
+        manifest.content.nativeExecution.artifact,
+        manifest.content.protocolArtifact,
+        manifest.content.datasetArtifact,
+        manifest.content.datasetAdmissionArtifact,
+      ],
+    });
+    return this.dependencies.client.transaction(async (transaction) => {
+      await transaction.query(`SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, [
+        `governed-valuation-component-run:${manifest.runId}`,
+      ]);
+      const existing = await transaction.query(
+        `SELECT 1 FROM outcome_governed_valuation_component_run WHERE run_id=$1`,
+        [manifest.runId]
+      );
+      if (existing.rowCount) {
+        const replay = await loadExactFrom(transaction, this.dependencies, manifest.runId);
+        if (
+          canonicalizeAflTradeJson(replay) !== canonicalizeAflTradeJson({ manifest, artifact })
+        ) {
+          throw new GovernedValuationComponentRunRepositoryError(
+            'REPLAY_CONFLICT',
+            'Component-run replay conflicts with retained evidence.'
+          );
+        }
+        return replay;
+      }
+      const content = manifest.content;
+      await transaction.query(
+        `INSERT INTO outcome_governed_valuation_component_run
+          (run_id,role,native_execution_kind,native_execution_id,artifact_id,
+           native_execution_artifact_id,protocol_id,protocol_artifact_id,dataset_id,
+           dataset_artifact_id,dataset_admission_id,dataset_admission_artifact_id,
+           dataset_admission_gate_ledger_revision,registered_at,content_sha256,
+           content_canonical_json,manifest_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17::jsonb)`,
+        [
+          manifest.runId,
+          content.role,
+          content.nativeExecution.kind,
+          content.nativeExecution.executionId,
+          artifact.artifactId,
+          content.nativeExecution.artifact.artifactId,
+          content.protocolId,
+          content.protocolArtifact.artifactId,
+          content.datasetId,
+          content.datasetArtifact.artifactId,
+          content.datasetAdmissionId,
+          content.datasetAdmissionArtifact.artifactId,
+          content.datasetAdmissionGateLedgerRevision,
+          content.registeredAt,
+          manifest.runId.slice('model-run:'.length),
+          canonicalizeAflTradeJson(content),
+          canonicalizeAflTradeJson(manifest),
+        ]
+      );
+      return loadExactFrom(transaction, this.dependencies, manifest.runId);
+    });
+  }
+
+  loadExact(runId: string): Promise<RetainedGovernedValuationComponentRun> {
+    return loadExactFrom(this.dependencies.client, this.dependencies, runId);
+  }
+}

--- a/src/server/aflTradeIntelligence/valuation/postgresPreparedValuationInputSetStore.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPreparedValuationInputSetStore.ts
@@ -10,6 +10,14 @@ import {
 } from './preparedValuationInputSet';
 
 interface PreparedSetRow {
+  content_sha256: string;
+  schema_version: string;
+  environment: string;
+  scope_key: string;
+  factual_release_scope_key: string;
+  factual_release_id: string;
+  qualification_report_id: string;
+  prepared_at: Date | string;
   prepared_set_json: unknown;
   content_canonical_json: string;
   prepared_set_canonical_json: string;
@@ -28,6 +36,30 @@ interface PreparedEntryRow {
   state: 'ready' | 'blocked';
   entry_canonical_json: string;
   entry_json: unknown;
+}
+
+interface CurrentPreparedSetHeadRow {
+  scope_key: string;
+  prepared_input_set_id: string;
+  revision: number;
+  activated_at: Date | string;
+}
+
+export interface AflTradeCurrentPreparedValuationInputHead {
+  readonly scopeKey: string;
+  readonly preparedInputSetId: string;
+  readonly revision: number;
+  readonly activatedAt: string;
+}
+
+export interface AflTradeCurrentPreparedValuationInputSet {
+  readonly head: AflTradeCurrentPreparedValuationInputHead;
+  readonly preparedInputSet: AflTradePreparedValuationInputSet;
+}
+
+export interface AflTradeCurrentPreparedValuationInputTrade
+  extends AflTradeCurrentPreparedValuationInputSet {
+  readonly entry: AflTradePreparedValuationInputEntry;
 }
 
 export class AflTradePreparedValuationInputSetStoreError extends Error {
@@ -56,7 +88,9 @@ async function loadExactFromClient(
   preparedInputSetId: string
 ): Promise<AflTradePreparedValuationInputSet> {
   const result = await client.query<PreparedSetRow>(
-    `SELECT prepared_set_json,content_canonical_json,prepared_set_canonical_json,finalized_at,
+    `SELECT content_sha256,schema_version,environment,scope_key,factual_release_scope_key,
+       factual_release_id,qualification_report_id,prepared_at,
+       prepared_set_json,content_canonical_json,prepared_set_canonical_json,finalized_at,
        trade_count,ready_count,blocked_count,
        (SELECT count(*)::integer FROM outcome_prepared_valuation_input_entry entry
          WHERE entry.prepared_input_set_id=prepared.prepared_input_set_id) AS actual_count,
@@ -87,8 +121,20 @@ async function loadExactFromClient(
       'Stored prepared valuation input set does not satisfy its contract.'
     );
   }
+  const preparedAt =
+    row.prepared_at instanceof Date
+      ? row.prepared_at.toISOString()
+      : new Date(row.prepared_at).toISOString();
   if (
     prepared.preparedInputSetId !== preparedInputSetId ||
+    row.content_sha256 !== digestFromId(preparedInputSetId, 'prepared-valuation-input-set') ||
+    row.schema_version !== prepared.content.schemaVersion ||
+    row.environment !== prepared.content.environment ||
+    row.scope_key !== prepared.content.scopeKey ||
+    row.factual_release_scope_key !== prepared.content.factualReleaseScopeKey ||
+    row.factual_release_id !== prepared.content.factualReleaseId ||
+    row.qualification_report_id !== prepared.content.qualificationReportId ||
+    preparedAt !== prepared.content.preparedAt ||
     !row.finalized_at ||
     row.content_canonical_json !== canonicalizeAflTradeJson(prepared.content) ||
     row.prepared_set_canonical_json !== canonicalizeAflTradeJson(prepared) ||
@@ -130,6 +176,74 @@ async function loadExactFromClient(
   return prepared;
 }
 
+function authenticateCurrentHead(
+  row: CurrentPreparedSetHeadRow
+): AflTradeCurrentPreparedValuationInputHead {
+  const activatedAt =
+    row.activated_at instanceof Date
+      ? row.activated_at.toISOString()
+      : new Date(row.activated_at).toISOString();
+  if (
+    row.scope_key.trim() === '' ||
+    row.prepared_input_set_id.trim() === '' ||
+    !Number.isSafeInteger(row.revision) ||
+    row.revision <= 0
+  ) {
+    throw new AflTradePreparedValuationInputSetStoreError(
+      'INTEGRITY_MISMATCH',
+      'Current prepared valuation input head is malformed.'
+    );
+  }
+  return {
+    scopeKey: row.scope_key,
+    preparedInputSetId: row.prepared_input_set_id,
+    revision: row.revision,
+    activatedAt,
+  };
+}
+
+async function loadCurrentFromClient(
+  client: AflOutcomeSqlTransaction,
+  scopeKey: string
+): Promise<AflTradeCurrentPreparedValuationInputSet | null> {
+  const result = await client.query<CurrentPreparedSetHeadRow>(
+    `SELECT scope_key,prepared_input_set_id,revision,activated_at
+       FROM outcome_current_prepared_valuation_input_set WHERE scope_key=$1`,
+    [scopeKey]
+  );
+  const row = result.rows[0];
+  if (!row) return null;
+  const head = authenticateCurrentHead(row);
+  const preparedInputSet = await loadExactFromClient(client, head.preparedInputSetId);
+  if (
+    preparedInputSet.content.schemaVersion !==
+      'afl-trade-prepared-valuation-input-set/v3' ||
+    preparedInputSet.content.scopeKey !== scopeKey ||
+    head.scopeKey !== scopeKey
+  ) {
+    throw new AflTradePreparedValuationInputSetStoreError(
+      'INTEGRITY_MISMATCH',
+      'Current prepared valuation input head does not authenticate finalized v3 scope authority.'
+    );
+  }
+  return { head, preparedInputSet };
+}
+
+export async function loadCurrentAflTradePreparedValuationInputTradeFromTransaction(
+  transaction: AflOutcomeSqlTransaction,
+  input: { readonly scopeKey: string; readonly tradeId: string }
+): Promise<AflTradeCurrentPreparedValuationInputTrade | null> {
+  if (input.scopeKey.trim() === '' || input.tradeId.trim() === '') {
+    throw new TypeError('Current prepared trade authority requires a complete selector.');
+  }
+  const current = await loadCurrentFromClient(transaction, input.scopeKey);
+  if (!current) return null;
+  const entry = current.preparedInputSet.content.entries.find(
+    ({ tradeId }) => tradeId === input.tradeId
+  );
+  return entry ? { ...current, entry } : null;
+}
+
 export interface AflTradePreparedValuationInputSetStore {
   register(prepared: AflTradePreparedValuationInputSet): Promise<AflTradePreparedValuationInputSet>;
   loadExact(preparedInputSetId: string): Promise<AflTradePreparedValuationInputSet>;
@@ -137,6 +251,16 @@ export interface AflTradePreparedValuationInputSetStore {
     readonly preparedInputSetId: string;
     readonly tradeId: string;
   }): Promise<AflTradePreparedValuationInputEntry | null>;
+  activateCurrent(input: {
+    readonly scopeKey: string;
+    readonly preparedInputSetId: string;
+    readonly expectedRevision: number;
+  }): Promise<AflTradeCurrentPreparedValuationInputHead>;
+  loadCurrent(scopeKey: string): Promise<AflTradeCurrentPreparedValuationInputSet | null>;
+  loadCurrentTrade(input: {
+    readonly scopeKey: string;
+    readonly tradeId: string;
+  }): Promise<AflTradeCurrentPreparedValuationInputTrade | null>;
 }
 
 export class PostgresAflTradePreparedValuationInputSetStore implements AflTradePreparedValuationInputSetStore {
@@ -231,5 +355,73 @@ export class PostgresAflTradePreparedValuationInputSetStore implements AflTradeP
   }): Promise<AflTradePreparedValuationInputEntry | null> {
     const prepared = await this.loadExact(input.preparedInputSetId);
     return prepared.content.entries.find(({ tradeId }) => tradeId === input.tradeId) ?? null;
+  }
+
+  activateCurrent(input: {
+    readonly scopeKey: string;
+    readonly preparedInputSetId: string;
+    readonly expectedRevision: number;
+  }): Promise<AflTradeCurrentPreparedValuationInputHead> {
+    if (
+      input.scopeKey.trim() === '' ||
+      input.preparedInputSetId.trim() === '' ||
+      !Number.isSafeInteger(input.expectedRevision) ||
+      input.expectedRevision < 0
+    ) {
+      throw new TypeError('Prepared valuation input activation requires a valid CAS selector.');
+    }
+    return this.client.transaction(async (transaction) => {
+      await transaction.query(
+        `SELECT activate_outcome_current_prepared_valuation_input_set($1,$2,$3)`,
+        [input.scopeKey, input.preparedInputSetId, input.expectedRevision]
+      );
+      const result = await transaction.query<CurrentPreparedSetHeadRow>(
+        `SELECT scope_key,prepared_input_set_id,revision,activated_at
+           FROM outcome_current_prepared_valuation_input_set WHERE scope_key=$1`,
+        [input.scopeKey]
+      );
+      const row = result.rows[0];
+      if (!row) {
+        throw new AflTradePreparedValuationInputSetStoreError(
+          'INTEGRITY_MISMATCH',
+          'Prepared valuation input activation did not retain a current head.'
+        );
+      }
+      const head = authenticateCurrentHead(row);
+      if (
+        head.preparedInputSetId !== input.preparedInputSetId ||
+        head.revision !== input.expectedRevision + 1
+      ) {
+        throw new AflTradePreparedValuationInputSetStoreError(
+          'INTEGRITY_MISMATCH',
+          'Prepared valuation input activation returned an unexpected head revision.'
+        );
+      }
+      return head;
+    });
+  }
+
+  loadCurrent(scopeKey: string): Promise<AflTradeCurrentPreparedValuationInputSet | null> {
+    if (scopeKey.trim() === '') throw new TypeError('Current prepared authority requires a scope.');
+    return this.client.transaction(async (transaction) => {
+      await transaction.query(`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ`);
+      return loadCurrentFromClient(transaction, scopeKey);
+    });
+  }
+
+  async loadCurrentTrade(input: {
+    readonly scopeKey: string;
+    readonly tradeId: string;
+  }): Promise<AflTradeCurrentPreparedValuationInputTrade | null> {
+    if (input.tradeId.trim() === '') {
+      throw new TypeError('Current prepared trade authority requires a trade identifier.');
+    }
+    return this.client.transaction(async (transaction) => {
+      await transaction.query(`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ`);
+      return loadCurrentAflTradePreparedValuationInputTradeFromTransaction(
+        transaction,
+        input
+      );
+    });
   }
 }

--- a/src/server/aflTradeIntelligence/valuation/preparedValuationInputSet.ts
+++ b/src/server/aflTradeIntelligence/valuation/preparedValuationInputSet.ts
@@ -67,6 +67,38 @@ const readyEntrySchema = z
     }
   });
 
+const readyEntryV2Schema = z
+  .object({
+    tradeId: publicIdSchema,
+    state: z.literal('ready'),
+    calculationInputPackageId: aflTradeContentAddressedIdSchema(
+      'valuation-calculation-input'
+    ),
+    calculationInputArtifact: aflTradeArtifactRefSchema,
+    inputTraceId: aflTradeContentAddressedIdSchema('private-evaluation-input-trace'),
+    inputTraceArtifact: aflTradeArtifactRefSchema,
+  })
+  .strict()
+  .superRefine((entry, context) => {
+    if (entry.calculationInputArtifact.artifactId === entry.inputTraceArtifact.artifactId) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Calculation input and trace must be distinct immutable artifacts.',
+      });
+    }
+  });
+
+const readyEntryV3Schema = z
+  .object({
+    tradeId: publicIdSchema,
+    state: z.literal('ready'),
+    materializationManifestId: aflTradeContentAddressedIdSchema(
+      'private-evaluation-materialization-manifest'
+    ),
+    materializationManifestArtifact: aflTradeArtifactRefSchema,
+  })
+  .strict();
+
 const blockedEntrySchema = z
   .object({
     tradeId: publicIdSchema,
@@ -89,15 +121,36 @@ const blockedEntrySchema = z
     }
   });
 
-export const aflTradePreparedValuationInputEntrySchema = z.discriminatedUnion('state', [
+const aflTradePreparedValuationInputEntryV1Schema = z.discriminatedUnion('state', [
+  readyEntrySchema,
+  blockedEntrySchema,
+]);
+
+const aflTradePreparedValuationInputEntryV2Schema = z.discriminatedUnion('state', [
+  readyEntryV2Schema,
+  blockedEntrySchema,
+]);
+
+const aflTradePreparedValuationInputEntryV3Schema = z.discriminatedUnion('state', [
+  readyEntryV3Schema,
+  blockedEntrySchema,
+]);
+
+export const aflTradePreparedValuationInputEntrySchema = z.union([
+  readyEntryV3Schema,
+  readyEntryV2Schema,
   readyEntrySchema,
   blockedEntrySchema,
 ]);
 
 export const AFL_TRADE_PREPARED_VALUATION_INPUT_SET_SCHEMA_VERSION =
   'afl-trade-prepared-valuation-input-set/v1' as const;
+export const AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V2_SCHEMA_VERSION =
+  'afl-trade-prepared-valuation-input-set/v2' as const;
+export const AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V3_SCHEMA_VERSION =
+  'afl-trade-prepared-valuation-input-set/v3' as const;
 
-export const aflTradePreparedValuationInputSetContentSchema = z
+const aflTradePreparedValuationInputSetContentV1Schema = z
   .object({
     schemaVersion: z.literal(AFL_TRADE_PREPARED_VALUATION_INPUT_SET_SCHEMA_VERSION),
     environment: z.literal('non_production'),
@@ -114,7 +167,7 @@ export const aflTradePreparedValuationInputSetContentSchema = z
     qualificationReportArtifact: aflTradeArtifactRefSchema,
     sourceQualificationEvidenceRefs: z.array(aflTradeArtifactRefSchema).min(1).max(1_000),
     releaseTradeIds: z.array(publicIdSchema).min(1).max(10_000),
-    entries: z.array(aflTradePreparedValuationInputEntrySchema).min(1).max(10_000),
+    entries: z.array(aflTradePreparedValuationInputEntryV1Schema).min(1).max(10_000),
     tradeCount: z.number().int().positive().max(10_000),
     readyCount: z.number().int().nonnegative().max(10_000),
     blockedCount: z.number().int().nonnegative().max(10_000),
@@ -226,6 +279,277 @@ export const aflTradePreparedValuationInputSetContentSchema = z
       });
     }
   });
+
+const aflTradePreparedValuationInputSetContentV2Schema = z
+  .object({
+    schemaVersion: z.literal(AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V2_SCHEMA_VERSION),
+    environment: z.literal('non_production'),
+    scopeKey: publicIdSchema,
+    factualReleaseScopeKey: publicIdSchema,
+    factualReleaseId: aflTradeContentAddressedIdSchema('outcome-release'),
+    factualReleaseArtifact: aflTradeArtifactRefSchema,
+    releaseMembershipArtifact: aflTradeArtifactRefSchema,
+    preparationAuthority: z.literal('authenticated_calculation_evidence_snapshot'),
+    qualificationOperation: z.literal(
+      'valuation_model_training_and_derived_feature_creation'
+    ),
+    qualificationReportId: aflTradeContentAddressedIdSchema('valuation-source-qualification'),
+    qualificationReportArtifact: aflTradeArtifactRefSchema,
+    sourceQualificationEvidenceRefs: z.array(aflTradeArtifactRefSchema).min(1).max(1_000),
+    valuationInputBundleId: aflTradeContentAddressedIdSchema('valuation-input-bundle'),
+    valuationInputBundleArtifact: aflTradeArtifactRefSchema,
+    releaseTradeIds: z.array(publicIdSchema).min(1).max(10_000),
+    entries: z.array(aflTradePreparedValuationInputEntryV2Schema).min(1).max(10_000),
+    tradeCount: z.number().int().positive().max(10_000),
+    readyCount: z.number().int().nonnegative().max(10_000),
+    blockedCount: z.number().int().nonnegative().max(10_000),
+    preparedAt: isoDateTimeSchema,
+    publicationEligible: z.literal(false),
+    limitation: z.literal(
+      'Private preparation evidence only; not a valuation result, publication approval, or activation authority.'
+    ),
+  })
+  .strict()
+  .superRefine((content, context) => {
+    const sourceEvidenceIds = content.sourceQualificationEvidenceRefs.map(
+      ({ artifactId }) => artifactId
+    );
+    if (
+      new Set(sourceEvidenceIds).size !== sourceEvidenceIds.length ||
+      sourceEvidenceIds.some(
+        (artifactId, index) => index > 0 && sourceEvidenceIds[index - 1]! > artifactId
+      )
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['sourceQualificationEvidenceRefs'],
+        message: 'Source qualification evidence must be unique and canonically ordered.',
+      });
+    }
+
+    if (
+      new Set(content.releaseTradeIds).size !== content.releaseTradeIds.length ||
+      content.releaseTradeIds.some(
+        (tradeId, index) => index > 0 && content.releaseTradeIds[index - 1]! > tradeId
+      )
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['releaseTradeIds'],
+        message: 'Factual-release trade IDs must be unique and use canonical order.',
+      });
+    }
+    const entryTradeIds = content.entries.map(({ tradeId }) => tradeId);
+    if (
+      entryTradeIds.length !== content.releaseTradeIds.length ||
+      entryTradeIds.some((tradeId, index) => tradeId !== content.releaseTradeIds[index])
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['entries'],
+        message: 'Prepared entries must classify the exact factual-release trade set.',
+      });
+    }
+
+    const readyEntries = content.entries.filter(
+      (entry): entry is z.infer<typeof readyEntryV2Schema> => entry.state === 'ready'
+    );
+    const blockedCount = content.entries.length - readyEntries.length;
+    if (
+      content.tradeCount !== content.entries.length ||
+      content.readyCount !== readyEntries.length ||
+      content.blockedCount !== blockedCount
+    ) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Prepared input-set counts must match the exact entry classifications.',
+      });
+    }
+
+    for (const field of ['calculationInputPackageId', 'inputTraceId'] as const) {
+      const ids = readyEntries.map((entry) => entry[field]);
+      if (new Set(ids).size !== ids.length) {
+        context.addIssue({
+          code: 'custom',
+          path: ['entries'],
+          message: `Ready prepared entries require unique ${field} values.`,
+        });
+      }
+    }
+    const readyArtifactIds = readyEntries.flatMap((entry) => [
+      entry.calculationInputArtifact.artifactId,
+      entry.inputTraceArtifact.artifactId,
+    ]);
+    if (
+      new Set([...readyArtifactIds, content.valuationInputBundleArtifact.artifactId]).size !==
+      readyArtifactIds.length + 1
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['entries'],
+        message: 'Each ready input, trace, and valuation bundle must retain distinct bytes.',
+      });
+    }
+
+    const preparedAt = Date.parse(content.preparedAt);
+    const parentArtifacts = [
+      content.factualReleaseArtifact,
+      content.releaseMembershipArtifact,
+      content.qualificationReportArtifact,
+      content.valuationInputBundleArtifact,
+    ];
+    const entryArtifacts = content.entries.flatMap((entry) =>
+      entry.state === 'ready'
+        ? [entry.calculationInputArtifact, entry.inputTraceArtifact]
+        : entry.blockers.flatMap(({ evidenceRefs }) => evidenceRefs)
+    );
+    if (
+      [...parentArtifacts, ...content.sourceQualificationEvidenceRefs, ...entryArtifacts].some(
+        (artifact) => Date.parse(artifact.createdAt) > preparedAt
+      )
+    ) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Every prepared input-set artifact must exist before preparation completes.',
+      });
+    }
+  });
+
+const aflTradePreparedValuationInputSetContentV3Schema = z
+  .object({
+    schemaVersion: z.literal(AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V3_SCHEMA_VERSION),
+    environment: z.literal('non_production'),
+    scopeKey: publicIdSchema,
+    factualReleaseScopeKey: publicIdSchema,
+    factualReleaseId: aflTradeContentAddressedIdSchema('outcome-release'),
+    factualReleaseArtifact: aflTradeArtifactRefSchema,
+    releaseMembershipArtifact: aflTradeArtifactRefSchema,
+    preparationAuthority: z.literal('authenticated_calculation_evidence_snapshot'),
+    qualificationOperation: z.literal(
+      'valuation_model_training_and_derived_feature_creation'
+    ),
+    qualificationReportId: aflTradeContentAddressedIdSchema('valuation-source-qualification'),
+    qualificationReportArtifact: aflTradeArtifactRefSchema,
+    sourceQualificationEvidenceRefs: z.array(aflTradeArtifactRefSchema).min(1).max(1_000),
+    valuationInputBundleId: aflTradeContentAddressedIdSchema('valuation-input-bundle'),
+    valuationInputBundleArtifact: aflTradeArtifactRefSchema,
+    releaseTradeIds: z.array(publicIdSchema).min(1).max(10_000),
+    entries: z.array(aflTradePreparedValuationInputEntryV3Schema).min(1).max(10_000),
+    tradeCount: z.number().int().positive().max(10_000),
+    readyCount: z.number().int().nonnegative().max(10_000),
+    blockedCount: z.number().int().nonnegative().max(10_000),
+    preparedAt: isoDateTimeSchema,
+    publicationEligible: z.literal(false),
+    limitation: z.literal(
+      'Private preparation evidence only; not a valuation result, publication approval, or activation authority.'
+    ),
+  })
+  .strict()
+  .superRefine((content, context) => {
+    const sourceEvidenceIds = content.sourceQualificationEvidenceRefs.map(
+      ({ artifactId }) => artifactId
+    );
+    if (
+      new Set(sourceEvidenceIds).size !== sourceEvidenceIds.length ||
+      sourceEvidenceIds.some(
+        (artifactId, index) => index > 0 && sourceEvidenceIds[index - 1]! > artifactId
+      )
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['sourceQualificationEvidenceRefs'],
+        message: 'Source qualification evidence must be unique and canonically ordered.',
+      });
+    }
+    if (
+      new Set(content.releaseTradeIds).size !== content.releaseTradeIds.length ||
+      content.releaseTradeIds.some(
+        (tradeId, index) => index > 0 && content.releaseTradeIds[index - 1]! > tradeId
+      )
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['releaseTradeIds'],
+        message: 'Factual-release trade IDs must be unique and use canonical order.',
+      });
+    }
+    const entryTradeIds = content.entries.map(({ tradeId }) => tradeId);
+    if (
+      entryTradeIds.length !== content.releaseTradeIds.length ||
+      entryTradeIds.some((tradeId, index) => tradeId !== content.releaseTradeIds[index])
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['entries'],
+        message: 'Prepared entries must classify the exact factual-release trade set.',
+      });
+    }
+    const readyEntries = content.entries.filter(
+      (entry): entry is z.infer<typeof readyEntryV3Schema> => entry.state === 'ready'
+    );
+    if (
+      content.tradeCount !== content.entries.length ||
+      content.readyCount !== readyEntries.length ||
+      content.blockedCount !== content.entries.length - readyEntries.length
+    ) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Prepared input-set counts must match the exact entry classifications.',
+      });
+    }
+    const manifestIds = readyEntries.map(({ materializationManifestId }) =>
+      materializationManifestId
+    );
+    if (new Set(manifestIds).size !== manifestIds.length) {
+      context.addIssue({
+        code: 'custom',
+        path: ['entries'],
+        message: 'Ready prepared entries require unique materialization manifest identities.',
+      });
+    }
+    const readyArtifacts = readyEntries.map(({ materializationManifestArtifact }) =>
+      materializationManifestArtifact
+    );
+    const artifactIds = [
+      content.valuationInputBundleArtifact.artifactId,
+      ...readyArtifacts.map(({ artifactId }) => artifactId),
+    ];
+    if (new Set(artifactIds).size !== artifactIds.length) {
+      context.addIssue({
+        code: 'custom',
+        path: ['entries'],
+        message: 'Each ready manifest and valuation bundle must retain distinct bytes.',
+      });
+    }
+    const entryArtifacts = content.entries.flatMap((entry) =>
+      entry.state === 'ready'
+        ? [entry.materializationManifestArtifact]
+        : entry.blockers.flatMap(({ evidenceRefs }) => evidenceRefs)
+    );
+    const parents = [
+      content.factualReleaseArtifact,
+      content.releaseMembershipArtifact,
+      content.qualificationReportArtifact,
+      content.valuationInputBundleArtifact,
+      ...content.sourceQualificationEvidenceRefs,
+      ...entryArtifacts,
+    ];
+    if (parents.some(({ createdAt }) => Date.parse(createdAt) > Date.parse(content.preparedAt))) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Every prepared input-set artifact must exist before preparation completes.',
+      });
+    }
+  });
+
+export const aflTradePreparedValuationInputSetContentSchema = z.discriminatedUnion(
+  'schemaVersion',
+  [
+    aflTradePreparedValuationInputSetContentV1Schema,
+    aflTradePreparedValuationInputSetContentV2Schema,
+    aflTradePreparedValuationInputSetContentV3Schema,
+  ]
+);
 
 export const aflTradePreparedValuationInputSetSchema = z
   .object({

--- a/src/server/aflTradeIntelligence/valuation/tradeCalculationNarrative.ts
+++ b/src/server/aflTradeIntelligence/valuation/tradeCalculationNarrative.ts
@@ -1,0 +1,404 @@
+import { AFL_TRADE_VALUATION_VIEWS } from '@/types/aflTradeIntelligence';
+
+import {
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '../artifacts/contentAddress';
+import type { AflTradeAssetLineageNarrativeEvidence } from './assetLineageNarrativeEvidence';
+import type {
+  AflTradePickCalculationEvidence,
+  AflTradePlayerCalculationEvidence,
+} from './calculationNarrativeEvidence';
+import type {
+  AflTradeValuationAssetContribution,
+  AflTradeValuationExplanationClub,
+  AflTradeValuationExplanationDocument,
+} from './tradeValuationExplanation';
+
+type ValuationView = (typeof AFL_TRADE_VALUATION_VIEWS)[number];
+type ModelEvidence = AflTradePlayerCalculationEvidence | AflTradePickCalculationEvidence;
+
+export interface AflTradeCalculationNarrativeInput {
+  explanation: AflTradeValuationExplanationDocument;
+  assets: readonly Readonly<{
+    assetId: string;
+    modelEvidence: ModelEvidence;
+    lineage: AflTradeAssetLineageNarrativeEvidence;
+  }>[];
+}
+
+interface AssetIdentity {
+  assetId: string;
+  assetKind: AflTradeValuationAssetContribution['assetKind'];
+  label: string;
+  fromClubId: string;
+  toClubId: string;
+}
+
+const EPSILON = 1e-9;
+
+function close(left: number, right: number): boolean {
+  return Number.isFinite(left) && Number.isFinite(right) && Math.abs(left - right) <= EPSILON;
+}
+
+function sum(values: readonly number[]): number {
+  return values.reduce((total, value) => total + value, 0);
+}
+
+function formatted(value: number): string {
+  const normalized = close(value, 0) ? 0 : value;
+  return Number.isInteger(normalized) ? normalized.toString() : normalized.toFixed(4).replace(/0+$/u, '').replace(/\.$/u, '');
+}
+
+function signed(value: number): string {
+  return `${value >= 0 ? '+' : ''}${formatted(value)}`;
+}
+
+function assertDistribution(
+  distribution: AflTradeValuationAssetContribution['distribution'],
+  expectedMean: number
+): void {
+  if (
+    !close(distribution.mean, expectedMean) ||
+    ![distribution.median, distribution.p10, distribution.p90].every(Number.isFinite) ||
+    distribution.p10 > distribution.median ||
+    distribution.median > distribution.p90
+  ) {
+    throw new TypeError('Trade calculation narrative requires reconciled package uncertainty.');
+  }
+}
+
+function identityOf(asset: AflTradeValuationAssetContribution): AssetIdentity {
+  return {
+    assetId: asset.assetId,
+    assetKind: asset.assetKind,
+    label: asset.label,
+    fromClubId: asset.fromClubId,
+    toClubId: asset.toClubId,
+  };
+}
+
+function assertSameAsset(
+  expected: AflTradeValuationAssetContribution,
+  candidate: AflTradeValuationAssetContribution
+): void {
+  if (canonicalizeAflTradeJson(expected) !== canonicalizeAflTradeJson(candidate)) {
+    throw new TypeError('Trade calculation narrative found inconsistent duplicated asset values.');
+  }
+}
+
+function assertLedgerArithmetic(club: AflTradeValuationExplanationClub): void {
+  const receivedMean = sum(club.received.assets.map(({ additiveMean }) => additiveMean));
+  const givenUpMean = sum(club.givenUp.assets.map(({ additiveMean }) => additiveMean));
+  if (
+    !close(club.received.additiveMean, receivedMean) ||
+    !close(club.givenUp.additiveMean, givenUpMean) ||
+    !close(club.net.additiveMean, receivedMean - givenUpMean)
+  ) {
+    throw new TypeError('Trade calculation narrative package arithmetic does not reconcile.');
+  }
+  assertDistribution(club.received.distribution, receivedMean);
+  assertDistribution(club.givenUp.distribution, givenUpMean);
+  assertDistribution(club.net.distribution, receivedMean - givenUpMean);
+}
+
+function packageSummary(
+  club: AflTradeValuationExplanationClub,
+  valueUnitId: string
+): string {
+  const arithmetic = `${formatted(club.received.additiveMean)} - ${formatted(club.givenUp.additiveMean)} = ${signed(club.net.additiveMean)} ${valueUnitId}`;
+  if (club.grade.grade === null) {
+    return `${arithmetic}. The package grade is unavailable (${club.grade.reasonCode}).`;
+  }
+  return `${arithmetic}, resulting in a ${club.grade.state} ${club.grade.grade} package grade.`;
+}
+
+function assertPlayerEvidence(
+  evidence: Exclude<AflTradePlayerCalculationEvidence, { state: 'unavailable' }>
+): void {
+  const seasonYears = evidence.seasons.map(({ seasonYear }) => seasonYear);
+  const gamesPlayed = sum(evidence.seasons.map((season) => season.gamesPlayed));
+  const contribution = sum(evidence.seasons.map((season) => season.contribution));
+  const contributionPerGame = gamesPlayed === 0 ? null : contribution / gamesPlayed;
+  const perSeasonRatesReconcile = evidence.seasons.every((season) => {
+    const expected =
+      season.gamesPlayed === 0 ? null : season.contribution / season.gamesPlayed;
+    return (
+      (expected === null && season.contributionPerGame === null) ||
+      (expected !== null &&
+        season.contributionPerGame !== null &&
+        close(expected, season.contributionPerGame))
+    );
+  });
+  if (
+    canonicalizeAflTradeJson(seasonYears) !==
+      canonicalizeAflTradeJson(evidence.horizon.observedSeasons) ||
+    !evidence.horizon.observedSeasons.every((season) =>
+      evidence.horizon.requiredSeasons.includes(season)
+    ) ||
+    (evidence.state === 'mature_observed' &&
+      canonicalizeAflTradeJson(evidence.horizon.observedSeasons) !==
+        canonicalizeAflTradeJson(evidence.horizon.requiredSeasons)) ||
+    !close(evidence.totals.gamesPlayed, gamesPlayed) ||
+    !close(evidence.totals.contribution, contribution) ||
+    ((contributionPerGame === null) !== (evidence.totals.contributionPerGame === null)) ||
+    (contributionPerGame !== null &&
+      evidence.totals.contributionPerGame !== null &&
+      !close(evidence.totals.contributionPerGame, contributionPerGame)) ||
+    !perSeasonRatesReconcile
+  ) {
+    throw new TypeError(
+      'Trade calculation narrative player evidence totals do not reconcile to retained seasons.'
+    );
+  }
+}
+
+function playerStory(
+  label: string,
+  evidence: Exclude<AflTradePlayerCalculationEvidence, { state: 'unavailable' }>,
+  valueUnitId: string
+): string {
+  assertPlayerEvidence(evidence);
+  const totals = evidence.totals;
+  const seasonCount = evidence.horizon.observedSeasons.length;
+  const perGame = totals.contributionPerGame === null ? 'unavailable' : formatted(totals.contributionPerGame);
+  const censoring = evidence.state === 'right_censored' ? ' The current season is right-censored.' : '';
+  return `${label} records ${formatted(totals.gamesPlayed)} games for ${formatted(totals.contribution)} ${valueUnitId} across ${seasonCount} observed season${seasonCount === 1 ? '' : 's'} (${perGame} per game).${censoring}`;
+}
+
+function pickStory(label: string, evidence: AflTradePickCalculationEvidence): string {
+  return `${label} is estimated from ${evidence.cohort.observationCount} observations across ${evidence.cohort.draftClassCount} draft classes (picks ${evidence.cohort.minimumSelectionNumber}-${evidence.cohort.maximumSelectionNumber}), with an expected ${formatted(evidence.expected.contribution)} ${evidence.valueUnit} and ${formatted(evidence.expected.games)} games over ${evidence.fixedHorizonSeasons} seasons.`;
+}
+
+function contributionStory(input: {
+  identity: AssetIdentity;
+  contribution: AflTradeValuationAssetContribution;
+  view: ValuationView;
+  evidence: ModelEvidence;
+  valueUnitId: string;
+  valuationCalculationId: string;
+  effectiveThrough: string;
+}): string {
+  const { identity, contribution, view, evidence, valueUnitId } = input;
+  const value = formatted(contribution.additiveMean);
+  if (view === 'at_trade') {
+    if (evidence.kind === 'pick') {
+      if (!close(contribution.additiveMean, evidence.expected.contribution)) {
+        throw new TypeError(
+          'Trade calculation narrative pick at-trade value does not reconcile to its cohort expectation.'
+        );
+      }
+      return `${identity.label}: ${value} ${valueUnitId} expected from ${evidence.cohort.observationCount} observations across ${evidence.cohort.draftClassCount} draft classes (picks ${evidence.cohort.minimumSelectionNumber}-${evidence.cohort.maximumSelectionNumber}).`;
+    }
+    return `${identity.label}: ${value} ${valueUnitId} at-trade model estimate from authenticated calculation ${input.valuationCalculationId}.`;
+  }
+  if (view === 'realized') {
+    if (evidence.kind === 'player') {
+      if (evidence.state === 'unavailable' || !close(contribution.additiveMean, evidence.totals.contribution)) {
+        throw new TypeError(
+          'Trade calculation narrative player realized value does not reconcile to retained seasons.'
+        );
+      }
+      const rate =
+        evidence.totals.contributionPerGame === null
+          ? 'unavailable'
+          : formatted(evidence.totals.contributionPerGame);
+      return `${identity.label}: ${value} ${valueUnitId} from ${formatted(evidence.totals.gamesPlayed)} games at ${rate} per game across ${evidence.seasons.length} observed seasons.`;
+    }
+    return contribution.additiveMean === 0
+      ? `${identity.label}: 0 ${valueUnitId} realized; no observed successor contribution is credited at this cutoff.`
+      : `${identity.label}: ${value} ${valueUnitId} realized through its retained transformation lineage.`;
+  }
+  if (view === 'remaining') {
+    return `${identity.label}: ${value} ${valueUnitId} remaining model estimate through ${input.effectiveThrough}.`;
+  }
+  const components = contribution.currentComponents!;
+  return `${identity.label}: ${value} = ${formatted(components.realizedMean)} realized + ${formatted(components.remainingMean)} remaining ${valueUnitId}.`;
+}
+
+function authenticateExplanation(explanation: AflTradeValuationExplanationDocument): void {
+  const { explanationId, ...content } = explanation;
+  if (createAflTradeContentAddress('valuation-explanation', content) !== explanationId) {
+    throw new TypeError('Trade calculation narrative requires an authentic explanation artifact.');
+  }
+}
+
+/**
+ * Builds a deterministic reader artifact from one already-derived four-view explanation. It does
+ * not calculate new values or grades: it authenticates and rechecks the package calculation, then
+ * binds each asset to the exact model evidence and temporal lineage used to explain that value.
+ */
+export function createAflTradeCalculationNarrative(input: AflTradeCalculationNarrativeInput) {
+  const explanation = input.explanation;
+  if (
+    explanation.coverage.status !== 'complete' ||
+    explanation.coverage.ratio !== 1 ||
+    explanation.methodology.assetGradeTreatment !== 'prohibited' ||
+    explanation.methodology.currentIdentity !== 'realized_plus_remaining' ||
+    canonicalizeAflTradeJson(explanation.views.map(({ view }) => view)) !==
+      canonicalizeAflTradeJson(AFL_TRADE_VALUATION_VIEWS)
+  ) {
+    throw new TypeError('Trade calculation narrative requires one complete canonical four-view calculation.');
+  }
+
+  const identities = new Map<string, AssetIdentity>();
+  const contributions = new Map<string, Map<ValuationView, AflTradeValuationAssetContribution>>();
+  const narrativeViews = explanation.views.map((tradeView) => {
+    const receivedCounts = new Map<string, number>();
+    const givenUpCounts = new Map<string, number>();
+    const clubs = tradeView.clubs.map((club) => {
+      assertLedgerArithmetic(club);
+      for (const [side, assets] of [
+        ['received', club.received.assets],
+        ['givenUp', club.givenUp.assets],
+      ] as const) {
+        for (const asset of assets) {
+          if (
+            (side === 'received' && asset.toClubId !== club.aflClubId) ||
+            (side === 'givenUp' && asset.fromClubId !== club.aflClubId)
+          ) {
+            throw new TypeError('Trade calculation narrative asset direction does not match its club package.');
+          }
+          const currentIdentity = identityOf(asset);
+          const knownIdentity = identities.get(asset.assetId);
+          if (
+            knownIdentity !== undefined &&
+            canonicalizeAflTradeJson(knownIdentity) !== canonicalizeAflTradeJson(currentIdentity)
+          ) {
+            throw new TypeError('Trade calculation narrative asset identity changed between package views.');
+          }
+          identities.set(asset.assetId, currentIdentity);
+          const byView = contributions.get(asset.assetId) ?? new Map();
+          const knownContribution = byView.get(tradeView.view);
+          if (knownContribution === undefined) byView.set(tradeView.view, asset);
+          else assertSameAsset(knownContribution, asset);
+          contributions.set(asset.assetId, byView);
+          const counts = side === 'received' ? receivedCounts : givenUpCounts;
+          counts.set(asset.assetId, (counts.get(asset.assetId) ?? 0) + 1);
+          if (
+            (tradeView.view === 'current' &&
+              (asset.currentComponents === null ||
+                !close(
+                  asset.additiveMean,
+                  asset.currentComponents.realizedMean + asset.currentComponents.remainingMean
+                ))) ||
+            (tradeView.view !== 'current' && asset.currentComponents !== null)
+          ) {
+            throw new TypeError('Trade calculation narrative current value does not reconcile to realized plus remaining.');
+          }
+        }
+      }
+      return {
+        aflClubId: club.aflClubId,
+        clubName: club.clubName,
+        receivedAssetIds: club.received.assets.map(({ assetId }) => assetId),
+        givenUpAssetIds: club.givenUp.assets.map(({ assetId }) => assetId),
+        arithmetic: {
+          receivedMean: club.received.additiveMean,
+          givenUpMean: club.givenUp.additiveMean,
+          estimatedAdvantageMean: club.net.additiveMean,
+        },
+        uncertainty: { ...club.net.distribution },
+        finishAheadProbability: club.finishAheadProbability,
+        grade: { ...club.grade },
+        summary: packageSummary(club, explanation.valueUnitId),
+      };
+    });
+    if (
+      [...identities].some(
+        ([assetId]) => receivedCounts.get(assetId) !== 1 || givenUpCounts.get(assetId) !== 1
+      ) ||
+      !close(sum(clubs.map(({ arithmetic }) => arithmetic.estimatedAdvantageMean)), 0) ||
+      !close(
+        sum(clubs.map(({ finishAheadProbability }) => finishAheadProbability)) +
+          tradeView.practicalEquivalenceProbability,
+        1
+      )
+    ) {
+      throw new TypeError('Trade calculation narrative requires globally balanced club packages.');
+    }
+    return {
+      view: tradeView.view,
+      practicalEquivalenceProbability: tradeView.practicalEquivalenceProbability,
+      verdict: { ...tradeView.verdict, aflClubIds: [...tradeView.verdict.aflClubIds] },
+      clubs,
+    };
+  });
+
+  authenticateExplanation(explanation);
+  const evidenceByAssetId = new Map(input.assets.map((entry) => [entry.assetId, entry]));
+  if (evidenceByAssetId.size !== input.assets.length || evidenceByAssetId.size !== identities.size) {
+    throw new TypeError('Trade calculation narrative requires exactly one evidence package per asset.');
+  }
+  const assets = [...identities.values()]
+    .sort((left, right) => left.assetId.localeCompare(right.assetId))
+    .map((identity) => {
+      const evidencePackage = evidenceByAssetId.get(identity.assetId);
+      if (
+        evidencePackage === undefined ||
+        evidencePackage.lineage.rootAssetId !== identity.assetId ||
+        !evidencePackage.lineage.nodes.some(({ assetId }) => assetId === identity.assetId) ||
+        (identity.assetKind === 'player' && evidencePackage.modelEvidence.kind !== 'player') ||
+        (identity.assetKind !== 'player' && evidencePackage.modelEvidence.kind !== 'pick') ||
+        (evidencePackage.modelEvidence.kind === 'player' &&
+          evidencePackage.modelEvidence.state === 'unavailable')
+      ) {
+        throw new TypeError('Trade calculation narrative evidence does not authenticate its asset.');
+      }
+      const modelEvidence = evidencePackage.modelEvidence;
+      const story =
+        modelEvidence.kind === 'player'
+          ? playerStory(identity.label, modelEvidence, explanation.valueUnitId)
+          : pickStory(identity.label, modelEvidence);
+      return {
+        ...identity,
+        contributions: AFL_TRADE_VALUATION_VIEWS.map((view) => {
+          const contribution = contributions.get(identity.assetId)?.get(view);
+          if (contribution === undefined) {
+            throw new TypeError('Trade calculation narrative is missing an asset view contribution.');
+          }
+          return {
+            view,
+            ...contribution,
+            story: contributionStory({
+              identity,
+              contribution,
+              view,
+              evidence: modelEvidence,
+              valueUnitId: explanation.valueUnitId,
+              valuationCalculationId: explanation.valuationCalculationId,
+              effectiveThrough: explanation.effectiveThrough,
+            }),
+          };
+        }),
+        modelEvidence,
+        lineage: evidencePackage.lineage,
+        story,
+      };
+    });
+  const content = {
+    schemaVersion: 'afl-trade-calculation-narrative/v1' as const,
+    tradeId: explanation.tradeId,
+    explanationId: explanation.explanationId,
+    valuationCaseId: explanation.valuationCaseId,
+    valuationCalculationId: explanation.valuationCalculationId,
+    valueUnitId: explanation.valueUnitId,
+    defaultView: explanation.defaultView,
+    publicationProhibited: explanation.authority.publicationProhibited,
+    methodology: {
+      additiveStatistic: explanation.methodology.additiveStatistic,
+      uncertaintyStatistic: explanation.methodology.uncertaintyStatistic,
+      packageMedianIsAdditive: explanation.methodology.packageMedianIsAdditive,
+      currentIdentity: explanation.methodology.currentIdentity,
+      gradeScope: 'club_package_only' as const,
+      practicalEquivalenceBasis: explanation.methodology.practicalEquivalenceBasis,
+      practicalEquivalencePolicy: { ...explanation.methodology.practicalEquivalencePolicy },
+    },
+    views: narrativeViews,
+    assets,
+  };
+  return {
+    narrativeId: createAflTradeContentAddress('trade-calculation-narrative', content),
+    content,
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/tradeValuationExplanation.ts
+++ b/src/server/aflTradeIntelligence/valuation/tradeValuationExplanation.ts
@@ -4,14 +4,24 @@ import { AFL_TRADE_VALUATION_VIEWS } from '@/types/aflTradeIntelligence';
 
 import { createAflTradeContentAddress } from '../artifacts/contentAddress';
 import {
+  authenticateGovernedPrivateEvaluationExplanationSource,
+  type GovernedPrivateEvaluationExplanationSource,
+} from './internal/governedPrivateEvaluationExplanationSource';
+import { governedPrivateEvaluationExplanationPolicySchema } from './internal/governedPrivateEvaluationExplanationPolicy';
+import { governedPrivateEvaluationInputTraceSchema } from './internal/governedPrivateEvaluationInputTrace';
+import {
   deriveAflTradeStatlyGradesFromProbabilities,
   type AflTradeStatlyGrade,
   type AflTradeStatlyGradeState,
 } from './statlyGradePolicy';
 import {
   aflTradeValuationCalculationSchema,
+  calculateAflTradeValuation,
   type AflTradeValuationCalculation,
 } from './tradeValuationCalculation';
+import {
+  aflTradeValuationCalculationInputPackageSchema,
+} from './valuationCalculationInputPackage';
 import { aflTradeValuationCaseSchema, type AflTradeValuationCase } from './valuationCaseContracts';
 
 export const AFL_TRADE_VALUATION_EXPLANATION_SCHEMA_VERSION =
@@ -21,12 +31,14 @@ type ValuationView = (typeof AFL_TRADE_VALUATION_VIEWS)[number];
 type SelectedLayer = 'gross' | 'listSpotAdjusted' | 'scarcityAdjusted';
 type AssetKind = 'player' | 'current_pick' | 'future_pick';
 
-export type AflTradeValuationExplanationAuthority = {
-  kind: 'private_synthetic';
-  assumptionSetId: string;
-  publicationProhibited: true;
-  warning: 'Fabricated rank-based test values — not real AFL data.';
-};
+export type AflTradeValuationExplanationAuthority =
+  | {
+      kind: 'private_synthetic';
+      assumptionSetId: string;
+      publicationProhibited: true;
+      warning: 'Fabricated rank-based test values — not real AFL data.';
+    }
+  | GovernedPrivateEvaluationExplanationSource['authority'];
 
 export interface AflTradeValuationExplanationTransfer {
   transferId: string;
@@ -209,7 +221,7 @@ export interface AflTradeValuationExplanationDocument {
     status: 'complete';
     ratio: 1;
   };
-  confidenceLevel: 'low' | 'moderate' | 'high';
+  confidenceLevel: 'unavailable' | 'low' | 'moderate' | 'high';
   selectedLayer: SelectedLayer;
   views: readonly AflTradeValuationExplanationView[];
   methodology: {
@@ -220,7 +232,8 @@ export interface AflTradeValuationExplanationDocument {
     currentIdentity: 'realized_plus_remaining';
     practicalEquivalenceBasis: string;
     practicalEquivalencePolicy: {
-      assumptionSetId: string;
+      assumptionSetId?: string;
+      explanationPolicyId?: string;
       valueUnitId: string;
       bandByView: Record<ValuationView, number>;
     };
@@ -237,6 +250,12 @@ export interface CreateAflTradeValuationExplanationInput {
     confidenceLevel: 'low' | 'moderate' | 'high';
     developmentPreview: boolean;
   };
+}
+
+export interface CreateGovernedAflTradeValuationExplanationInput {
+  trace: unknown;
+  explanationPolicy: unknown;
+  calculationInputPackage: unknown;
 }
 
 export type AflTradeValuationExplanationResult =
@@ -261,6 +280,22 @@ interface WeightedValue {
 interface PreparedAsset {
   contribution: AflTradeValuationAssetContribution;
   selectedSamples: readonly WeightedValue[];
+}
+
+interface ValidatedExplanationSource {
+  valuationCase: AflTradeValuationCase;
+  calculation: AflTradeValuationCalculation;
+  authority: AflTradeValuationExplanationAuthority;
+  transfers: readonly AflTradeValuationExplanationTransfer[];
+  selectedLayer: SelectedLayer;
+  gradeContext: CreateAflTradeValuationExplanationInput['gradeContext'] | null;
+  effectiveAt: string;
+  effectiveThrough: string;
+  practicalEquivalenceBasis: string;
+  practicalEquivalenceBandByView: Record<ValuationView, number>;
+  practicalEquivalencePolicyReference:
+    | { assumptionSetId: string }
+    | { explanationPolicyId: string };
 }
 
 function contractViolation(message: string, cause?: unknown): never {
@@ -356,12 +391,9 @@ function subtractSamples(
   }));
 }
 
-function validateInput(input: CreateAflTradeValuationExplanationInput): {
-  valuationCase: AflTradeValuationCase;
-  calculation: AflTradeValuationCalculation;
-  authority: AflTradeValuationExplanationAuthority;
-  transfers: readonly AflTradeValuationExplanationTransfer[];
-} {
+function validateSyntheticInput(
+  input: CreateAflTradeValuationExplanationInput
+): ValidatedExplanationSource {
   let valuationCase: AflTradeValuationCase;
   let calculation: AflTradeValuationCalculation;
   let directionEvidence: AflTradeValuationExplanationDirectionEvidence;
@@ -481,6 +513,105 @@ function validateInput(input: CreateAflTradeValuationExplanationInput): {
       warning: 'Fabricated rank-based test values — not real AFL data.',
     },
     transfers,
+    selectedLayer: input.selectedLayer,
+    gradeContext: input.gradeContext,
+    effectiveAt: directionEvidence.content.effectiveAt,
+    effectiveThrough: directionEvidence.content.effectiveThrough,
+    practicalEquivalenceBasis:
+      directionEvidence.content.explanationPolicy.practicalEquivalenceBasis,
+    practicalEquivalenceBandByView:
+      directionEvidence.content.explanationPolicy.practicalEquivalenceBandByView,
+    practicalEquivalencePolicyReference: {
+      assumptionSetId: directionEvidence.assumptionSetId,
+    },
+  };
+}
+
+function validateGovernedInput(
+  input: CreateGovernedAflTradeValuationExplanationInput
+): ValidatedExplanationSource {
+  const trace = governedPrivateEvaluationInputTraceSchema.parse(input.trace);
+  const explanationPolicy = governedPrivateEvaluationExplanationPolicySchema.parse(
+    input.explanationPolicy
+  );
+  const calculationInputPackage = aflTradeValuationCalculationInputPackageSchema.parse(
+    input.calculationInputPackage
+  );
+  if (calculationInputPackage.content.schemaVersion !== 'afl-trade-valuation-calculation-input-package/v2') {
+    contractViolation('Governed explanation requires an authenticated v2 calculation input package.');
+  }
+  const source = authenticateGovernedPrivateEvaluationExplanationSource({
+    trace,
+    policy: explanationPolicy,
+  });
+  const packageContent = calculationInputPackage.content;
+  const valuationCase = packageContent.valuationCase;
+  const caseContent = valuationCase.content;
+  const currentContext = caseContent.viewContexts.find(({ view }) => view === 'current')!;
+  if (
+    packageContent.authority.inputTraceId !== trace.inputTraceId ||
+    packageContent.valuationInputBundleId !== trace.content.valuationInputBundleId ||
+    packageContent.tradeId !== trace.content.selector.tradeId ||
+    caseContent.tradeId !== source.selector.tradeId ||
+    caseContent.tradeEffectiveAt !== source.effectiveAt ||
+    caseContent.valueUnitId !== source.valueUnitId ||
+    Date.parse(packageContent.createdAt) < Date.parse(trace.content.derivedAt) ||
+    Date.parse(packageContent.createdAt) < Date.parse(explanationPolicy.content.createdAt)
+  ) {
+    contractViolation('Governed calculation package does not match its exact trace, policy, unit, or time ancestry.');
+  }
+  const tracedComponents = new Map(trace.content.components.map((component) => [component.role, component]));
+  if (
+    packageContent.componentDrawSet.content.components.some((component) => {
+      const traced = tracedComponents.get(component.role);
+      return (
+        traced === undefined ||
+        traced.runId !== component.runId ||
+        traced.protocolId !== component.protocolId ||
+        traced.datasetId !== component.datasetId ||
+        traced.gate3DecisionId !== component.gate3DecisionId
+      );
+    })
+  ) {
+    contractViolation('Governed calculation components do not match the authenticated model ancestry.');
+  }
+  if (
+    caseContent.parties.length !== source.clubs.length ||
+    caseContent.parties.some((party) => {
+      const club = source.clubs.find(({ aflClubId }) => aflClubId === party.aflClubId);
+      return (
+        club === undefined ||
+        club.clubName !== party.clubName ||
+        !exactSet(club.receivedAssetIds, party.receivedRootAssetIds)
+      );
+    }) ||
+    !exactSet(
+      source.transfers.map(({ assetId }) => assetId),
+      caseContent.parties.flatMap(({ receivedRootAssetIds }) => receivedRootAssetIds)
+    )
+  ) {
+    contractViolation('Governed transaction clubs and directed roots do not match the valuation case.');
+  }
+  const calculation = calculateAflTradeValuation(
+    valuationCase,
+    packageContent.componentDrawSet,
+    packageContent.realizedContributionLedger,
+    packageContent.packagePolicy
+  );
+  return {
+    valuationCase,
+    calculation,
+    authority: source.authority,
+    transfers: source.transfers,
+    selectedLayer: source.selectedLayer,
+    gradeContext: null,
+    effectiveAt: source.effectiveAt,
+    effectiveThrough: currentContext.effectiveAt,
+    practicalEquivalenceBasis: source.practicalEquivalence.basis,
+    practicalEquivalenceBandByView: source.practicalEquivalence.bandByView,
+    practicalEquivalencePolicyReference: {
+      explanationPolicyId: source.authority.explanationPolicyId,
+    },
   };
 }
 
@@ -583,7 +714,7 @@ function prepareLedger(
 }
 
 function buildViews(input: {
-  source: CreateAflTradeValuationExplanationInput;
+  source: ValidatedExplanationSource;
   valuationCase: AflTradeValuationCase;
   calculation: AflTradeValuationCalculation;
   transfers: readonly AflTradeValuationExplanationTransfer[];
@@ -617,7 +748,7 @@ function buildViews(input: {
     const finishAheadProbabilities = completePackages.map(() => 0);
     let practicalEquivalenceProbability = 0;
     const practicalEquivalenceBand =
-      input.source.directionEvidence.content.explanationPolicy.practicalEquivalenceBandByView[view];
+      input.source.practicalEquivalenceBandByView[view];
     input.calculation.content.draws.forEach((draw, drawIndex) => {
       const values = completePackages.map((item) => item.netSamples[drawIndex]!.value);
       const maximum = Math.max(...values);
@@ -638,20 +769,22 @@ function buildViews(input: {
     finishAheadProbabilities.forEach((probability, index) => {
       finishAheadProbabilities[index] = normalizeNumber(probability);
     });
-    const gradeResult = deriveAflTradeStatlyGradesFromProbabilities({
-      view,
-      availability: 'available',
-      clubs: completePackages.map((item, index) => ({
-        aflClubId: item.party.aflClubId,
-        clubName: item.party.clubName,
-        finishesAheadProbability: finishAheadProbabilities[index]!,
-      })),
-      confidenceLevel: input.source.gradeContext.confidenceLevel,
-      coverageRatio: 1,
-      coverageStatus: 'complete',
-      developmentPreview: input.source.gradeContext.developmentPreview,
-      practicalEquivalenceProbability,
-    });
+    const gradeResult = input.source.gradeContext
+      ? deriveAflTradeStatlyGradesFromProbabilities({
+          view,
+          availability: 'available',
+          clubs: completePackages.map((item, index) => ({
+            aflClubId: item.party.aflClubId,
+            clubName: item.party.clubName,
+            finishesAheadProbability: finishAheadProbabilities[index]!,
+          })),
+          confidenceLevel: input.source.gradeContext.confidenceLevel,
+          coverageRatio: 1,
+          coverageStatus: 'complete',
+          developmentPreview: input.source.gradeContext.developmentPreview,
+          practicalEquivalenceProbability,
+        })
+      : null;
     const highestProbability = Math.max(...finishAheadProbabilities);
     const leaders = completePackages
       .filter(
@@ -666,7 +799,9 @@ function buildViews(input: {
         aflClubIds: leaders,
       },
       clubs: completePackages.map((item, index) => {
-        const grade = gradeResult.clubs.find(({ aflClubId }) => aflClubId === item.party.aflClubId);
+        const grade = gradeResult?.clubs.find(
+          ({ aflClubId }) => aflClubId === item.party.aflClubId
+        );
         return {
           aflClubId: item.party.aflClubId,
           clubName: item.party.clubName,
@@ -682,7 +817,7 @@ function buildViews(input: {
           grade: {
             grade: grade?.grade ?? null,
             state: grade?.state ?? 'unavailable',
-            reasonCode: gradeResult.reasonCode,
+            reasonCode: gradeResult?.reasonCode ?? 'grade_confidence_authority_unavailable',
           },
         };
       }),
@@ -690,11 +825,11 @@ function buildViews(input: {
   }).filter((view): view is NonNullable<typeof view> => view !== null);
 }
 
-export function createAflTradeValuationExplanation(
-  input: CreateAflTradeValuationExplanationInput
+function createExplanationDocument(
+  source: ValidatedExplanationSource
 ): AflTradeValuationExplanationResult {
-  const { valuationCase, calculation, authority, transfers } = validateInput(input);
-  const views = buildViews({ source: input, valuationCase, calculation, transfers });
+  const { valuationCase, calculation, authority, transfers } = source;
+  const views = buildViews({ source, valuationCase, calculation, transfers });
   if (!views || views.length !== AFL_TRADE_VALUATION_VIEWS.length) {
     return {
       state: 'unavailable',
@@ -714,14 +849,14 @@ export function createAflTradeValuationExplanation(
     valuationBundleId: valuationCase.content.valuationBundleId,
     valuationCaseId: valuationCase.valuationCaseId,
     valuationCalculationId: calculation.valuationCalculationId,
-    effectiveAt: input.directionEvidence.content.effectiveAt,
-    effectiveThrough: input.directionEvidence.content.effectiveThrough,
+    effectiveAt: source.effectiveAt,
+    effectiveThrough: source.effectiveThrough,
     coverage: {
       status: 'complete' as const,
       ratio: 1 as const,
     },
-    confidenceLevel: input.gradeContext.confidenceLevel,
-    selectedLayer: input.selectedLayer,
+    confidenceLevel: source.gradeContext?.confidenceLevel ?? ('unavailable' as const),
+    selectedLayer: source.selectedLayer,
     views,
     methodology: {
       additiveStatistic: 'probability_weighted_mean' as const,
@@ -729,13 +864,11 @@ export function createAflTradeValuationExplanation(
       packageMedianIsAdditive: false as const,
       assetGradeTreatment: 'prohibited' as const,
       currentIdentity: 'realized_plus_remaining' as const,
-      practicalEquivalenceBasis:
-        input.directionEvidence.content.explanationPolicy.practicalEquivalenceBasis,
+      practicalEquivalenceBasis: source.practicalEquivalenceBasis,
       practicalEquivalencePolicy: {
-        assumptionSetId: input.directionEvidence.assumptionSetId,
-        valueUnitId: input.directionEvidence.content.explanationPolicy.valueUnitId,
-        bandByView:
-          input.directionEvidence.content.explanationPolicy.practicalEquivalenceBandByView,
+        ...source.practicalEquivalencePolicyReference,
+        valueUnitId: valuationCase.content.valueUnitId,
+        bandByView: source.practicalEquivalenceBandByView,
       },
     },
   };
@@ -746,4 +879,16 @@ export function createAflTradeValuationExplanation(
       ...content,
     },
   };
+}
+
+export function createAflTradeValuationExplanation(
+  input: CreateAflTradeValuationExplanationInput
+): AflTradeValuationExplanationResult {
+  return createExplanationDocument(validateSyntheticInput(input));
+}
+
+export function createGovernedAflTradeValuationExplanation(
+  input: CreateGovernedAflTradeValuationExplanationInput
+): AflTradeValuationExplanationResult {
+  return createExplanationDocument(validateGovernedInput(input));
 }

--- a/src/server/aflTradeIntelligence/valuation/valuationCalculationInputPackage.ts
+++ b/src/server/aflTradeIntelligence/valuation/valuationCalculationInputPackage.ts
@@ -22,7 +22,7 @@ const publicIdSchema = z
   .max(200)
   .regex(/^[a-zA-Z0-9][a-zA-Z0-9._:-]*$/);
 
-const authoritySchema = z
+const fixtureAuthoritySchema = z
   .object({
     kind: z.literal('fabricated_test_fixture'),
     evidenceClassification: z.literal('fabricated_test_evidence_not_real_afl_data'),
@@ -30,13 +30,21 @@ const authoritySchema = z
   })
   .strict();
 
+const authenticatedAuthoritySchema = z
+  .object({
+    kind: z.literal('authenticated_non_production'),
+    inputTraceId: aflTradeContentAddressedIdSchema('private-evaluation-input-trace'),
+    publicationProhibited: z.literal(true),
+  })
+  .strict();
+
 export const AFL_TRADE_VALUATION_CALCULATION_INPUT_PACKAGE_SCHEMA_VERSION =
   'afl-trade-valuation-calculation-input-package/v1' as const;
+export const AFL_TRADE_VALUATION_CALCULATION_INPUT_PACKAGE_V2_SCHEMA_VERSION =
+  'afl-trade-valuation-calculation-input-package/v2' as const;
 
-export const aflTradeValuationCalculationInputPackageContentSchema = z
+const calculationInputKernelSchema = z
   .object({
-    schemaVersion: z.literal(AFL_TRADE_VALUATION_CALCULATION_INPUT_PACKAGE_SCHEMA_VERSION),
-    authority: authoritySchema,
     tradeId: publicIdSchema,
     valuationInputBundleId: aflTradeContentAddressedIdSchema('valuation-input-bundle'),
     valuationCase: aflTradeValuationCaseSchema,
@@ -49,8 +57,12 @@ export const aflTradeValuationCalculationInputPackageContentSchema = z
       'Calculation input only; not a result, model approval, publication approval, or activation authority.'
     ),
   })
-  .strict()
-  .superRefine((input, context) => {
+  .strict();
+
+function reconcileCalculationInput(
+  input: z.infer<typeof calculationInputKernelSchema>,
+  context: z.RefinementCtx
+) {
     const valuationCase = input.valuationCase.content;
     const drawSet = input.componentDrawSet.content;
     const ledger = input.realizedContributionLedger.content;
@@ -93,7 +105,30 @@ export const aflTradeValuationCalculationInputPackageContentSchema = z
         message: 'Calculation input lineage or value-unit identity mismatch.',
       });
     }
-  });
+}
+
+const calculationInputV1Schema = z
+  .object({
+    schemaVersion: z.literal(AFL_TRADE_VALUATION_CALCULATION_INPUT_PACKAGE_SCHEMA_VERSION),
+    authority: fixtureAuthoritySchema,
+    ...calculationInputKernelSchema.shape,
+  })
+  .strict()
+  .superRefine(reconcileCalculationInput);
+
+const calculationInputV2Schema = z
+  .object({
+    schemaVersion: z.literal(AFL_TRADE_VALUATION_CALCULATION_INPUT_PACKAGE_V2_SCHEMA_VERSION),
+    authority: authenticatedAuthoritySchema,
+    ...calculationInputKernelSchema.shape,
+  })
+  .strict()
+  .superRefine(reconcileCalculationInput);
+
+export const aflTradeValuationCalculationInputPackageContentSchema = z.discriminatedUnion(
+  'schemaVersion',
+  [calculationInputV1Schema, calculationInputV2Schema]
+);
 
 export const aflTradeValuationCalculationInputPackageSchema = z
   .object({

--- a/tests/outcomes-integration/afl-authenticated-prepared-valuation-input-postgres.test.ts
+++ b/tests/outcomes-integration/afl-authenticated-prepared-valuation-input-postgres.test.ts
@@ -1,0 +1,438 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import {
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { createLocalAflTradeOfficialAfl2026Authority } from '@/server/aflTradeIntelligence/development/localOfficialAfl2026Authority';
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import { aflTradeSourceRightsProposalSchema } from '@/server/aflTradeIntelligence/source/sourceRights';
+import {
+  AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V2_SCHEMA_VERSION,
+  AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V3_SCHEMA_VERSION,
+  createAflTradePreparedValuationInputSet,
+} from '@/server/aflTradeIntelligence/valuation/preparedValuationInputSet';
+import { PostgresAflTradePreparedValuationInputSetStore } from '@/server/aflTradeIntelligence/valuation/postgresPreparedValuationInputSetStore';
+import { createGovernedPrivateEvaluationMaterializationManifest } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationMaterializationManifest';
+import { PostgresGovernedPrivateEvaluationMaterializationManifestRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationMaterializationManifestRepository';
+import { PostgresAflTradeValuationSourceQualificationReportStore } from '@/server/aflTradeIntelligence/valuation/postgresValuationSourceQualificationReportStore';
+import {
+  AFL_TRADE_VALUATION_SOURCE_QUALIFICATION_REPORT_SCHEMA_VERSION,
+  createAflTradeValuationSourceQualificationReport,
+} from '@/server/aflTradeIntelligence/valuation/valuationSourceQualificationReport';
+import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('AFL_OUTCOMES_TEST_DATABASE_URL must identify disposable PostgreSQL.');
+  })();
+const schemaName = `afl_authenticated_prepared_inputs_${process.pid}_${Date.now()}`;
+const adminPool = new Pool({ connectionString: databaseUrl });
+const pool = new Pool({
+  connectionString: databaseUrl,
+  options: `-c search_path=${schemaName}`,
+});
+const digest = (character: string) => character.repeat(64);
+
+function artifact(character: string) {
+  const contentSha256 = digest(character);
+  return {
+    artifactId: `artifact:${contentSha256}`,
+    contentSha256,
+    storageUri: `artifact://sha256/${contentSha256}`,
+    mediaType: 'application/json',
+    byteLength: 1,
+    createdAt: '2026-08-15T03:00:00.000Z',
+  };
+}
+
+const baseRights = createLocalAflTradeOfficialAfl2026Authority().capture.sourceRights;
+const allowedRightsContent = {
+  ...baseRights.content,
+  registerId: 'official-afl-player-stats-prepared-v2-fixture',
+  operations: {
+    ...baseRights.content.operations,
+    model_training: 'allowed' as const,
+    derived_feature_creation: 'allowed' as const,
+  },
+  fields: baseRights.content.fields.map((field) => ({
+    ...field,
+    uses: {
+      ...field.uses,
+      model_training: 'allowed' as const,
+      derived_feature: 'allowed' as const,
+    },
+  })),
+};
+const allowedRights = aflTradeSourceRightsProposalSchema.parse({
+  rightsArtifactId: createAflTradeContentAddress('source-rights', allowedRightsContent),
+  content: allowedRightsContent,
+});
+const canonicalMembers = [
+  {
+    recordKind: 'transaction',
+    canonicalRecordId: 'trade-a',
+    canonicalRecordSha256: digest('1'),
+    ordinal: 1,
+  },
+  {
+    recordKind: 'transaction',
+    canonicalRecordId: 'trade-b',
+    canonicalRecordSha256: digest('2'),
+    ordinal: 2,
+  },
+];
+const releaseManifest = {
+  releaseId: `outcome-release:${digest('3')}`,
+  content: {
+    canonicalMembers,
+    sourceCaptures: [{ captureId: 'capture-1', rightsArtifactId: allowedRights.rightsArtifactId }],
+  },
+};
+const qualificationReport = createAflTradeValuationSourceQualificationReport({
+  schemaVersion: AFL_TRADE_VALUATION_SOURCE_QUALIFICATION_REPORT_SCHEMA_VERSION,
+  environment: 'non_production',
+  operation: 'valuation_model_training_and_derived_feature_creation',
+  valuationScopeKey: 'afl-men:2026-trades',
+  factualReleaseScopeKey: 'public-afl-draft-trade-outcomes',
+  factualReleaseId: releaseManifest.releaseId,
+  factualReleaseArtifact: createAflTradeCanonicalJsonArtifactRef(
+    releaseManifest,
+    '2026-08-15T00:00:00.000Z'
+  ),
+  releaseMembershipArtifact: createAflTradeCanonicalJsonArtifactRef(
+    canonicalMembers,
+    '2026-08-15T00:00:00.000Z'
+  ),
+  releaseTradeIds: ['trade-a', 'trade-b'],
+  sourceRightsEvidenceRefs: [
+    createAflTradeCanonicalJsonArtifactRef(allowedRights, allowedRights.content.proposedAt),
+  ],
+  decision: { state: 'eligible_for_dataset_admission' },
+  evaluatedAt: '2026-08-15T02:00:00.000Z',
+  publicationEligible: false,
+  limitation:
+    'Source qualification only; not dataset admission, model approval, numerical output, publication approval, or activation authority.',
+});
+
+async function retainArtifact(reference: ReturnType<typeof artifact>) {
+  return pool.query(
+    `INSERT INTO outcome_artifact_custody
+      (artifact_id,content_sha256,storage_uri,media_type,byte_length,artifact_class,
+       environment,custody_profile_id,created_at,verified_at,custody_json)
+     VALUES ($1,$2,$3,$4,$5,'derived_private','non_production',NULL,$6,$6,$7::jsonb)`,
+    [
+      reference.artifactId,
+      reference.contentSha256,
+      reference.storageUri,
+      reference.mediaType,
+      reference.byteLength,
+      reference.createdAt,
+      canonicalizeAflTradeJson({
+        content: {
+          repositoryAssurance: 'local_non_production_filesystem',
+          custodyEnvironment: 'non_production',
+          custodyProfileId: null,
+          custodyProfile: null,
+        },
+      }),
+    ]
+  );
+}
+
+const materializationParentCreatedAt = '2026-08-15T03:00:00.000Z';
+const materializationManifestCreatedAt = '2026-08-15T03:30:00.000Z';
+
+function retainedJson(value: unknown) {
+  return createAflTradeCanonicalJsonArtifactRef(value, materializationParentCreatedAt);
+}
+
+function materializationManifest() {
+  const calculationInput = { kind: 'calculation-input', tradeId: 'trade-a' };
+  const inputTrace = { kind: 'input-trace', tradeId: 'trade-a' };
+  const explanationPolicy = { kind: 'explanation-policy', version: 1 };
+  const lineageGraph = { kind: 'lineage-graph', tradeId: 'trade-a' };
+  const pickBenchmark = { kind: 'pick-benchmark', pick: 12 };
+  const playerObservation = { kind: 'player-observation', playerId: 'player-a' };
+  return createGovernedPrivateEvaluationMaterializationManifest({
+    schemaVersion: 'private-evaluation-materialization-manifest/v1',
+    environment: 'non_production',
+    selector: { valuationScopeKey: 'afl-men:2026-trades', tradeId: 'trade-a' },
+    calculationInputPackageId: createAflTradeContentAddress(
+      'valuation-calculation-input',
+      calculationInput
+    ),
+    calculationInputArtifact: retainedJson(calculationInput),
+    inputTraceId: createAflTradeContentAddress('private-evaluation-input-trace', inputTrace),
+    inputTraceArtifact: retainedJson(inputTrace),
+    explanationPolicyId: createAflTradeContentAddress(
+      'private-evaluation-explanation-policy',
+      explanationPolicy
+    ),
+    explanationPolicyArtifact: retainedJson(explanationPolicy),
+    lineageGraphId: createAflTradeContentAddress('lineage-graph', lineageGraph),
+    lineageGraphArtifact: retainedJson(lineageGraph),
+    pickBenchmarks: [
+      {
+        benchmarkId: createAflTradeContentAddress('pick-pav-benchmark', pickBenchmark),
+        artifact: retainedJson(pickBenchmark),
+      },
+    ],
+    playerObservations: [
+      {
+        observationId: createAflTradeContentAddress(
+          'player-pav-observation',
+          playerObservation
+        ),
+        artifact: retainedJson(playerObservation),
+      },
+    ],
+    createdAt: materializationManifestCreatedAt,
+    publicationEligible: false,
+    limitation:
+      'Private materialization inputs only; not model, grade, activation, production, or publication authority.',
+  });
+}
+
+function preparedSetV3() {
+  const base = preparedSet().content;
+  const manifest = materializationManifest();
+  return createAflTradePreparedValuationInputSet({
+    ...base,
+    schemaVersion: AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V3_SCHEMA_VERSION,
+    entries: [
+      {
+        tradeId: 'trade-a',
+        state: 'ready',
+        materializationManifestId: manifest.manifestId,
+        materializationManifestArtifact: createAflTradeCanonicalJsonArtifactRef(
+          manifest,
+          materializationManifestCreatedAt
+        ),
+      },
+      base.entries[1]!,
+    ],
+  });
+}
+
+async function registerMaterializationManifest() {
+  const manifest = materializationManifest();
+  const parentArtifacts = [
+    manifest.content.calculationInputArtifact,
+    manifest.content.inputTraceArtifact,
+    manifest.content.explanationPolicyArtifact,
+    manifest.content.lineageGraphArtifact,
+    ...manifest.content.pickBenchmarks.map(({ artifact: reference }) => reference),
+    ...manifest.content.playerObservations.map(({ artifact: reference }) => reference),
+  ];
+  const manifestArtifact = createAflTradeCanonicalJsonArtifactRef(
+    manifest,
+    materializationManifestCreatedAt
+  );
+  await Promise.all([...parentArtifacts, manifestArtifact].map(retainArtifact));
+  const repository = new PostgresGovernedPrivateEvaluationMaterializationManifestRepository(
+    createPgAflOutcomeSqlClient(pool)
+  );
+  await expect(
+    repository.register({ manifest, artifact: manifestArtifact })
+  ).resolves.toEqual({ manifest, artifact: manifestArtifact });
+  await expect(repository.loadExact(manifest.manifestId)).resolves.toEqual({
+    manifest,
+    artifact: manifestArtifact,
+  });
+  return { manifest, manifestArtifact };
+}
+
+function preparedSet(inputTraceArtifact = artifact('c')) {
+  const entries = [
+    {
+      tradeId: 'trade-a',
+      state: 'ready' as const,
+      calculationInputPackageId: `valuation-calculation-input:${digest('4')}`,
+      calculationInputArtifact: artifact('b'),
+      inputTraceId: `private-evaluation-input-trace:${digest('5')}`,
+      inputTraceArtifact,
+    },
+    {
+      tradeId: 'trade-b',
+      state: 'blocked' as const,
+      blockers: [
+        {
+          code: 'lineage_unresolved' as const,
+          subject: { kind: 'lineage' as const, id: 'asset:pick-12' },
+          evidenceRefs: [artifact('d')],
+        },
+      ],
+    },
+  ];
+  return createAflTradePreparedValuationInputSet({
+    schemaVersion: AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V2_SCHEMA_VERSION,
+    environment: 'non_production',
+    scopeKey: 'afl-men:2026-trades',
+    factualReleaseScopeKey: 'public-afl-draft-trade-outcomes',
+    factualReleaseId: releaseManifest.releaseId,
+    factualReleaseArtifact: createAflTradeCanonicalJsonArtifactRef(
+      releaseManifest,
+      '2026-08-15T00:00:00.000Z'
+    ),
+    releaseMembershipArtifact: createAflTradeCanonicalJsonArtifactRef(
+      canonicalMembers,
+      '2026-08-15T00:00:00.000Z'
+    ),
+    preparationAuthority: 'authenticated_calculation_evidence_snapshot',
+    qualificationOperation: 'valuation_model_training_and_derived_feature_creation',
+    qualificationReportId: qualificationReport.qualificationReportId,
+    qualificationReportArtifact: createAflTradeCanonicalJsonArtifactRef(
+      qualificationReport,
+      qualificationReport.content.evaluatedAt
+    ),
+    sourceQualificationEvidenceRefs: qualificationReport.content.sourceRightsEvidenceRefs,
+    valuationInputBundleId: `valuation-input-bundle:${digest('6')}`,
+    valuationInputBundleArtifact: artifact('a'),
+    releaseTradeIds: ['trade-a', 'trade-b'],
+    entries,
+    tradeCount: 2,
+    readyCount: 1,
+    blockedCount: 1,
+    preparedAt: '2026-08-15T04:00:00.000Z',
+    publicationEligible: false,
+    limitation:
+      'Private preparation evidence only; not a valuation result, publication approval, or activation authority.',
+  });
+}
+
+beforeAll(async () => {
+  await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
+  const scoped = new URL(databaseUrl);
+  scoped.searchParams.set('schema', schemaName);
+  runOutcomesPrismaTestCommand(['migrate', 'deploy'], { databaseUrl: scoped.toString() });
+  await pool.query(
+    `INSERT INTO outcome_release_manifest
+      (release_id,scope_key,environment,created_at,effective_through,manifest_json)
+     VALUES ($1,'public-afl-draft-trade-outcomes','non_production',$2,$3,$4::jsonb)`,
+    [
+      releaseManifest.releaseId,
+      '2026-08-15T00:00:00.000Z',
+      '2026-08-14T23:59:59.000Z',
+      canonicalizeAflTradeJson(releaseManifest),
+    ]
+  );
+  await pool.query(
+    `INSERT INTO outcome_source_rights_proposal
+      (rights_artifact_id,provider,dataset,dataset_version,capability_id,proposed_at,content_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb)`,
+    [
+      allowedRights.rightsArtifactId,
+      allowedRights.content.provider,
+      allowedRights.content.dataset,
+      allowedRights.content.datasetVersion,
+      allowedRights.content.acquisition.kind === 'fitzroy'
+        ? allowedRights.content.acquisition.capabilities[0]!.capabilityId
+        : null,
+      allowedRights.content.proposedAt,
+      canonicalizeAflTradeJson(allowedRights),
+    ]
+  );
+  await new PostgresAflTradeValuationSourceQualificationReportStore(
+    createPgAflOutcomeSqlClient(pool)
+  ).register(qualificationReport);
+  await Promise.all(['a', 'b', 'c', 'd'].map((character) => retainArtifact(artifact(character))));
+});
+
+afterAll(async () => {
+  await pool.end();
+  await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  await adminPool.end();
+});
+
+describe('PostgreSQL authenticated prepared valuation inputs', () => {
+  it('persists and exactly replays one ready and one factual blocked trade', async () => {
+    const store = new PostgresAflTradePreparedValuationInputSetStore(
+      createPgAflOutcomeSqlClient(pool)
+    );
+    const expected = preparedSet();
+
+    await expect(store.register(expected)).resolves.toEqual(expected);
+    await expect(store.loadExact(expected.preparedInputSetId)).resolves.toEqual(expected);
+    await expect(
+      store.loadTrade({ preparedInputSetId: expected.preparedInputSetId, tradeId: 'trade-a' })
+    ).resolves.toMatchObject({ state: 'ready' });
+    await expect(
+      store.loadTrade({ preparedInputSetId: expected.preparedInputSetId, tradeId: 'trade-b' })
+    ).resolves.toMatchObject({ state: 'blocked' });
+  });
+
+  it('rolls back the complete set when one ready artifact is absent from custody', async () => {
+    const store = new PostgresAflTradePreparedValuationInputSetStore(
+      createPgAflOutcomeSqlClient(pool)
+    );
+    const missing = preparedSet(artifact('e'));
+
+    await expect(store.register(missing)).rejects.toThrow(/not retained exactly/i);
+    const retained = await pool.query(
+      `SELECT 1 FROM outcome_prepared_valuation_input_set WHERE prepared_input_set_id=$1`,
+      [missing.preparedInputSetId]
+    );
+    expect(retained.rowCount).toBe(0);
+  });
+
+  it('retains an append-only materialization manifest and activates only finalized v3 authority by CAS', async () => {
+    const { manifest } = await registerMaterializationManifest();
+    const store = new PostgresAflTradePreparedValuationInputSetStore(
+      createPgAflOutcomeSqlClient(pool)
+    );
+    const first = preparedSetV3();
+    await expect(store.register(first)).resolves.toEqual(first);
+
+    await expect(
+      store.activateCurrent({
+        scopeKey: first.content.scopeKey,
+        preparedInputSetId: first.preparedInputSetId,
+        expectedRevision: 0,
+      })
+    ).resolves.toMatchObject({
+      scopeKey: first.content.scopeKey,
+      preparedInputSetId: first.preparedInputSetId,
+      revision: 1,
+    });
+    await expect(store.loadCurrent(first.content.scopeKey)).resolves.toMatchObject({
+      head: { preparedInputSetId: first.preparedInputSetId, revision: 1 },
+      preparedInputSet: first,
+    });
+    await expect(
+      store.loadCurrentTrade({ scopeKey: first.content.scopeKey, tradeId: 'trade-a' })
+    ).resolves.toMatchObject({
+      head: { revision: 1 },
+      preparedInputSet: first,
+      entry: {
+        state: 'ready',
+        materializationManifestId: manifest.manifestId,
+      },
+    });
+
+    await expect(
+      pool.query(
+        `UPDATE outcome_private_evaluation_materialization_manifest SET trade_id='tampered'
+          WHERE materialization_manifest_id=$1`,
+        [manifest.manifestId]
+      )
+    ).rejects.toThrow(/append-only/i);
+    await expect(
+      store.activateCurrent({
+        scopeKey: first.content.scopeKey,
+        preparedInputSetId: first.preparedInputSetId,
+        expectedRevision: 0,
+      })
+    ).rejects.toThrow(/compare-and-swap/i);
+    await expect(
+      store.activateCurrent({
+        scopeKey: 'afl-men:2027-trades',
+        preparedInputSetId: first.preparedInputSetId,
+        expectedRevision: 0,
+      })
+    ).rejects.toThrow(/not finalized v3 authority/i);
+  });
+});

--- a/tests/outcomes-integration/afl-governed-pick-pav-model-execution-postgres.test.ts
+++ b/tests/outcomes-integration/afl-governed-pick-pav-model-execution-postgres.test.ts
@@ -1,0 +1,207 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { createAflTradeFixtureArtifactRepository } from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import { PostgresGovernedPickPavModelExecutionRepository } from '@/server/aflTradeIntelligence/modeling/postgresGovernedPickPavModelExecutionRepository';
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+
+import { createGovernedPickPavModelExecutionFixture } from '../testUtils/governedPickPavModelExecutionFixture';
+import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('A disposable AFL_OUTCOMES_TEST_DATABASE_URL is required.');
+  })();
+const schemaName = `afl_governed_pick_execution_${process.pid}_${Date.now()}`;
+const adminPool = new Pool({ connectionString: databaseUrl });
+const pool = new Pool({
+  connectionString: databaseUrl,
+  options: `-c search_path=${schemaName}`,
+});
+
+function scopedDatabaseUrl(targetSchema: string) {
+  const scoped = new URL(databaseUrl);
+  scoped.searchParams.set('schema', targetSchema);
+  return scoped.toString();
+}
+
+beforeAll(async () => {
+  await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
+  runOutcomesPrismaTestCommand(['migrate', 'deploy'], {
+    databaseUrl: scopedDatabaseUrl(schemaName),
+  });
+});
+
+afterAll(async () => {
+  await pool.end();
+  await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  await adminPool.end();
+});
+
+describe('governed pick-PAV native execution PostgreSQL custody', () => {
+  it('registers, exactly replays, and prevents mutation of one non-production execution', async () => {
+    const value = createGovernedPickPavModelExecutionFixture();
+    const artifacts = createAflTradeFixtureArtifactRepository({
+      artifactClass: 'derived_private',
+    });
+    const authorityReferences = [
+      value.execution.content.datasetArtifact,
+      value.execution.content.datasetAdmissionArtifact,
+      value.execution.content.protocolArtifact,
+    ];
+    for (const [index, document] of value.authorityDocuments.entries()) {
+      const reference = authorityReferences[index]!;
+      await artifacts.putIfAbsent(
+        reference,
+        new TextEncoder().encode(canonicalizeAflTradeJson(document))
+      );
+    }
+    const executionArtifact = createAflTradeCanonicalJsonArtifactRef(
+      value.execution,
+      value.execution.content.completedAt
+    );
+    await artifacts.putIfAbsent(
+      executionArtifact,
+      new TextEncoder().encode(canonicalizeAflTradeJson(value.execution))
+    );
+
+    const seed = await pool.connect();
+    await seed.query('BEGIN');
+    try {
+      await seed.query(`SET LOCAL session_replication_role='replica'`);
+      for (const reference of [...authorityReferences, executionArtifact]) {
+        await seed.query(
+          `INSERT INTO outcome_artifact_custody
+            (artifact_id,content_sha256,storage_uri,media_type,byte_length,artifact_class,
+             environment,custody_profile_id,created_at,verified_at,custody_json)
+           VALUES ($1,$2,$3,$4,$5,'derived_private','non_production',NULL,$6,$6,$7::jsonb)`,
+          [
+            reference.artifactId,
+            reference.contentSha256,
+            reference.storageUri,
+            reference.mediaType,
+            reference.byteLength,
+            reference.createdAt,
+            canonicalizeAflTradeJson({
+              assurance: 'isolated_postgres_governed_pick_execution_test',
+            }),
+          ]
+        );
+      }
+      const content = value.execution.content;
+      const [datasetDocument, admissionDocument, protocolDocument] =
+        value.authorityDocuments;
+      const observationSet = content.observationSet;
+      await seed.query(
+        `INSERT INTO outcome_pick_pav_observation_set
+          (observation_set_id,observation_set_sha256,environment,competition,release_id,
+           policy_id,created_at,knowledge_cutoff_at,status,calculation_count,
+           draft_class_count,observation_count,observation_set_canonical_json,
+           observation_set_json,finalized_at)
+         VALUES ($1,$2,'non_production',$3,$4,$5,$6,$7,'finalized',$8,$9,$10,$11,$12::jsonb,$6)`,
+        [
+          content.observationSetId,
+          content.observationSetId.slice('pick-pav-observation-set:'.length),
+          content.competition,
+          content.releaseId,
+          content.policyId,
+          observationSet.content.createdAt,
+          observationSet.content.knowledgeCutoffAt,
+          observationSet.content.calculations.length,
+          observationSet.content.draftClasses.length,
+          observationSet.content.observations.length,
+          canonicalizeAflTradeJson(observationSet),
+          canonicalizeAflTradeJson(observationSet),
+        ]
+      );
+      await seed.query(
+        `INSERT INTO outcome_valuation_dataset_candidate
+          (dataset_id,environment,scope_key,competition,created_at,knowledge_cutoff_at,
+           factual_release_id,factual_candidate_id,corpus_id,lineage_id,
+           source_member_set_sha256,row_count,row_set_sha256,row_set_canonical_json,
+           artifact_count,status,dataset_canonical_json,dataset_json,finalized_at)
+         VALUES ($1,'non_production','governed-pick-test',$2,$3,$3,$4,$5,$6,$7,$8,1,$8,
+                 '[]',10,'finalized',$9,$10::jsonb,$3)`,
+        [
+          content.datasetId,
+          content.competition,
+          content.datasetArtifact.createdAt,
+          content.releaseId,
+          `factual-release-candidate:${'1'.repeat(64)}`,
+          `corpus:${'2'.repeat(64)}`,
+          `corpus-factual-lineage:${'3'.repeat(64)}`,
+          '4'.repeat(64),
+          canonicalizeAflTradeJson(datasetDocument),
+          canonicalizeAflTradeJson(datasetDocument),
+        ]
+      );
+      await seed.query(
+        `INSERT INTO outcome_valuation_dataset_admission
+          (admission_id,dataset_id,environment,admitted_at,gate2_decision_id,
+           gate_ledger_revision,analytical_authority_receipt_id,
+           operational_authorization_receipt_id,source_count,status,
+           admission_canonical_json,admission_json,finalized_at)
+         VALUES ($1,$2,'non_production',$3,$4,$5,$6,$7,1,'finalized',$8,$9::jsonb,$3)`,
+        [
+          content.datasetAdmissionId,
+          content.datasetId,
+          content.datasetAdmissionArtifact.createdAt,
+          `gate-decision:${'5'.repeat(64)}`,
+          content.datasetAdmissionGateLedgerRevision,
+          `architecture-operation-receipt:${'6'.repeat(64)}`,
+          `architecture-operation-receipt:${'7'.repeat(64)}`,
+          canonicalizeAflTradeJson(admissionDocument),
+          canonicalizeAflTradeJson(admissionDocument),
+        ]
+      );
+      await seed.query(
+        `INSERT INTO outcome_valuation_model_protocol
+          (protocol_id,environment,dataset_id,admission_id,analytical_authority_receipt_id,
+           prepared_at,protocol_canonical_json,protocol_json)
+         VALUES ($1,'non_production',$2,$3,$4,$5,$6,$7::jsonb)`,
+        [
+          content.protocolId,
+          content.datasetId,
+          content.datasetAdmissionId,
+          `architecture-operation-receipt:${'6'.repeat(64)}`,
+          content.protocolArtifact.createdAt,
+          canonicalizeAflTradeJson(protocolDocument.content),
+          canonicalizeAflTradeJson(protocolDocument),
+        ]
+      );
+      await seed.query('COMMIT');
+    } catch (error) {
+      await seed.query('ROLLBACK');
+      throw error;
+    } finally {
+      seed.release();
+    }
+
+    const repository = new PostgresGovernedPickPavModelExecutionRepository({
+      client: createPgAflOutcomeSqlClient(pool),
+      artifactRepository: artifacts,
+      maximumArtifactBytes: 1024 * 1024,
+    });
+    await expect(
+      repository.register({ execution: value.execution, artifact: executionArtifact })
+    ).resolves.toEqual({ execution: value.execution, artifact: executionArtifact });
+    await expect(repository.loadExact(value.execution.executionId)).resolves.toEqual({
+      execution: value.execution,
+      artifact: executionArtifact,
+    });
+    await expect(
+      repository.register({ execution: value.execution, artifact: executionArtifact })
+    ).resolves.toEqual({ execution: value.execution, artifact: executionArtifact });
+
+    await expect(
+      pool.query(
+        `UPDATE outcome_governed_pick_pav_model_execution SET dataset_id=$2
+          WHERE execution_id=$1`,
+        [value.execution.executionId, `dataset:${'8'.repeat(64)}`]
+      )
+    ).rejects.toThrow(/append-only/i);
+  });
+});

--- a/tests/outcomes-integration/afl-governed-private-evaluation-lifecycle-postgres.test.ts
+++ b/tests/outcomes-integration/afl-governed-private-evaluation-lifecycle-postgres.test.ts
@@ -1,0 +1,477 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import {
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { createLocalAflTradeArtifactRepository } from '@/server/aflTradeIntelligence/development/localFileConditionalObjectStore';
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import { createGovernedPrivateEvaluationGeneration } from '@/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration';
+import { createReadyFixtureGovernedPrivateEvaluationAuthorityInspection } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationAuthoritySnapshot';
+import { createPostgresGovernedPrivateEvaluationWorkspace } from '@/server/aflTradeIntelligence/valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace';
+import {
+  createGovernedPrivateEvaluationTransitionIntent,
+  createGovernedPrivateEvaluationTransitionReceipt,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle';
+import { createPostgresGovernedPrivateEvaluationLifecycleRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationLifecycleRepository';
+import { createPostgresGovernedPrivateEvaluationStagingRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationStagingRepository';
+import { createGovernedPrivateEvaluationNarrativeFixture } from '../testUtils/governedPrivateEvaluationFixture';
+import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('AFL_OUTCOMES_TEST_DATABASE_URL must identify disposable PostgreSQL.');
+  })();
+const schemaName = `afl_governed_lifecycle_${process.pid}_${Date.now()}`;
+const adminPool = new Pool({ connectionString: databaseUrl });
+const pool = new Pool({
+  connectionString: databaseUrl,
+  options: `-c search_path=${schemaName}`,
+});
+const selector = {
+  valuationScopeKey: 'afl-trade-history:test-fixture',
+  tradeId: 'trade:adelaide-st-kilda',
+};
+const client = createPgAflOutcomeSqlClient(pool);
+let artifactRoot = '';
+let artifactRepository: ReturnType<
+  typeof createLocalAflTradeArtifactRepository
+>;
+let staging: ReturnType<typeof createPostgresGovernedPrivateEvaluationStagingRepository>;
+let lifecycle: ReturnType<typeof createPostgresGovernedPrivateEvaluationLifecycleRepository>;
+
+type Head = {
+  readonly status: 'absent' | 'active' | 'withdrawn';
+  readonly revision: number;
+  readonly generationId: string | null;
+};
+type Action =
+  | { readonly kind: 'construct_and_activate' }
+  | { readonly kind: 'withdraw'; readonly reason: string }
+  | { readonly kind: 'rollback'; readonly targetGenerationId: string }
+  | { readonly kind: 'recover' };
+
+function canonicalBytes(value: unknown): Uint8Array {
+  return new TextEncoder().encode(canonicalizeAflTradeJson(value));
+}
+
+async function trustedNow(): Promise<string> {
+  const result = await pool.query<{ trusted_at: Date }>(
+    `SELECT date_trunc('milliseconds',clock_timestamp()) AS trusted_at`
+  );
+  return result.rows[0]!.trusted_at.toISOString();
+}
+
+async function retainJson(value: unknown, createdAt: string) {
+  const reference = createAflTradeCanonicalJsonArtifactRef(value, createdAt);
+  await staging.retainArtifact({ reference, bytes: canonicalBytes(value) });
+  return reference;
+}
+
+async function seedPrivateEvaluationOperator(authorizedAt: string) {
+  const principalId = 'firebase:test-operator';
+  const authorityContent = {
+    principalRef: principalId,
+    role: 'afl_trade_private_evaluation_operator',
+    scopeKey: selector.valuationScopeKey,
+    provider: 'statly_modeling',
+    capabilityId: 'manage_private_trade_evaluation',
+    competition: 'AFLM',
+    validFromSeason: 1897,
+    validThroughSeason: 2200,
+    validFrom: authorizedAt,
+    validThrough: '2099-01-01T00:00:00.000Z',
+  };
+  const evidenceDocument = {
+    evidenceKind: 'reviewer_authority_evidence',
+    environment: 'test_fixture',
+    ...authorityContent,
+  };
+  const artifact = await retainJson(evidenceDocument, authorizedAt);
+  const authorityEvidenceId = createAflTradeContentAddress(
+    'reviewer-authority-evidence',
+    evidenceDocument
+  );
+  const decisionId = createAflTradeContentAddress('review-decision', {
+    authorityEvidenceId,
+    decision: 'approved',
+    decidedAt: authorizedAt,
+  });
+  const authorityClient = await pool.connect();
+  try {
+    await authorityClient.query('BEGIN');
+    await authorityClient.query(
+      `INSERT INTO outcome_review_decision
+        (decision_id,subject_type,subject_id,decision,rationale,evidence_json,decided_by,decided_at)
+       VALUES ($1,'governed_evidence_reference',$2,'approved',$3,$4::jsonb,$5,$6)`,
+      [
+        decisionId,
+        authorityEvidenceId,
+        'Approve fixture operator authority for governed private lifecycle proof.',
+        canonicalizeAflTradeJson({ artifact }),
+        'fixture-governance-writer',
+        authorizedAt,
+      ]
+    );
+    await authorityClient.query(
+      `INSERT INTO outcome_governed_evidence_reference
+        (reference_id,reference_sha256,evidence_kind,artifact_id,environment,status,
+         approval_decision_id,created_at,evidence_canonical_json,evidence_json)
+       VALUES ($1,$2,'reviewer_authority_evidence',$3,'test_fixture','approved',$4,$5,$6,$7::jsonb)`,
+      [
+        authorityEvidenceId,
+        authorityEvidenceId.slice('reviewer-authority-evidence:'.length),
+        artifact.artifactId,
+        decisionId,
+        authorizedAt,
+        canonicalizeAflTradeJson(evidenceDocument),
+        canonicalizeAflTradeJson(evidenceDocument),
+      ]
+    );
+    await authorityClient.query(
+      `INSERT INTO outcome_operational_principal_authority
+        (authority_evidence_id,principal_ref,role,scope_key,provider,capability_id,
+         competition,valid_from_season,valid_through_season,valid_from,valid_through)
+       VALUES ($1,$2,'afl_trade_private_evaluation_operator',$3,'statly_modeling',
+               'manage_private_trade_evaluation','AFLM',1897,2200,$4,$5)`,
+      [
+        authorityEvidenceId,
+        principalId,
+        selector.valuationScopeKey,
+        authorizedAt,
+        '2099-01-01T00:00:00.000Z',
+      ]
+    );
+    await authorityClient.query('COMMIT');
+  } catch (error) {
+    await authorityClient.query('ROLLBACK');
+    throw error;
+  } finally {
+    authorityClient.release();
+  }
+}
+
+async function seedInspection(head: Head, inspectedAt: string) {
+  const validThrough = new Date(Date.parse(inspectedAt) + 300_000).toISOString();
+  const retained = createReadyFixtureGovernedPrivateEvaluationAuthorityInspection({
+    selector,
+    head,
+    capturedAt: inspectedAt,
+    validThrough,
+    lastTransitionId:
+      head.status === 'absent'
+        ? null
+        : (
+            await pool.query<{ last_transition_id: string }>(
+              `SELECT last_transition_id FROM outcome_local_private_trade_evaluation_head
+                WHERE valuation_scope_key=$1 AND trade_id=$2`,
+              [selector.valuationScopeKey, selector.tradeId]
+            )
+          ).rows[0]!.last_transition_id,
+    playerModelRunId: `model-run:${'1'.repeat(64)}`,
+    pickModelRunId: `model-run:${'2'.repeat(64)}`,
+  });
+  const { snapshot, inspection } = retained;
+  const snapshotArtifact = await retainJson(snapshot, inspectedAt);
+  await pool.query(
+    `INSERT INTO outcome_private_evaluation_authority_snapshot
+      (snapshot_id,valuation_scope_key,trade_id,artifact_id,captured_at,valid_through,
+       expected_head_status,expected_head_revision,expected_head_generation_id,
+       content_sha256,content_canonical_json,snapshot_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
+    [
+      snapshot.snapshotId,
+      selector.valuationScopeKey,
+      selector.tradeId,
+      snapshotArtifact.artifactId,
+      inspectedAt,
+      validThrough,
+      head.status,
+      head.revision,
+      head.generationId,
+      snapshot.snapshotId.slice('private-evaluation-authority-snapshot:'.length),
+      canonicalizeAflTradeJson(snapshot.content),
+      canonicalizeAflTradeJson(snapshot),
+    ]
+  );
+  const inspectionArtifact = await retainJson(inspection, inspectedAt);
+  await pool.query(
+    `INSERT INTO outcome_private_evaluation_inspection_receipt
+      (inspection_id,snapshot_id,valuation_scope_key,trade_id,artifact_id,state,
+       inspected_at,valid_through,expected_head_status,expected_head_revision,
+       expected_head_generation_id,content_sha256,content_canonical_json,receipt_json)
+     VALUES ($1,$2,$3,$4,$5,'ready',$6,$7,$8,$9,$10,$11,$12,$13::jsonb)`,
+    [
+      inspection.inspectionId,
+      snapshot.snapshotId,
+      selector.valuationScopeKey,
+      selector.tradeId,
+      inspectionArtifact.artifactId,
+      inspectedAt,
+      validThrough,
+      head.status,
+      head.revision,
+      head.generationId,
+      inspection.inspectionId.slice('private-evaluation-inspection:'.length),
+      canonicalizeAflTradeJson(inspection.content),
+      canonicalizeAflTradeJson(inspection),
+    ]
+  );
+  return {
+    inspectionId: inspection.inspectionId,
+    snapshotId: snapshot.snapshotId,
+    validThrough,
+  };
+}
+
+async function transition(input: {
+  readonly marker: string;
+  readonly action: Action;
+  readonly fromHead: Head;
+  readonly previousTransitionId: string | null;
+  readonly generationId?: string;
+  readonly generationCreatedAt?: string;
+}) {
+  const requestedAt = await trustedNow();
+  const inspection = await seedInspection(input.fromHead, requestedAt);
+  const intent = createGovernedPrivateEvaluationTransitionIntent({
+    selector,
+    inspectionId: inspection.inspectionId,
+    authoritySnapshotId: input.action.kind === 'withdraw' ? null : inspection.snapshotId,
+    operationId: createAflTradeContentAddress('private-evaluation-operation', {
+      marker: input.marker,
+    }),
+    action: input.action,
+    expectedHead: input.fromHead,
+    review: {
+      principalId: 'firebase:test-operator',
+      rationale: `Exercise ${input.action.kind} against disposable PostgreSQL.`,
+    },
+    requestedAt,
+    expiresAt: inspection.validThrough,
+  });
+  const materialization =
+    input.action.kind === 'construct_and_activate'
+      ? createGovernedPrivateEvaluationGeneration({
+          selector,
+          transitionIntentId: intent.transitionIntentId,
+          generatedAt: input.generationCreatedAt ?? requestedAt,
+          narrative: createGovernedPrivateEvaluationNarrativeFixture(),
+        })
+      : undefined;
+  const toGenerationId = materialization?.generation.generationId ?? input.generationId ?? null;
+  const intentArtifact = createAflTradeCanonicalJsonArtifactRef(intent, requestedAt);
+  await staging.stage({ intent, intentArtifact, materialization });
+  const receipt = createGovernedPrivateEvaluationTransitionReceipt({
+    intent,
+    previousTransitionId: input.previousTransitionId,
+    toGenerationId,
+    transitionedAt: await trustedNow(),
+  });
+  const receiptArtifact = await retainJson(receipt, receipt.content.transitionedAt);
+  const result = await lifecycle.commit({ receipt, receiptArtifact });
+  return {
+    result,
+    receipt,
+    receiptArtifact,
+    generationId: toGenerationId!,
+    generationCreatedAt: materialization?.generation.content.generatedAt,
+  };
+}
+
+beforeAll(async () => {
+  artifactRoot = await mkdtemp(join(tmpdir(), 'statly-governed-lifecycle-'));
+  await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
+  const scoped = new URL(databaseUrl);
+  scoped.searchParams.set('schema', schemaName);
+  runOutcomesPrismaTestCommand(['migrate', 'deploy'], { databaseUrl: scoped.toString() });
+  artifactRepository = createLocalAflTradeArtifactRepository({
+    rootDirectory: artifactRoot,
+    repositoryId: 'governed-lifecycle-postgres-proof',
+    artifactClass: 'derived_private',
+    maximumObjectBytes: 4 * 1024 * 1024,
+  });
+  staging = createPostgresGovernedPrivateEvaluationStagingRepository({
+    client,
+    artifactRepository,
+    maximumArtifactBytes: 4 * 1024 * 1024,
+  });
+  lifecycle = createPostgresGovernedPrivateEvaluationLifecycleRepository({
+    client,
+    artifactRepository,
+    maximumArtifactBytes: 4 * 1024 * 1024,
+  });
+});
+
+afterAll(async () => {
+  await pool.end();
+  await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  await adminPool.end();
+  if (artifactRoot !== '') await rm(artifactRoot, { recursive: true, force: true });
+});
+
+describe('governed private evaluation PostgreSQL lifecycle', () => {
+  it('stages, activates, exactly replays, withdraws, verifies, and blocks unavailable reactivation', async () => {
+    const operatorAuthorizedAt = new Date(Date.parse(await trustedNow()) - 1_000).toISOString();
+    await seedPrivateEvaluationOperator(operatorAuthorizedAt);
+    const activation = await transition({
+      marker: 'activate',
+      action: { kind: 'construct_and_activate' },
+      fromHead: { status: 'absent', revision: 0, generationId: null },
+      previousTransitionId: null,
+    });
+    expect(activation.result).toMatchObject({ state: 'committed' });
+    await expect(
+      lifecycle.commit({
+        receipt: activation.receipt,
+        receiptArtifact: activation.receiptArtifact,
+      })
+    ).resolves.toMatchObject({ state: 'replayed' });
+
+    const workspace = createPostgresGovernedPrivateEvaluationWorkspace({
+      client,
+      artifactRepository,
+      maximumArtifactBytes: 4 * 1024 * 1024,
+      principalId: 'firebase:test-operator',
+      authorizeReader: async ({ principalId }) => principalId === 'firebase:test-operator',
+    });
+    const withdrawalInspection = await workspace.inspect(selector);
+    expect(withdrawalInspection).toMatchObject({
+      state: 'unavailable',
+      head: { status: 'active', revision: 1, generationId: activation.generationId },
+      blockers: [{ code: 'insufficient_data' }],
+    });
+    const readerWorkspace = createPostgresGovernedPrivateEvaluationWorkspace({
+      client,
+      artifactRepository,
+      maximumArtifactBytes: 4 * 1024 * 1024,
+      principalId: 'firebase:registered-reader',
+      authorizeReader: async ({ principalId }) => principalId === 'firebase:registered-reader',
+    });
+    await expect(
+      readerWorkspace.execute({
+        inspectionId: withdrawalInspection.inspectionId,
+        operationId: createAflTradeContentAddress('private-evaluation-operation', {
+          marker: 'registered-reader-withdrawal',
+        }),
+        action: { kind: 'withdraw', reason: 'Reader must not control lifecycle state.' },
+        review: { rationale: 'Prove registered-reader lifecycle denial.' },
+      })
+    ).rejects.toThrow('current governed operator authority');
+    const withdrawalOperationId = createAflTradeContentAddress('private-evaluation-operation', {
+      marker: 'workspace-withdraw',
+    });
+    await expect(
+      workspace.execute({
+        inspectionId: withdrawalInspection.inspectionId,
+        operationId: withdrawalOperationId,
+        action: { kind: 'withdraw', reason: 'Fixture safety withdrawal.' },
+        review: { rationale: 'Fail closed while component models are unavailable.' },
+      })
+    ).resolves.toMatchObject({
+      state: 'withdrawn',
+      head: { status: 'withdrawn', revision: 2, generationId: null },
+    });
+    const recoveryInspection = await workspace.inspect(selector);
+    expect(recoveryInspection).toMatchObject({
+      state: 'unavailable',
+      head: { status: 'withdrawn', revision: 2, generationId: null },
+      blockers: [{ code: 'insufficient_data' }],
+    });
+    await expect(
+      workspace.execute({
+        inspectionId: recoveryInspection.inspectionId,
+        operationId: createAflTradeContentAddress('private-evaluation-operation', {
+          marker: 'workspace-recover',
+        }),
+        action: { kind: 'recover' },
+        review: { rationale: 'Unavailable real authority cannot recover a fixture grade.' },
+      })
+    ).resolves.toMatchObject({
+      state: 'invalid_transition',
+      message: 'Rollback and recovery require exact ready calculation authority.',
+    });
+    await expect(
+      workspace.execute({
+        inspectionId: recoveryInspection.inspectionId,
+        operationId: createAflTradeContentAddress('private-evaluation-operation', {
+          marker: 'verify-reconstruction',
+        }),
+        action: {
+          kind: 'verify_reconstruction',
+          generationId: activation.generationId,
+        },
+        review: { rationale: 'Verify the exact withdrawn derivation without reactivating it.' },
+      })
+    ).resolves.toMatchObject({
+      state: 'reconstruction_verified',
+      generationId: activation.generationId,
+      exactMatch: true,
+    });
+
+    const withdrawnHead = await pool.query<{ last_transition_id: string }>(
+      `SELECT last_transition_id FROM outcome_local_private_trade_evaluation_head
+        WHERE valuation_scope_key=$1 AND trade_id=$2`,
+      [selector.valuationScopeKey, selector.tradeId]
+    );
+    const replacement = await transition({
+      marker: 'activate-replacement',
+      action: { kind: 'construct_and_activate' },
+      fromHead: {
+        status: 'withdrawn',
+        revision: 2,
+        generationId: null,
+      },
+      previousTransitionId: withdrawnHead.rows[0]!.last_transition_id,
+      generationCreatedAt: activation.generationCreatedAt,
+    });
+    expect(replacement.generationId).not.toBe(activation.generationId);
+
+    const rollbackInspection = await workspace.inspect(selector);
+    await expect(
+      workspace.execute({
+        inspectionId: rollbackInspection.inspectionId,
+        operationId: createAflTradeContentAddress('private-evaluation-operation', {
+          marker: 'workspace-rollback',
+        }),
+        action: { kind: 'rollback', targetGenerationId: activation.generationId },
+        review: { rationale: 'Unavailable real authority cannot restore a fixture grade.' },
+      })
+    ).resolves.toMatchObject({
+      state: 'invalid_transition',
+      message: 'Rollback and recovery require exact ready calculation authority.',
+    });
+
+    const head = await pool.query(
+      `SELECT valuation_scope_key,trade_id,revision,status,generation_id,last_transition_id
+         FROM outcome_local_private_trade_evaluation_head`
+    );
+    expect(head.rows).toEqual([
+      {
+        valuation_scope_key: selector.valuationScopeKey,
+        trade_id: selector.tradeId,
+        revision: 3,
+        status: 'active',
+        generation_id: replacement.generationId,
+        last_transition_id: replacement.receipt.transitionId,
+      },
+    ]);
+    await expect(
+      pool.query(`UPDATE outcome_private_evaluation_transition_receipt SET action='withdraw'`)
+    ).rejects.toThrow(/append-only/i);
+    await expect(
+      pool.query(
+        `SELECT generation_id FROM outcome_local_private_trade_evaluation_generation
+          WHERE valuation_scope_key=$1 AND trade_id=$2`,
+        ['escaped-scope', selector.tradeId]
+      )
+    ).resolves.toMatchObject({ rows: [] });
+  });
+});

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1084,6 +1084,12 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0055_private_reviewed_evidence_currentness',
       '0056_local_workbook_player_identity_review',
       '0057_local_workbook_player_identity_authority',
+      '0058_governed_private_evaluation_lifecycle',
+      '0059_authenticated_prepared_valuation_inputs',
+      '0060_materialization_manifest_prepared_inputs',
+      '0061_governed_valuation_component_runs',
+      '0062_authenticated_prepared_v3_ancestry',
+      '0063_governed_pick_pav_model_execution',
     ]);
 
     const tables = await query<{ table_name: string }>(
@@ -1093,6 +1099,7 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
     const tableNames = new Set(tables.rows.map(({ table_name }) => table_name));
     for (const expected of [
       'outcome_artifact_custody',
+      'outcome_governed_pick_pav_model_execution',
       'outcome_source_capture_attempt',
       'outcome_source_capture_season',
       'outcome_import_row',

--- a/tests/testUtils/governedPickPavModelExecutionFixture.ts
+++ b/tests/testUtils/governedPickPavModelExecutionFixture.ts
@@ -1,0 +1,187 @@
+import { createHash } from 'node:crypto';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { createGovernedAflTradePickPavModelExecution } from '@/server/aflTradeIntelligence/modeling/governedPickPavModelExecution';
+import { createAflTradePickPavPolicy } from '@/server/aflTradeIntelligence/modeling/pickOutcomeContracts';
+import { computeAflTradePickPavModelExecutionOutputs } from '@/server/aflTradeIntelligence/modeling/pickPavModelExecution';
+import { materializeAflTradePickPavObservationSet } from '@/server/aflTradeIntelligence/modeling/pickPavObservationService';
+
+const RETAINED_AT = '2015-01-03T00:00:00.000Z';
+const COMPLETED_AT = '2015-01-03T00:00:01.000Z';
+const years = [2000, 2001, 2002, 2003, 2006, 2009, 2012] as const;
+
+const sha = (value: string) => createHash('sha256').update(value).digest('hex');
+const addressed = (prefix: string, value: string) =>
+  createAflTradeContentAddress(prefix, { fixture: value });
+const decision = (value: string) => ({
+  id: `review-decision:${sha(value)}`,
+  sha256: sha(value),
+});
+
+function createObservationSet() {
+  const releaseId = addressed('outcome-release', 'governed-pick-execution-release');
+  const methodId = addressed('hpn-pav-method', 'governed-pick-execution-method');
+  const policy = createAflTradePickPavPolicy({
+    schemaVersion: 'afl-trade-pick-pav-policy/v1',
+    authorityBoundary:
+      'private_released_draft_selection_exact_finalized_hpn_pav_no_grade_publication_or_fantasy_ownership',
+    publicationEligible: false,
+    environment: 'non_production',
+    competition: 'AFLM',
+    policyVersion: 'governed-pick-execution-v1',
+    supportedPathway: 'national',
+    supportedAccess: 'open',
+    firstOutcomeSeasonOffset: 1,
+    fixedHorizonSeasons: 1,
+    methodId,
+    sourceValueUnit: 'season_pav',
+    outcomeValueUnit: 'fixed_horizon_pav',
+    categoryMinimums: {
+      replacementLevel: 10,
+      regularContributor: 30,
+      highQuality: 60,
+      elite: 90,
+    },
+    partitions: [
+      { role: 'train', fromDraftYear: 2000, throughDraftYear: 2003 },
+      { role: 'calibration', fromDraftYear: 2006, throughDraftYear: 2006 },
+      { role: 'validation', fromDraftYear: 2009, throughDraftYear: 2009 },
+      { role: 'final_test', fromDraftYear: 2012, throughDraftYear: 2012 },
+    ],
+    approvalDecision: decision('governed-pick-execution-policy'),
+    createdAt: '1999-01-01T00:00:00.000Z',
+  });
+  const selections = years.map((draftYear, index) => ({
+    releaseId,
+    selectionId: addressed('draft-selection', `${draftYear}:${index}`),
+    eventId: `draft:${draftYear}:national`,
+    eventVersionId: addressed('event-version', `draft:${draftYear}:national`),
+    eventDate: `${draftYear}-11-20`,
+    recordedAt: `${draftYear}-11-21T00:00:00.000Z`,
+    draftYear,
+    pathway: 'national' as const,
+    actualSelectionNumber: index < 4 ? [10, 14, 14, 20][index]! : 14,
+    nominalSelectionNumber: index < 4 ? [10, 14, 14, 20][index]! : 14,
+    draftRound: 1,
+    pickId: `pick:${draftYear}:national:${index + 1}`,
+    playerId: `player:${draftYear}`,
+    clubId: `club:${draftYear}`,
+    access: {
+      state: 'open' as const,
+      decision: decision(`access:${draftYear}`),
+      recordedAt: `${draftYear}-11-22T00:00:00.000Z`,
+    },
+  }));
+  const calculations = years.map((draftYear, index) => {
+    const seasonYear = draftYear + 1;
+    const calculationSha256 = sha(`calculation:${draftYear}`);
+    const sourceRowIds = Array.from(
+      { length: 10 },
+      (_, rowIndex) => `decoded-row:${draftYear}:${rowIndex + 1}`
+    );
+    return {
+      calculation: {
+        calculationId: `hpn-pav-season:${calculationSha256}`,
+        calculationSha256,
+        inputSetId: addressed('hpn-pav-input-set', `input:${draftYear}`),
+        methodId,
+        seasonYear,
+        effectiveThrough: `${seasonYear}-12-31T23:59:59.000Z`,
+        calculatedAt: `${seasonYear + 1}-01-01T00:00:00.000Z`,
+      },
+      playerValues: [
+        {
+          calculationId: `hpn-pav-season:${calculationSha256}`,
+          calculationSha256,
+          seasonYear,
+          spellVersionId: addressed('acquisition-spell-version', `spell:${draftYear}`),
+          playerId: `player:${draftYear}`,
+          playerSha256: sha(`player:${draftYear}`),
+          clubId: `club:${draftYear}`,
+          sourceRowIds,
+          gamesPlayed: sourceRowIds.length,
+          totalPav: [100, 60, 80, 20, 70, 65, 75][index]!,
+        },
+      ],
+    };
+  });
+  return materializeAflTradePickPavObservationSet({
+    environment: 'non_production',
+    competition: 'AFLM',
+    createdAt: '2015-01-02T00:00:00.000Z',
+    knowledgeCutoffAt: '2015-01-01T00:00:00.000Z',
+    releaseId,
+    policy,
+    selections,
+    calculations,
+  });
+}
+
+export function createGovernedPickPavModelExecutionFixture() {
+  const observationSet = createObservationSet();
+  const datasetId = addressed('dataset', 'governed-pick-dataset');
+  const datasetAdmissionId = addressed(
+    'dataset-admission',
+    'governed-pick-dataset-admission'
+  );
+  const datasetDocument = {
+    content: { factualParent: { factualReleaseId: observationSet.content.releaseId } },
+  } as const;
+  const datasetAdmissionDocument = {
+    content: { factualReleaseId: observationSet.content.releaseId },
+  } as const;
+  const protocolContent = {
+    environment: 'non_production',
+    datasetId,
+    datasetAdmission: { admissionId: datasetAdmissionId },
+  } as const;
+  const protocolId = createAflTradeContentAddress('model-protocol', protocolContent);
+  const protocolDocument = { protocolId, content: protocolContent } as const;
+  const execution = createGovernedAflTradePickPavModelExecution({
+    outputs: computeAflTradePickPavModelExecutionOutputs({
+      observationSet,
+      benchmarkConfig: {
+        schemaVersion: 'afl-trade-pick-pav-distribution-benchmark-config/v1',
+        minimumBlockObservations: 1,
+        eligibility: 'mature_open_access_national_draft_training_observations',
+        informationWeight: 'eligible_selection_count',
+        smoother: 'weighted_non_increasing_isotonic',
+        sparseBlockMergePolicy: 'nearest_adjacent_fitted_mean_left_tie_break',
+        interpolation: 'left_block_carry_forward_within_training_domain',
+        extrapolation: 'prohibited',
+        estimatorStatus: 'benchmark_only_requires_temporal_validation_and_approval',
+      },
+      validationConfig: {
+        schemaVersion: 'afl-trade-pick-pav-validation-config/v1',
+        evaluatedAt: RETAINED_AT,
+        minimumEligibleObservations: 3,
+        minimumPartitionObservations: 1,
+        nominalIntervalCoverage: 0.8,
+      },
+    }),
+    completedAt: COMPLETED_AT,
+    authority: {
+      datasetId,
+      datasetArtifact: createAflTradeCanonicalJsonArtifactRef(
+        datasetDocument,
+        RETAINED_AT
+      ),
+      datasetAdmissionId,
+      datasetAdmissionArtifact: createAflTradeCanonicalJsonArtifactRef(
+        datasetAdmissionDocument,
+        RETAINED_AT
+      ),
+      datasetAdmissionGateLedgerRevision: 7,
+      protocolId,
+      protocolArtifact: createAflTradeCanonicalJsonArtifactRef(
+        protocolDocument,
+        RETAINED_AT
+      ),
+    },
+  });
+  return {
+    execution,
+    authorityDocuments: [datasetDocument, datasetAdmissionDocument, protocolDocument],
+  };
+}

--- a/tests/testUtils/governedPrivateEvaluationAuthenticatedCalculationFixture.ts
+++ b/tests/testUtils/governedPrivateEvaluationAuthenticatedCalculationFixture.ts
@@ -1,0 +1,484 @@
+import { createHash } from 'node:crypto';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { createLocalSyntheticValuationScenario } from '@/server/aflTradeIntelligence/development/localSyntheticValuationScenario';
+import { createAflTradePickPavPolicy } from '@/server/aflTradeIntelligence/modeling/pickOutcomeContracts';
+import { fitAflTradePickPavDistributionBenchmark } from '@/server/aflTradeIntelligence/modeling/pickPavDistributionBenchmark';
+import { materializeAflTradePickPavObservationSet } from '@/server/aflTradeIntelligence/modeling/pickPavObservationService';
+import { createAflTradeComponentDrawSet } from '@/server/aflTradeIntelligence/valuation/componentDrawSet';
+import { createGovernedPrivateEvaluationExplanationPolicy } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationExplanationPolicy';
+import { createGovernedPrivateEvaluationInputTrace } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationInputTrace';
+import { createGovernedPrivateEvaluationMaterializationManifest } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationMaterializationManifest';
+import { createAflTradePackagePolicy } from '@/server/aflTradeIntelligence/valuation/packagePolicy';
+import { createAflTradeRealizedContributionLedger } from '@/server/aflTradeIntelligence/valuation/realizedContributionLedger';
+import { createAflTradeValuationCalculationInputPackage } from '@/server/aflTradeIntelligence/valuation/valuationCalculationInputPackage';
+import {
+  createAflTradeLineageGraphId,
+  createAflTradeValuationCase,
+} from '@/server/aflTradeIntelligence/valuation/valuationCaseContracts';
+
+const CREATED_AT = '2026-08-19T09:00:00.000Z';
+const DERIVED_AT = '2026-08-19T10:00:00.000Z';
+const benchmarkYears = [2000, 2001, 2002, 2003, 2006, 2009, 2012] as const;
+const benchmarkSelections = new Map<number, number>([
+  [2000, 10],
+  [2001, 14],
+  [2002, 20],
+  [2003, 25],
+  [2006, 10],
+  [2009, 14],
+  [2012, 20],
+]);
+const benchmarkContributions = new Map<number, number>([
+  [2000, 20.8],
+  [2001, 10.4],
+  [2002, 7.8],
+  [2003, 5.2],
+  [2006, 18],
+  [2009, 9],
+  [2012, 6],
+]);
+
+function artifact(label: string) {
+  const contentSha256 = createAflTradeContentAddress('artifact', label).split(':')[1]!;
+  return {
+    artifactId: `artifact:${contentSha256}`,
+    contentSha256,
+    storageUri: `artifact://sha256/${contentSha256}`,
+    mediaType: 'application/json',
+    byteLength: 128,
+    createdAt: CREATED_AT,
+  };
+}
+
+function addressed(prefix: string, label: string) {
+  return createAflTradeContentAddress(prefix, { fixture: label });
+}
+
+function sha(value: string) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function createPickBenchmark() {
+  const releaseId = addressed('outcome-release', 'authenticated-calculation');
+  const methodId = addressed('hpn-pav-method', 'authenticated-calculation');
+  const policy = createAflTradePickPavPolicy({
+    schemaVersion: 'afl-trade-pick-pav-policy/v1',
+    authorityBoundary:
+      'private_released_draft_selection_exact_finalized_hpn_pav_no_grade_publication_or_fantasy_ownership',
+    publicationEligible: false,
+    environment: 'test_fixture',
+    competition: 'AFLM',
+    policyVersion: 'authenticated-calculation-fixture-v1',
+    supportedPathway: 'national',
+    supportedAccess: 'open',
+    firstOutcomeSeasonOffset: 1,
+    fixedHorizonSeasons: 1,
+    methodId,
+    sourceValueUnit: 'season_pav',
+    outcomeValueUnit: 'fixed_horizon_pav',
+    categoryMinimums: {
+      replacementLevel: 5,
+      regularContributor: 10,
+      highQuality: 15,
+      elite: 20,
+    },
+    partitions: [
+      { role: 'train', fromDraftYear: 2000, throughDraftYear: 2003 },
+      { role: 'calibration', fromDraftYear: 2006, throughDraftYear: 2006 },
+      { role: 'validation', fromDraftYear: 2009, throughDraftYear: 2009 },
+      { role: 'final_test', fromDraftYear: 2012, throughDraftYear: 2012 },
+    ],
+    approvalDecision: {
+      id: `review-decision:${sha('authenticated-calculation')}`,
+      sha256: sha('authenticated-calculation'),
+    },
+    createdAt: '1999-01-01T00:00:00.000Z',
+  });
+  const selections = benchmarkYears.map((draftYear) => {
+    const selectionNumber = benchmarkSelections.get(draftYear)!;
+    return {
+      releaseId,
+      selectionId: addressed('draft-selection', `${draftYear}:${selectionNumber}`),
+      eventId: `draft:${draftYear}:national`,
+      eventVersionId: addressed('event-version', `draft:${draftYear}:national`),
+      eventDate: `${draftYear}-11-20`,
+      recordedAt: `${draftYear}-11-21T00:00:00.000Z`,
+      draftYear,
+      pathway: 'national' as const,
+      actualSelectionNumber: selectionNumber,
+      nominalSelectionNumber: selectionNumber,
+      draftRound: selectionNumber <= 20 ? 1 : 2,
+      pickId: `pick:${draftYear}:national:${selectionNumber}`,
+      playerId: `player:${draftYear}`,
+      clubId: `club:${draftYear}`,
+      access: {
+        state: 'open' as const,
+        decision: {
+          id: `review-decision:${sha(`access:${draftYear}`)}`,
+          sha256: sha(`access:${draftYear}`),
+        },
+        recordedAt: `${draftYear}-11-22T00:00:00.000Z`,
+      },
+    };
+  });
+  const calculations = benchmarkYears.map((draftYear) => {
+    const seasonYear = draftYear + 1;
+    const calculationSha256 = sha(`calculation:${draftYear}`);
+    const sourceRowIds = Array.from(
+      { length: 10 },
+      (_, index) => `decoded-row:${draftYear}:${index + 1}`
+    );
+    return {
+      calculation: {
+        calculationId: `hpn-pav-season:${calculationSha256}`,
+        calculationSha256,
+        inputSetId: addressed('hpn-pav-input-set', `input:${draftYear}`),
+        methodId,
+        seasonYear,
+        effectiveThrough: `${seasonYear}-12-31T23:59:59.000Z`,
+        calculatedAt: `${seasonYear + 1}-01-01T00:00:00.000Z`,
+      },
+      playerValues: [
+        {
+          calculationId: `hpn-pav-season:${calculationSha256}`,
+          calculationSha256,
+          seasonYear,
+          spellVersionId: addressed('acquisition-spell-version', `spell:${draftYear}`),
+          playerId: `player:${draftYear}`,
+          playerSha256: sha(`player:${draftYear}`),
+          clubId: `club:${draftYear}`,
+          sourceRowIds,
+          gamesPlayed: sourceRowIds.length,
+          totalPav: benchmarkContributions.get(draftYear)!,
+        },
+      ],
+    };
+  });
+  const observationSet = materializeAflTradePickPavObservationSet({
+    environment: 'test_fixture',
+    competition: 'AFLM',
+    createdAt: '2015-01-02T00:00:00.000Z',
+    knowledgeCutoffAt: '2015-01-01T00:00:00.000Z',
+    releaseId,
+    policy,
+    selections,
+    calculations,
+  });
+  return fitAflTradePickPavDistributionBenchmark(observationSet, {
+    schemaVersion: 'afl-trade-pick-pav-distribution-benchmark-config/v1',
+    minimumBlockObservations: 1,
+    eligibility: 'mature_open_access_national_draft_training_observations',
+    informationWeight: 'eligible_selection_count',
+    smoother: 'weighted_non_increasing_isotonic',
+    sparseBlockMergePolicy: 'nearest_adjacent_fitted_mean_left_tie_break',
+    interpolation: 'left_block_carry_forward_within_training_domain',
+    extrapolation: 'prohibited',
+    estimatorStatus: 'benchmark_only_requires_temporal_validation_and_approval',
+  });
+}
+
+export function createGovernedPrivateEvaluationAuthenticatedCalculationFixture() {
+  const definition = {
+    schemaVersion: 'local-synthetic-trade-definition/v1' as const,
+    basis: { kind: 'private_workbook' as const, basisId: 'authenticated-contract-fixture' },
+    tradeId: 'trade:authenticated-three-club',
+    effectiveAt: '2023-10-18T00:00:00.000Z',
+    effectiveThrough: '2026-08-19T00:00:00.000Z',
+    parties: [
+      { aflClubId: 'club:alpha', clubName: 'Alpha' },
+      { aflClubId: 'club:bravo', clubName: 'Bravo' },
+      { aflClubId: 'club:charlie', clubName: 'Charlie' },
+    ],
+    transfers: [
+      {
+        transferId: 'transfer:01',
+        fromClubId: 'club:alpha',
+        toClubId: 'club:bravo',
+        assetId: 'asset:01',
+        assetKind: 'current_pick' as const,
+        displayLabel: 'Pick 25',
+        directionBasis: 'archive_recorded_transfer' as const,
+      },
+      {
+        transferId: 'transfer:02',
+        fromClubId: 'club:alpha',
+        toClubId: 'club:charlie',
+        assetId: 'asset:02',
+        assetKind: 'current_pick' as const,
+        displayLabel: 'Pick 14',
+        directionBasis: 'archive_recorded_transfer' as const,
+      },
+      {
+        transferId: 'transfer:03',
+        fromClubId: 'club:bravo',
+        toClubId: 'club:alpha',
+        assetId: 'asset:03',
+        assetKind: 'future_pick' as const,
+        displayLabel: 'Future pick resolved as Pick 20',
+        directionBasis: 'archive_recorded_transfer' as const,
+      },
+      {
+        transferId: 'transfer:04',
+        fromClubId: 'club:charlie',
+        toClubId: 'club:alpha',
+        assetId: 'asset:04',
+        assetKind: 'future_pick' as const,
+        displayLabel: 'Future pick resolved as Pick 10',
+        directionBasis: 'archive_recorded_transfer' as const,
+      },
+    ],
+  };
+  const scenario = createLocalSyntheticValuationScenario({
+    environment: 'test_fixture',
+    definition,
+    valuationBundleId: addressed('valuation-bundle', 'authenticated-calculation'),
+    scenario: 'baseline',
+    assessedAt: CREATED_AT,
+  });
+  const valuationInputBundleId = addressed('valuation-input-bundle', 'authenticated-calculation');
+  const componentDrawSet = createAflTradeComponentDrawSet({
+    ...scenario.componentDrawSet.content,
+    valuationInputBundleId,
+    valueUnitId: 'fixed_horizon_pav',
+  });
+  const realizedContributionLedger = createAflTradeRealizedContributionLedger({
+    ...scenario.realizedContributionLedger.content,
+    valuationInputBundleId,
+    valueUnitId: 'fixed_horizon_pav',
+  });
+  const packagePolicy = createAflTradePackagePolicy({
+    ...scenario.packagePolicy.content,
+    valuationInputBundleId,
+    valueUnitId: 'fixed_horizon_pav',
+  });
+  const valuationCase = createAflTradeValuationCase({
+    ...scenario.valuationCase.content,
+    valuationInputBundleId,
+    valueUnitId: 'fixed_horizon_pav',
+    componentDrawSetId: componentDrawSet.componentDrawSetId,
+    realizedContributionLedgerId: realizedContributionLedger.realizedContributionLedgerId,
+    packagePolicyId: packagePolicy.packagePolicyId,
+  });
+  const traceComponents = componentDrawSet.content.components.map((component, index) => ({
+    role: component.role,
+    runId: component.runId,
+    protocolId: component.protocolId,
+    datasetId: component.datasetId,
+    datasetAdmissionId: addressed('dataset-admission', `component-${index}`),
+    gate3DecisionId: component.gate3DecisionId,
+    evidence: {
+      runManifest: artifact(`run-${index}`),
+      protocol: artifact(`protocol-${index}`),
+      datasetAdmission: artifact(`admission-${index}`),
+      gate3Decision: artifact(`gate-${index}`),
+    },
+  }));
+  const pickBenchmark = createPickBenchmark();
+  const pickBenchmarkArtifact = createAflTradeCanonicalJsonArtifactRef(
+    pickBenchmark,
+    CREATED_AT
+  );
+  const selectionByAssetId = new Map([
+    ['asset:01', 25],
+    ['asset:02', 14],
+    ['asset:03', 20],
+    ['asset:04', 10],
+  ]);
+  const lineageLabel = (assetId: string, rootAssetId: string) => {
+    const selectionNumber = selectionByAssetId.get(rootAssetId)!;
+    if (assetId === rootAssetId) {
+      return definition.transfers.find((transfer) => transfer.assetId === rootAssetId)!
+        .displayLabel;
+    }
+    const assetType = scenario.lineageGraph.assets.find((asset) => asset.assetId === assetId)!
+      .assetType;
+    if (assetType === 'current_pick_entitlement') return `Pick ${selectionNumber}`;
+    if (assetType === 'draft_selection') return `Pick ${selectionNumber} draft selection`;
+    return `Player selected with Pick ${selectionNumber}`;
+  };
+  const transformationsFor = (rootAssetId: string) => {
+    const transformations = [];
+    let sourceAssetId = rootAssetId;
+    for (let ordinal = 0; ordinal < 3; ordinal += 1) {
+      const edge = scenario.lineageGraph.edges.find(
+        (candidate) => candidate.sourceAssetId === sourceAssetId
+      );
+      if (edge === undefined) break;
+      const ids = [edge.sourceAssetId, edge.targetAssetId].sort();
+      transformations.push({
+        ordinal,
+        kind:
+          scenario.lineageGraph.assets.find(({ assetId }) => assetId === edge.targetAssetId)!
+            .assetType === 'current_pick_entitlement'
+            ? ('renumbered' as const)
+            : ('selected_player' as const),
+        fromAssetIds: [edge.sourceAssetId],
+        toAssetIds: [edge.targetAssetId],
+        effectiveAt: edge.effectiveAt,
+        economicAllocationDecisionId: null,
+        assetLabels: ids.map((assetId) => ({
+          assetId,
+          displayLabel: lineageLabel(assetId, rootAssetId),
+        })),
+        evidenceRef: artifact(`lineage-${edge.edgeId}`),
+      });
+      sourceAssetId = edge.targetAssetId;
+    }
+    return transformations;
+  };
+  const trace = createGovernedPrivateEvaluationInputTrace({
+    schemaVersion: 'private-evaluation-input-trace/v1',
+    environment: 'non_production',
+    selector: {
+      valuationScopeKey: 'afl-men:authenticated-contract-fixture',
+      tradeId: definition.tradeId,
+    },
+    factualReleaseId: addressed('outcome-release', 'authenticated-calculation'),
+    valuationInputBundleId,
+    components: traceComponents,
+    transaction: {
+      effectiveAt: definition.effectiveAt,
+      clubs: definition.parties,
+      transfers: definition.transfers.map((transfer) => ({
+        transferId: transfer.transferId,
+        assetId: transfer.assetId,
+        assetKind:
+          transfer.assetKind === 'current_pick'
+            ? ('current_pick_entitlement' as const)
+            : ('future_pick_entitlement' as const),
+        fromClubId: transfer.fromClubId,
+        toClubId: transfer.toClubId,
+        displayLabel: transfer.displayLabel,
+        evidenceRef: artifact(transfer.transferId),
+      })),
+    },
+    seasonUniverse: [
+      {
+        season: 2024,
+        status: 'complete',
+        startsAt: '2024-03-01T00:00:00.000Z',
+        endsAt: '2024-09-30T23:59:59.999Z',
+        evidenceRef: artifact('season-2024'),
+      },
+      {
+        season: 2025,
+        status: 'complete',
+        startsAt: '2025-03-01T00:00:00.000Z',
+        endsAt: '2025-09-30T23:59:59.999Z',
+        evidenceRef: artifact('season-2025'),
+      },
+      {
+        season: 2026,
+        status: 'right_censored',
+        startsAt: '2026-03-01T00:00:00.000Z',
+        endsAt: '2026-09-30T00:00:00.000Z',
+        evidenceRef: artifact('season-2026'),
+      },
+    ],
+    playerHorizons: [],
+    pickLineages: definition.transfers.map((transfer) => ({
+      rootAssetId: transfer.assetId,
+      pickIdentityId: `pick-identity:${transfer.assetId.split(':')[1]}`,
+      pickIdentityLabel: transfer.displayLabel,
+      receivingClubId: transfer.toClubId,
+      pickObservationSetId: pickBenchmark.content.observationSetId,
+      pickModelExecutionId: addressed('pick-pav-model-execution', transfer.assetId),
+      pickBenchmarkId: pickBenchmark.benchmarkId,
+      pickBenchmarkArtifact,
+      resolvedSelectionNumber: selectionByAssetId.get(transfer.assetId)!,
+      custody: [
+        {
+          ordinal: 0,
+          clubId: transfer.toClubId,
+          clubName: definition.parties.find(({ aflClubId }) => aflClubId === transfer.toClubId)!
+            .clubName,
+          heldFrom: definition.effectiveAt,
+          heldThrough: null,
+          evidenceRef: artifact(`custody-${transfer.assetId}`),
+        },
+      ],
+      transformations: transformationsFor(transfer.assetId),
+    })),
+    derivedAt: DERIVED_AT,
+    publicationEligible: false,
+    limitation:
+      'Authenticated calculation-input trace only; contains no caller-supplied values, grades, publication approval, or activation authority.',
+  });
+  const explanationPolicy = createGovernedPrivateEvaluationExplanationPolicy({
+    schemaVersion: 'private-evaluation-explanation-policy/v1',
+    environment: 'non_production',
+    valueUnitId: valuationCase.content.valueUnitId,
+    selectedLayer: 'scarcityAdjusted',
+    practicalEquivalence: {
+      basis: `absolute club package net difference in ${valuationCase.content.valueUnitId}`,
+      bandByView: [
+        { view: 'at_trade', maximumDifference: 0 },
+        { view: 'realized', maximumDifference: 0 },
+        { view: 'remaining', maximumDifference: 0 },
+        { view: 'current', maximumDifference: 0 },
+      ],
+    },
+    createdAt: CREATED_AT,
+    publicationEligible: false,
+    limitation:
+      'Private calculation explanation policy only; not model, grade, publication, or activation authority.',
+  });
+  const calculationInputPackage = createAflTradeValuationCalculationInputPackage({
+    schemaVersion: 'afl-trade-valuation-calculation-input-package/v2',
+    authority: {
+      kind: 'authenticated_non_production',
+      inputTraceId: trace.inputTraceId,
+      publicationProhibited: true,
+    },
+    tradeId: definition.tradeId,
+    valuationInputBundleId,
+    valuationCase,
+    componentDrawSet,
+    realizedContributionLedger,
+    packagePolicy,
+    createdAt: DERIVED_AT,
+    publicationEligible: false,
+    limitation:
+      'Calculation input only; not a result, model approval, publication approval, or activation authority.',
+  });
+  const materializationManifest = createGovernedPrivateEvaluationMaterializationManifest({
+    schemaVersion: 'private-evaluation-materialization-manifest/v1',
+    environment: 'non_production',
+    selector: trace.content.selector,
+    calculationInputPackageId: calculationInputPackage.calculationInputPackageId,
+    calculationInputArtifact: createAflTradeCanonicalJsonArtifactRef(
+      calculationInputPackage,
+      DERIVED_AT
+    ),
+    inputTraceId: trace.inputTraceId,
+    inputTraceArtifact: createAflTradeCanonicalJsonArtifactRef(trace, DERIVED_AT),
+    explanationPolicyId: explanationPolicy.policyId,
+    explanationPolicyArtifact: createAflTradeCanonicalJsonArtifactRef(
+      explanationPolicy,
+      CREATED_AT
+    ),
+    lineageGraphId: createAflTradeLineageGraphId(scenario.lineageGraph),
+    lineageGraphArtifact: createAflTradeCanonicalJsonArtifactRef(
+      scenario.lineageGraph,
+      DERIVED_AT
+    ),
+    pickBenchmarks: [
+      { benchmarkId: pickBenchmark.benchmarkId, artifact: pickBenchmarkArtifact },
+    ],
+    playerObservations: [],
+    createdAt: DERIVED_AT,
+    publicationEligible: false,
+    limitation:
+      'Private materialization inputs only; not model, grade, activation, production, or publication authority.',
+  });
+  return {
+    trace,
+    explanationPolicy,
+    calculationInputPackage,
+    pickBenchmarks: [pickBenchmark],
+    lineageGraph: scenario.lineageGraph,
+    materializationManifest,
+  };
+}

--- a/tests/testUtils/governedPrivateEvaluationFixture.ts
+++ b/tests/testUtils/governedPrivateEvaluationFixture.ts
@@ -1,0 +1,270 @@
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import type { AflTradeAssetLineageNarrativeEvidence } from '@/server/aflTradeIntelligence/valuation/assetLineageNarrativeEvidence';
+import type {
+  AflTradePickCalculationEvidence,
+  AflTradePlayerCalculationEvidence,
+} from '@/server/aflTradeIntelligence/valuation/calculationNarrativeEvidence';
+import {
+  createAflTradeCalculationNarrative,
+  type AflTradeCalculationNarrativeInput,
+} from '@/server/aflTradeIntelligence/valuation/tradeCalculationNarrative';
+import type {
+  AflTradeValuationAssetContribution,
+  AflTradeValuationExplanationDocument,
+} from '@/server/aflTradeIntelligence/valuation/tradeValuationExplanation';
+
+const addressed = (kind: string, marker: string) => `${kind}:${marker.repeat(64)}`;
+const views = ['at_trade', 'realized', 'remaining', 'current'] as const;
+
+function asset(
+  assetId: string,
+  assetKind: 'player' | 'current_pick',
+  label: string,
+  fromClubId: string,
+  toClubId: string,
+  value: number,
+  view: (typeof views)[number]
+): AflTradeValuationAssetContribution {
+  return {
+    assetId,
+    assetKind,
+    label,
+    fromClubId,
+    toClubId,
+    additiveMean: value,
+    distribution: { mean: value, median: value, p10: value - 1, p90: value + 1 },
+    currentComponents:
+      view === 'current'
+        ? assetId === 'asset:player-a'
+          ? { realizedMean: 72, remainingMean: 20 }
+          : { realizedMean: 0, remainingMean: 70 }
+        : null,
+    layers: {
+      grossMean: value,
+      listSpotAdjustedMean: value,
+      scarcityAdjustedMean: value,
+      listSpotDelta: 0,
+      scarcityDelta: 0,
+    },
+    evidenceState: 'complete',
+  };
+}
+
+function explanation(): AflTradeValuationExplanationDocument {
+  const values = {
+    at_trade: { player: 80, pick: 70 },
+    realized: { player: 72, pick: 0 },
+    remaining: { player: 20, pick: 70 },
+    current: { player: 92, pick: 70 },
+  } as const;
+  const content = {
+    schemaVersion: 'afl-trade-valuation-explanation/v1' as const,
+    tradeId: 'trade:adelaide-st-kilda',
+    defaultView: 'current' as const,
+    authority: {
+      kind: 'private_synthetic' as const,
+      assumptionSetId: addressed('artifact', 'a'),
+      publicationProhibited: true as const,
+      warning: 'Fabricated rank-based test values — not real AFL data.' as const,
+    },
+    valueUnitId: 'fixed_horizon_pav',
+    valuationBundleId: addressed('valuation-bundle', 'b'),
+    valuationCaseId: addressed('valuation-case', 'c'),
+    valuationCalculationId: addressed('valuation-calculation', 'd'),
+    effectiveAt: '2026-08-19T00:00:00.000Z',
+    effectiveThrough: '2026-08-19T23:59:59.999Z',
+    coverage: { status: 'complete' as const, ratio: 1 as const },
+    confidenceLevel: 'high' as const,
+    selectedLayer: 'scarcityAdjusted' as const,
+    views: views.map((view) => {
+      const player = asset(
+        'asset:player-a',
+        'player',
+        'Player A',
+        'afl-club:st-kilda',
+        'afl-club:adelaide',
+        values[view].player,
+        view
+      );
+      const pick = asset(
+        'asset:pick-14',
+        'current_pick',
+        'Pick 14',
+        'afl-club:adelaide',
+        'afl-club:st-kilda',
+        values[view].pick,
+        view
+      );
+      const net = player.additiveMean - pick.additiveMean;
+      const club = (
+        aflClubId: string,
+        clubName: string,
+        received: AflTradeValuationAssetContribution,
+        givenUp: AflTradeValuationAssetContribution,
+        sign: 1 | -1
+      ) => ({
+        aflClubId,
+        clubName,
+        received: {
+          assets: [received],
+          additiveMean: received.additiveMean,
+          distribution: received.distribution,
+        },
+        givenUp: {
+          assets: [givenUp],
+          additiveMean: givenUp.additiveMean,
+          distribution: givenUp.distribution,
+        },
+        net: {
+          additiveMean: sign * net,
+          distribution: {
+            mean: sign * net,
+            median: sign * net,
+            p10: sign * net - 1,
+            p90: sign * net + 1,
+          },
+        },
+        finishAheadProbability: sign === 1 ? 0.8 : 0.1,
+        grade: {
+          grade: sign === 1 ? ('A+' as const) : ('D' as const),
+          state: 'provisional' as const,
+          reasonCode: 'complete_high_confidence_development_preview',
+        },
+      });
+      return {
+        view,
+        practicalEquivalenceProbability: 0.1,
+        verdict: { kind: 'favours_club' as const, aflClubIds: ['afl-club:adelaide'] },
+        clubs: [
+          club('afl-club:adelaide', 'Adelaide', player, pick, 1),
+          club('afl-club:st-kilda', 'St Kilda', pick, player, -1),
+        ],
+      };
+    }),
+    methodology: {
+      additiveStatistic: 'probability_weighted_mean' as const,
+      uncertaintyStatistic: 'joint_draw_weighted_quantiles' as const,
+      packageMedianIsAdditive: false as const,
+      assetGradeTreatment: 'prohibited' as const,
+      currentIdentity: 'realized_plus_remaining' as const,
+      practicalEquivalenceBasis: 'Fixture threshold.',
+      practicalEquivalencePolicy: {
+        assumptionSetId: addressed('artifact', 'a'),
+        valueUnitId: 'fixed_horizon_pav',
+        bandByView: { at_trade: 1, realized: 1, remaining: 1, current: 1 },
+      },
+    },
+  };
+  return {
+    explanationId: createAflTradeContentAddress('valuation-explanation', content),
+    ...content,
+  };
+}
+
+function lineage(
+  assetId: string,
+  assetType: 'player' | 'current_pick_entitlement'
+): AflTradeAssetLineageNarrativeEvidence {
+  return {
+    lineageGraphId: addressed('lineage-graph', assetId === 'asset:player-a' ? 'e' : 'f'),
+    rootAssetId: assetId,
+    cutoff: {
+      effectiveAsOf: '2026-08-19T00:00:00.000Z',
+      knowledgeCutoffAt: '2026-08-19T00:00:00.000Z',
+    },
+    nodes: [
+      {
+        assetId,
+        assetType,
+        label: assetId === 'asset:player-a' ? 'Player A' : 'Pick 14',
+        depth: 0,
+        effectiveFrom: '2020-10-10T00:00:00.000Z',
+        evidenceId: `evidence:${assetId}`,
+      },
+    ],
+    transformations: [],
+    custodyHistory: [],
+    dispositions: [],
+    frontierAssetIds: [assetId],
+  };
+}
+
+function narrativeInput(): AflTradeCalculationNarrativeInput {
+  const playerEvidence: AflTradePlayerCalculationEvidence = {
+    kind: 'player',
+    state: 'mature_observed',
+    observationId: addressed('player-pav-observation', '1'),
+    releaseId: addressed('outcome-release', '2'),
+    playerId: 'asset:player-a',
+    acquisitionSpell: {
+      spellId: 'spell:player-a',
+      spellVersionId: addressed('acquisition-spell-version', '3'),
+      clubId: 'afl-club:adelaide',
+      effectiveFrom: '2020-10-10',
+      effectiveThrough: null,
+      recordedAt: '2020-10-10T00:00:00.000Z',
+    },
+    predictionSeason: 2020,
+    evidenceCutoffAt: '2026-08-19T00:00:00.000Z',
+    horizon: {
+      endsAt: '2026-12-31T23:59:59.999Z',
+      requiredSeasons: [2021, 2022, 2023, 2024, 2025, 2026],
+      observedSeasons: [2021, 2022, 2023, 2024, 2025, 2026],
+    },
+    seasons: [2021, 2022, 2023, 2024, 2025, 2026].map((seasonYear, index) => ({
+      seasonYear,
+      gamesPlayed: 25,
+      contribution: 12,
+      contributionPerGame: 0.48,
+      calculationId: addressed('hpn-pav-season', String(index + 1)),
+      calculationSha256: String(index + 1).repeat(64),
+      effectiveThrough: `${seasonYear}-09-30T23:59:59.000Z`,
+      sourceObservationIds: [`provider-row:player-a:${seasonYear}`],
+    })),
+    totals: { gamesPlayed: 150, contribution: 72, contributionPerGame: 0.48 },
+  };
+  const pickEvidence: AflTradePickCalculationEvidence = {
+    kind: 'pick',
+    benchmarkId: addressed('pick-pav-benchmark', '4'),
+    observationSetId: addressed('pick-pav-observation-set', '5'),
+    policyId: addressed('pick-pav-policy', '6'),
+    methodId: addressed('hpn-pav-method', '7'),
+    valueUnit: 'fixed_horizon_pav',
+    selectionNumber: 14,
+    cohort: {
+      minimumSelectionNumber: 12,
+      maximumSelectionNumber: 16,
+      observationCount: 48,
+      draftClassCount: 12,
+      sourceSelectionNumbers: [12, 13, 14, 15, 16],
+    },
+    expected: { contribution: 70, games: 82 },
+    centralRange: {
+      contribution: { p10: 20, p50: 65, p90: 130 },
+      games: { p10: 12, p50: 76, p90: 180 },
+    },
+    outcomeProbabilities: [],
+    empiricalSupportObservationIds: [addressed('pick-pav-observation', '8')],
+    fixedHorizonSeasons: 5,
+    limitation: 'Training-only mature cohort.',
+  };
+  return {
+    explanation: explanation(),
+    assets: [
+      {
+        assetId: 'asset:player-a',
+        modelEvidence: playerEvidence,
+        lineage: lineage('asset:player-a', 'player'),
+      },
+      {
+        assetId: 'asset:pick-14',
+        modelEvidence: pickEvidence,
+        lineage: lineage('asset:pick-14', 'current_pick_entitlement'),
+      },
+    ],
+  };
+}
+
+export function createGovernedPrivateEvaluationNarrativeFixture() {
+  return createAflTradeCalculationNarrative(narrativeInput());
+}

--- a/tests/testUtils/governedPrivateEvaluationMultiClubFixture.ts
+++ b/tests/testUtils/governedPrivateEvaluationMultiClubFixture.ts
@@ -1,0 +1,182 @@
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import type { AflTradeAssetLineageNarrativeEvidence } from '@/server/aflTradeIntelligence/valuation/assetLineageNarrativeEvidence';
+import type { AflTradePickCalculationEvidence } from '@/server/aflTradeIntelligence/valuation/calculationNarrativeEvidence';
+import { createAflTradeCalculationNarrative } from '@/server/aflTradeIntelligence/valuation/tradeCalculationNarrative';
+import type {
+  AflTradeValuationAssetContribution,
+  AflTradeValuationExplanationDocument,
+} from '@/server/aflTradeIntelligence/valuation/tradeValuationExplanation';
+
+const views = ['at_trade', 'realized', 'remaining', 'current'] as const;
+
+function addressed(kind: string, index: number): string {
+  return `${kind}:${(index % 15).toString(16).repeat(64)}`;
+}
+
+function distribution(mean: number) {
+  return { mean, median: mean, p10: mean - 1, p90: mean + 1 };
+}
+
+export function createGovernedPrivateEvaluationMultiClubNarrativeFixture(
+  clubCount: 3 | 4
+) {
+  const clubs = Array.from({ length: clubCount }, (_, index) => ({
+    aflClubId: `afl-club:fixture-${index + 1}`,
+    clubName: `Fixture Club ${index + 1}`,
+  }));
+  const assetIdentities = clubs.map((fromClub, index) => ({
+    assetId: `asset:fixture-pick-${index + 1}`,
+    assetKind: 'current_pick' as const,
+    label: `Pick ${10 + index}`,
+    fromClubId: fromClub.aflClubId,
+    toClubId: clubs[(index + 1) % clubCount]!.aflClubId,
+    value: 50 + index * 10,
+  }));
+  const contribution = (
+    identity: (typeof assetIdentities)[number],
+    view: (typeof views)[number]
+  ): AflTradeValuationAssetContribution => {
+    const value = view === 'realized' ? 0 : identity.value;
+    return {
+      ...identity,
+      additiveMean: value,
+      distribution: distribution(value),
+      currentComponents: view === 'current' ? { realizedMean: 0, remainingMean: value } : null,
+      layers: {
+        grossMean: value,
+        listSpotAdjustedMean: value,
+        scarcityAdjustedMean: value,
+        listSpotDelta: 0,
+        scarcityDelta: 0,
+      },
+      evidenceState: 'complete',
+    };
+  };
+  const explanationContent = {
+    schemaVersion: 'afl-trade-valuation-explanation/v1' as const,
+    tradeId: `trade:fixture-${clubCount}-club`,
+    defaultView: 'current' as const,
+    authority: {
+      kind: 'private_synthetic' as const,
+      assumptionSetId: addressed('artifact', 1),
+      publicationProhibited: true as const,
+      warning: 'Fabricated rank-based test values — not real AFL data.' as const,
+    },
+    valueUnitId: 'fixed_horizon_pav',
+    valuationBundleId: addressed('valuation-bundle', 2),
+    valuationCaseId: addressed('valuation-case', 3),
+    valuationCalculationId: addressed('valuation-calculation', 4),
+    effectiveAt: '2026-08-19T00:00:00.000Z',
+    effectiveThrough: '2026-08-19T23:59:59.999Z',
+    coverage: { status: 'complete' as const, ratio: 1 as const },
+    confidenceLevel: 'high' as const,
+    selectedLayer: 'scarcityAdjusted' as const,
+    views: views.map((view) => {
+      const contributions = new Map(
+        assetIdentities.map((identity) => [identity.assetId, contribution(identity, view)])
+      );
+      return {
+        view,
+        practicalEquivalenceProbability: 0.1,
+        verdict: { kind: 'favours_club' as const, aflClubIds: [clubs[0]!.aflClubId] },
+        clubs: clubs.map((club, clubIndex) => {
+          const received = contributions.get(
+            assetIdentities[(clubIndex - 1 + clubCount) % clubCount]!.assetId
+          )!;
+          const givenUp = contributions.get(assetIdentities[clubIndex]!.assetId)!;
+          const net = received.additiveMean - givenUp.additiveMean;
+          return {
+            ...club,
+            received: {
+              assets: [received],
+              additiveMean: received.additiveMean,
+              distribution: distribution(received.additiveMean),
+            },
+            givenUp: {
+              assets: [givenUp],
+              additiveMean: givenUp.additiveMean,
+              distribution: distribution(givenUp.additiveMean),
+            },
+            net: { additiveMean: net, distribution: distribution(net) },
+            finishAheadProbability: 0.9 / clubCount,
+            grade: {
+              grade: 'B' as const,
+              state: 'provisional' as const,
+              reasonCode: 'complete_high_confidence_development_preview',
+            },
+          };
+        }),
+      };
+    }),
+    methodology: {
+      additiveStatistic: 'probability_weighted_mean' as const,
+      uncertaintyStatistic: 'joint_draw_weighted_quantiles' as const,
+      packageMedianIsAdditive: false as const,
+      assetGradeTreatment: 'prohibited' as const,
+      currentIdentity: 'realized_plus_remaining' as const,
+      practicalEquivalenceBasis: 'Fixture threshold.',
+      practicalEquivalencePolicy: {
+        assumptionSetId: addressed('artifact', 1),
+        valueUnitId: 'fixed_horizon_pav',
+        bandByView: { at_trade: 1, realized: 1, remaining: 1, current: 1 },
+      },
+    },
+  };
+  const explanation: AflTradeValuationExplanationDocument = {
+    explanationId: createAflTradeContentAddress('valuation-explanation', explanationContent),
+    ...explanationContent,
+  };
+  return createAflTradeCalculationNarrative({
+    explanation,
+    assets: assetIdentities.map((identity, index) => {
+      const modelEvidence: AflTradePickCalculationEvidence = {
+        kind: 'pick',
+        benchmarkId: addressed('pick-pav-benchmark', 5 + index),
+        observationSetId: addressed('pick-pav-observation-set', 6 + index),
+        policyId: addressed('pick-pav-policy', 7 + index),
+        methodId: addressed('hpn-pav-method', 8 + index),
+        valueUnit: 'fixed_horizon_pav',
+        selectionNumber: 10 + index,
+        cohort: {
+          minimumSelectionNumber: 8 + index,
+          maximumSelectionNumber: 12 + index,
+          observationCount: 48,
+          draftClassCount: 12,
+          sourceSelectionNumbers: [8 + index, 9 + index, 10 + index, 11 + index, 12 + index],
+        },
+        expected: { contribution: identity.value, games: 80 + index },
+        centralRange: {
+          contribution: { p10: 20, p50: identity.value, p90: 130 },
+          games: { p10: 12, p50: 76, p90: 180 },
+        },
+        outcomeProbabilities: [],
+        empiricalSupportObservationIds: [addressed('pick-pav-observation', 9 + index)],
+        fixedHorizonSeasons: 5,
+        limitation: 'Training-only multi-club fixture cohort.',
+      };
+      const lineage: AflTradeAssetLineageNarrativeEvidence = {
+        lineageGraphId: addressed('lineage-graph', 10 + index),
+        rootAssetId: identity.assetId,
+        cutoff: {
+          effectiveAsOf: '2026-08-19T00:00:00.000Z',
+          knowledgeCutoffAt: '2026-08-19T00:00:00.000Z',
+        },
+        nodes: [
+          {
+            assetId: identity.assetId,
+            assetType: 'current_pick_entitlement',
+            label: identity.label,
+            depth: 0,
+            effectiveFrom: '2025-10-10T00:00:00.000Z',
+            evidenceId: `evidence:${identity.assetId}`,
+          },
+        ],
+        transformations: [],
+        custodyHistory: [],
+        dispositions: [],
+        frontierAssetIds: [identity.assetId],
+      };
+      return { assetId: identity.assetId, modelEvidence, lineage };
+    }),
+  });
+}

--- a/tests/unit/afl-trade-intelligence-asset-lineage-narrative-evidence.test.ts
+++ b/tests/unit/afl-trade-intelligence-asset-lineage-narrative-evidence.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAflTradeLineageFixture } from '@/server/aflTradeIntelligence/domain/lineageFixtures';
+import { deriveAflTradeAssetLineageNarrativeEvidence } from '@/server/aflTradeIntelligence/valuation/assetLineageNarrativeEvidence';
+
+const cutoff = {
+  effectiveAsOf: '2026-01-01T00:00:00.000Z',
+  knowledgeCutoffAt: '2026-01-01T00:00:00.000Z',
+};
+const display = {
+  assets: [
+    { assetId: 'fixture:future-right-a', label: '2024 future first-round pick' },
+    { assetId: 'fixture:current-pick-9', label: 'Pick 9' },
+    { assetId: 'fixture:current-pick-12', label: 'Pick 12' },
+    { assetId: 'fixture:draft-selection-12', label: '2024 draft selection 12' },
+    { assetId: 'fixture:player-kestrel', label: 'Kestrel Player' },
+  ],
+  clubs: [
+    { aflClubId: 'fixture-club-a', clubName: 'Fixture Club A' },
+    { aflClubId: 'fixture-club-b', clubName: 'Fixture Club B' },
+  ],
+};
+
+describe('asset lineage narrative evidence', () => {
+  it('projects an ordered future-pick-to-player story with custody handoffs', () => {
+    const graph = buildAflTradeLineageFixture('future_pick_to_player').graph;
+    const evidence = deriveAflTradeAssetLineageNarrativeEvidence(
+      graph,
+      'fixture:future-right-a',
+      cutoff,
+      display
+    );
+
+    expect(evidence.nodes.map(({ assetId, assetType, depth }) => ({
+      assetId,
+      assetType,
+      depth,
+    }))).toEqual([
+      { assetId: 'fixture:future-right-a', assetType: 'future_pick_entitlement', depth: 0 },
+      { assetId: 'fixture:current-pick-9', assetType: 'current_pick_entitlement', depth: 1 },
+      { assetId: 'fixture:current-pick-12', assetType: 'current_pick_entitlement', depth: 2 },
+      { assetId: 'fixture:draft-selection-12', assetType: 'draft_selection', depth: 3 },
+      { assetId: 'fixture:player-kestrel', assetType: 'player', depth: 4 },
+    ]);
+    expect(evidence.transformations.map(({ kind }) => kind)).toEqual([
+      'future_right_resolved_to_pick',
+      'pick_renumbered_to_pick',
+      'pick_exercised_at_selection',
+      'selection_created_player',
+    ]);
+    expect(evidence.nodes.map(({ label }) => label)).toEqual([
+      '2024 future first-round pick',
+      'Pick 9',
+      'Pick 12',
+      '2024 draft selection 12',
+      'Kestrel Player',
+    ]);
+    expect(evidence.transformations.at(-1)).toMatchObject({
+      sourceLabel: '2024 draft selection 12',
+      targetLabel: 'Kestrel Player',
+    });
+    expect(
+      evidence.custodyHistory
+        .filter(({ assetId }) => assetId === 'fixture:future-right-a')
+        .map(({ aflClubId, clubName }) => ({ aflClubId, clubName }))
+    ).toEqual([
+      { aflClubId: 'fixture-club-a', clubName: 'Fixture Club A' },
+      { aflClubId: 'fixture-club-b', clubName: 'Fixture Club B' },
+    ]);
+    expect(evidence.frontierAssetIds).toEqual(['fixture:player-kestrel']);
+  });
+
+  it('rejects invalid lineage rather than rendering a plausible story', () => {
+    const graph = buildAflTradeLineageFixture('invalid_cycle').graph;
+
+    expect(() =>
+      deriveAflTradeAssetLineageNarrativeEvidence(graph, graph.assets[0]!.assetId, cutoff, display)
+    ).toThrow(/valid authenticated lineage graph/i);
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-evaluation-panel.test.tsx
+++ b/tests/unit/afl-trade-intelligence-governed-evaluation-panel.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import { AflTradePackageEvaluationPanel } from '@/components/draft/AflTradePackageEvaluationPanel';
+import { createGovernedPrivateEvaluationNarrativeFixture } from '../testUtils/governedPrivateEvaluationFixture';
+import { createGovernedPrivateEvaluationMultiClubNarrativeFixture } from '../testUtils/governedPrivateEvaluationMultiClubFixture';
+
+describe('AFL trade package evaluation panel', () => {
+  it('shows one complete package grade per club and tells each asset story under one view switch', () => {
+    const narrative = createGovernedPrivateEvaluationNarrativeFixture();
+    render(<AflTradePackageEvaluationPanel narrative={narrative.content} />);
+
+    expect(screen.getByRole('group', { name: 'Trade valuation views' })).toBeInTheDocument();
+    expect(screen.getAllByRole('article')).toHaveLength(2);
+    const adelaide = screen.getByRole('article', { name: 'Adelaide package' });
+    const stKilda = screen.getByRole('article', { name: 'St Kilda package' });
+    expect(within(adelaide).getByText('Received')).toBeInTheDocument();
+    expect(within(adelaide).getByText('Gave up')).toBeInTheDocument();
+    expect(within(adelaide).getByText(/92 - 70 = \+22 fixed_horizon_pav/u)).toBeInTheDocument();
+    expect(within(adelaide).getByLabelText(/Adelaide provisional package grade A\+/u)).toBeInTheDocument();
+    expect(within(stKilda).getByLabelText(/St Kilda provisional package grade D/u)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Realized' }));
+    expect(
+      within(adelaide).getByText(/72 fixed_horizon_pav from 150 games at 0.48 per game/u)
+    ).toBeInTheDocument();
+
+    fireEvent.click(within(adelaide).getByText('Pick 14 calculation and lineage'));
+    expect(
+      within(adelaide).getAllByText(/48 observations across 12 draft classes/u)
+    ).not.toHaveLength(0);
+    expect(
+      within(adelaide).getByText('Pick 14', { selector: '[data-lineage-label]' })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/asset grade/iu)).not.toBeInTheDocument();
+  });
+
+  it('switches current contribution stories without splitting assets from their club packages', () => {
+    const narrative = createGovernedPrivateEvaluationNarrativeFixture();
+    render(<AflTradePackageEvaluationPanel narrative={narrative.content} />);
+
+    expect(screen.getAllByText(/92 = 72 realized \+ 20 remaining fixed_horizon_pav/u)).not.toHaveLength(0);
+    fireEvent.click(screen.getByRole('button', { name: 'At trade' }));
+    expect(
+      screen.getAllByText(/70 fixed_horizon_pav expected from 48 observations across 12 draft classes/u)
+    ).not.toHaveLength(0);
+    expect(screen.getAllByRole('article')).toHaveLength(2);
+  });
+
+  it.each([3, 4] as const)(
+    'renders one complete package bank for every club in a %i-club transaction',
+    (clubCount) => {
+      const narrative = createGovernedPrivateEvaluationMultiClubNarrativeFixture(clubCount);
+      render(<AflTradePackageEvaluationPanel narrative={narrative.content} />);
+
+      expect(screen.getAllByRole('group', { name: 'Trade valuation views' })).toHaveLength(1);
+      const packages = screen.getAllByRole('article');
+      expect(packages).toHaveLength(clubCount);
+      for (let index = 0; index < clubCount; index += 1) {
+        const clubPackage = screen.getByRole('article', {
+          name: `Fixture Club ${index + 1} package`,
+        });
+        expect(within(clubPackage).getByRole('region', { name: 'Received package' })).toBeInTheDocument();
+        expect(within(clubPackage).getByRole('region', { name: 'Gave up package' })).toBeInTheDocument();
+        expect(
+          within(clubPackage).getByLabelText(
+            `Fixture Club ${index + 1} provisional package grade B`
+          )
+        ).toBeInTheDocument();
+      }
+      const current = narrative.content.views.find(({ view }) => view === 'current')!;
+      expect(
+        current.clubs.reduce(
+          (total, club) => total + club.arithmetic.estimatedAdvantageMean,
+          0
+        )
+      ).toBe(0);
+    }
+  );
+});

--- a/tests/unit/afl-trade-intelligence-governed-native-component-execution.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-native-component-execution.test.ts
@@ -1,0 +1,81 @@
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { createAflTradeFixtureArtifactRepository } from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import { authenticateGovernedNativeComponentExecution } from '@/server/aflTradeIntelligence/valuation/internal/governedNativeComponentExecution';
+import { createGovernedValuationComponentRunManifest } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest';
+
+import { createGovernedPickPavModelExecutionFixture } from '../testUtils/governedPickPavModelExecutionFixture';
+
+async function fixture() {
+  const value = createGovernedPickPavModelExecutionFixture();
+  const artifacts = createAflTradeFixtureArtifactRepository({ artifactClass: 'derived_private' });
+  const nativeArtifact = createAflTradeCanonicalJsonArtifactRef(
+    value.execution,
+    value.execution.content.completedAt
+  );
+  await artifacts.putIfAbsent(
+    nativeArtifact,
+    new TextEncoder().encode(canonicalizeAflTradeJson(value.execution))
+  );
+  const component = createGovernedValuationComponentRunManifest({
+    environment: 'non_production',
+    role: 'draft_pick_and_future_pick_distribution',
+    nativeExecution: {
+      kind: 'governed_pick_pav_model_execution',
+      executionId: value.execution.executionId,
+      artifact: nativeArtifact,
+    },
+    protocolId: value.execution.content.protocolId,
+    protocolArtifact: value.execution.content.protocolArtifact,
+    datasetId: value.execution.content.datasetId,
+    datasetArtifact: value.execution.content.datasetArtifact,
+    datasetAdmissionId: value.execution.content.datasetAdmissionId,
+    datasetAdmissionArtifact: value.execution.content.datasetAdmissionArtifact,
+    datasetAdmissionGateLedgerRevision:
+      value.execution.content.datasetAdmissionGateLedgerRevision,
+    registeredAt: '2015-01-03T00:00:02.000Z',
+  });
+  return { ...value, artifacts, component };
+}
+
+describe('governed native component execution authentication', () => {
+  it('authenticates the exact retained governed pick execution', async () => {
+    const value = await fixture();
+    await expect(
+      authenticateGovernedNativeComponentExecution({
+        manifest: value.component,
+        artifactRepository: value.artifacts,
+        maximumArtifactBytes: 1024 * 1024,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects wrapper ancestry substitution and substituted native bytes', async () => {
+    const value = await fixture();
+    const wrongDataset = createGovernedValuationComponentRunManifest({
+      ...value.component.content,
+      datasetId: `dataset:${'0'.repeat(64)}`,
+    });
+    await expect(
+      authenticateGovernedNativeComponentExecution({
+        manifest: wrongDataset,
+        artifactRepository: value.artifacts,
+        maximumArtifactBytes: 1024 * 1024,
+      })
+    ).rejects.toThrow(/ancestry|dataset|native/i);
+
+    await expect(
+      authenticateGovernedNativeComponentExecution({
+        manifest: value.component,
+        artifactRepository: {
+          ...value.artifacts,
+          loadExact: async (reference) => ({
+            reference,
+            bytes: new TextEncoder().encode('substituted'),
+          }),
+        },
+        maximumArtifactBytes: 1024 * 1024,
+      })
+    ).rejects.toThrow(/bytes|artifact|native/i);
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-pick-pav-model-execution-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-pick-pav-model-execution-migration.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const migrationPath =
+  'prisma/afl-trade-outcomes/migrations/0063_governed_pick_pav_model_execution/migration.sql';
+
+describe('governed pick-PAV model execution migration', () => {
+  it('adds append-only non-production execution custody without changing fixture evidence', () => {
+    expect(existsSync(join(process.cwd(), migrationPath))).toBe(true);
+    const sql = readFileSync(join(process.cwd(), migrationPath), 'utf8');
+
+    expect(sql).toContain('CREATE TABLE "outcome_governed_pick_pav_model_execution"');
+    expect(sql).toContain('"dataset_admission_id" TEXT NOT NULL');
+    expect(sql).toContain('"dataset_admission_gate_ledger_revision" INTEGER NOT NULL');
+    expect(sql).toContain('"protocol_id" TEXT NOT NULL');
+    expect(sql).toContain('"execution_artifact_id" TEXT NOT NULL');
+    expect(sql).toContain('REFERENCES "outcome_valuation_dataset_admission"("admission_id")');
+    expect(sql).toContain('REFERENCES "outcome_valuation_model_protocol"("protocol_id")');
+    expect(sql).toContain('REFERENCES "outcome_artifact_custody"("artifact_id")');
+    expect(sql).toContain('outcome_afl_trade_canonical_json(dataset_row."dataset_json")');
+    expect(sql).toContain('outcome_afl_trade_canonical_json(admission_row."admission_json")');
+    expect(sql).toContain('outcome_afl_trade_canonical_json(protocol_row."protocol_json")');
+    expect(sql).toContain('Governed pick-PAV model executions are append-only');
+    expect(sql).toContain("'afl-trade-pick-pav-model-execution/v2'");
+    expect(sql).toContain("'gate_3_review_required'");
+  });
+
+  it('introduces a native kind that cannot be confused with the legacy fixture execution', () => {
+    const sql = readFileSync(join(process.cwd(), migrationPath), 'utf8');
+
+    expect(sql).toContain("'governed_pick_pav_model_execution'");
+    expect(sql).toContain("'pick_pav_model_execution'");
+    expect(sql).toContain('DROP CONSTRAINT "outcome_governed_valuation_component_run_role_check"');
+    expect(sql).toContain('ADD CONSTRAINT "outcome_governed_valuation_component_run_role_check"');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-pick-pav-model-execution.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-pick-pav-model-execution.test.ts
@@ -1,0 +1,185 @@
+import { createHash } from 'node:crypto';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createAflTradePickPavPolicy } from '@/server/aflTradeIntelligence/modeling/pickOutcomeContracts';
+import {
+  computeAflTradePickPavModelExecutionOutputs,
+} from '@/server/aflTradeIntelligence/modeling/pickPavModelExecution';
+import { materializeAflTradePickPavObservationSet } from '@/server/aflTradeIntelligence/modeling/pickPavObservationService';
+import { createGovernedAflTradePickPavModelExecution } from '@/server/aflTradeIntelligence/modeling/governedPickPavModelExecution';
+
+const sha = (value: string) => createHash('sha256').update(value).digest('hex');
+const addressed = (prefix: string, value: string) => `${prefix}:${sha(value)}`;
+const releaseId = addressed('outcome-release', 'governed-pick-execution-release');
+const methodId = addressed('hpn-pav-method', 'governed-pick-execution-method');
+const years = [2000, 2001, 2002, 2003, 2006, 2009, 2012] as const;
+
+function observationSet() {
+  const policy = createAflTradePickPavPolicy({
+    schemaVersion: 'afl-trade-pick-pav-policy/v1',
+    authorityBoundary:
+      'private_released_draft_selection_exact_finalized_hpn_pav_no_grade_publication_or_fantasy_ownership',
+    publicationEligible: false,
+    environment: 'non_production',
+    competition: 'AFLM',
+    policyVersion: 'governed-pick-execution-v1',
+    supportedPathway: 'national',
+    supportedAccess: 'open',
+    firstOutcomeSeasonOffset: 1,
+    fixedHorizonSeasons: 1,
+    methodId,
+    sourceValueUnit: 'season_pav',
+    outcomeValueUnit: 'fixed_horizon_pav',
+    categoryMinimums: {
+      replacementLevel: 10,
+      regularContributor: 30,
+      highQuality: 60,
+      elite: 90,
+    },
+    partitions: [
+      { role: 'train', fromDraftYear: 2000, throughDraftYear: 2003 },
+      { role: 'calibration', fromDraftYear: 2006, throughDraftYear: 2006 },
+      { role: 'validation', fromDraftYear: 2009, throughDraftYear: 2009 },
+      { role: 'final_test', fromDraftYear: 2012, throughDraftYear: 2012 },
+    ],
+    approvalDecision: {
+      id: addressed('review-decision', 'governed-pick-execution-policy'),
+      sha256: sha('governed-pick-execution-policy'),
+    },
+    createdAt: '1999-01-01T00:00:00.000Z',
+  });
+  const selections = years.map((draftYear, index) => ({
+    releaseId,
+    selectionId: addressed('draft-selection', `${draftYear}:${index}`),
+    eventId: `draft:${draftYear}:national`,
+    eventVersionId: addressed('event-version', `draft:${draftYear}:national`),
+    eventDate: `${draftYear}-11-20`,
+    recordedAt: `${draftYear}-11-21T00:00:00.000Z`,
+    draftYear,
+    pathway: 'national' as const,
+    actualSelectionNumber: index < 4 ? [10, 14, 14, 20][index]! : 14,
+    nominalSelectionNumber: index < 4 ? [10, 14, 14, 20][index]! : 14,
+    draftRound: 1,
+    pickId: `pick:${draftYear}:national:${index + 1}`,
+    playerId: `player:${draftYear}`,
+    clubId: `club:${draftYear}`,
+    access: {
+      state: 'open' as const,
+      decision: {
+        id: addressed('review-decision', `access:${draftYear}`),
+        sha256: sha(`access:${draftYear}`),
+      },
+      recordedAt: `${draftYear}-11-22T00:00:00.000Z`,
+    },
+  }));
+  const calculations = years.map((draftYear, index) => {
+    const seasonYear = draftYear + 1;
+    const calculationSha256 = sha(`calculation:${draftYear}`);
+    const sourceRowIds = Array.from(
+      { length: 10 },
+      (_, rowIndex) => `decoded-row:${draftYear}:${rowIndex + 1}`
+    );
+    return {
+      calculation: {
+        calculationId: `hpn-pav-season:${calculationSha256}`,
+        calculationSha256,
+        inputSetId: addressed('hpn-pav-input-set', `input:${draftYear}`),
+        methodId,
+        seasonYear,
+        effectiveThrough: `${seasonYear}-12-31T23:59:59.000Z`,
+        calculatedAt: `${seasonYear + 1}-01-01T00:00:00.000Z`,
+      },
+      playerValues: [
+        {
+          calculationId: `hpn-pav-season:${calculationSha256}`,
+          calculationSha256,
+          seasonYear,
+          spellVersionId: addressed('acquisition-spell-version', `spell:${draftYear}`),
+          playerId: `player:${draftYear}`,
+          playerSha256: sha(`player:${draftYear}`),
+          clubId: `club:${draftYear}`,
+          sourceRowIds,
+          gamesPlayed: sourceRowIds.length,
+          totalPav: [100, 60, 80, 20, 70, 65, 75][index]!,
+        },
+      ],
+    };
+  });
+  return materializeAflTradePickPavObservationSet({
+    environment: 'non_production',
+    competition: 'AFLM',
+    createdAt: '2015-01-02T00:00:00.000Z',
+    knowledgeCutoffAt: '2015-01-01T00:00:00.000Z',
+    releaseId,
+    policy,
+    selections,
+    calculations,
+  });
+}
+
+describe('governed pick-PAV model execution', () => {
+  it('creates a non-production Gate 3 candidate bound to admitted dataset authority', () => {
+    const set = observationSet();
+    const retainedAt = '2015-01-03T00:00:00.000Z';
+    const datasetId = addressed('dataset', 'governed-pick-dataset');
+    const datasetAdmissionId = addressed(
+      'dataset-admission',
+      'governed-pick-dataset-admission'
+    );
+    const protocolId = addressed('model-protocol', 'governed-pick-protocol');
+    const execution = createGovernedAflTradePickPavModelExecution({
+      outputs: computeAflTradePickPavModelExecutionOutputs({
+        observationSet: set,
+        benchmarkConfig: {
+          schemaVersion: 'afl-trade-pick-pav-distribution-benchmark-config/v1',
+          minimumBlockObservations: 1,
+          eligibility: 'mature_open_access_national_draft_training_observations',
+          informationWeight: 'eligible_selection_count',
+          smoother: 'weighted_non_increasing_isotonic',
+          sparseBlockMergePolicy: 'nearest_adjacent_fitted_mean_left_tie_break',
+          interpolation: 'left_block_carry_forward_within_training_domain',
+          extrapolation: 'prohibited',
+          estimatorStatus: 'benchmark_only_requires_temporal_validation_and_approval',
+        },
+        validationConfig: {
+          schemaVersion: 'afl-trade-pick-pav-validation-config/v1',
+          evaluatedAt: retainedAt,
+          minimumEligibleObservations: 3,
+          minimumPartitionObservations: 1,
+          nominalIntervalCoverage: 0.8,
+        },
+      }),
+      completedAt: '2015-01-03T00:00:01.000Z',
+      authority: {
+        datasetId,
+        datasetArtifact: createAflTradeCanonicalJsonArtifactRef(
+          { kind: 'dataset', datasetId },
+          retainedAt
+        ),
+        datasetAdmissionId,
+        datasetAdmissionArtifact: createAflTradeCanonicalJsonArtifactRef(
+          { kind: 'dataset_admission', datasetAdmissionId },
+          retainedAt
+        ),
+        datasetAdmissionGateLedgerRevision: 7,
+        protocolId,
+        protocolArtifact: createAflTradeCanonicalJsonArtifactRef(
+          { kind: 'pick_protocol', protocolId },
+          retainedAt
+        ),
+      },
+    });
+
+    expect(execution.content).toMatchObject({
+      schemaVersion: 'afl-trade-pick-pav-model-execution/v2',
+      environment: 'non_production',
+      approvalStatus: 'gate_3_review_required',
+      publicationEligible: false,
+      datasetId,
+      datasetAdmissionId,
+      datasetAdmissionGateLedgerRevision: 7,
+      protocolId,
+    });
+    expect(execution.content).not.toHaveProperty('grade');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-authority-snapshot.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-authority-snapshot.test.ts
@@ -1,0 +1,277 @@
+import {
+  authenticateGovernedPrivateEvaluationAuthorityInspection,
+  createReadyGovernedPrivateEvaluationAuthorityInspectionV3,
+  createReadyGovernedPrivateEvaluationAuthorityInspection,
+  createReadyFixtureGovernedPrivateEvaluationAuthorityInspection,
+  createUnavailableNonProductionGovernedPrivateEvaluationAuthorityInspection,
+  createUnavailableGovernedPrivateEvaluationAuthorityInspection,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationAuthoritySnapshot';
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+
+const selector = {
+  valuationScopeKey: 'afl-trade-history:test-fixture',
+  tradeId: 'trade:adelaide-st-kilda',
+};
+const generationId = `local-private-trade-evaluation-generation:${'a'.repeat(64)}`;
+const transitionId = `private-evaluation-transition:${'b'.repeat(64)}`;
+const capturedAt = '2026-08-19T10:00:00.000Z';
+
+function artifact(label: string) {
+  return createAflTradeCanonicalJsonArtifactRef({ label }, '2026-08-19T09:00:00.000Z');
+}
+
+function readyAuthorityInput() {
+  return {
+    selector,
+    capturedAt,
+    validThrough: '2026-08-19T10:05:00.000Z',
+    head: { status: 'absent' as const, revision: 0, generationId: null },
+    lastTransitionId: null,
+    preparedInputSetId: `prepared-valuation-input-set:${'1'.repeat(64)}`,
+    preparedInputSetArtifact: artifact('prepared-input-set'),
+    factualReleaseId: `outcome-release:${'2'.repeat(64)}`,
+    valuationInputBundleId: `valuation-input-bundle:${'3'.repeat(64)}`,
+    valuationInputBundleArtifact: artifact('valuation-input-bundle'),
+    calculationInputPackageId: `valuation-calculation-input:${'4'.repeat(64)}`,
+    calculationInputArtifact: artifact('calculation-input'),
+    inputTraceId: `private-evaluation-input-trace:${'5'.repeat(64)}`,
+    inputTraceArtifact: artifact('input-trace'),
+    gateLedgerRevision: 17,
+    components: [
+      {
+        role: 'player_contribution_and_availability' as const,
+        runId: `model-run:${'6'.repeat(64)}`,
+        protocolId: `model-protocol:${'7'.repeat(64)}`,
+        datasetId: `dataset:${'8'.repeat(64)}`,
+        datasetAdmissionId: `dataset-admission:${'9'.repeat(64)}`,
+        datasetAdmissionGateLedgerRevision: 11,
+        gate3DecisionId: `gate-decision:${'a'.repeat(64)}`,
+        gate3DecisionVersion: 3,
+      },
+      {
+        role: 'draft_pick_and_future_pick_distribution' as const,
+        runId: `model-run:${'b'.repeat(64)}`,
+        protocolId: `model-protocol:${'c'.repeat(64)}`,
+        datasetId: `dataset:${'d'.repeat(64)}`,
+        datasetAdmissionId: `dataset-admission:${'e'.repeat(64)}`,
+        datasetAdmissionGateLedgerRevision: 12,
+        gate3DecisionId: `gate-decision:${'f'.repeat(64)}`,
+        gate3DecisionVersion: 2,
+      },
+    ],
+  };
+}
+
+describe('governed private evaluation authority snapshot', () => {
+  it('retains unavailable real authority as non-production rather than a synthetic fixture', () => {
+    const retained = createUnavailableNonProductionGovernedPrivateEvaluationAuthorityInspection({
+      selector: { valuationScopeKey: 'afl-men:2026-trades', tradeId: 'trade:real-three-club' },
+      capturedAt,
+      validThrough: '2026-08-19T10:05:00.000Z',
+      head: { status: 'absent', revision: 0, generationId: null },
+      lastTransitionId: null,
+      blockers: [{ code: 'model_not_approved', message: 'Pick model Gate 3 is absent.' }],
+    });
+
+    expect(retained.snapshot.content).toMatchObject({
+      schemaVersion: 'private-evaluation-authority-snapshot/v3',
+      environment: 'non_production',
+      calculationAuthority: {
+        state: 'unavailable',
+        playerModelRunId: null,
+        pickModelRunId: null,
+      },
+    });
+    expect(retained.inspection.content).toMatchObject({
+      schemaVersion: 'private-evaluation-inspection/v3',
+      state: 'unavailable',
+      environment: 'non_production',
+    });
+  });
+
+  it('retains unavailable model authority with the exact active head needed for withdrawal', () => {
+    const retained = createUnavailableGovernedPrivateEvaluationAuthorityInspection({
+      selector,
+      capturedAt: '2026-08-19T10:00:00.000Z',
+      validThrough: '2026-08-19T10:05:00.000Z',
+      head: { status: 'active', revision: 4, generationId },
+      lastTransitionId: transitionId,
+      blockers: [
+        {
+          code: 'model_not_approved',
+          message:
+            'Externally approved player and pick model runs are not both available for this trade.',
+        },
+      ],
+    });
+
+    expect(authenticateGovernedPrivateEvaluationAuthorityInspection(retained)).toEqual(retained);
+    expect(retained.snapshot.content).toMatchObject({
+      selector,
+      head: { status: 'active', revision: 4, generationId },
+      lastTransitionId: transitionId,
+      calculationAuthority: {
+        state: 'unavailable',
+        playerModelRunId: null,
+        pickModelRunId: null,
+      },
+    });
+    expect(retained.result).toEqual({
+      state: 'unavailable',
+      selector,
+      inspectionId: retained.inspection.inspectionId,
+      validThrough: '2026-08-19T10:05:00.000Z',
+      head: { status: 'active', revision: 4, generationId },
+      blockers: retained.inspection.content.blockers,
+    });
+  });
+
+  it('rejects changed blockers and invalid predecessor/head combinations', () => {
+    const retained = createUnavailableGovernedPrivateEvaluationAuthorityInspection({
+      selector,
+      capturedAt: '2026-08-19T10:00:00.000Z',
+      validThrough: '2026-08-19T10:05:00.000Z',
+      head: { status: 'absent', revision: 0, generationId: null },
+      lastTransitionId: null,
+      blockers: [{ code: 'model_not_approved', message: 'No approved component runs.' }],
+    });
+    const tampered = structuredClone(retained);
+    tampered.inspection.content.blockers[0]!.message = 'Pretend the models are approved.';
+    expect(() => authenticateGovernedPrivateEvaluationAuthorityInspection(tampered)).toThrow(
+      /content|inspection|authenticate/i
+    );
+    expect(() =>
+      createUnavailableGovernedPrivateEvaluationAuthorityInspection({
+        selector,
+        capturedAt: '2026-08-19T10:00:00.000Z',
+        validThrough: '2026-08-19T10:05:00.000Z',
+        head: { status: 'absent', revision: 0, generationId: null },
+        lastTransitionId: transitionId,
+        blockers: [{ code: 'model_not_approved', message: 'No approved component runs.' }],
+      })
+    ).toThrow(/predecessor|head/i);
+  });
+
+  it('authenticates synthetic-ready component runs and rejects changed model authority', () => {
+    const retained = createReadyFixtureGovernedPrivateEvaluationAuthorityInspection({
+      selector,
+      capturedAt: '2026-08-19T10:00:00.000Z',
+      validThrough: '2026-08-19T10:05:00.000Z',
+      head: { status: 'absent', revision: 0, generationId: null },
+      lastTransitionId: null,
+      playerModelRunId: `model-run:${'c'.repeat(64)}`,
+      pickModelRunId: `model-run:${'d'.repeat(64)}`,
+    });
+
+    expect(retained.result).toEqual({
+      state: 'ready',
+      selector,
+      inspectionId: retained.inspection.inspectionId,
+      validThrough: '2026-08-19T10:05:00.000Z',
+      head: { status: 'absent', revision: 0, generationId: null },
+      blockers: [],
+    });
+    const tampered = structuredClone(retained);
+    tampered.snapshot.content.calculationAuthority.playerModelRunId =
+      `model-run:${'e'.repeat(64)}`;
+    expect(() => authenticateGovernedPrivateEvaluationAuthorityInspection(tampered)).toThrow();
+  });
+
+  it('authenticates the exact non-production calculation ancestry needed for construction', () => {
+    const input = readyAuthorityInput();
+    const retained = createReadyGovernedPrivateEvaluationAuthorityInspection(input);
+
+    expect(retained.result).toEqual({
+      state: 'ready',
+      selector,
+      inspectionId: retained.inspection.inspectionId,
+      validThrough: input.validThrough,
+      head: input.head,
+      blockers: [],
+    });
+    expect(retained.snapshot.content).toMatchObject({
+      schemaVersion: 'private-evaluation-authority-snapshot/v2',
+      environment: 'non_production',
+      calculationAuthority: {
+        state: 'ready',
+        preparedInputSetId: input.preparedInputSetId,
+        factualReleaseId: input.factualReleaseId,
+        valuationInputBundleId: input.valuationInputBundleId,
+        calculationInputPackageId: input.calculationInputPackageId,
+        inputTraceId: input.inputTraceId,
+        gateLedgerRevision: 17,
+        components: input.components,
+      },
+    });
+    expect(authenticateGovernedPrivateEvaluationAuthorityInspection(retained)).toEqual(retained);
+  });
+
+  it('pins ready v3 authority to one current prepared head and its exact replay manifest', () => {
+    const legacy = readyAuthorityInput();
+    const retained = createReadyGovernedPrivateEvaluationAuthorityInspectionV3({
+      selector: legacy.selector,
+      capturedAt: legacy.capturedAt,
+      validThrough: legacy.validThrough,
+      head: legacy.head,
+      lastTransitionId: legacy.lastTransitionId,
+      preparedInputHeadRevision: 4,
+      preparedInputSetId: legacy.preparedInputSetId,
+      factualReleaseId: legacy.factualReleaseId,
+      factualRegistryRevision: 21,
+      activeFactualReleaseRevision: 7,
+      privateValuationDecisionId: `private-valuation-evaluation-decision:${'1'.repeat(64)}`,
+      privateValuationDecisionRevision: 3,
+      materializationManifestId: `private-evaluation-materialization-manifest:${'0'.repeat(64)}`,
+      materializationManifestArtifact: artifact('materialization-manifest'),
+      valuationInputBundleId: legacy.valuationInputBundleId,
+      valuationInputBundleArtifact: legacy.valuationInputBundleArtifact,
+      gateLedgerRevision: legacy.gateLedgerRevision,
+      components: legacy.components,
+    });
+
+    expect(retained.snapshot.content).toMatchObject({
+      schemaVersion: 'private-evaluation-authority-snapshot/v3',
+      environment: 'non_production',
+      calculationAuthority: {
+        state: 'ready',
+        preparedInputHeadRevision: 4,
+        preparedInputSetId: legacy.preparedInputSetId,
+        materializationManifestId: expect.stringMatching(
+          /^private-evaluation-materialization-manifest:/
+        ),
+        factualReleaseId: legacy.factualReleaseId,
+        factualRegistryRevision: 21,
+        activeFactualReleaseRevision: 7,
+        privateValuationDecisionId: expect.stringMatching(
+          /^private-valuation-evaluation-decision:/
+        ),
+        privateValuationDecisionRevision: 3,
+        valuationInputBundleId: legacy.valuationInputBundleId,
+        components: legacy.components,
+      },
+    });
+    expect(authenticateGovernedPrivateEvaluationAuthorityInspection(retained)).toEqual(retained);
+
+    const tampered = structuredClone(retained);
+    tampered.inspection.content.calculationAuthority.privateValuationDecisionRevision = 4;
+    expect(() => authenticateGovernedPrivateEvaluationAuthorityInspection(tampered)).toThrow();
+  });
+
+  it('rejects substituted non-production authority and non-canonical component roles', () => {
+    const retained = createReadyGovernedPrivateEvaluationAuthorityInspection(
+      readyAuthorityInput()
+    );
+    const substituted = structuredClone(retained);
+    substituted.inspection.content.calculationAuthority.inputTraceId =
+      `private-evaluation-input-trace:${'0'.repeat(64)}`;
+    expect(() =>
+      authenticateGovernedPrivateEvaluationAuthorityInspection(substituted)
+    ).toThrow();
+
+    const reordered = readyAuthorityInput();
+    reordered.components.reverse();
+    expect(() => createReadyGovernedPrivateEvaluationAuthorityInspection(reordered)).toThrow(
+      /component|role|canonical/i
+    );
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-execution.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-execution.test.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
 import { createUnavailableGovernedPrivateEvaluationAuthorityInspection } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationAuthoritySnapshot';
 import { createPostgresGovernedPrivateEvaluationExecutionService } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationExecutionService';
+import { createGovernedPrivateEvaluationTransitionIntent } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle';
 
 const selector = {
   valuationScopeKey: 'afl-trade-history:test-fixture',
@@ -38,15 +39,18 @@ function retainedInspection(
 class ExecutionSqlClient implements AflOutcomeSqlClient {
   readonly retained;
   private readonly operatorAuthorized;
+  private readonly stagedIntent;
 
   constructor(
     options: Readonly<{
       operatorAuthorized?: boolean;
       head?: InspectionHead;
+      stagedIntent?: ReturnType<typeof createGovernedPrivateEvaluationTransitionIntent>;
     }> = {}
   ) {
     this.operatorAuthorized = options.operatorAuthorized ?? true;
     this.retained = retainedInspection(options.head);
+    this.stagedIntent = options.stagedIntent;
   }
 
   async query<Row>(sql: string): Promise<AflOutcomeSqlQueryResult<Row>> {
@@ -58,6 +62,12 @@ class ExecutionSqlClient implements AflOutcomeSqlClient {
     }
     if (sql.includes('FROM outcome_private_evaluation_transition_receipt')) {
       return { rows: [], rowCount: 0 } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('FROM outcome_private_evaluation_transition_intent')) {
+      return {
+        rows: this.stagedIntent === undefined ? [] : [{ intent_json: this.stagedIntent }],
+        rowCount: this.stagedIntent === undefined ? 0 : 1,
+      } as AflOutcomeSqlQueryResult<Row>;
     }
     if (sql.includes('FROM outcome_private_evaluation_inspection_receipt ir')) {
       return {
@@ -145,6 +155,60 @@ describe('governed private evaluation execution service', () => {
     );
     expect(retainArtifact).toHaveBeenCalledOnce();
     expect(commit).toHaveBeenCalledOnce();
+  });
+
+  it('resumes the exact staged intent when retrying an operation before receipt commit', async () => {
+    const retained = retainedInspection();
+    const stagedIntent = createGovernedPrivateEvaluationTransitionIntent({
+      selector,
+      inspectionId: retained.inspection.inspectionId,
+      authoritySnapshotId: null,
+      operationId,
+      action: { kind: 'withdraw', reason: 'Remove the unavailable active grade.' },
+      expectedHead: retained.inspection.content.head,
+      review: {
+        principalId: 'firebase:authenticated-operator',
+        rationale: 'Fail closed while model authority is unavailable.',
+      },
+      requestedAt: '2026-08-19T10:00:30.000Z',
+      expiresAt: retained.inspection.content.validThrough,
+    });
+    const client = new ExecutionSqlClient({ stagedIntent });
+    const stage = vi.fn();
+    const retainArtifact = vi.fn(async (artifact) => artifact.reference);
+    const commit = vi.fn(async (input) => ({
+      state: 'committed' as const,
+      head: input.receipt.content.toHead,
+      transitionId: input.receipt.transitionId,
+    }));
+    const service = createPostgresGovernedPrivateEvaluationExecutionService({
+      client,
+      principalId: 'firebase:authenticated-operator',
+      staging: { stage, retainArtifact },
+      lifecycle: { commit },
+      reconstruction: { verify: vi.fn() },
+    });
+
+    await expect(
+      service.execute({
+        inspectionId: client.retained.inspection.inspectionId,
+        operationId,
+        action: { kind: 'withdraw', reason: 'Remove the unavailable active grade.' },
+        review: { rationale: 'Fail closed while model authority is unavailable.' },
+      })
+    ).resolves.toMatchObject({ state: 'withdrawn', operationId });
+
+    expect(stage).not.toHaveBeenCalled();
+    expect(commit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        receipt: expect.objectContaining({
+          content: expect.objectContaining({
+            intent: stagedIntent,
+            transitionedAt: stagedIntent.content.requestedAt,
+          }),
+        }),
+      })
+    );
   });
 
   it('keeps construction unavailable without approved component model runs', async () => {

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-execution.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-execution.test.ts
@@ -1,0 +1,240 @@
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlQueryResult,
+  AflOutcomeSqlTransaction,
+} from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { createUnavailableGovernedPrivateEvaluationAuthorityInspection } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationAuthoritySnapshot';
+import { createPostgresGovernedPrivateEvaluationExecutionService } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationExecutionService';
+
+const selector = {
+  valuationScopeKey: 'afl-trade-history:test-fixture',
+  tradeId: 'trade:adelaide-st-kilda',
+};
+const generationId = `local-private-trade-evaluation-generation:${'b'.repeat(64)}`;
+const priorGenerationId = `local-private-trade-evaluation-generation:${'a'.repeat(64)}`;
+const transitionId = `private-evaluation-transition:${'c'.repeat(64)}`;
+const operationId = `private-evaluation-operation:${'d'.repeat(64)}`;
+const now = '2026-08-19T10:01:00.000Z';
+
+type InspectionHead = Readonly<{
+  status: 'active' | 'withdrawn';
+  revision: number;
+  generationId: string | null;
+}>;
+
+function retainedInspection(
+  head: InspectionHead = { status: 'active', revision: 1, generationId }
+) {
+  return createUnavailableGovernedPrivateEvaluationAuthorityInspection({
+    selector,
+    capturedAt: '2026-08-19T10:00:00.000Z',
+    validThrough: '2026-08-19T10:05:00.000Z',
+    head,
+    lastTransitionId: transitionId,
+    blockers: [{ code: 'model_not_approved', message: 'Approved model runs are unavailable.' }],
+  });
+}
+
+class ExecutionSqlClient implements AflOutcomeSqlClient {
+  readonly retained;
+  private readonly operatorAuthorized;
+
+  constructor(
+    options: Readonly<{
+      operatorAuthorized?: boolean;
+      head?: InspectionHead;
+    }> = {}
+  ) {
+    this.operatorAuthorized = options.operatorAuthorized ?? true;
+    this.retained = retainedInspection(options.head);
+  }
+
+  async query<Row>(sql: string): Promise<AflOutcomeSqlQueryResult<Row>> {
+    if (sql.includes('SELECT from_generation_id')) {
+      return {
+        rows: [{ from_generation_id: priorGenerationId }],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('FROM outcome_private_evaluation_transition_receipt')) {
+      return { rows: [], rowCount: 0 } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('FROM outcome_private_evaluation_inspection_receipt ir')) {
+      return {
+        rows: [
+          {
+            receipt_json: this.retained.inspection,
+            snapshot_json: this.retained.snapshot,
+          },
+        ],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('transaction_timestamp()')) {
+      return {
+        rows: [{ trusted_at: new Date(now) }],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('FROM outcome_operational_principal_authority')) {
+      return {
+        rows: this.operatorAuthorized
+          ? [{ authority_evidence_id: `reviewer-authority-evidence:${'e'.repeat(64)}` }]
+          : [],
+        rowCount: this.operatorAuthorized ? 1 : 0,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    throw new Error(`Unexpected SQL: ${sql}`);
+  }
+
+  async transaction<T>(
+    work: (transaction: AflOutcomeSqlTransaction) => Promise<T>
+  ): Promise<T> {
+    return work(this);
+  }
+}
+
+describe('governed private evaluation execution service', () => {
+  it('derives operator identity internally and withdraws from unavailable model authority', async () => {
+    const client = new ExecutionSqlClient();
+    const stage = vi.fn(async (input) => ({
+      transitionIntentId: input.intent.transitionIntentId,
+      generationId: null,
+    }));
+    const retainArtifact = vi.fn(async (artifact) => artifact.reference);
+    const commit = vi.fn(async (input) => ({
+      state: 'committed' as const,
+      head: input.receipt.content.toHead,
+      transitionId: input.receipt.transitionId,
+    }));
+    const service = createPostgresGovernedPrivateEvaluationExecutionService({
+      client,
+      principalId: 'firebase:authenticated-operator',
+      staging: { stage, retainArtifact },
+      lifecycle: { commit },
+      reconstruction: { verify: vi.fn() },
+    });
+    const inspectionId = client.retained.inspection.inspectionId;
+
+    await expect(
+      service.execute({
+        inspectionId,
+        operationId,
+        action: { kind: 'withdraw', reason: 'Remove the unavailable active grade.' },
+        review: { rationale: 'Fail closed while model authority is unavailable.' },
+      })
+    ).resolves.toMatchObject({
+      state: 'withdrawn',
+      selector,
+      inspectionId,
+      operationId,
+      head: { status: 'withdrawn', revision: 2, generationId: null },
+    });
+    expect(stage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: expect.objectContaining({
+          content: expect.objectContaining({
+            authoritySnapshotId: null,
+            review: {
+              principalId: 'firebase:authenticated-operator',
+              rationale: 'Fail closed while model authority is unavailable.',
+            },
+          }),
+        }),
+      })
+    );
+    expect(retainArtifact).toHaveBeenCalledOnce();
+    expect(commit).toHaveBeenCalledOnce();
+  });
+
+  it('keeps construction unavailable without approved component model runs', async () => {
+    const client = new ExecutionSqlClient();
+    const stage = vi.fn();
+    const service = createPostgresGovernedPrivateEvaluationExecutionService({
+      client,
+      principalId: 'firebase:authenticated-operator',
+      staging: { stage, retainArtifact: vi.fn() },
+      lifecycle: { commit: vi.fn() },
+      reconstruction: { verify: vi.fn() },
+    });
+
+    await expect(
+      service.execute({
+        inspectionId: client.retained.inspection.inspectionId,
+        operationId,
+        action: { kind: 'construct_and_activate' },
+        review: { rationale: 'Attempt construction.' },
+      })
+    ).resolves.toMatchObject({
+      state: 'unavailable',
+      selector,
+      blockers: [{ code: 'model_not_approved' }],
+    });
+    expect(stage).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: 'rollback',
+      head: { status: 'active', revision: 2, generationId } as const,
+      action: { kind: 'rollback', targetGenerationId: priorGenerationId } as const,
+    },
+    {
+      label: 'recovery',
+      head: { status: 'withdrawn', revision: 2, generationId: null } as const,
+      action: { kind: 'recover' } as const,
+    },
+  ])('rejects $label when calculation authority is unavailable', async ({ head, action }) => {
+    const client = new ExecutionSqlClient({ head });
+    const stage = vi.fn();
+    const commit = vi.fn(async (input) => ({
+      state: 'committed' as const,
+      head: input.receipt.content.toHead,
+      transitionId: input.receipt.transitionId,
+    }));
+    const verify = vi.fn();
+    const service = createPostgresGovernedPrivateEvaluationExecutionService({
+      client,
+      principalId: 'firebase:authenticated-operator',
+      staging: { stage, retainArtifact: vi.fn() },
+      lifecycle: { commit },
+      reconstruction: { verify },
+    });
+
+    await expect(
+      service.execute({
+        inspectionId: client.retained.inspection.inspectionId,
+        operationId,
+        action,
+        review: { rationale: 'Unavailable real authority cannot reactivate a fixture grade.' },
+      })
+    ).resolves.toMatchObject({
+      state: 'invalid_transition',
+      selector,
+      message: 'Rollback and recovery require exact ready calculation authority.',
+    });
+    expect(verify).not.toHaveBeenCalled();
+    expect(stage).not.toHaveBeenCalled();
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('rejects an authenticated identity without current governed operator authority', async () => {
+    const client = new ExecutionSqlClient({ operatorAuthorized: false });
+    const service = createPostgresGovernedPrivateEvaluationExecutionService({
+      client,
+      principalId: 'firebase:authenticated-reader',
+      staging: { stage: vi.fn(), retainArtifact: vi.fn() },
+      lifecycle: { commit: vi.fn() },
+      reconstruction: { verify: vi.fn() },
+    });
+
+    await expect(
+      service.execute({
+        inspectionId: client.retained.inspection.inspectionId,
+        operationId,
+        action: { kind: 'withdraw', reason: 'Attempt an unauthorized withdrawal.' },
+        review: { rationale: 'A registered reader must not control lifecycle state.' },
+      })
+    ).rejects.toThrow('current governed operator authority');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-explanation-policy.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-explanation-policy.test.ts
@@ -1,0 +1,56 @@
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import {
+  createGovernedPrivateEvaluationExplanationPolicy,
+  governedPrivateEvaluationExplanationPolicySchema,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationExplanationPolicy';
+
+function content() {
+  return {
+    schemaVersion: 'private-evaluation-explanation-policy/v1' as const,
+    environment: 'non_production' as const,
+    valueUnitId: 'fixed_horizon_pav',
+    selectedLayer: 'scarcityAdjusted' as const,
+    practicalEquivalence: {
+      basis: 'absolute club package net difference in fixed_horizon_pav',
+      bandByView: [
+        { view: 'at_trade' as const, maximumDifference: 2 },
+        { view: 'realized' as const, maximumDifference: 1 },
+        { view: 'remaining' as const, maximumDifference: 2 },
+        { view: 'current' as const, maximumDifference: 2 },
+      ],
+    },
+    createdAt: '2026-08-19T09:00:00.000Z',
+    publicationEligible: false as const,
+    limitation:
+      'Private calculation explanation policy only; not model, grade, publication, or activation authority.' as const,
+  };
+}
+
+describe('governed private evaluation explanation policy', () => {
+  it('content-addresses the exact four-view comparison policy', () => {
+    const policy = createGovernedPrivateEvaluationExplanationPolicy(content());
+
+    expect(policy.policyId).toBe(
+      createAflTradeContentAddress('private-evaluation-explanation-policy', policy.content)
+    );
+    expect(policy.content.practicalEquivalence.bandByView.map(({ view }) => view)).toEqual([
+      'at_trade',
+      'realized',
+      'remaining',
+      'current',
+    ]);
+  });
+
+  it('rejects reordered or negative policy bands and changed retained content', () => {
+    const reordered = content();
+    reordered.practicalEquivalence.bandByView.reverse();
+    expect(() => createGovernedPrivateEvaluationExplanationPolicy(reordered)).toThrow(
+      /canonical|view/i
+    );
+
+    const policy = createGovernedPrivateEvaluationExplanationPolicy(content());
+    const tampered = structuredClone(policy);
+    tampered.content.practicalEquivalence.bandByView[0]!.maximumDifference = -1;
+    expect(() => governedPrivateEvaluationExplanationPolicySchema.parse(tampered)).toThrow();
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-input-trace.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-input-trace.test.ts
@@ -1,0 +1,420 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  GOVERNED_PRIVATE_EVALUATION_INPUT_TRACE_SCHEMA_VERSION,
+  createGovernedPrivateEvaluationInputTrace,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationInputTrace';
+import { createGovernedPrivateEvaluationExplanationPolicy } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationExplanationPolicy';
+import { authenticateGovernedPrivateEvaluationExplanationSource } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationExplanationSource';
+import { deriveGovernedPrivateEvaluationTransaction } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationTransaction';
+
+const digest = (character: string) =>
+  character.charCodeAt(0).toString(16).padStart(2, '0').repeat(32);
+const addressed = (kind: string, character: string) => `${kind}:${digest(character)}`;
+
+function artifact(character: string, createdAt = '2026-08-19T09:00:00.000Z') {
+  return {
+    artifactId: addressed('artifact', character),
+    contentSha256: digest(character),
+    storageUri: `artifact://sha256/${digest(character)}`,
+    mediaType: 'application/json',
+    byteLength: 512,
+    createdAt,
+  };
+}
+
+function component(
+  role:
+    | 'player_contribution_and_availability'
+    | 'draft_pick_and_future_pick_distribution',
+  character: string
+) {
+  return {
+    role,
+    runId: addressed('model-run', character),
+    protocolId: addressed('model-protocol', character),
+    datasetId: addressed('dataset', character),
+    datasetAdmissionId: addressed('dataset-admission', character),
+    gate3DecisionId: addressed('gate-decision', character),
+    evidence: {
+      runManifest: artifact(character),
+      protocol: artifact(String.fromCharCode(character.charCodeAt(0) + 2)),
+      datasetAdmission: artifact(String.fromCharCode(character.charCodeAt(0) + 4)),
+      gate3Decision: artifact(String.fromCharCode(character.charCodeAt(0) + 6)),
+    },
+  };
+}
+
+function inputTrace() {
+  return {
+    schemaVersion: GOVERNED_PRIVATE_EVALUATION_INPUT_TRACE_SCHEMA_VERSION,
+    environment: 'non_production' as const,
+    selector: {
+      valuationScopeKey: 'afl-men:2023-trades',
+      tradeId: 'trade:carlton-fremantle-gold-coast',
+    },
+    factualReleaseId: addressed('outcome-release', '1'),
+    valuationInputBundleId: addressed('valuation-input-bundle', '2'),
+    components: [
+      component('player_contribution_and_availability', '3'),
+      component('draft_pick_and_future_pick_distribution', '4'),
+    ],
+    transaction: {
+      effectiveAt: '2023-10-18T00:00:00.000Z',
+      clubs: [
+        { aflClubId: 'club:carlton', clubName: 'Carlton' },
+        { aflClubId: 'club:fremantle', clubName: 'Fremantle' },
+        { aflClubId: 'club:gold-coast', clubName: 'Gold Coast' },
+      ],
+      transfers: [
+        {
+          transferId: 'transfer:pick-12',
+          assetId: 'asset:pick-12',
+          assetKind: 'current_pick_entitlement' as const,
+          fromClubId: 'club:carlton',
+          toClubId: 'club:fremantle',
+          displayLabel: '2023 pick 12',
+          evidenceRef: artifact('b', '2023-10-18T00:00:00.000Z'),
+        },
+        {
+          transferId: 'transfer:pick-future',
+          assetId: 'asset:pick-future',
+          assetKind: 'future_pick_entitlement' as const,
+          fromClubId: 'club:fremantle',
+          toClubId: 'club:gold-coast',
+          displayLabel: 'Fremantle 2024 second-round pick',
+          evidenceRef: artifact('c', '2023-10-18T00:00:00.000Z'),
+        },
+        {
+          transferId: 'transfer:player-a',
+          assetId: 'asset:player-a',
+          assetKind: 'player' as const,
+          fromClubId: 'club:gold-coast',
+          toClubId: 'club:carlton',
+          displayLabel: 'Player A',
+          evidenceRef: artifact('a', '2023-10-18T00:00:00.000Z'),
+        },
+      ],
+    },
+    seasonUniverse: [
+      {
+        season: 2024,
+        status: 'complete' as const,
+        startsAt: '2024-03-01T00:00:00.000Z',
+        endsAt: '2024-09-30T23:59:59.999Z',
+        evidenceRef: artifact('d', '2024-10-01T00:00:00.000Z'),
+      },
+      {
+        season: 2025,
+        status: 'complete' as const,
+        startsAt: '2025-03-01T00:00:00.000Z',
+        endsAt: '2025-09-30T23:59:59.999Z',
+        evidenceRef: artifact('e', '2025-10-01T00:00:00.000Z'),
+      },
+      {
+        season: 2026,
+        status: 'right_censored' as const,
+        startsAt: '2026-03-01T00:00:00.000Z',
+        endsAt: '2026-09-30T23:59:59.999Z',
+        evidenceRef: artifact('f'),
+      },
+    ],
+    playerHorizons: [
+      {
+        assetId: 'asset:player-a',
+        playerId: 'player:a',
+        playerName: 'Player A',
+        playerObservationId: addressed('player-pav-observation', '7'),
+        playerObservationArtifact: artifact('p'),
+        receivingClubId: 'club:carlton',
+        acquisitionSpells: [
+          {
+            spellVersionId: 'acquisition-spell-version:player-a-carlton',
+            clubId: 'club:carlton',
+            clubName: 'Carlton',
+            joinedAt: '2023-10-18T00:00:00.000Z',
+            departedAt: null,
+            evidenceRef: artifact('g', '2023-10-18T00:00:00.000Z'),
+          },
+        ],
+        requiredSeasons: [
+          { season: 2024, status: 'complete' as const, evidenceRef: artifact('h') },
+          { season: 2025, status: 'complete' as const, evidenceRef: artifact('i') },
+          { season: 2026, status: 'right_censored' as const, evidenceRef: artifact('j') },
+        ],
+      },
+    ],
+    pickLineages: [
+      {
+        rootAssetId: 'asset:pick-12',
+        pickIdentityId: 'pick-identity:2023-round-1-carlton',
+        pickIdentityLabel: 'Carlton 2023 first-round pick',
+        receivingClubId: 'club:fremantle',
+        pickObservationSetId: addressed('pick-pav-observation-set', '5'),
+        pickModelExecutionId: addressed('pick-pav-model-execution', '6'),
+        pickBenchmarkId: addressed('pick-pav-benchmark', '7'),
+        pickBenchmarkArtifact: artifact('q'),
+        resolvedSelectionNumber: 18,
+        custody: [
+          {
+            ordinal: 0,
+            clubId: 'club:fremantle',
+            clubName: 'Fremantle',
+            heldFrom: '2023-10-18T00:00:00.000Z',
+            heldThrough: '2024-10-15T00:00:00.000Z',
+            evidenceRef: artifact('k'),
+          },
+          {
+            ordinal: 1,
+            clubId: 'club:hawthorn',
+            clubName: 'Hawthorn',
+            heldFrom: '2024-10-15T00:00:00.000Z',
+            heldThrough: null,
+            evidenceRef: artifact('l'),
+          },
+        ],
+        transformations: [
+          {
+            ordinal: 0,
+            kind: 'renumbered' as const,
+            fromAssetIds: ['asset:pick-12'],
+            toAssetIds: ['asset:pick-18'],
+            effectiveAt: '2024-11-01T00:00:00.000Z',
+            economicAllocationDecisionId: null,
+            assetLabels: [
+              { assetId: 'asset:pick-12', displayLabel: '2023 pick 12' },
+              { assetId: 'asset:pick-18', displayLabel: '2023 pick 18' },
+            ],
+            evidenceRef: artifact('m'),
+          },
+          {
+            ordinal: 1,
+            kind: 'selected_player' as const,
+            fromAssetIds: ['asset:pick-18'],
+            toAssetIds: ['asset:selected-player'],
+            effectiveAt: '2024-11-20T00:00:00.000Z',
+            economicAllocationDecisionId: null,
+            assetLabels: [
+              { assetId: 'asset:pick-18', displayLabel: '2023 pick 18' },
+              { assetId: 'asset:selected-player', displayLabel: 'Selected Player' },
+            ],
+            evidenceRef: artifact('n'),
+          },
+        ],
+      },
+      {
+        rootAssetId: 'asset:pick-future',
+        pickIdentityId: 'pick-identity:2024-round-2-fremantle',
+        pickIdentityLabel: 'Fremantle 2024 second-round pick',
+        receivingClubId: 'club:gold-coast',
+        pickObservationSetId: addressed('pick-pav-observation-set', '5'),
+        pickModelExecutionId: addressed('pick-pav-model-execution', '6'),
+        pickBenchmarkId: addressed('pick-pav-benchmark', '7'),
+        pickBenchmarkArtifact: artifact('r'),
+        resolvedSelectionNumber: null,
+        custody: [
+          {
+            ordinal: 0,
+            clubId: 'club:gold-coast',
+            clubName: 'Gold Coast',
+            heldFrom: '2023-10-18T00:00:00.000Z',
+            heldThrough: null,
+            evidenceRef: artifact('o'),
+          },
+        ],
+        transformations: [],
+      },
+    ],
+    derivedAt: '2026-08-19T10:00:00.000Z',
+    publicationEligible: false as const,
+    limitation:
+      'Authenticated calculation-input trace only; contains no caller-supplied values, grades, publication approval, or activation authority.' as const,
+  };
+}
+
+function explanationPolicy(createdAt = '2026-08-19T09:30:00.000Z') {
+  return createGovernedPrivateEvaluationExplanationPolicy({
+    schemaVersion: 'private-evaluation-explanation-policy/v1',
+    environment: 'non_production',
+    valueUnitId: 'fixed_horizon_pav',
+    selectedLayer: 'scarcityAdjusted',
+    practicalEquivalence: {
+      basis: 'absolute club package net difference in fixed_horizon_pav',
+      bandByView: [
+        { view: 'at_trade', maximumDifference: 2 },
+        { view: 'realized', maximumDifference: 1 },
+        { view: 'remaining', maximumDifference: 2 },
+        { view: 'current', maximumDifference: 2 },
+      ],
+    },
+    createdAt,
+    publicationEligible: false,
+    limitation:
+      'Private calculation explanation policy only; not model, grade, publication, or activation authority.',
+  });
+}
+
+describe('governed private evaluation input trace', () => {
+  it('authenticates one complete three-club transaction with player horizons and pick lineage', () => {
+    const trace = createGovernedPrivateEvaluationInputTrace(inputTrace());
+    const transaction = deriveGovernedPrivateEvaluationTransaction(trace);
+
+    expect(trace.inputTraceId).toMatch(/^private-evaluation-input-trace:[a-f0-9]{64}$/);
+    expect(trace.content.transaction.clubs.map(({ clubName }) => clubName)).toEqual([
+      'Carlton',
+      'Fremantle',
+      'Gold Coast',
+    ]);
+    expect(trace.content.playerHorizons[0]?.requiredSeasons.map(({ season }) => season)).toEqual([
+      2024, 2025, 2026,
+    ]);
+    expect(trace.content.playerHorizons[0]?.playerObservationId).toMatch(
+      /^player-pav-observation:[a-f0-9]{64}$/
+    );
+    expect(trace.content.pickLineages.map(({ resolvedSelectionNumber }) => resolvedSelectionNumber))
+      .toEqual([18, null]);
+    expect(trace.content.pickLineages[0]?.custody.map(({ clubId }) => clubId)).toEqual([
+      'club:fremantle',
+      'club:hawthorn',
+    ]);
+    expect(transaction.transfers).toEqual([
+      expect.objectContaining({
+        assetId: 'asset:pick-12',
+        fromClubId: 'club:carlton',
+        toClubId: 'club:fremantle',
+        assetKind: 'current_pick',
+        displayLabel: '2023 pick 12',
+      }),
+      expect.objectContaining({
+        assetId: 'asset:pick-future',
+        fromClubId: 'club:fremantle',
+        toClubId: 'club:gold-coast',
+        assetKind: 'future_pick',
+      }),
+      expect.objectContaining({
+        assetId: 'asset:player-a',
+        fromClubId: 'club:gold-coast',
+        toClubId: 'club:carlton',
+        assetKind: 'player',
+      }),
+    ]);
+    expect(transaction.clubs).toEqual([
+      expect.objectContaining({
+        aflClubId: 'club:carlton',
+        receivedAssetIds: ['asset:player-a'],
+        givenUpAssetIds: ['asset:pick-12'],
+      }),
+      expect.objectContaining({
+        aflClubId: 'club:fremantle',
+        receivedAssetIds: ['asset:pick-12'],
+        givenUpAssetIds: ['asset:pick-future'],
+      }),
+      expect.objectContaining({
+        aflClubId: 'club:gold-coast',
+        receivedAssetIds: ['asset:pick-future'],
+        givenUpAssetIds: ['asset:player-a'],
+      }),
+    ]);
+  });
+
+  it('normalizes exact archive directions and retained four-view policy without grade authority', () => {
+    const trace = createGovernedPrivateEvaluationInputTrace(inputTrace());
+    const policy = explanationPolicy();
+
+    expect(authenticateGovernedPrivateEvaluationExplanationSource({ trace, policy })).toEqual({
+      authority: {
+        kind: 'authenticated_non_production',
+        inputTraceId: trace.inputTraceId,
+        explanationPolicyId: policy.policyId,
+        publicationProhibited: true,
+      },
+      selector: trace.content.selector,
+      effectiveAt: trace.content.transaction.effectiveAt,
+      valueUnitId: 'fixed_horizon_pav',
+      selectedLayer: 'scarcityAdjusted',
+      practicalEquivalence: {
+        basis: 'absolute club package net difference in fixed_horizon_pav',
+        bandByView: { at_trade: 2, realized: 1, remaining: 2, current: 2 },
+      },
+      clubs: expect.arrayContaining([
+        expect.objectContaining({ aflClubId: 'club:carlton', clubName: 'Carlton' }),
+      ]),
+      transfers: expect.arrayContaining([
+        expect.objectContaining({
+          assetId: 'asset:pick-12',
+          fromClubId: 'club:carlton',
+          toClubId: 'club:fremantle',
+          directionBasis: 'archive_recorded_transfer',
+        }),
+      ]),
+    });
+  });
+
+  it('rejects an explanation policy created after its authenticated input trace', () => {
+    const trace = createGovernedPrivateEvaluationInputTrace(inputTrace());
+
+    expect(() =>
+      authenticateGovernedPrivateEvaluationExplanationSource({
+        trace,
+        policy: explanationPolicy('2026-08-19T10:00:00.001Z'),
+      })
+    ).toThrow(/policy.*before|trace/i);
+  });
+
+  it('rejects an omitted completed player season', () => {
+    const input = inputTrace();
+    input.playerHorizons[0]!.requiredSeasons.splice(1, 1);
+
+    expect(() => createGovernedPrivateEvaluationInputTrace(input)).toThrow(
+      'Player horizon must contain every applicable season from the authenticated universe.'
+    );
+  });
+
+  it('rejects an omitted season from the post-trade season universe', () => {
+    const input = inputTrace();
+    input.seasonUniverse.splice(1, 1);
+    input.playerHorizons[0]!.requiredSeasons.splice(1, 1);
+
+    expect(() => createGovernedPrivateEvaluationInputTrace(input)).toThrow(
+      'Season universe must contain every consecutive post-trade season through the current cutoff.'
+    );
+  });
+
+  it('rejects a transaction club without a directed transfer', () => {
+    const input = inputTrace();
+    input.transaction.clubs.push({ aflClubId: 'club:melbourne', clubName: 'Melbourne' });
+
+    expect(() => createGovernedPrivateEvaluationInputTrace(input)).toThrow(
+      'Transaction clubs must equal the exact clubs participating in directed transfers.'
+    );
+  });
+
+  it('rejects ambiguous split lineage without an approved economic allocation', () => {
+    const input = inputTrace();
+    input.pickLineages[0]!.transformations[0] = {
+      ...input.pickLineages[0]!.transformations[0]!,
+      kind: 'split',
+      toAssetIds: ['asset:pick-18', 'asset:pick-35'],
+    };
+
+    expect(() => createGovernedPrivateEvaluationInputTrace(input)).toThrow(
+      'Split or merged transformations require one approved economic-allocation decision.'
+    );
+  });
+
+  it('rejects caller-supplied values or grades', () => {
+    const input = inputTrace() as ReturnType<typeof inputTrace> & { score?: number };
+    input.score = 18.4;
+
+    expect(() => createGovernedPrivateEvaluationInputTrace(input)).toThrow();
+  });
+
+  it('rejects a lineage transformation without labels for its complete frontier', () => {
+    const input = inputTrace();
+    input.pickLineages[0]!.transformations[0]!.assetLabels.pop();
+
+    expect(() => createGovernedPrivateEvaluationInputTrace(input)).toThrow(
+      /lineage|label|transformation/i
+    );
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-lifecycle-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-lifecycle-migration.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const migrationPath =
+  'prisma/afl-trade-outcomes/migrations/0058_governed_private_evaluation_lifecycle/migration.sql';
+
+function read(path: string): string {
+  return readFileSync(join(process.cwd(), path), 'utf8');
+}
+
+describe('governed private evaluation lifecycle migration', () => {
+  it('is a forward migration after the landed 0057 authority boundary', () => {
+    expect(existsSync(join(process.cwd(), migrationPath))).toBe(true);
+  });
+
+  it('persists immutable inspection ancestry and dormant generations before activation', () => {
+    const migration = read(migrationPath);
+    const inspectionTable = migration.slice(
+      migration.indexOf('CREATE TABLE "outcome_private_evaluation_inspection_receipt"'),
+      migration.indexOf('CREATE TABLE "outcome_private_evaluation_transition_intent"')
+    );
+    const intentTable = migration.slice(
+      migration.indexOf('CREATE TABLE "outcome_private_evaluation_transition_intent"'),
+      migration.indexOf('CREATE TABLE "outcome_local_private_trade_evaluation_generation"')
+    );
+
+    expect(migration).toContain('outcome_private_evaluation_authority_snapshot');
+    expect(migration).toContain('outcome_private_evaluation_inspection_receipt');
+    expect(migration).toContain('outcome_private_evaluation_transition_intent');
+    expect(migration).toContain('outcome_local_private_trade_evaluation_generation');
+    expect(migration).toContain('transition_intent_id');
+    expect(migration).toContain('generation_artifact_id');
+    expect(migration).toContain('projection_manifest_artifact_id');
+    expect(migration).toContain("DEFAULT clock_timestamp()");
+    expect(migration).toContain('Private evaluation authority records are append-only');
+    expect(migration).toContain('Private evaluation generations are append-only');
+    expect(inspectionTable).toContain(
+      `("state"='unavailable' AND "valid_through" IS NOT NULL AND "expected_head_status" IS NOT NULL AND "expected_head_revision" IS NOT NULL)`
+    );
+    expect(inspectionTable).toContain(
+      `("expected_head_status"='absent' AND "expected_head_revision"=0 AND "expected_head_generation_id" IS NULL)`
+    );
+    expect(intentTable).toContain('"authority_snapshot_id" TEXT');
+    expect(intentTable).toContain(
+      `CHECK (("action"='withdraw') = ("authority_snapshot_id" IS NULL))`
+    );
+    expect(intentTable).toContain(
+      'REFERENCES "outcome_private_evaluation_authority_snapshot"("snapshot_id", "valuation_scope_key", "trade_id")'
+    );
+  });
+
+  it('adds exact governed authority for private evaluation operators', () => {
+    const migration = read(migrationPath);
+
+    expect(migration).toContain(`'afl_trade_private_evaluation_operator'`);
+    expect(migration).toContain(`"capability_id" = 'manage_private_trade_evaluation'`);
+    expect(migration).toContain(`"provider" = 'statly_modeling'`);
+    expect(migration).toContain(`"scope_key" ~ '^afl-men:[0-9]{4}-trades$'`);
+    expect(migration).toContain(`"scope_key" = 'afl-trade-history:test-fixture'`);
+  });
+
+  it('keys every mutable lifecycle head by scope and trade, including withdrawn heads', () => {
+    const migration = read(migrationPath);
+    const head = migration.slice(
+      migration.indexOf('CREATE TABLE "outcome_local_private_trade_evaluation_head"'),
+      migration.indexOf('CREATE TABLE "outcome_private_evaluation_transition_receipt"')
+    );
+
+    expect(head).toMatch(/PRIMARY KEY \("valuation_scope_key", "trade_id"\)/u);
+    expect(head).not.toMatch(/PRIMARY KEY \("trade_id"\)/u);
+    expect(head).toContain(
+      "CHECK ((status='active' AND generation_id IS NOT NULL) OR (status IN ('withdrawn') AND generation_id IS NULL))"
+    );
+  });
+
+  it('retains an append-only receipt for every CAS transition without a generation cycle', () => {
+    const migration = read(migrationPath);
+    const receiptTable = migration.slice(
+      migration.indexOf('CREATE TABLE "outcome_private_evaluation_transition_receipt"'),
+      migration.indexOf('ALTER TABLE "outcome_local_private_trade_evaluation_head"')
+    );
+
+    expect(migration).toContain('outcome_private_evaluation_transition_receipt');
+    expect(migration).toContain('UNIQUE ("transition_intent_id")');
+    expect(migration).toContain('from_revision');
+    expect(migration).toContain('to_revision');
+    expect(migration).toContain('from_generation_id');
+    expect(migration).toContain('to_generation_id');
+    expect(receiptTable).toContain(
+      `CHECK ("action" IN ('construct_and_activate','withdraw','rollback','recover'))`
+    );
+    expect(migration).toContain('Private evaluation transition receipts are append-only');
+    expect(migration).not.toMatch(
+      /outcome_local_private_trade_evaluation_generation[\s\S]*activation_receipt_id/u
+    );
+  });
+
+  it('records reconstruction verification without mutating lifecycle state', () => {
+    const migration = read(migrationPath);
+    const intentTable = migration.slice(
+      migration.indexOf('CREATE TABLE "outcome_private_evaluation_transition_intent"'),
+      migration.indexOf('CREATE TABLE "outcome_local_private_trade_evaluation_generation"')
+    );
+
+    expect(intentTable).not.toContain('verify_reconstruction');
+    expect(migration).toContain(
+      'CREATE TABLE "outcome_private_evaluation_reconstruction_verification"'
+    );
+    expect(migration).toContain('UNIQUE ("operation_id")');
+    expect(migration).toContain('CHECK ("exact_match"=TRUE)');
+    expect(migration).toContain('Private evaluation reconstruction verifications are append-only');
+  });
+
+  it('keeps the Prisma schema aligned with the composite PostgreSQL authority model', () => {
+    const schema = read('prisma/afl-trade-outcomes/schema.prisma');
+
+    expect(schema).toContain('model OutcomePrivateEvaluationAuthoritySnapshot');
+    expect(schema).toContain('model OutcomePrivateEvaluationInspectionReceipt');
+    expect(schema).toContain('model OutcomePrivateEvaluationTransitionIntent');
+    expect(schema).toContain('model OutcomeLocalPrivateTradeEvaluationGeneration');
+    expect(schema).toContain('model OutcomeLocalPrivateTradeEvaluationHead');
+    expect(schema).toContain('model OutcomePrivateEvaluationTransitionReceipt');
+    expect(schema).toContain('model OutcomePrivateEvaluationReconstructionVerification');
+    expect(schema).toContain('@@id([valuationScopeKey, tradeId])');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-lifecycle.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-lifecycle.test.ts
@@ -1,0 +1,155 @@
+import {
+  createGovernedPrivateEvaluationTransitionIntent,
+  createGovernedPrivateEvaluationTransitionReceipt,
+  governedPrivateEvaluationTransitionIntentSchema,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle';
+
+const selector = {
+  valuationScopeKey: 'afl-trade-history:current',
+  tradeId: 'trade:three-club:1',
+};
+const inspectionId = `private-evaluation-inspection:${'a'.repeat(64)}`;
+const generationOne = `local-private-trade-evaluation-generation:${'b'.repeat(64)}`;
+const generationTwo = `local-private-trade-evaluation-generation:${'c'.repeat(64)}`;
+const authoritySnapshotId = `private-evaluation-authority-snapshot:${'d'.repeat(64)}`;
+const operationId = (character: string) => `private-evaluation-operation:${character.repeat(64)}`;
+const review = {
+  principalId: 'firebase:operator-1',
+  rationale: 'Apply the reviewed private test-fixture lifecycle transition.',
+};
+
+function intent(input: {
+  action:
+    | { kind: 'construct_and_activate' }
+    | { kind: 'withdraw'; reason: string }
+    | { kind: 'rollback'; targetGenerationId: string }
+    | { kind: 'recover' };
+  expectedHead: {
+    status: 'absent' | 'active' | 'withdrawn';
+    revision: number;
+    generationId: string | null;
+  };
+  operationCharacter: string;
+}) {
+  return createGovernedPrivateEvaluationTransitionIntent({
+    selector,
+    inspectionId,
+    authoritySnapshotId:
+      input.action.kind === 'withdraw' ? null : authoritySnapshotId,
+    operationId: operationId(input.operationCharacter),
+    action: input.action,
+    expectedHead: input.expectedHead,
+    review,
+    requestedAt: '2026-08-19T10:00:00.000Z',
+    expiresAt: '2026-08-19T10:05:00.000Z',
+  });
+}
+
+describe('governed private evaluation lifecycle', () => {
+  it('constructs, withdraws, and recovers one exact generation', () => {
+    const activationIntent = intent({
+      action: { kind: 'construct_and_activate' },
+      expectedHead: { status: 'absent', revision: 0, generationId: null },
+      operationCharacter: '1',
+    });
+    const activation = createGovernedPrivateEvaluationTransitionReceipt({
+      intent: activationIntent,
+      previousTransitionId: null,
+      toGenerationId: generationOne,
+      transitionedAt: '2026-08-19T10:01:00.000Z',
+    });
+    expect(activation.content.toHead).toEqual({
+      status: 'active',
+      revision: 1,
+      generationId: generationOne,
+    });
+
+    const withdrawalIntent = intent({
+      action: { kind: 'withdraw', reason: 'Operator safety withdrawal.' },
+      expectedHead: activation.content.toHead,
+      operationCharacter: '2',
+    });
+    const withdrawal = createGovernedPrivateEvaluationTransitionReceipt({
+      intent: withdrawalIntent,
+      previousTransitionId: activation.transitionId,
+      toGenerationId: null,
+      transitionedAt: '2026-08-19T10:02:00.000Z',
+    });
+    expect(withdrawal.content.toHead).toEqual({
+      status: 'withdrawn',
+      revision: 2,
+      generationId: null,
+    });
+
+    const recoveryIntent = intent({
+      action: { kind: 'recover' },
+      expectedHead: withdrawal.content.toHead,
+      operationCharacter: '3',
+    });
+    const recovery = createGovernedPrivateEvaluationTransitionReceipt({
+      intent: recoveryIntent,
+      previousTransitionId: withdrawal.transitionId,
+      toGenerationId: generationOne,
+      transitionedAt: '2026-08-19T10:03:00.000Z',
+    });
+    expect(recovery.content.toHead).toEqual({
+      status: 'active',
+      revision: 3,
+      generationId: generationOne,
+    });
+  });
+
+  it('rolls an active head back to one exact previously active generation', () => {
+    const rollbackIntent = intent({
+      action: { kind: 'rollback', targetGenerationId: generationOne },
+      expectedHead: { status: 'active', revision: 2, generationId: generationTwo },
+      operationCharacter: '4',
+    });
+    const rollback = createGovernedPrivateEvaluationTransitionReceipt({
+      intent: rollbackIntent,
+      previousTransitionId: `private-evaluation-transition:${'e'.repeat(64)}`,
+      toGenerationId: generationOne,
+      transitionedAt: '2026-08-19T10:01:00.000Z',
+    });
+
+    expect(rollback.content.toHead).toEqual({
+      status: 'active',
+      revision: 3,
+      generationId: generationOne,
+    });
+  });
+
+  it('rejects illegal state changes, expiry, and content-address tampering', () => {
+    expect(() =>
+      intent({
+        action: { kind: 'recover' },
+        expectedHead: { status: 'active', revision: 1, generationId: generationOne },
+        operationCharacter: '5',
+      })
+    ).toThrow();
+
+    const withdrawalIntent = intent({
+      action: { kind: 'withdraw', reason: 'Operator safety withdrawal.' },
+      expectedHead: { status: 'active', revision: 1, generationId: generationOne },
+      operationCharacter: '6',
+    });
+    expect(() =>
+      createGovernedPrivateEvaluationTransitionReceipt({
+        intent: withdrawalIntent,
+        previousTransitionId: `private-evaluation-transition:${'f'.repeat(64)}`,
+        toGenerationId: null,
+        transitionedAt: '2026-08-19T10:06:00.000Z',
+      })
+    ).toThrow();
+
+    expect(() =>
+      governedPrivateEvaluationTransitionIntentSchema.parse({
+        ...withdrawalIntent,
+        content: {
+          ...withdrawalIntent.content,
+          selector: { ...selector, tradeId: 'trade:escaped' },
+        },
+      })
+    ).toThrow();
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-materialization-manifest.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-materialization-manifest.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createAflTradeLineageGraphId } from '@/server/aflTradeIntelligence/valuation/valuationCaseContracts';
+import { createGovernedPrivateEvaluationMaterializationManifest } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationMaterializationManifest';
+import { PostgresGovernedPrivateEvaluationMaterializationManifestRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationMaterializationManifestRepository';
+import { createGovernedPrivateEvaluationAuthenticatedCalculationFixture } from '../testUtils/governedPrivateEvaluationAuthenticatedCalculationFixture';
+
+const CREATED_AT = '2026-08-19T10:30:00.000Z';
+
+function input() {
+  const fixture = createGovernedPrivateEvaluationAuthenticatedCalculationFixture();
+  return {
+    schemaVersion: 'private-evaluation-materialization-manifest/v1' as const,
+    environment: 'non_production' as const,
+    selector: fixture.trace.content.selector,
+    calculationInputPackageId: fixture.calculationInputPackage.calculationInputPackageId,
+    calculationInputArtifact: createAflTradeCanonicalJsonArtifactRef(
+      fixture.calculationInputPackage,
+      CREATED_AT
+    ),
+    inputTraceId: fixture.trace.inputTraceId,
+    inputTraceArtifact: createAflTradeCanonicalJsonArtifactRef(fixture.trace, CREATED_AT),
+    explanationPolicyId: fixture.explanationPolicy.policyId,
+    explanationPolicyArtifact: createAflTradeCanonicalJsonArtifactRef(
+      fixture.explanationPolicy,
+      CREATED_AT
+    ),
+    lineageGraphId: createAflTradeLineageGraphId(fixture.lineageGraph),
+    lineageGraphArtifact: createAflTradeCanonicalJsonArtifactRef(
+      fixture.lineageGraph,
+      CREATED_AT
+    ),
+    pickBenchmarks: fixture.pickBenchmarks.map((benchmark) => ({
+      benchmarkId: benchmark.benchmarkId,
+      artifact: createAflTradeCanonicalJsonArtifactRef(benchmark, CREATED_AT),
+    })),
+    playerObservations: [],
+    createdAt: CREATED_AT,
+    publicationEligible: false as const,
+    limitation:
+      'Private materialization inputs only; not model, grade, activation, production, or publication authority.' as const,
+  };
+}
+
+describe('governed private-evaluation materialization manifest', () => {
+  it('exposes registration and exact replay only through the private PostgreSQL repository', () => {
+    const repository = new PostgresGovernedPrivateEvaluationMaterializationManifestRepository({
+      query: async () => ({ rows: [], rowCount: 0 }),
+      transaction: async (work) =>
+        work({ query: async () => ({ rows: [], rowCount: 0 }) }),
+    });
+
+    expect(repository.register).toEqual(expect.any(Function));
+    expect(repository.loadExact).toEqual(expect.any(Function));
+  });
+
+  it('pins every exact parent required to replay one trade calculation and story', () => {
+    const manifest = createGovernedPrivateEvaluationMaterializationManifest(input());
+
+    expect(manifest.manifestId).toMatch(
+      /^private-evaluation-materialization-manifest:[a-f0-9]{64}$/
+    );
+    expect(manifest.content).toMatchObject({
+      environment: 'non_production',
+      selector: {
+        valuationScopeKey: 'afl-men:authenticated-contract-fixture',
+        tradeId: 'trade:authenticated-three-club',
+      },
+      pickBenchmarks: [
+        expect.objectContaining({ benchmarkId: expect.stringMatching(/^pick-pav-benchmark:/) }),
+      ],
+      playerObservations: [],
+      publicationEligible: false,
+    });
+  });
+
+  it('rejects an artifact reused for two distinct retained parents', () => {
+    const value = input();
+    value.explanationPolicyArtifact = value.inputTraceArtifact;
+
+    expect(() => createGovernedPrivateEvaluationMaterializationManifest(value)).toThrow(
+      'Materialization manifest parents require distinct retained bytes.'
+    );
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-materializer.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-materializer.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+
+import { createGovernedPrivateEvaluationInputTrace } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationInputTrace';
+import {
+  materializeGovernedPrivateEvaluation,
+  replayGovernedPrivateEvaluationMaterialization,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationMaterializer';
+import { createAflTradeValuationCalculationInputPackage } from '@/server/aflTradeIntelligence/valuation/valuationCalculationInputPackage';
+import { createGovernedPrivateEvaluationAuthenticatedCalculationFixture } from '../testUtils/governedPrivateEvaluationAuthenticatedCalculationFixture';
+
+describe('governed private-evaluation materializer', () => {
+  it('derives exact calculation stories and club package arithmetic from authenticated evidence', () => {
+    const fixture = createGovernedPrivateEvaluationAuthenticatedCalculationFixture();
+
+    const result = replayGovernedPrivateEvaluationMaterialization({
+      ...fixture,
+      playerObservations: [],
+    });
+
+    expect(result.state).toBe('ready');
+    if (result.state !== 'ready') throw new Error('Expected ready materialization.');
+
+    expect(result.explanation.authority).toMatchObject({
+      kind: 'authenticated_non_production',
+      inputTraceId: fixture.trace.inputTraceId,
+      publicationProhibited: true,
+    });
+    expect(result.narrative.content.assets).toHaveLength(4);
+    expect(result.narrative.content.assets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          assetId: 'asset:01',
+          label: 'Pick 25',
+          story: expect.stringContaining(
+            'estimated from 1 observations across 1 draft classes (picks 25-25)'
+          ),
+          modelEvidence: expect.objectContaining({
+            kind: 'pick',
+            selectionNumber: 25,
+            expected: expect.objectContaining({ contribution: 5.2 }),
+          }),
+          lineage: expect.objectContaining({
+            rootAssetId: 'asset:01',
+            frontierAssetIds: [expect.stringMatching(/^artifact:[a-f0-9]{64}$/)],
+            nodes: expect.arrayContaining([
+              expect.objectContaining({ assetId: 'asset:01', label: 'Pick 25', depth: 0 }),
+              expect.objectContaining({
+                label: 'Player selected with Pick 25',
+                depth: 2,
+              }),
+            ]),
+          }),
+        }),
+      ])
+    );
+
+    const current = result.narrative.content.views.find(({ view }) => view === 'current')!;
+    const alpha = current.clubs.find(({ aflClubId }) => aflClubId === 'club:alpha')!;
+    expect(alpha).toMatchObject({
+      receivedAssetIds: ['asset:03', 'asset:04'],
+      givenUpAssetIds: ['asset:01', 'asset:02'],
+      arithmetic: {
+        receivedMean: 21.3,
+        givenUpMean: 10.8,
+        estimatedAdvantageMean: 10.5,
+      },
+      grade: {
+        grade: null,
+        state: 'unavailable',
+        reasonCode: 'grade_confidence_authority_unavailable',
+      },
+      summary: expect.stringContaining('21.3 - 10.8 = +10.5'),
+    });
+    expect(
+      result.narrative.content.assets.find(({ assetId }) => assetId === 'asset:01')!
+        .contributions
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          view: 'at_trade',
+          story: expect.stringContaining(
+            '5.2 fixed_horizon_pav expected from 1 observations'
+          ),
+        }),
+        expect.objectContaining({
+          view: 'current',
+          story: expect.stringContaining('realized +'),
+        }),
+      ])
+    );
+  });
+
+  it('rejects a valid-looking parent substituted after the retained manifest', () => {
+    const fixture = createGovernedPrivateEvaluationAuthenticatedCalculationFixture();
+    const materializationManifest = {
+      ...fixture.materializationManifest,
+      content: {
+        ...fixture.materializationManifest.content,
+        lineageGraphArtifact:
+          fixture.materializationManifest.content.explanationPolicyArtifact,
+      },
+    };
+
+    expect(() =>
+      replayGovernedPrivateEvaluationMaterialization({
+        ...fixture,
+        materializationManifest,
+        playerObservations: [],
+      })
+    ).toThrow();
+  });
+
+  it('returns explicit unavailability rather than calculating through an unresolved pick', () => {
+    const fixture = createGovernedPrivateEvaluationAuthenticatedCalculationFixture();
+    const trace = createGovernedPrivateEvaluationInputTrace({
+      ...fixture.trace.content,
+      pickLineages: fixture.trace.content.pickLineages.map((lineage, index) =>
+        index === 0 ? { ...lineage, resolvedSelectionNumber: null } : lineage
+      ),
+    });
+    const calculationInputPackage = createAflTradeValuationCalculationInputPackage({
+      ...fixture.calculationInputPackage.content,
+      authority: {
+        kind: 'authenticated_non_production',
+        inputTraceId: trace.inputTraceId,
+        publicationProhibited: true,
+      },
+    });
+
+    const result = materializeGovernedPrivateEvaluation({
+      ...fixture,
+      trace,
+      calculationInputPackage,
+      playerObservations: [],
+    });
+
+    expect(result).toEqual({
+      state: 'unavailable',
+      tradeId: fixture.trace.content.selector.tradeId,
+      blockers: [
+        {
+          code: 'pick_selection_unresolved',
+          assetId: 'asset:01',
+          message: 'Pick 25 has no authenticated resolved selection number.',
+        },
+      ],
+    });
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-recovery-contract.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-recovery-contract.test.ts
@@ -1,0 +1,52 @@
+import { createGovernedPrivateEvaluationWorkspaceForInternalComposition } from '@/server/aflTradeIntelligence/valuation/internal/createGovernedPrivateEvaluationWorkspace';
+
+const selector = {
+  valuationScopeKey: 'afl-trade-history:current',
+  tradeId: 'trade:three-club:1',
+};
+const inspectionId = `private-evaluation-inspection:${'a'.repeat(64)}`;
+const operationId = `private-evaluation-operation:${'b'.repeat(64)}`;
+const generationId = `local-private-trade-evaluation-generation:${'c'.repeat(64)}`;
+
+describe('governed private evaluation recovery contract', () => {
+  it('recovers the retained withdrawn generation without accepting a caller target', async () => {
+    const execute = vi.fn(async () => ({
+      state: 'recovered' as const,
+      selector,
+      inspectionId,
+      operationId,
+      generationId,
+      head: {
+        status: 'active' as const,
+        revision: 3,
+        generationId,
+      },
+    }));
+    const workspace = createGovernedPrivateEvaluationWorkspaceForInternalComposition({
+      inspect: vi.fn(),
+      execute,
+      read: vi.fn(),
+    });
+    const command = {
+      inspectionId,
+      operationId,
+      action: { kind: 'recover' as const },
+      review: { rationale: 'Restore the last withdrawn authenticated generation.' },
+    };
+
+    await expect(workspace.execute(command)).resolves.toMatchObject({
+      state: 'recovered',
+      generationId,
+      head: { status: 'active', revision: 3 },
+    });
+    expect(execute).toHaveBeenCalledWith(command);
+
+    await expect(
+      workspace.execute({
+        ...command,
+        action: { kind: 'recover', targetGenerationId: generationId },
+      } as unknown as typeof command)
+    ).rejects.toThrow();
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-workspace.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-workspace.test.ts
@@ -1,0 +1,306 @@
+import { globSync, readFileSync } from 'node:fs';
+
+import { createAflTradeByteArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createGovernedPrivateEvaluationWorkspaceForInternalComposition } from '@/server/aflTradeIntelligence/valuation/internal/createGovernedPrivateEvaluationWorkspace';
+
+const selector = {
+  valuationScopeKey: 'afl-trade-history:current',
+  tradeId: 'trade:three-club:1',
+};
+
+const inspectionId = `private-evaluation-inspection:${'a'.repeat(64)}`;
+const generationId = `local-private-trade-evaluation-generation:${'b'.repeat(64)}`;
+const operationId = `private-evaluation-operation:${'d'.repeat(64)}`;
+const projectionManifestId = `private-evaluation-projection-manifest:${'e'.repeat(64)}`;
+
+function createWorkspace() {
+  const inspect = vi.fn(async () => ({
+    state: 'unavailable' as const,
+    selector,
+    inspectionId,
+    validThrough: '2026-08-19T10:05:00.000Z',
+    head: { status: 'active' as const, revision: 1, generationId },
+    blockers: [
+      {
+        code: 'model_not_approved' as const,
+        message: 'No admitted model run covers this transaction.',
+      },
+    ],
+  }));
+  const execute = vi.fn(async () => ({
+    state: 'unavailable' as const,
+    selector,
+    inspectionId,
+    operationId,
+    blockers: [
+      {
+        code: 'model_not_approved' as const,
+        message: 'No admitted model run covers this transaction.',
+      },
+    ],
+  }));
+  const read = vi.fn(async (request: {
+    selection: { kind: 'current' | 'generation' };
+    document: { kind: 'archive_summary' | 'detail' | 'reader_api' | 'json_export' };
+  }) => ({
+    state: 'unavailable' as const,
+    selector,
+    selection: request.selection,
+    document: request.document,
+    reason: 'not_found' as const,
+  }));
+
+  return {
+    workspace: createGovernedPrivateEvaluationWorkspaceForInternalComposition({
+      inspect,
+      execute,
+      read,
+    }),
+    adapters: { inspect, execute, read },
+  };
+}
+
+describe('GovernedPrivateEvaluationWorkspace', () => {
+  it('exposes only inspect, execute, and read', () => {
+    const { workspace } = createWorkspace();
+
+    expect(Object.keys(workspace).sort()).toEqual(['execute', 'inspect', 'read']);
+  });
+
+  it('keeps the internal composition constructor out of production imports', () => {
+    const permitted = new Set([
+      'src/server/aflTradeIntelligence/valuation/governedPrivateEvaluationWorkspace.ts',
+    ]);
+    const offenders = globSync('src/**/*.{ts,tsx}')
+      .filter((path) => !path.includes('/valuation/internal/') && !permitted.has(path))
+      .filter((path) =>
+        readFileSync(path, 'utf8').includes('valuation/internal/createGovernedPrivateEvaluationWorkspace')
+      );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('inspects one composite valuation-scope and trade selector', async () => {
+    const { workspace, adapters } = createWorkspace();
+
+    await expect(workspace.inspect(selector)).resolves.toMatchObject({
+      state: 'unavailable',
+      selector,
+      inspectionId,
+      validThrough: '2026-08-19T10:05:00.000Z',
+      head: { status: 'active', revision: 1, generationId },
+      blockers: [{ code: 'model_not_approved' }],
+    });
+    expect(adapters.inspect).toHaveBeenCalledWith(selector);
+
+    await expect(
+      workspace.inspect({
+        valuationScopeKey: selector.valuationScopeKey,
+        tradeId: '',
+      })
+    ).rejects.toThrow();
+
+    adapters.inspect.mockResolvedValueOnce({
+      state: 'ready',
+      selector,
+      inspectionId,
+      validThrough: '2026-08-19T10:00:00.000Z',
+      head: { status: 'active', revision: 0, generationId },
+      blockers: [],
+    });
+    await expect(workspace.inspect(selector)).rejects.toThrow();
+  });
+
+  it('executes only a retained inspection and stable operation identifier', async () => {
+    const { workspace, adapters } = createWorkspace();
+    const command = {
+      inspectionId,
+      operationId,
+      action: { kind: 'construct_and_activate' as const },
+      review: {
+        rationale: 'Activate the reviewed calculation generation.',
+      },
+    };
+
+    await expect(workspace.execute(command)).resolves.toMatchObject({
+      state: 'unavailable',
+      selector,
+      inspectionId,
+      operationId: command.operationId,
+    });
+    expect(adapters.execute).toHaveBeenCalledWith(command);
+
+    await expect(
+      workspace.execute({
+        ...command,
+        authority: { publicationEligible: true },
+      } as unknown as typeof command)
+    ).rejects.toThrow();
+    await expect(
+      workspace.execute({
+        ...command,
+        assets: [],
+      } as unknown as typeof command)
+    ).rejects.toThrow();
+    await expect(
+      workspace.execute({
+        ...command,
+        principalId: 'operator:robert',
+      } as unknown as typeof command)
+    ).rejects.toThrow();
+    await expect(
+      workspace.execute({
+        ...command,
+        requestedAt: '2026-08-19T10:00:00.000Z',
+      } as unknown as typeof command)
+    ).rejects.toThrow();
+    await expect(
+      workspace.execute({
+        ...command,
+        grade: 'A+',
+      } as unknown as typeof command)
+    ).rejects.toThrow();
+    expect(adapters.execute).toHaveBeenCalledTimes(1);
+
+    adapters.execute.mockResolvedValueOnce({
+      state: 'unavailable',
+      selector,
+      inspectionId: `private-evaluation-inspection:${'c'.repeat(64)}`,
+      operationId: command.operationId,
+      blockers: [
+        {
+          code: 'model_not_approved',
+          message: 'No admitted model run covers this transaction.',
+        },
+      ],
+    });
+    await expect(workspace.execute(command)).rejects.toThrow('escaped its inspection');
+  });
+
+  it('reads only current or one explicit generation and rejects selector escape', async () => {
+    const { workspace, adapters } = createWorkspace();
+
+    await expect(
+      workspace.read({
+        selector,
+        selection: { kind: 'current' },
+        document: { kind: 'archive_summary' },
+      })
+    ).resolves.toMatchObject({
+      state: 'unavailable',
+      selector,
+      selection: { kind: 'current' },
+      document: { kind: 'archive_summary' },
+    });
+    await expect(
+      workspace.read({
+        selector,
+        selection: { kind: 'generation', generationId },
+        document: { kind: 'detail' },
+      })
+    ).resolves.toMatchObject({
+      state: 'unavailable',
+      selector,
+      selection: { kind: 'generation', generationId },
+      document: { kind: 'detail' },
+    });
+    expect(adapters.read).toHaveBeenCalledTimes(2);
+
+    const bytes = new TextEncoder().encode('{"retained":true}\n');
+    adapters.read.mockResolvedValueOnce({
+      state: 'available',
+      selector,
+      selection: { kind: 'current' },
+      generationId,
+      projectionManifestId,
+      lifecycle: { status: 'active', current: true },
+      document: {
+        kind: 'json_export',
+        artifact: createAflTradeByteArtifactRef(
+          bytes,
+          'application/json',
+          '2026-08-19T10:00:00.000Z'
+        ),
+      },
+      bytes,
+    });
+    await expect(
+      workspace.read({
+        selector,
+        selection: { kind: 'current' },
+        document: { kind: 'json_export' },
+      })
+    ).resolves.toMatchObject({
+      state: 'available',
+      generationId,
+      projectionManifestId,
+      lifecycle: { status: 'active', current: true },
+      document: { kind: 'json_export' },
+    });
+
+    adapters.read.mockResolvedValueOnce({
+      state: 'unavailable',
+      selector: { ...selector, tradeId: 'trade:escaped' },
+      selection: { kind: 'current' },
+      document: { kind: 'detail' },
+      reason: 'not_found',
+    });
+    await expect(
+      workspace.read({
+        selector,
+        selection: { kind: 'current' },
+        document: { kind: 'detail' },
+      })
+    ).rejects.toThrow('escaped its selector');
+
+    adapters.read.mockResolvedValueOnce({
+      state: 'available',
+      selector,
+      selection: { kind: 'generation', generationId },
+      generationId,
+      projectionManifestId,
+      lifecycle: { status: 'active', current: true },
+      document: {
+        kind: 'archive_summary',
+        artifact: createAflTradeByteArtifactRef(
+          bytes,
+          'application/json',
+          '2026-08-19T10:00:00.000Z'
+        ),
+      },
+      bytes,
+    });
+    await expect(
+      workspace.read({
+        selector,
+        selection: { kind: 'generation', generationId },
+        document: { kind: 'detail' },
+      })
+    ).rejects.toThrow('escaped its document selection');
+
+    adapters.read.mockResolvedValueOnce({
+      state: 'available',
+      selector,
+      selection: { kind: 'current' },
+      generationId,
+      projectionManifestId,
+      lifecycle: { status: 'active', current: true },
+      document: {
+        kind: 'json_export',
+        artifact: createAflTradeByteArtifactRef(
+          bytes,
+          'application/json',
+          '2026-08-19T10:00:00.000Z'
+        ),
+      },
+      bytes: new TextEncoder().encode('{"retained":false}\n'),
+    });
+    await expect(
+      workspace.read({
+        selector,
+        selection: { kind: 'current' },
+        document: { kind: 'json_export' },
+      })
+    ).rejects.toThrow('returned unauthenticated bytes');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-ready-component-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-ready-component-authority.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { aflTradeGateDecisionRecordSchema } from '@/server/aflTradeIntelligence/governance/gateDecisionTypes';
+import { authenticateGovernedReadyComponentAuthority } from '@/server/aflTradeIntelligence/valuation/internal/governedReadyComponentAuthority';
+import { createGovernedValuationComponentRunManifest } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest';
+
+const capturedAt = '2026-08-20T10:00:00.000Z';
+const createdAt = '2026-08-20T09:00:00.000Z';
+
+function artifact(label: string) {
+  const contentSha256 = createAflTradeContentAddress('artifact', label).split(':')[1]!;
+  return {
+    artifactId: `artifact:${contentSha256}`,
+    contentSha256,
+    storageUri: `artifact://sha256/${contentSha256}`,
+    mediaType: 'application/json',
+    byteLength: 128,
+    createdAt,
+  };
+}
+
+function fixture() {
+  const protocolId = createAflTradeContentAddress('model-protocol', { fixture: 'player' });
+  const datasetId = createAflTradeContentAddress('dataset', { fixture: 'player' });
+  const datasetAdmissionId = createAflTradeContentAddress('dataset-admission', {
+    fixture: 'player',
+  });
+  const run = createGovernedValuationComponentRunManifest({
+    environment: 'non_production',
+    role: 'player_contribution_and_availability',
+    nativeExecution: {
+      kind: 'admitted_player_model_run',
+      executionId: createAflTradeContentAddress('model-run', { fixture: 'native-player' }),
+      artifact: artifact('native-player'),
+    },
+    protocolId,
+    protocolArtifact: artifact('player-protocol'),
+    datasetId,
+    datasetArtifact: artifact('player-dataset'),
+    datasetAdmissionId,
+    datasetAdmissionArtifact: artifact('player-admission'),
+    datasetAdmissionGateLedgerRevision: 11,
+    registeredAt: createdAt,
+  });
+  const runArtifact = createAflTradeCanonicalJsonArtifactRef(run, createdAt);
+  const decisionContent = {
+    schemaVersion: 'afl-trade-gate-decision/v1' as const,
+    proposalId: createAflTradeContentAddress('gate-proposal', { fixture: 'player-gate3' }),
+    gate: 'gate_3_model_validity' as const,
+    decisionKey: 'private-player-component-run-v1',
+    version: 2,
+    environment: 'non_production' as const,
+    scope: {
+      scopeKey: 'afl-men:2025-trades',
+      description: 'Player component model validity.',
+      dimensions: [],
+      exclusions: [],
+    },
+    state: 'approved' as const,
+    authorityKind: 'external_human_record' as const,
+    accountableOwner: 'statly-model-owner',
+    decidedBy: 'statly-independent-reviewer',
+    reviewers: [],
+    authorityEvidenceIds: [artifact('review-evidence').artifactId],
+    conditionResults: [],
+    rationale: 'Independent review accepted this exact component envelope.',
+    limitations: ['Private non-production calculation only.'],
+    decidedAt: '2026-08-20T09:10:00.000Z',
+    effectiveAt: '2026-08-20T09:15:00.000Z',
+    revalidateAt: '2026-09-20T09:15:00.000Z',
+    supersedesDecisionId: null,
+    affectedArtifacts: [{ kind: 'model_run' as const, artifactId: run.runId }],
+    withdrawalActions: [],
+  };
+  const gate3Decision = aflTradeGateDecisionRecordSchema.parse({
+    decisionId: createAflTradeContentAddress('gate-decision', decisionContent),
+    content: decisionContent,
+  });
+  return {
+    run: { manifest: run, artifact: runArtifact },
+    traceComponent: {
+      role: run.content.role,
+      runId: run.runId,
+      protocolId,
+      datasetId,
+      datasetAdmissionId,
+      gate3DecisionId: gate3Decision.decisionId,
+      evidence: {
+        runManifest: runArtifact,
+        protocol: run.content.protocolArtifact,
+        datasetAdmission: run.content.datasetAdmissionArtifact,
+        gate3Decision: createAflTradeCanonicalJsonArtifactRef(
+          gate3Decision,
+          gate3Decision.content.decidedAt!
+        ),
+      },
+    },
+    gate3Decision,
+  };
+}
+
+function replaceDecision(
+  value: ReturnType<typeof fixture>,
+  content: typeof value.gate3Decision.content
+) {
+  const gate3Decision = aflTradeGateDecisionRecordSchema.parse({
+    decisionId: createAflTradeContentAddress('gate-decision', content),
+    content,
+  });
+  const gate3DecisionArtifact = createAflTradeCanonicalJsonArtifactRef(
+    gate3Decision,
+    gate3Decision.content.decidedAt!
+  );
+  return {
+    ...value,
+    traceComponent: {
+      ...value.traceComponent,
+      gate3DecisionId: gate3Decision.decisionId,
+      evidence: { ...value.traceComponent.evidence, gate3Decision: gate3DecisionArtifact },
+    },
+    gate3Decision,
+    gate3DecisionArtifact,
+  };
+}
+
+describe('governed ready component authority', () => {
+  it('returns only exact current externally reviewed Gate 3 authority', () => {
+    const value = fixture();
+    expect(
+      authenticateGovernedReadyComponentAuthority({
+        ...value,
+        gate3DecisionArtifact: value.traceComponent.evidence.gate3Decision,
+        gate3IsCurrent: true,
+        gateLedgerRevision: 19,
+        capturedAt,
+      })
+    ).toEqual({
+      role: value.traceComponent.role,
+      runId: value.traceComponent.runId,
+      protocolId: value.traceComponent.protocolId,
+      datasetId: value.traceComponent.datasetId,
+      datasetAdmissionId: value.traceComponent.datasetAdmissionId,
+      datasetAdmissionGateLedgerRevision: 11,
+      gate3DecisionId: value.gate3Decision.decisionId,
+      gate3DecisionVersion: 2,
+    });
+  });
+
+  it('rejects superseded, expired, and fixture-only review authority', () => {
+    const value = fixture();
+    const common = {
+      ...value,
+      gate3DecisionArtifact: value.traceComponent.evidence.gate3Decision,
+      gateLedgerRevision: 19,
+      capturedAt,
+    };
+    expect(() =>
+      authenticateGovernedReadyComponentAuthority({ ...common, gate3IsCurrent: false })
+    ).toThrow(/current/i);
+
+    const expired = replaceDecision(value, {
+      ...value.gate3Decision.content,
+      revalidateAt: capturedAt,
+    });
+    expect(() =>
+      authenticateGovernedReadyComponentAuthority({
+        ...common,
+        ...expired,
+        gate3IsCurrent: true,
+      })
+    ).toThrow(/current|revalidation/i);
+
+    const fixtureOnly = replaceDecision(value, {
+      ...value.gate3Decision.content,
+      authorityKind: 'fixture',
+    });
+    expect(() =>
+      authenticateGovernedReadyComponentAuthority({
+        ...common,
+        ...fixtureOnly,
+        gate3IsCurrent: true,
+      })
+    ).toThrow(/external human/i);
+  });
+
+  it('rejects a legacy pick fixture wrapper even when a Gate 3 record names it', () => {
+    const value = fixture();
+    const legacyPickRun = createGovernedValuationComponentRunManifest({
+      ...value.run.manifest.content,
+      role: 'draft_pick_and_future_pick_distribution',
+      nativeExecution: {
+        kind: 'pick_pav_model_execution',
+        executionId: createAflTradeContentAddress('pick-pav-model-execution', {
+          fixture: 'legacy-pick',
+        }),
+        artifact: artifact('legacy-pick'),
+      },
+    });
+    const runArtifact = createAflTradeCanonicalJsonArtifactRef(legacyPickRun, createdAt);
+    const replaced = replaceDecision(value, {
+      ...value.gate3Decision.content,
+      affectedArtifacts: [{ kind: 'model_run', artifactId: legacyPickRun.runId }],
+    });
+
+    expect(() =>
+      authenticateGovernedReadyComponentAuthority({
+        traceComponent: {
+          role: legacyPickRun.content.role,
+          runId: legacyPickRun.runId,
+          protocolId: legacyPickRun.content.protocolId,
+          datasetId: legacyPickRun.content.datasetId,
+          datasetAdmissionId: legacyPickRun.content.datasetAdmissionId,
+          gate3DecisionId: replaced.gate3Decision.decisionId,
+          evidence: {
+            runManifest: runArtifact,
+            protocol: legacyPickRun.content.protocolArtifact,
+            datasetAdmission: legacyPickRun.content.datasetAdmissionArtifact,
+            gate3Decision: replaced.gate3DecisionArtifact,
+          },
+        },
+        run: { manifest: legacyPickRun, artifact: runArtifact },
+        gate3Decision: replaced.gate3Decision,
+        gate3DecisionArtifact: replaced.gate3DecisionArtifact,
+        gate3IsCurrent: true,
+        gateLedgerRevision: 19,
+        capturedAt,
+      })
+    ).toThrow(/governed|fixture|eligible/i);
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-valuation-component-run-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-valuation-component-run-migration.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const migrationPath =
+  'prisma/afl-trade-outcomes/migrations/0061_governed_valuation_component_runs/migration.sql';
+
+function migration(): string {
+  return readFileSync(join(process.cwd(), migrationPath), 'utf8');
+}
+
+describe('governed valuation component-run migration', () => {
+  it('adds one forward append-only component-run registry', () => {
+    expect(existsSync(join(process.cwd(), migrationPath))).toBe(true);
+    const sql = migration();
+
+    expect(sql).toContain('CREATE TABLE "outcome_governed_valuation_component_run"');
+    expect(sql).toContain('"run_id" TEXT NOT NULL');
+    expect(sql).toContain('"native_execution_kind" TEXT NOT NULL');
+    expect(sql).toContain('"native_execution_id" TEXT NOT NULL');
+    expect(sql).toContain('"artifact_id" TEXT NOT NULL');
+    expect(sql).toContain('"manifest_json" JSONB NOT NULL');
+    expect(sql).toContain('REFERENCES "outcome_artifact_custody"("artifact_id")');
+    expect(sql).toContain('Governed valuation component runs are append-only');
+  });
+
+  it('enforces role-specific native execution identities and immutable ancestry', () => {
+    const sql = migration();
+
+    expect(sql).toContain("'player_contribution_and_availability'");
+    expect(sql).toContain("'draft_pick_and_future_pick_distribution'");
+    expect(sql).toContain("'admitted_player_model_run'");
+    expect(sql).toContain("'pick_pav_model_execution'");
+    expect(sql).toContain("'^model-run:[a-f0-9]{64}$'");
+    expect(sql).toContain("'^pick-pav-model-execution:[a-f0-9]{64}$'");
+    expect(sql).toContain('UNIQUE ("native_execution_kind", "native_execution_id")');
+    expect(sql).toContain('"dataset_admission_gate_ledger_revision" INTEGER NOT NULL');
+    expect(sql).toContain('"content_canonical_json" TEXT NOT NULL');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-valuation-component-run.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-valuation-component-run.test.ts
@@ -1,0 +1,120 @@
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import {
+  authenticateGovernedValuationComponentRunManifest,
+  createGovernedValuationComponentRunManifest,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest';
+
+const registeredAt = '2026-08-20T10:00:00.000Z';
+const retainedAt = '2026-08-20T09:00:00.000Z';
+const id = (kind: string, marker: string) => `${kind}:${marker.repeat(64)}`;
+const artifact = (label: string) =>
+  createAflTradeCanonicalJsonArtifactRef({ label }, retainedAt);
+
+function common() {
+  return {
+    environment: 'non_production' as const,
+    protocolId: id('model-protocol', '1'),
+    protocolArtifact: artifact('protocol'),
+    datasetId: id('dataset', '2'),
+    datasetArtifact: artifact('dataset'),
+    datasetAdmissionId: id('dataset-admission', '3'),
+    datasetAdmissionArtifact: artifact('dataset-admission'),
+    datasetAdmissionGateLedgerRevision: 12,
+    registeredAt,
+  };
+}
+
+describe('governed valuation component run manifest', () => {
+  it('normalizes admitted player and pick executions without granting Gate 3', () => {
+    const player = createGovernedValuationComponentRunManifest({
+      ...common(),
+      role: 'player_contribution_and_availability',
+      nativeExecution: {
+        kind: 'admitted_player_model_run',
+        executionId: id('model-run', '4'),
+        artifact: artifact('player-run'),
+      },
+    });
+    const pick = createGovernedValuationComponentRunManifest({
+      ...common(),
+      role: 'draft_pick_and_future_pick_distribution',
+      nativeExecution: {
+        kind: 'governed_pick_pav_model_execution',
+        executionId: id('pick-pav-model-execution', '5'),
+        artifact: artifact('pick-run'),
+      },
+    });
+
+    for (const manifest of [player, pick]) {
+      expect(manifest.runId).toMatch(/^model-run:[a-f0-9]{64}$/);
+      expect(manifest.content).toMatchObject({
+        schemaVersion: 'governed-valuation-component-run/v1',
+        environment: 'non_production',
+        approvalState: 'gate_3_review_required',
+        publicationEligible: false,
+      });
+      expect(authenticateGovernedValuationComponentRunManifest(manifest)).toEqual(manifest);
+    }
+    expect(player.content.nativeExecution.kind).toBe('admitted_player_model_run');
+    expect(pick.content.nativeExecution.kind).toBe('governed_pick_pav_model_execution');
+  });
+
+  it('rejects role substitution and duplicate retained evidence', () => {
+    expect(() =>
+      createGovernedValuationComponentRunManifest({
+        ...common(),
+        role: 'draft_pick_and_future_pick_distribution',
+        nativeExecution: {
+          kind: 'admitted_player_model_run',
+          executionId: id('model-run', '4'),
+          artifact: artifact('player-run'),
+        },
+      })
+    ).toThrow(/role|execution/i);
+
+    const duplicate = common();
+    duplicate.datasetAdmissionArtifact = duplicate.datasetArtifact;
+    expect(() =>
+      createGovernedValuationComponentRunManifest({
+        ...duplicate,
+        role: 'player_contribution_and_availability',
+        nativeExecution: {
+          kind: 'admitted_player_model_run',
+          executionId: id('model-run', '4'),
+          artifact: artifact('player-run'),
+        },
+      })
+    ).toThrow(/distinct|artifact|evidence/i);
+  });
+
+  it('rejects future evidence and changed content under a retained run identity', () => {
+    const manifest = createGovernedValuationComponentRunManifest({
+      ...common(),
+      role: 'draft_pick_and_future_pick_distribution',
+      nativeExecution: {
+        kind: 'governed_pick_pav_model_execution',
+        executionId: id('pick-pav-model-execution', '5'),
+        artifact: artifact('pick-run'),
+      },
+    });
+    const tampered = structuredClone(manifest);
+    tampered.content.datasetAdmissionGateLedgerRevision = 13;
+    expect(() => authenticateGovernedValuationComponentRunManifest(tampered)).toThrow();
+
+    expect(() =>
+      createGovernedValuationComponentRunManifest({
+        ...common(),
+        protocolArtifact: createAflTradeCanonicalJsonArtifactRef(
+          { label: 'future-protocol' },
+          '2026-08-20T11:00:00.000Z'
+        ),
+        role: 'draft_pick_and_future_pick_distribution',
+        nativeExecution: {
+          kind: 'governed_pick_pav_model_execution',
+          executionId: id('pick-pav-model-execution', '5'),
+          artifact: artifact('pick-run'),
+        },
+      })
+    ).toThrow(/before|future|registered/i);
+  });
+});

--- a/tests/unit/afl-trade-intelligence-pick-pav-distribution-benchmark.test.ts
+++ b/tests/unit/afl-trade-intelligence-pick-pav-distribution-benchmark.test.ts
@@ -8,6 +8,7 @@ import {
   fitAflTradePickPavDistributionBenchmark,
 } from '@/server/aflTradeIntelligence/modeling/pickPavDistributionBenchmark';
 import { materializeAflTradePickPavObservationSet } from '@/server/aflTradeIntelligence/modeling/pickPavObservationService';
+import { deriveAflTradePickCalculationEvidence } from '@/server/aflTradeIntelligence/valuation/calculationNarrativeEvidence';
 
 const sha = (value: string) => createHash('sha256').update(value).digest('hex');
 const addressed = (prefix: string, value: string) => `${prefix}:${sha(value)}`;
@@ -205,6 +206,54 @@ describe('exact-pick PAV distribution benchmark', () => {
 
     expect(() => aflTradePickPavDistributionBenchmarkSchema.parse(tampered)).toThrow(
       /exact fitted empirical distribution|content-address/i
+    );
+  });
+
+  it('derives the complete pick-value story from the authenticated empirical cohort', () => {
+    const benchmark = fitAflTradePickPavDistributionBenchmark(observationSet(), config);
+    const pick14 = benchmark.content.selectionCurve.find(
+      ({ selectionNumber }) => selectionNumber === 14
+    )!;
+    const cohort = benchmark.content.distributionBlocks[pick14.distributionBlockIndex]!;
+
+    expect(deriveAflTradePickCalculationEvidence(benchmark, 14)).toEqual({
+      kind: 'pick',
+      benchmarkId: benchmark.benchmarkId,
+      observationSetId: benchmark.content.observationSetId,
+      policyId: benchmark.content.policyId,
+      methodId: benchmark.content.methodId,
+      valueUnit: 'fixed_horizon_pav',
+      selectionNumber: 14,
+      cohort: {
+        minimumSelectionNumber: 14,
+        maximumSelectionNumber: 14,
+        observationCount: 2,
+        draftClassCount: 2,
+        sourceSelectionNumbers: [14],
+      },
+      expected: {
+        contribution: 70,
+        games: 10,
+      },
+      centralRange: {
+        contribution: { p10: 60, p50: 60, p90: 80 },
+        games: { p10: 10, p50: 10, p90: 10 },
+      },
+      outcomeProbabilities: cohort.distribution.outcomeProbabilities,
+      empiricalSupportObservationIds: cohort.empiricalSupport.map(
+        ({ observationId }) => observationId
+      ),
+      fixedHorizonSeasons: 1,
+      limitation:
+        'Training-only mature national-draft benchmark; active careers and held-out cohorts are excluded, not treated as zero.',
+    });
+  });
+
+  it('does not invent a cohort for a pick outside the authenticated model support', () => {
+    const benchmark = fitAflTradePickPavDistributionBenchmark(observationSet(), config);
+
+    expect(() => deriveAflTradePickCalculationEvidence(benchmark, 30)).toThrow(
+      /outside the authenticated pick-model support/i
     );
   });
 });

--- a/tests/unit/afl-trade-intelligence-player-pav-observation-contracts.test.ts
+++ b/tests/unit/afl-trade-intelligence-player-pav-observation-contracts.test.ts
@@ -8,6 +8,7 @@ import {
   createAflTradePlayerPavPolicy,
   type AflTradePlayerPavObservation,
 } from '@/server/aflTradeIntelligence/modeling/playerPavObservationContracts';
+import { deriveAflTradePlayerCalculationEvidence } from '@/server/aflTradeIntelligence/valuation/calculationNarrativeEvidence';
 
 const digest = (marker: string) => marker.repeat(64);
 const calculationId = (seasonYear: number) =>
@@ -197,6 +198,69 @@ describe('player PAV observation contracts', () => {
     });
 
     expect(result.outcome.state).toBe('right_censored');
+    expect(deriveAflTradePlayerCalculationEvidence(result)).toMatchObject({
+      state: 'right_censored',
+      evidenceCutoffAt: '2018-01-01T00:00:00.000Z',
+      horizon: {
+        requiredSeasons: [2017, 2018, 2019],
+        observedSeasons: [2017],
+      },
+      totals: {
+        gamesPlayed: 2,
+        contribution: targetValues[0]!.totalPav,
+        contributionPerGame: targetValues[0]!.totalPav / 2,
+      },
+    });
+  });
+
+  it('derives the player-value story from exact receiving-club seasons and games', () => {
+    const player = observation(1, 'train', 2001);
+
+    expect(deriveAflTradePlayerCalculationEvidence(player)).toMatchObject({
+      kind: 'player',
+      state: 'mature_observed',
+      observationId: player.observationId,
+      releaseId: player.releaseId,
+      playerId: 'afl-player:fixture',
+      acquisitionSpell: player.acquisitionSpell,
+      predictionSeason: 2001,
+      evidenceCutoffAt: '2005-01-01T00:00:00.000Z',
+      horizon: {
+        requiredSeasons: [2002, 2003, 2004],
+        observedSeasons: [2002, 2003, 2004],
+      },
+      seasons: [
+        {
+          seasonYear: 2002,
+          gamesPlayed: 2,
+          contribution: 21,
+          contributionPerGame: 10.5,
+          calculationId: calculationId(2002),
+          sourceObservationIds: ['provider-row:2002:1', 'provider-row:2002:2'],
+        },
+        {
+          seasonYear: 2003,
+          gamesPlayed: 2,
+          contribution: 24,
+          contributionPerGame: 12,
+          calculationId: calculationId(2003),
+          sourceObservationIds: ['provider-row:2003:1', 'provider-row:2003:2'],
+        },
+        {
+          seasonYear: 2004,
+          gamesPlayed: 2,
+          contribution: 27,
+          contributionPerGame: 13.5,
+          calculationId: calculationId(2004),
+          sourceObservationIds: ['provider-row:2004:1', 'provider-row:2004:2'],
+        },
+      ],
+      totals: {
+        gamesPlayed: 6,
+        contribution: 72,
+        contributionPerGame: 12,
+      },
+    });
   });
 
   it('separates historical football availability from later calculation custody', () => {
@@ -273,6 +337,12 @@ describe('player PAV observation contracts', () => {
     expect(result.outcome).toEqual({
       state: 'unavailable',
       reason: 'feature_history_incomplete',
+    });
+    expect(deriveAflTradePlayerCalculationEvidence(result)).toMatchObject({
+      state: 'unavailable',
+      reason: 'feature_history_incomplete',
+      seasons: [],
+      totals: null,
     });
   });
 });

--- a/tests/unit/afl-trade-intelligence-postgres-governed-calculation-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-calculation-authority.test.ts
@@ -1,0 +1,332 @@
+import { createAflTradeFixtureArtifactRepository } from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import {
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import type {
+  AflOutcomeSqlQueryResult,
+  AflOutcomeSqlTransaction,
+} from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationCalculationAuthority';
+import { createAflTradePreparedValuationInputSet } from '@/server/aflTradeIntelligence/valuation/preparedValuationInputSet';
+
+import { createGovernedPrivateEvaluationAuthenticatedCalculationFixture } from '../testUtils/governedPrivateEvaluationAuthenticatedCalculationFixture';
+
+class NoPreparedAuthorityTransaction implements AflOutcomeSqlTransaction {
+  readonly calls: { sql: string; parameters: readonly unknown[] }[] = [];
+
+  async query<Row>(
+    sql: string,
+    parameters: readonly unknown[] = []
+  ): Promise<AflOutcomeSqlQueryResult<Row>> {
+    this.calls.push({ sql, parameters });
+    if (sql.includes('FROM outcome_current_prepared_valuation_input_set')) {
+      return { rows: [], rowCount: 0 };
+    }
+    throw new Error(`Unexpected SQL: ${sql}`);
+  }
+}
+
+function readyPreparedFixture() {
+  const calculation = createGovernedPrivateEvaluationAuthenticatedCalculationFixture();
+  const createdAt = '2026-08-19T11:00:00.000Z';
+  const evidence = (label: string) =>
+    createAflTradeCanonicalJsonArtifactRef({ fixture: label }, '2026-08-19T08:00:00.000Z');
+  const prepared = createAflTradePreparedValuationInputSet({
+    schemaVersion: 'afl-trade-prepared-valuation-input-set/v3',
+    environment: 'non_production',
+    scopeKey: calculation.trace.content.selector.valuationScopeKey,
+    factualReleaseScopeKey: 'public-afl-draft-trade-outcomes',
+    factualReleaseId: calculation.trace.content.factualReleaseId,
+    factualReleaseArtifact: evidence('release'),
+    releaseMembershipArtifact: evidence('membership'),
+    preparationAuthority: 'authenticated_calculation_evidence_snapshot',
+    qualificationOperation: 'valuation_model_training_and_derived_feature_creation',
+    qualificationReportId: createAflTradeContentAddress('valuation-source-qualification', {
+      fixture: 'qualification',
+    }),
+    qualificationReportArtifact: evidence('qualification'),
+    sourceQualificationEvidenceRefs: [evidence('source')],
+    valuationInputBundleId: calculation.trace.content.valuationInputBundleId,
+    valuationInputBundleArtifact: evidence('valuation-input-bundle'),
+    releaseTradeIds: [calculation.trace.content.selector.tradeId],
+    entries: [
+      {
+        tradeId: calculation.trace.content.selector.tradeId,
+        state: 'ready',
+        materializationManifestId: calculation.materializationManifest.manifestId,
+        materializationManifestArtifact: createAflTradeCanonicalJsonArtifactRef(
+          calculation.materializationManifest,
+          calculation.materializationManifest.content.createdAt
+        ),
+      },
+    ],
+    tradeCount: 1,
+    readyCount: 1,
+    blockedCount: 0,
+    preparedAt: createdAt,
+    publicationEligible: false,
+    limitation:
+      'Private preparation evidence only; not a valuation result, publication approval, or activation authority.',
+  });
+  return { calculation, prepared };
+}
+
+class ReadyPreparedAuthorityTransaction implements AflOutcomeSqlTransaction {
+  readonly calls: { sql: string; parameters: readonly unknown[] }[] = [];
+  readonly fixture = readyPreparedFixture();
+
+  constructor(private readonly retainManifestRow = false) {}
+
+  async query<Row>(
+    sql: string,
+    parameters: readonly unknown[] = []
+  ): Promise<AflOutcomeSqlQueryResult<Row>> {
+    this.calls.push({ sql, parameters });
+    const { prepared } = this.fixture;
+    if (sql.includes('FROM outcome_current_prepared_valuation_input_set')) {
+      return {
+        rows: [
+          {
+            scope_key: prepared.content.scopeKey,
+            prepared_input_set_id: prepared.preparedInputSetId,
+            revision: 3,
+            activated_at: prepared.content.preparedAt,
+          },
+        ] as Row[],
+        rowCount: 1,
+      };
+    }
+    if (sql.includes('FROM outcome_prepared_valuation_input_set prepared')) {
+      return {
+        rows: [
+          {
+            content_sha256: prepared.preparedInputSetId.split(':')[1],
+            schema_version: prepared.content.schemaVersion,
+            environment: prepared.content.environment,
+            scope_key: prepared.content.scopeKey,
+            factual_release_scope_key: prepared.content.factualReleaseScopeKey,
+            factual_release_id: prepared.content.factualReleaseId,
+            qualification_report_id: prepared.content.qualificationReportId,
+            prepared_at: prepared.content.preparedAt,
+            prepared_set_json: prepared,
+            content_canonical_json: canonicalizeAflTradeJson(prepared.content),
+            prepared_set_canonical_json: canonicalizeAflTradeJson(prepared),
+            finalized_at: prepared.content.preparedAt,
+            trade_count: 1,
+            ready_count: 1,
+            blocked_count: 0,
+            actual_count: 1,
+            actual_ready_count: 1,
+            actual_blocked_count: 0,
+          },
+        ] as Row[],
+        rowCount: 1,
+      };
+    }
+    if (sql.includes('FROM outcome_prepared_valuation_input_entry')) {
+      const entry = prepared.content.entries[0]!;
+      return {
+        rows: [
+          {
+            ordinal: 1,
+            trade_id: entry.tradeId,
+            state: entry.state,
+            entry_canonical_json: canonicalizeAflTradeJson(entry),
+            entry_json: entry,
+          },
+        ] as Row[],
+        rowCount: 1,
+      };
+    }
+    if (sql.includes('FROM outcome_private_evaluation_materialization_manifest')) {
+      if (this.retainManifestRow) {
+        const manifest = this.fixture.calculation.materializationManifest;
+        const artifact = prepared.content.entries[0]!.state === 'ready'
+          ? prepared.content.entries[0]!.materializationManifestArtifact
+          : undefined;
+        if (artifact === undefined) throw new Error('Expected ready manifest artifact.');
+        return {
+          rows: [
+            {
+              materialization_manifest_id: manifest.manifestId,
+              content_sha256: manifest.manifestId.split(':')[1],
+              valuation_scope_key: manifest.content.selector.valuationScopeKey,
+              trade_id: manifest.content.selector.tradeId,
+              created_at: manifest.content.createdAt,
+              content_canonical_json: canonicalizeAflTradeJson(manifest.content),
+              manifest_canonical_json: canonicalizeAflTradeJson(manifest),
+              manifest_json: manifest,
+              artifact_id: artifact.artifactId,
+              artifact_content_sha256: artifact.contentSha256,
+              storage_uri: artifact.storageUri,
+              media_type: artifact.mediaType,
+              byte_length: artifact.byteLength,
+              artifact_created_at: artifact.createdAt,
+              artifact_environment: 'non_production',
+              artifact_class: 'derived_private',
+            },
+          ] as Row[],
+          rowCount: 1,
+        };
+      }
+      return { rows: [], rowCount: 0 };
+    }
+    throw new Error(`Unexpected SQL: ${sql}`);
+  }
+}
+
+async function retainReadyFixtureArtifacts(
+  transaction: ReadyPreparedAuthorityTransaction,
+  repository: ReturnType<typeof createAflTradeFixtureArtifactRepository>
+) {
+  const { calculation, prepared } = transaction.fixture;
+  const readyEntry = prepared.content.entries[0];
+  if (readyEntry?.state !== 'ready') throw new Error('Expected ready fixture entry.');
+  const documents = [
+    [readyEntry.materializationManifestArtifact, calculation.materializationManifest],
+    [prepared.content.factualReleaseArtifact, { fixture: 'release' }],
+    [prepared.content.releaseMembershipArtifact, { fixture: 'membership' }],
+    [prepared.content.qualificationReportArtifact, { fixture: 'qualification' }],
+    [prepared.content.sourceQualificationEvidenceRefs[0]!, { fixture: 'source' }],
+    [prepared.content.valuationInputBundleArtifact, { fixture: 'valuation-input-bundle' }],
+    [
+      calculation.materializationManifest.content.calculationInputArtifact,
+      calculation.calculationInputPackage,
+    ],
+    [calculation.materializationManifest.content.inputTraceArtifact, calculation.trace],
+    [
+      calculation.materializationManifest.content.explanationPolicyArtifact,
+      calculation.explanationPolicy,
+    ],
+    [calculation.materializationManifest.content.lineageGraphArtifact, calculation.lineageGraph],
+    [
+      calculation.materializationManifest.content.pickBenchmarks[0]!.artifact,
+      calculation.pickBenchmarks[0],
+    ],
+  ] as const;
+  for (const [reference, document] of documents) {
+    await repository.putIfAbsent(
+      reference,
+      new TextEncoder().encode(canonicalizeAflTradeJson(document))
+    );
+  }
+}
+
+describe('PostgreSQL governed calculation-authority capture', () => {
+  it('fails closed when no current authenticated v3 prepared trade exists', async () => {
+    const transaction = new NoPreparedAuthorityTransaction();
+    const capture = createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture({
+      artifactRepository: createAflTradeFixtureArtifactRepository({
+        artifactClass: 'derived_private',
+      }),
+      maximumArtifactBytes: 1024 * 1024,
+    });
+
+    await expect(
+      capture({
+        transaction,
+        selector: {
+          valuationScopeKey: 'afl-men:2026-trades',
+          tradeId: 'trade:fixture',
+        },
+        capturedAt: '2026-08-20T10:00:00.000Z',
+      })
+    ).resolves.toEqual({
+      state: 'unavailable',
+      blockers: [
+        {
+          code: 'insufficient_data',
+          message:
+            'No current authenticated v3 prepared calculation inputs cover this trade.',
+        },
+      ],
+    });
+    expect(transaction.calls[0]?.parameters).toEqual(['afl-men:2026-trades']);
+  });
+
+  it('refuses a ready prepared entry whose retained materialization manifest is absent', async () => {
+    const transaction = new ReadyPreparedAuthorityTransaction();
+    const capture = createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture({
+      artifactRepository: createAflTradeFixtureArtifactRepository({
+        artifactClass: 'derived_private',
+      }),
+      maximumArtifactBytes: 1024 * 1024,
+    });
+
+    await expect(
+      capture({
+        transaction,
+        selector: transaction.fixture.calculation.trace.content.selector,
+        capturedAt: '2026-08-20T10:00:00.000Z',
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('refuses SQL manifest custody when the exact retained object bytes are absent', async () => {
+    const transaction = new ReadyPreparedAuthorityTransaction(true);
+    const capture = createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture({
+      artifactRepository: createAflTradeFixtureArtifactRepository({
+        artifactClass: 'derived_private',
+      }),
+      maximumArtifactBytes: 1024 * 1024,
+    });
+
+    await expect(
+      capture({
+        transaction,
+        selector: transaction.fixture.calculation.trace.content.selector,
+        capturedAt: '2026-08-20T10:00:00.000Z',
+      })
+    ).rejects.toMatchObject({ code: 'READBACK_MISMATCH' });
+  });
+
+  it('refuses a retained manifest when any bounded derivation parent is absent', async () => {
+    const transaction = new ReadyPreparedAuthorityTransaction(true);
+    const artifactRepository = createAflTradeFixtureArtifactRepository({
+      artifactClass: 'derived_private',
+    });
+    const manifest = transaction.fixture.calculation.materializationManifest;
+    const reference = createAflTradeCanonicalJsonArtifactRef(
+      manifest,
+      manifest.content.createdAt
+    );
+    await artifactRepository.putIfAbsent(
+      reference,
+      new TextEncoder().encode(canonicalizeAflTradeJson(manifest))
+    );
+    const capture = createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture({
+      artifactRepository,
+      maximumArtifactBytes: 1024 * 1024,
+    });
+
+    await expect(
+      capture({
+        transaction,
+        selector: manifest.content.selector,
+        capturedAt: '2026-08-20T10:00:00.000Z',
+      })
+    ).rejects.toMatchObject({ code: 'READBACK_MISMATCH' });
+  });
+
+  it('rejects SHA-valid JSON that is not the authenticated valuation input bundle contract', async () => {
+    const transaction = new ReadyPreparedAuthorityTransaction(true);
+    const artifactRepository = createAflTradeFixtureArtifactRepository({
+      artifactClass: 'derived_private',
+    });
+    await retainReadyFixtureArtifacts(transaction, artifactRepository);
+    const capture = createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture({
+      artifactRepository,
+      maximumArtifactBytes: 1024 * 1024,
+    });
+
+    await expect(
+      capture({
+        transaction,
+        selector: transaction.fixture.calculation.trace.content.selector,
+        capturedAt: '2026-08-20T10:00:00.000Z',
+      })
+    ).rejects.toThrow('Retained valuation input bundle failed exact contract authentication.');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-postgres-governed-current-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-current-authority.test.ts
@@ -1,0 +1,137 @@
+import { createAflTradeFixtureArtifactRepository } from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import type {
+  AflOutcomeSqlQueryResult,
+  AflOutcomeSqlTransaction,
+} from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import {
+  capturePostgresGovernedPrivateEvaluationCurrentAuthority,
+  loadCurrentGovernedComponentAuthority,
+  loadCurrentPrivateValuationDecision,
+} from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationCurrentAuthority';
+
+class InactiveFactualAuthorityTransaction implements AflOutcomeSqlTransaction {
+  async query<Row>(
+    sql: string,
+    parameters: readonly unknown[] = []
+  ): Promise<AflOutcomeSqlQueryResult<Row>> {
+    if (!sql.includes('FROM outcome_registry_head')) {
+      throw new Error(`Unexpected SQL: ${sql} ${JSON.stringify(parameters)}`);
+    }
+    return {
+      rows: [
+        {
+          revision: 0,
+          last_event_id: null,
+          registry_json: { revision: 0, releases: {}, activeByScope: {}, events: [] },
+          active_release_id: null,
+          active_revision: null,
+          activated_at: null,
+        },
+      ] as Row[],
+      rowCount: 1,
+    };
+  }
+}
+
+describe('PostgreSQL governed current calculation authority', () => {
+  it('fails closed when the prepared factual release is no longer active', async () => {
+    await expect(
+      capturePostgresGovernedPrivateEvaluationCurrentAuthority({
+        transaction: new InactiveFactualAuthorityTransaction(),
+        selector: {
+          valuationScopeKey: 'afl-men:2026-trades',
+          tradeId: 'trade:fixture',
+        },
+        capturedAt: '2026-08-20T10:00:00.000Z',
+        prepared: {
+          factualReleaseScopeKey: 'public-afl-draft-trade-outcomes',
+          factualReleaseId: `outcome-release:${'1'.repeat(64)}`,
+          factualReleaseArtifact: {} as never,
+          releaseMembershipArtifact: {} as never,
+          sourceQualificationEvidenceRefs: [],
+        },
+        trace: {} as never,
+        materializationManifestId: `private-evaluation-materialization-manifest:${'2'.repeat(64)}`,
+        materializationManifestArtifact: {} as never,
+        valuationInputBundleId: `valuation-input-bundle:${'3'.repeat(64)}`,
+        valuationInputBundleArtifact: {} as never,
+        preparedInputHeadRevision: 1,
+        preparedInputSetId: `prepared-valuation-input-set:${'4'.repeat(64)}`,
+        artifactRepository: createAflTradeFixtureArtifactRepository({
+          artifactClass: 'derived_private',
+        }),
+        maximumArtifactBytes: 1024 * 1024,
+      })
+    ).resolves.toEqual({
+      state: 'unavailable',
+      blockers: [
+        {
+          code: 'source_blocked',
+          message: 'The exact prepared factual release is not the current active release.',
+        },
+      ],
+    });
+  });
+
+  it('fails closed when no current private derived-calculation decision exists', async () => {
+    const transaction: AflOutcomeSqlTransaction = {
+      async query<Row>(sql: string): Promise<AflOutcomeSqlQueryResult<Row>> {
+        if (!sql.includes('FROM outcome_private_valuation_evaluation_head')) {
+          throw new Error(`Unexpected SQL: ${sql}`);
+        }
+        return { rows: [], rowCount: 0 };
+      },
+    };
+
+    await expect(
+      loadCurrentPrivateValuationDecision(transaction, {
+        valuationScopeKey: 'afl-men:2026-trades',
+        factualReleaseScopeKey: 'public-afl-draft-trade-outcomes',
+        factualReleaseId: `outcome-release:${'1'.repeat(64)}`,
+        factualReleaseArtifact: {} as never,
+        releaseMembershipArtifact: {} as never,
+        sourceQualificationEvidenceRefs: [],
+      })
+    ).resolves.toEqual({
+      state: 'unavailable',
+      blockers: [
+        {
+          code: 'source_blocked',
+          message: 'No current authorized private derived-calculation decision covers this release.',
+        },
+      ],
+    });
+  });
+
+  it('keeps model authority unavailable when the Gate ledger has no decisions', async () => {
+    const transaction: AflOutcomeSqlTransaction = {
+      async query<Row>(sql: string): Promise<AflOutcomeSqlQueryResult<Row>> {
+        if (!sql.includes('FROM outcome_gate_ledger_head')) {
+          throw new Error(`Unexpected SQL: ${sql}`);
+        }
+        return { rows: [{ revision: 0 }] as Row[], rowCount: 1 };
+      },
+    };
+
+    await expect(
+      loadCurrentGovernedComponentAuthority({
+        transaction,
+        trace: {} as never,
+        capturedAt: '2026-08-20T10:00:00.000Z',
+        artifactRepository: createAflTradeFixtureArtifactRepository({
+          artifactClass: 'derived_private',
+        }),
+        maximumArtifactBytes: 1024 * 1024,
+      })
+    ).resolves.toEqual({
+      state: 'unavailable',
+      blockers: [
+        {
+          code: 'model_not_approved',
+          message:
+            'Current external Gate 3 approval is unavailable for both governed model components.',
+        },
+      ],
+    });
+  });
+});

--- a/tests/unit/afl-trade-intelligence-postgres-governed-pick-pav-model-execution.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-pick-pav-model-execution.test.ts
@@ -1,0 +1,166 @@
+import {
+  createAflTradeCanonicalJsonArtifactRef,
+  type AflTradeArtifactRef,
+} from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import {
+  createAflTradeFixtureArtifactRepository,
+  type AflTradeImmutableArtifactRepository,
+} from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlQueryResult,
+  AflOutcomeSqlTransaction,
+} from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { PostgresGovernedPickPavModelExecutionRepository } from '@/server/aflTradeIntelligence/modeling/postgresGovernedPickPavModelExecutionRepository';
+
+import { createGovernedPickPavModelExecutionFixture } from '../testUtils/governedPickPavModelExecutionFixture';
+
+class GovernedPickExecutionSqlClient implements AflOutcomeSqlClient {
+  row: Record<string, unknown> | null = null;
+
+  constructor(private readonly executionArtifact: AflTradeArtifactRef) {}
+
+  async query<Row>(
+    sql: string,
+    parameters: readonly unknown[] = []
+  ): Promise<AflOutcomeSqlQueryResult<Row>> {
+    if (sql.includes('pg_advisory_xact_lock')) return { rows: [], rowCount: 1 };
+    if (sql.includes('SELECT 1 FROM outcome_governed_pick_pav_model_execution')) {
+      return { rows: [], rowCount: this.row === null ? 0 : 1 };
+    }
+    if (sql.includes('SELECT') && sql.includes('outcome_governed_pick_pav_model_execution')) {
+      return {
+        rows: this.row === null ? [] : [this.row as Row],
+        rowCount: this.row === null ? 0 : 1,
+      };
+    }
+    if (sql.includes('INSERT INTO outcome_governed_pick_pav_model_execution')) {
+      const artifact = this.executionArtifact;
+      this.row = {
+        execution_id: parameters[0],
+        observation_set_id: parameters[1],
+        dataset_id: parameters[2],
+        dataset_artifact_id: parameters[3],
+        dataset_admission_id: parameters[4],
+        dataset_admission_artifact_id: parameters[5],
+        dataset_admission_gate_ledger_revision: parameters[6],
+        protocol_id: parameters[7],
+        protocol_artifact_id: parameters[8],
+        execution_artifact_id: parameters[9],
+        final_test_evaluation_started_at: parameters[10],
+        completed_at: parameters[11],
+        content_sha256: parameters[12],
+        content_canonical_json: parameters[13],
+        execution_json: JSON.parse(String(parameters[14])),
+        artifact_content_sha256: artifact.contentSha256,
+        artifact_storage_uri: artifact.storageUri,
+        artifact_media_type: artifact.mediaType,
+        artifact_byte_length: artifact.byteLength,
+        artifact_created_at: artifact.createdAt,
+      };
+      return { rows: [], rowCount: 1 };
+    }
+    throw new Error(`Unexpected SQL: ${sql}`);
+  }
+
+  transaction<T>(work: (transaction: AflOutcomeSqlTransaction) => Promise<T>): Promise<T> {
+    return work(this);
+  }
+}
+
+async function retain(
+  repository: AflTradeImmutableArtifactRepository,
+  value: unknown,
+  createdAt: string
+) {
+  const reference = createAflTradeCanonicalJsonArtifactRef(value, createdAt);
+  await repository.putIfAbsent(
+    reference,
+    new TextEncoder().encode(canonicalizeAflTradeJson(value))
+  );
+  return reference;
+}
+
+async function fixture() {
+  const value = createGovernedPickPavModelExecutionFixture();
+  const artifacts = createAflTradeFixtureArtifactRepository({ artifactClass: 'derived_private' });
+  const authorityReferences = [
+    value.execution.content.datasetArtifact,
+    value.execution.content.datasetAdmissionArtifact,
+    value.execution.content.protocolArtifact,
+  ];
+  for (const [index, document] of value.authorityDocuments.entries()) {
+    const retained = await retain(artifacts, document, authorityReferences[index]!.createdAt);
+    expect(retained).toEqual(authorityReferences[index]);
+  }
+  const executionArtifact = await retain(
+    artifacts,
+    value.execution,
+    value.execution.content.completedAt
+  );
+  return { ...value, artifacts, executionArtifact };
+}
+
+describe('PostgreSQL governed pick-PAV execution repository', () => {
+  it('registers and exactly replays one physically retained governed execution', async () => {
+    const value = await fixture();
+    const client = new GovernedPickExecutionSqlClient(value.executionArtifact);
+    const repository = new PostgresGovernedPickPavModelExecutionRepository({
+      client,
+      artifactRepository: value.artifacts,
+      maximumArtifactBytes: 1024 * 1024,
+    });
+
+    await expect(
+      repository.register({
+        execution: value.execution,
+        artifact: value.executionArtifact,
+      })
+    ).resolves.toEqual({ execution: value.execution, artifact: value.executionArtifact });
+    await expect(repository.loadExact(value.execution.executionId)).resolves.toEqual({
+      execution: value.execution,
+      artifact: value.executionArtifact,
+    });
+    await expect(
+      repository.register({
+        execution: value.execution,
+        artifact: value.executionArtifact,
+      })
+    ).resolves.toEqual({ execution: value.execution, artifact: value.executionArtifact });
+  });
+
+  it('rejects relational substitution and substituted retained bytes', async () => {
+    const value = await fixture();
+    const client = new GovernedPickExecutionSqlClient(value.executionArtifact);
+    const repository = new PostgresGovernedPickPavModelExecutionRepository({
+      client,
+      artifactRepository: value.artifacts,
+      maximumArtifactBytes: 1024 * 1024,
+    });
+    await repository.register({ execution: value.execution, artifact: value.executionArtifact });
+
+    const exactRow = structuredClone(client.row);
+    client.row = { ...exactRow, dataset_id: `dataset:${'0'.repeat(64)}` };
+    await expect(repository.loadExact(value.execution.executionId)).rejects.toThrow(
+      /integrity|ancestry|disagree/i
+    );
+    client.row = exactRow;
+
+    const substituted: AflTradeImmutableArtifactRepository = {
+      ...value.artifacts,
+      loadExact: async (reference, maximumBytes) =>
+        reference.artifactId === value.executionArtifact.artifactId
+          ? { reference, bytes: new TextEncoder().encode('substituted') }
+          : value.artifacts.loadExact(reference, maximumBytes),
+    };
+    const rejecting = new PostgresGovernedPickPavModelExecutionRepository({
+      client,
+      artifactRepository: substituted,
+      maximumArtifactBytes: 1024 * 1024,
+    });
+    await expect(rejecting.loadExact(value.execution.executionId)).rejects.toThrow(
+      /artifact|bytes|custody|integrity/i
+    );
+  });
+});

--- a/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-inspection.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-inspection.test.ts
@@ -1,0 +1,233 @@
+import type { AflTradeArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import {
+  createAflTradeCanonicalJsonArtifactRef,
+} from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlQueryResult,
+  AflOutcomeSqlTransaction,
+} from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { createPostgresGovernedPrivateEvaluationInspectionRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationInspectionRepository';
+
+const selector = {
+  valuationScopeKey: 'afl-trade-history:test-fixture',
+  tradeId: 'trade:adelaide-st-kilda',
+};
+const capturedAt = '2026-08-19T10:00:00.000Z';
+const generationId = `local-private-trade-evaluation-generation:${'a'.repeat(64)}`;
+const transitionId = `private-evaluation-transition:${'b'.repeat(64)}`;
+
+class InspectionSqlClient implements AflOutcomeSqlClient {
+  readonly calls: { sql: string; parameters: readonly unknown[] }[] = [];
+
+  async query<Row>(
+    sql: string,
+    parameters: readonly unknown[] = []
+  ): Promise<AflOutcomeSqlQueryResult<Row>> {
+    this.calls.push({ sql, parameters });
+    if (sql.includes('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ')) {
+      return { rows: [], rowCount: null };
+    }
+    if (sql.includes('transaction_timestamp()')) {
+      return {
+        rows: [{ trusted_at: new Date(capturedAt) }],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('FROM outcome_local_private_trade_evaluation_head')) {
+      return {
+        rows: [
+          {
+            status: 'active',
+            revision: 4,
+            generation_id: generationId,
+            last_transition_id: transitionId,
+          },
+        ],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('INSERT INTO outcome_private_evaluation_authority_snapshot')) {
+      return { rows: [], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('INSERT INTO outcome_private_evaluation_inspection_receipt')) {
+      return { rows: [], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+    }
+    throw new Error(`Unexpected SQL: ${sql}`);
+  }
+
+  async transaction<T>(
+    work: (transaction: AflOutcomeSqlTransaction) => Promise<T>
+  ): Promise<T> {
+    return work(this);
+  }
+}
+
+describe('PostgreSQL governed private evaluation inspection repository', () => {
+  it('retains one repeatable-read unavailable inspection with the exact active head', async () => {
+    const client = new InspectionSqlClient();
+    const retained: { reference: AflTradeArtifactRef; bytes: Uint8Array }[] = [];
+    const repository = createPostgresGovernedPrivateEvaluationInspectionRepository({
+      client,
+      retainArtifact: async (artifact) => {
+        retained.push(artifact);
+        return artifact.reference;
+      },
+      validityMilliseconds: 5 * 60 * 1_000,
+    });
+
+    await expect(repository.inspect(selector)).resolves.toMatchObject({
+      state: 'unavailable',
+      selector,
+      validThrough: '2026-08-19T10:05:00.000Z',
+      head: { status: 'active', revision: 4, generationId },
+      blockers: [{ code: 'model_not_approved' }],
+    });
+    expect(retained).toHaveLength(2);
+    const retainedDocuments = retained.map(({ bytes }) =>
+      JSON.parse(new TextDecoder().decode(bytes))
+    );
+    expect(retainedDocuments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: expect.objectContaining({
+            schemaVersion: 'private-evaluation-authority-snapshot/v3',
+            environment: 'non_production',
+            calculationAuthority: expect.objectContaining({ state: 'unavailable' }),
+            blockers: [expect.objectContaining({ code: 'model_not_approved' })],
+          }),
+        }),
+        expect.objectContaining({
+          content: expect.objectContaining({
+            schemaVersion: 'private-evaluation-inspection/v3',
+            environment: 'non_production',
+            state: 'unavailable',
+          }),
+        }),
+      ])
+    );
+    const firstInsert = client.calls.findIndex((call) =>
+      call.sql.includes('INSERT INTO outcome_private_evaluation_authority_snapshot')
+    );
+    expect(firstInsert).toBeGreaterThan(-1);
+    expect(
+      client.calls.some((call) =>
+        call.sql.includes('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ')
+      )
+    ).toBe(true);
+    expect(
+      client.calls.find((call) =>
+        call.sql.includes('FROM outcome_local_private_trade_evaluation_head')
+      )?.parameters
+    ).toEqual([selector.valuationScopeKey, selector.tradeId]);
+    expect(
+      client.calls.some((call) =>
+        call.sql.includes('INSERT INTO outcome_private_evaluation_inspection_receipt')
+      )
+    ).toBe(true);
+  });
+
+  it('retains ready v3 authority captured inside the same repeatable-read transaction', async () => {
+    const client = new InspectionSqlClient();
+    const retained: { reference: AflTradeArtifactRef; bytes: Uint8Array }[] = [];
+    const addressed = (prefix: string, label: string) =>
+      createAflTradeContentAddress(prefix, { fixture: label });
+    const manifestArtifact = createAflTradeCanonicalJsonArtifactRef(
+      { kind: 'materialization-manifest' },
+      '2026-08-19T09:00:00.000Z'
+    );
+    const bundleArtifact = createAflTradeCanonicalJsonArtifactRef(
+      { kind: 'valuation-input-bundle' },
+      '2026-08-19T09:00:00.000Z'
+    );
+    const components = [
+      'player_contribution_and_availability',
+      'draft_pick_and_future_pick_distribution',
+    ].map((role, index) => ({
+      role: role as
+        | 'player_contribution_and_availability'
+        | 'draft_pick_and_future_pick_distribution',
+      runId: addressed('model-run', `run-${index}`),
+      protocolId: addressed('model-protocol', `protocol-${index}`),
+      datasetId: addressed('dataset', `dataset-${index}`),
+      datasetAdmissionId: addressed('dataset-admission', `admission-${index}`),
+      datasetAdmissionGateLedgerRevision: 10 + index,
+      gate3DecisionId: addressed('gate-decision', `gate-${index}`),
+      gate3DecisionVersion: 2,
+    }));
+    let captureTransaction: AflOutcomeSqlTransaction | null = null;
+    const repository = createPostgresGovernedPrivateEvaluationInspectionRepository({
+      client,
+      retainArtifact: async (artifact) => {
+        retained.push(artifact);
+        return artifact.reference;
+      },
+      captureCalculationAuthority: async (input) => {
+        captureTransaction = input.transaction;
+        expect(input.selector).toEqual(selector);
+        expect(input.capturedAt).toBe(capturedAt);
+        return {
+          state: 'ready' as const,
+          preparedInputHeadRevision: 4,
+          preparedInputSetId: addressed('prepared-valuation-input-set', 'prepared'),
+          factualRegistryRevision: 20,
+          factualReleaseId: addressed('outcome-release', 'release'),
+          activeFactualReleaseRevision: 18,
+          privateValuationDecisionId: addressed(
+            'private-valuation-evaluation-decision',
+            'private-decision'
+          ),
+          privateValuationDecisionRevision: 3,
+          materializationManifestId: addressed(
+            'private-evaluation-materialization-manifest',
+            'manifest'
+          ),
+          materializationManifestArtifact: manifestArtifact,
+          valuationInputBundleId: addressed('valuation-input-bundle', 'bundle'),
+          valuationInputBundleArtifact: bundleArtifact,
+          gateLedgerRevision: 24,
+          components,
+        };
+      },
+      validityMilliseconds: 5 * 60 * 1_000,
+    });
+
+    await expect(repository.inspect(selector)).resolves.toMatchObject({
+      state: 'ready',
+      selector,
+      head: { status: 'active', revision: 4, generationId },
+      blockers: [],
+    });
+    expect(captureTransaction).toBe(client);
+    expect(retained).toHaveLength(2);
+    const documents = retained.map(({ bytes }) =>
+      JSON.parse(new TextDecoder().decode(bytes))
+    );
+    expect(documents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: expect.objectContaining({
+            schemaVersion: 'private-evaluation-authority-snapshot/v3',
+            calculationAuthority: expect.objectContaining({
+              state: 'ready',
+              factualRegistryRevision: 20,
+              privateValuationDecisionRevision: 3,
+              components,
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          content: expect.objectContaining({
+            schemaVersion: 'private-evaluation-inspection/v3',
+            state: 'ready',
+          }),
+        }),
+      ])
+    );
+    const inspectionInsert = client.calls.find((call) =>
+      call.sql.includes('INSERT INTO outcome_private_evaluation_inspection_receipt')
+    );
+    expect(inspectionInsert?.parameters).toContain('ready');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-lifecycle.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-lifecycle.test.ts
@@ -1,0 +1,643 @@
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createAflTradeFixtureArtifactRepository } from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import { canonicalizeAflTradeJson } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlQueryResult,
+  AflOutcomeSqlTransaction,
+} from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import {
+  createGovernedPrivateEvaluationTransitionIntent,
+  createGovernedPrivateEvaluationTransitionReceipt,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle';
+import {
+  createReadyFixtureGovernedPrivateEvaluationAuthorityInspection,
+  createUnavailableGovernedPrivateEvaluationAuthorityInspection,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationAuthoritySnapshot';
+import { createPostgresGovernedPrivateEvaluationLifecycleRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationLifecycleRepository';
+
+const selector = {
+  valuationScopeKey: 'afl-trade-history:scope-b',
+  tradeId: 'trade:shared-id',
+};
+const generationId = `local-private-trade-evaluation-generation:${'c'.repeat(64)}`;
+const operationId = `private-evaluation-operation:${'d'.repeat(64)}`;
+const transitionTime = '2026-08-19T10:01:00.000Z';
+
+interface QueryCall {
+  readonly sql: string;
+  readonly parameters: readonly unknown[];
+}
+
+class RecordingSqlClient implements AflOutcomeSqlClient {
+  readonly calls: QueryCall[] = [];
+
+  constructor(
+    private readonly respond: (
+      sql: string,
+      parameters: readonly unknown[]
+    ) => AflOutcomeSqlQueryResult<unknown>
+  ) {}
+
+  async query<Row>(
+    sql: string,
+    parameters: readonly unknown[] = []
+  ): Promise<AflOutcomeSqlQueryResult<Row>> {
+    this.calls.push({ sql, parameters });
+    return this.respond(sql, parameters) as AflOutcomeSqlQueryResult<Row>;
+  }
+
+  async transaction<T>(
+    work: (transaction: AflOutcomeSqlTransaction) => Promise<T>
+  ): Promise<T> {
+    return work(this);
+  }
+}
+
+function retainedAuthority(input: {
+  readonly head: { status: 'absent' | 'active' | 'withdrawn'; revision: number; generationId: string | null };
+  readonly lastTransitionId: string | null;
+}) {
+  return createReadyFixtureGovernedPrivateEvaluationAuthorityInspection({
+    selector,
+    capturedAt: '2026-08-19T10:00:00.000Z',
+    validThrough: '2026-08-19T10:05:00.000Z',
+    head: input.head,
+    lastTransitionId: input.lastTransitionId,
+    playerModelRunId: `model-run:${'1'.repeat(64)}`,
+    pickModelRunId: `model-run:${'2'.repeat(64)}`,
+  });
+}
+
+function activationFixture() {
+  const retained = retainedAuthority({
+    head: { status: 'absent', revision: 0, generationId: null },
+    lastTransitionId: null,
+  });
+  const intent = createGovernedPrivateEvaluationTransitionIntent({
+    selector,
+    inspectionId: retained.inspection.inspectionId,
+    authoritySnapshotId: retained.snapshot.snapshotId,
+    operationId,
+    action: { kind: 'construct_and_activate' },
+    expectedHead: { status: 'absent', revision: 0, generationId: null },
+    review: {
+      principalId: 'firebase:operator-1',
+      rationale: 'Activate the retained fixture generation.',
+    },
+    requestedAt: '2026-08-19T10:00:00.000Z',
+    expiresAt: '2026-08-19T10:05:00.000Z',
+  });
+  const receipt = createGovernedPrivateEvaluationTransitionReceipt({
+    intent,
+    previousTransitionId: null,
+    toGenerationId: generationId,
+    transitionedAt: transitionTime,
+  });
+  return { receipt, retained };
+}
+
+async function repositoryFor(
+  client: AflOutcomeSqlClient,
+  retained: ReturnType<typeof retainedAuthority>
+) {
+  const artifactRepository = createAflTradeFixtureArtifactRepository({
+    artifactClass: 'derived_private',
+  });
+  for (const document of [retained.snapshot, retained.inspection]) {
+    const reference = createAflTradeCanonicalJsonArtifactRef(
+      document,
+      retained.snapshot.content.capturedAt
+    );
+    await artifactRepository.putIfAbsent(
+      reference,
+      new TextEncoder().encode(canonicalizeAflTradeJson(document))
+    );
+  }
+  return createPostgresGovernedPrivateEvaluationLifecycleRepository({
+    client,
+    artifactRepository,
+    maximumArtifactBytes: 1024 * 1024,
+  });
+}
+
+function storedAuthority(
+  sql: string,
+  receipt: ReturnType<typeof createGovernedPrivateEvaluationTransitionReceipt>,
+  retained: ReturnType<typeof retainedAuthority>
+): AflOutcomeSqlQueryResult<unknown> | null {
+  if (!sql.includes('FROM outcome_private_evaluation_transition_intent ti')) return null;
+  const intent = receipt.content.intent.content;
+  return {
+    rows: [
+      {
+        intent_json: receipt.content.intent,
+        authority_snapshot_id: intent.authoritySnapshotId,
+        inspection_snapshot_id: intent.authoritySnapshotId,
+        inspection_state: 'ready',
+        inspection_valid_through: intent.expiresAt,
+        inspection_head_status: intent.expectedHead.status,
+        inspection_head_revision: intent.expectedHead.revision,
+        inspection_head_generation_id: intent.expectedHead.generationId,
+        snapshot_id: intent.authoritySnapshotId,
+        snapshot_valid_through: intent.expiresAt,
+        snapshot_head_status: intent.expectedHead.status,
+        snapshot_head_revision: intent.expectedHead.revision,
+        snapshot_head_generation_id: intent.expectedHead.generationId,
+        snapshot_json: retained.snapshot,
+        inspection_json: retained.inspection,
+        snapshot_artifact_id: createAflTradeCanonicalJsonArtifactRef(
+          retained.snapshot,
+          retained.snapshot.content.capturedAt
+        ).artifactId,
+        snapshot_artifact_sha256: createAflTradeCanonicalJsonArtifactRef(
+          retained.snapshot,
+          retained.snapshot.content.capturedAt
+        ).contentSha256,
+        snapshot_artifact_storage_uri: createAflTradeCanonicalJsonArtifactRef(
+          retained.snapshot,
+          retained.snapshot.content.capturedAt
+        ).storageUri,
+        snapshot_artifact_media_type: 'application/json',
+        snapshot_artifact_byte_length: new TextEncoder().encode(
+          canonicalizeAflTradeJson(retained.snapshot)
+        ).byteLength,
+        snapshot_artifact_created_at: retained.snapshot.content.capturedAt,
+        inspection_artifact_id: createAflTradeCanonicalJsonArtifactRef(
+          retained.inspection,
+          retained.snapshot.content.capturedAt
+        ).artifactId,
+        inspection_artifact_sha256: createAflTradeCanonicalJsonArtifactRef(
+          retained.inspection,
+          retained.snapshot.content.capturedAt
+        ).contentSha256,
+        inspection_artifact_storage_uri: createAflTradeCanonicalJsonArtifactRef(
+          retained.inspection,
+          retained.snapshot.content.capturedAt
+        ).storageUri,
+        inspection_artifact_media_type: 'application/json',
+        inspection_artifact_byte_length: new TextEncoder().encode(
+          canonicalizeAflTradeJson(retained.inspection)
+        ).byteLength,
+        inspection_artifact_created_at: retained.snapshot.content.capturedAt,
+      },
+    ],
+    rowCount: 1,
+  };
+}
+
+function operatorAuthority(sql: string): AflOutcomeSqlQueryResult<unknown> | null {
+  if (!sql.includes('FROM outcome_operational_principal_authority')) return null;
+  return {
+    rows: [{ authority_evidence_id: `reviewer-authority-evidence:${'e'.repeat(64)}` }],
+    rowCount: 1,
+  };
+}
+
+describe('PostgreSQL governed private evaluation lifecycle repository', () => {
+  it('rejects activation when exact stored snapshot authority is absent', async () => {
+    const { receipt, retained } = activationFixture();
+    const client = new RecordingSqlClient((sql) => {
+      if (sql.includes('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE')) {
+        return { rows: [], rowCount: null };
+      }
+      if (sql.includes('WHERE operation_id=$1')) return { rows: [], rowCount: 0 };
+      if (sql.includes('transaction_timestamp()')) {
+        return { rows: [{ trusted_at: transitionTime }], rowCount: 1 };
+      }
+      if (sql.includes('pg_advisory_xact_lock')) return { rows: [{}], rowCount: 1 };
+      if (sql.includes('FROM outcome_local_private_trade_evaluation_head')) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.includes('FROM outcome_local_private_trade_evaluation_generation')) {
+        return { rows: [{ generation_id: generationId }], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO outcome_private_evaluation_transition_receipt')) {
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO outcome_local_private_trade_evaluation_head')) {
+        return { rows: [], rowCount: 1 };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    const repository = await repositoryFor(client, retained);
+
+    await expect(
+      repository.commit({
+        receipt,
+        receiptArtifact: createAflTradeCanonicalJsonArtifactRef(receipt, transitionTime),
+      })
+    ).rejects.toThrow(/stored|snapshot|authority/i);
+  });
+
+  it('locks, proves, and CAS-activates by valuation scope and trade together', async () => {
+    const { receipt, retained } = activationFixture();
+    const client = new RecordingSqlClient((sql) => {
+      const authority = storedAuthority(sql, receipt, retained);
+      if (authority !== null) return authority;
+      const operator = operatorAuthority(sql);
+      if (operator !== null) return operator;
+      if (sql.includes('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE')) {
+        return { rows: [], rowCount: null };
+      }
+      if (sql.includes('WHERE operation_id=$1')) return { rows: [], rowCount: 0 };
+      if (sql.includes('transaction_timestamp()')) {
+        return { rows: [{ trusted_at: transitionTime }], rowCount: 1 };
+      }
+      if (sql.includes('pg_advisory_xact_lock')) return { rows: [{}], rowCount: 1 };
+      if (sql.includes('FROM outcome_local_private_trade_evaluation_head')) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (
+        sql.includes('FROM outcome_local_private_trade_evaluation_generation')
+      ) {
+        return { rows: [{ generation_id: generationId }], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO outcome_private_evaluation_transition_receipt')) {
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO outcome_local_private_trade_evaluation_head')) {
+        return { rows: [], rowCount: 1 };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    const repository = await repositoryFor(client, retained);
+    const receiptArtifact = createAflTradeCanonicalJsonArtifactRef(receipt, transitionTime);
+
+    await expect(repository.commit({ receipt, receiptArtifact })).resolves.toEqual({
+      state: 'committed',
+      head: receipt.content.toHead,
+      transitionId: receipt.transitionId,
+    });
+
+    const lock = client.calls.find(({ sql }) => sql.includes('pg_advisory_xact_lock'));
+    expect(lock?.parameters[0]).toContain(selector.valuationScopeKey);
+    expect(lock?.parameters[0]).toContain(selector.tradeId);
+    const headRead = client.calls.find(({ sql }) =>
+      sql.includes('FROM outcome_local_private_trade_evaluation_head')
+    );
+    expect(headRead?.sql).toContain('valuation_scope_key=$1');
+    expect(headRead?.sql).toContain('trade_id=$2');
+    expect(headRead?.parameters).toEqual([
+      selector.valuationScopeKey,
+      selector.tradeId,
+    ]);
+    const headWrite = client.calls.find(({ sql }) =>
+      sql.includes('INSERT INTO outcome_local_private_trade_evaluation_head')
+    );
+    expect(headWrite?.sql).toContain('ON CONFLICT (valuation_scope_key,trade_id)');
+  });
+
+  it('returns conflict before writing when the composite head is stale', async () => {
+    const { receipt, retained } = activationFixture();
+    const client = new RecordingSqlClient((sql) => {
+      const authority = storedAuthority(sql, receipt, retained);
+      if (authority !== null) return authority;
+      const operator = operatorAuthority(sql);
+      if (operator !== null) return operator;
+      if (sql.includes('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE')) {
+        return { rows: [], rowCount: null };
+      }
+      if (sql.includes('WHERE operation_id=$1')) return { rows: [], rowCount: 0 };
+      if (sql.includes('transaction_timestamp()')) {
+        return { rows: [{ trusted_at: transitionTime }], rowCount: 1 };
+      }
+      if (sql.includes('pg_advisory_xact_lock')) return { rows: [{}], rowCount: 1 };
+      if (sql.includes('FROM outcome_local_private_trade_evaluation_head')) {
+        return {
+          rows: [
+            {
+              status: 'active',
+              revision: 7,
+              generation_id: generationId,
+              last_transition_id: `private-evaluation-transition:${'e'.repeat(64)}`,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    const repository = await repositoryFor(client, retained);
+
+    await expect(
+      repository.commit({
+        receipt,
+        receiptArtifact: createAflTradeCanonicalJsonArtifactRef(receipt, transitionTime),
+      })
+    ).resolves.toMatchObject({
+      state: 'conflict',
+      actualHead: { status: 'active', revision: 7 },
+    });
+    expect(
+      client.calls.some(({ sql }) =>
+        sql.includes('INSERT INTO outcome_private_evaluation_transition_receipt')
+      )
+    ).toBe(false);
+  });
+
+  it('recovers only the generation retained by the exact withdrawal receipt', async () => {
+    const previousTransitionId = `private-evaluation-transition:${'f'.repeat(64)}`;
+    const retained = retainedAuthority({
+      head: { status: 'withdrawn', revision: 2, generationId: null },
+      lastTransitionId: previousTransitionId,
+    });
+    const intent = createGovernedPrivateEvaluationTransitionIntent({
+      selector,
+      inspectionId: retained.inspection.inspectionId,
+      authoritySnapshotId: retained.snapshot.snapshotId,
+      operationId,
+      action: { kind: 'recover' },
+      expectedHead: { status: 'withdrawn', revision: 2, generationId: null },
+      review: {
+        principalId: 'firebase:operator-1',
+        rationale: 'Recover the last withdrawn fixture generation.',
+      },
+      requestedAt: '2026-08-19T10:00:00.000Z',
+      expiresAt: '2026-08-19T10:05:00.000Z',
+    });
+    const receipt = createGovernedPrivateEvaluationTransitionReceipt({
+      intent,
+      previousTransitionId,
+      toGenerationId: generationId,
+      transitionedAt: transitionTime,
+    });
+    const client = new RecordingSqlClient((sql) => {
+      const authority = storedAuthority(sql, receipt, retained);
+      if (authority !== null) return authority;
+      const operator = operatorAuthority(sql);
+      if (operator !== null) return operator;
+      if (sql.includes('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE')) {
+        return { rows: [], rowCount: null };
+      }
+      if (sql.includes('WHERE operation_id=$1')) return { rows: [], rowCount: 0 };
+      if (sql.includes('transaction_timestamp()')) {
+        return { rows: [{ trusted_at: transitionTime }], rowCount: 1 };
+      }
+      if (sql.includes('pg_advisory_xact_lock')) return { rows: [{}], rowCount: 1 };
+      if (sql.includes('FROM outcome_local_private_trade_evaluation_head')) {
+        return {
+          rows: [
+            {
+              status: 'withdrawn',
+              revision: 2,
+              generation_id: null,
+              last_transition_id: receipt.content.previousTransitionId,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes("action='withdraw'")) {
+        return { rows: [{ from_generation_id: generationId }], rowCount: 1 };
+      }
+      if (sql.includes('FROM outcome_local_private_trade_evaluation_generation')) {
+        return { rows: [{ generation_id: generationId }], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO outcome_private_evaluation_transition_receipt')) {
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO outcome_local_private_trade_evaluation_head')) {
+        return { rows: [], rowCount: 1 };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    const repository = await repositoryFor(client, retained);
+
+    await expect(
+      repository.commit({
+        receipt,
+        receiptArtifact: createAflTradeCanonicalJsonArtifactRef(receipt, transitionTime),
+      })
+    ).resolves.toMatchObject({ state: 'committed' });
+    const recoveryRead = client.calls.find(({ sql }) => sql.includes("action='withdraw'"));
+    expect(recoveryRead?.parameters).toEqual([
+      selector.valuationScopeKey,
+      selector.tradeId,
+      2,
+      receipt.content.previousTransitionId,
+    ]);
+  });
+
+  it('rejects recovery when relational columns claim ready but retained authority is unavailable', async () => {
+    const previousTransitionId = `private-evaluation-transition:${'f'.repeat(64)}`;
+    const retained = createUnavailableGovernedPrivateEvaluationAuthorityInspection({
+      selector,
+      capturedAt: '2026-08-19T10:00:00.000Z',
+      validThrough: '2026-08-19T10:05:00.000Z',
+      head: { status: 'withdrawn', revision: 2, generationId: null },
+      lastTransitionId: previousTransitionId,
+      blockers: [{ code: 'model_not_approved', message: 'Model evidence is unavailable.' }],
+    });
+    const intent = createGovernedPrivateEvaluationTransitionIntent({
+      selector,
+      inspectionId: retained.inspection.inspectionId,
+      authoritySnapshotId: retained.snapshot.snapshotId,
+      operationId,
+      action: { kind: 'recover' },
+      expectedHead: { status: 'withdrawn', revision: 2, generationId: null },
+      review: {
+        principalId: 'firebase:operator-1',
+        rationale: 'Attempt recovery without exact ready calculation authority.',
+      },
+      requestedAt: '2026-08-19T10:00:00.000Z',
+      expiresAt: '2026-08-19T10:05:00.000Z',
+    });
+    const receipt = createGovernedPrivateEvaluationTransitionReceipt({
+      intent,
+      previousTransitionId,
+      toGenerationId: generationId,
+      transitionedAt: transitionTime,
+    });
+    const client = new RecordingSqlClient((sql) => {
+      const authority = storedAuthority(sql, receipt, retained);
+      if (authority !== null) return authority;
+      const operator = operatorAuthority(sql);
+      if (operator !== null) return operator;
+      if (sql.includes('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE')) {
+        return { rows: [], rowCount: null };
+      }
+      if (sql.includes('WHERE operation_id=$1')) return { rows: [], rowCount: 0 };
+      if (sql.includes('transaction_timestamp()')) {
+        return { rows: [{ trusted_at: transitionTime }], rowCount: 1 };
+      }
+      if (sql.includes('pg_advisory_xact_lock')) return { rows: [{}], rowCount: 1 };
+      if (sql.includes('FROM outcome_local_private_trade_evaluation_head')) {
+        return {
+          rows: [
+            {
+              status: 'withdrawn',
+              revision: 2,
+              generation_id: null,
+              last_transition_id: previousTransitionId,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes("action='withdraw'")) {
+        return { rows: [{ from_generation_id: generationId }], rowCount: 1 };
+      }
+      if (sql.includes('FROM outcome_local_private_trade_evaluation_generation')) {
+        return { rows: [{ generation_id: generationId }], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO outcome_private_evaluation_transition_receipt')) {
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO outcome_local_private_trade_evaluation_head')) {
+        return { rows: [], rowCount: 1 };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    const repository = await repositoryFor(client, retained);
+
+    await expect(
+      repository.commit({
+        receipt,
+        receiptArtifact: createAflTradeCanonicalJsonArtifactRef(receipt, transitionTime),
+      })
+    ).rejects.toThrow(/retained|ready|authority/i);
+    expect(
+      client.calls.some(({ sql }) =>
+        sql.includes('INSERT INTO outcome_private_evaluation_transition_receipt')
+      )
+    ).toBe(false);
+  });
+
+  it('rejects authentic retained authority from a different selector', async () => {
+    const retained = createReadyFixtureGovernedPrivateEvaluationAuthorityInspection({
+      selector: { valuationScopeKey: 'afl-trade-history:other-scope', tradeId: selector.tradeId },
+      capturedAt: '2026-08-19T10:00:00.000Z',
+      validThrough: '2026-08-19T10:05:00.000Z',
+      head: { status: 'absent', revision: 0, generationId: null },
+      lastTransitionId: null,
+      playerModelRunId: `model-run:${'1'.repeat(64)}`,
+      pickModelRunId: `model-run:${'2'.repeat(64)}`,
+    });
+    const intent = createGovernedPrivateEvaluationTransitionIntent({
+      selector,
+      inspectionId: retained.inspection.inspectionId,
+      authoritySnapshotId: retained.snapshot.snapshotId,
+      operationId,
+      action: { kind: 'construct_and_activate' },
+      expectedHead: { status: 'absent', revision: 0, generationId: null },
+      review: {
+        principalId: 'firebase:operator-1',
+        rationale: 'Attempt cross-scope authority reuse.',
+      },
+      requestedAt: '2026-08-19T10:00:00.000Z',
+      expiresAt: '2026-08-19T10:05:00.000Z',
+    });
+    const receipt = createGovernedPrivateEvaluationTransitionReceipt({
+      intent,
+      previousTransitionId: null,
+      toGenerationId: generationId,
+      transitionedAt: transitionTime,
+    });
+    const client = new RecordingSqlClient((sql) => {
+      const authority = storedAuthority(sql, receipt, retained);
+      if (authority !== null) return authority;
+      const operator = operatorAuthority(sql);
+      if (operator !== null) return operator;
+      if (sql.includes('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE')) {
+        return { rows: [], rowCount: null };
+      }
+      if (sql.includes('WHERE operation_id=$1')) return { rows: [], rowCount: 0 };
+      if (sql.includes('transaction_timestamp()')) {
+        return { rows: [{ trusted_at: transitionTime }], rowCount: 1 };
+      }
+      if (sql.includes('pg_advisory_xact_lock')) return { rows: [{}], rowCount: 1 };
+      if (sql.includes('FROM outcome_local_private_trade_evaluation_head')) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.includes('FROM outcome_local_private_trade_evaluation_generation')) {
+        return { rows: [{ generation_id: generationId }], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO outcome_private_evaluation_transition_receipt')) {
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO outcome_local_private_trade_evaluation_head')) {
+        return { rows: [], rowCount: 1 };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    const repository = await repositoryFor(client, retained);
+
+    await expect(
+      repository.commit({
+        receipt,
+        receiptArtifact: createAflTradeCanonicalJsonArtifactRef(receipt, transitionTime),
+      })
+    ).rejects.toThrow(/retained|selector|authority/i);
+    expect(
+      client.calls.some(({ sql }) =>
+        sql.includes('INSERT INTO outcome_private_evaluation_transition_receipt')
+      )
+    ).toBe(false);
+  });
+
+  it('rejects a staged transition when operator authority is absent at CAS time', async () => {
+    const { receipt, retained } = activationFixture();
+    const client = new RecordingSqlClient((sql) => {
+      const authority = storedAuthority(sql, receipt, retained);
+      if (authority !== null) return authority;
+      if (sql.includes('FROM outcome_operational_principal_authority')) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.includes('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE')) {
+        return { rows: [], rowCount: null };
+      }
+      if (sql.includes('WHERE operation_id=$1')) return { rows: [], rowCount: 0 };
+      if (sql.includes('transaction_timestamp()')) {
+        return { rows: [{ trusted_at: transitionTime }], rowCount: 1 };
+      }
+      if (sql.includes('pg_advisory_xact_lock')) return { rows: [{}], rowCount: 1 };
+      if (sql.includes('FROM outcome_local_private_trade_evaluation_head')) {
+        return { rows: [], rowCount: 0 };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    const repository = await repositoryFor(client, retained);
+
+    await expect(
+      repository.commit({
+        receipt,
+        receiptArtifact: createAflTradeCanonicalJsonArtifactRef(receipt, transitionTime),
+      })
+    ).rejects.toThrow('current governed operator authority');
+  });
+
+  it('rejects relational authority when its retained snapshot bytes are absent', async () => {
+    const { receipt, retained } = activationFixture();
+    const client = new RecordingSqlClient((sql) => {
+      const authority = storedAuthority(sql, receipt, retained);
+      if (authority !== null) return authority;
+      if (sql.includes('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE')) {
+        return { rows: [], rowCount: null };
+      }
+      if (sql.includes('WHERE operation_id=$1')) return { rows: [], rowCount: 0 };
+      if (sql.includes('transaction_timestamp()')) {
+        return { rows: [{ trusted_at: transitionTime }], rowCount: 1 };
+      }
+      if (sql.includes('pg_advisory_xact_lock')) return { rows: [{}], rowCount: 1 };
+      if (sql.includes('FROM outcome_local_private_trade_evaluation_head')) {
+        return { rows: [], rowCount: 0 };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    const repository = createPostgresGovernedPrivateEvaluationLifecycleRepository({
+      client,
+      artifactRepository: createAflTradeFixtureArtifactRepository({
+        artifactClass: 'derived_private',
+      }),
+      maximumArtifactBytes: 1024 * 1024,
+    });
+
+    await expect(
+      repository.commit({
+        receipt,
+        receiptArtifact: createAflTradeCanonicalJsonArtifactRef(receipt, transitionTime),
+      })
+    ).rejects.toThrow('exact retained authority bytes');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-read.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-read.test.ts
@@ -1,0 +1,359 @@
+import {
+  createAflTradeByteArtifactRef,
+  createAflTradeCanonicalJsonArtifactRef,
+} from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import type { AflTradeImmutableArtifactRepository } from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import { createAflTradeFixtureArtifactRepository } from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import {
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlQueryResult,
+  AflOutcomeSqlTransaction,
+} from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { createGovernedPrivateEvaluationGeneration } from '@/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration';
+import { createPostgresGovernedPrivateEvaluationReadRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationReadRepository';
+import { createGovernedPrivateEvaluationNarrativeFixture } from '../testUtils/governedPrivateEvaluationFixture';
+
+const selector = {
+  valuationScopeKey: 'afl-trade-history:test-fixture',
+  tradeId: 'trade:adelaide-st-kilda',
+};
+const generatedAt = '2026-08-19T10:00:00.000Z';
+const materialization = createGovernedPrivateEvaluationGeneration({
+  selector,
+  transitionIntentId: `private-evaluation-transition-intent:${'a'.repeat(64)}`,
+  generatedAt,
+  narrative: createGovernedPrivateEvaluationNarrativeFixture(),
+});
+
+class ReadSqlClient implements AflOutcomeSqlClient {
+  status: 'active' | 'withdrawn' | 'absent' = 'active';
+  activeGenerationId: string | null = materialization.generation.generationId;
+  generationJson: unknown = materialization.generation;
+  queryCount = 0;
+
+  async query<Row>(sql: string): Promise<AflOutcomeSqlQueryResult<Row>> {
+    this.queryCount += 1;
+    if (sql.includes('FROM outcome_local_private_trade_evaluation_head h')) {
+      return {
+        rows:
+          this.status === 'absent'
+            ? []
+            : [
+                {
+                  status: this.status,
+                  generation_json:
+                    this.status === 'active' ? this.generationJson : null,
+                },
+              ],
+        rowCount: this.status === 'absent' ? 0 : 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('outcome_local_private_trade_evaluation_generation')) {
+      return {
+        rows: [
+          {
+            generation_json: this.generationJson,
+            head_status: this.status === 'absent' ? null : this.status,
+            head_generation_id: this.status === 'active' ? this.activeGenerationId : null,
+            last_action: this.status === 'withdrawn' ? 'withdraw' : null,
+            last_from_generation_id:
+              this.status === 'withdrawn' ? materialization.generation.generationId : null,
+          },
+        ],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    throw new Error(`Unexpected SQL: ${sql}`);
+  }
+
+  async transaction<T>(
+    work: (transaction: AflOutcomeSqlTransaction) => Promise<T>
+  ): Promise<T> {
+    return work(this);
+  }
+}
+
+async function retainedArtifacts(): Promise<AflTradeImmutableArtifactRepository> {
+  const repository = createAflTradeFixtureArtifactRepository({
+    artifactClass: 'derived_private',
+  });
+  for (const artifact of materialization.artifacts) {
+    await repository.putIfAbsent(artifact.reference, artifact.bytes);
+  }
+  return repository;
+}
+
+describe('PostgreSQL governed private evaluation read repository', () => {
+  it('authenticates current and explicit historical projection bytes', async () => {
+    const client = new ReadSqlClient();
+    const repository = createPostgresGovernedPrivateEvaluationReadRepository({
+      client,
+      artifactRepository: await retainedArtifacts(),
+      maximumArtifactBytes: 4 * 1024 * 1024,
+      principalId: 'firebase:registered-reader',
+      authorizeReader: async () => true,
+    });
+
+    await expect(
+      repository.read({
+        selector,
+        selection: { kind: 'current' },
+        document: { kind: 'detail' },
+      })
+    ).resolves.toMatchObject({
+      state: 'available',
+      selector,
+      selection: { kind: 'current' },
+      generationId: materialization.generation.generationId,
+      projectionManifestId: materialization.projectionManifest.projectionManifestId,
+      lifecycle: { status: 'active', current: true },
+      document: { kind: 'detail' },
+    });
+
+    const exported = await repository.read({
+      selector,
+      selection: {
+        kind: 'generation',
+        generationId: materialization.generation.generationId,
+      },
+      document: { kind: 'json_export' },
+    });
+    expect(exported).toMatchObject({
+      state: 'available',
+      lifecycle: { status: 'active', current: true },
+    });
+    if (exported.state !== 'available') throw new Error('Expected exact export bytes.');
+    expect(new TextDecoder().decode(exported.bytes).endsWith('\n')).toBe(true);
+  });
+
+  it('keeps withdrawn current reads unavailable while preserving explicit history', async () => {
+    const client = new ReadSqlClient();
+    client.status = 'withdrawn';
+    const repository = createPostgresGovernedPrivateEvaluationReadRepository({
+      client,
+      artifactRepository: await retainedArtifacts(),
+      maximumArtifactBytes: 4 * 1024 * 1024,
+      principalId: 'firebase:registered-reader',
+      authorizeReader: async () => true,
+    });
+
+    await expect(
+      repository.read({
+        selector,
+        selection: { kind: 'current' },
+        document: { kind: 'archive_summary' },
+      })
+    ).resolves.toEqual({
+      state: 'unavailable',
+      selector,
+      selection: { kind: 'current' },
+      document: { kind: 'archive_summary' },
+      reason: 'withdrawn',
+    });
+    await expect(
+      repository.read({
+        selector,
+        selection: {
+          kind: 'generation',
+          generationId: materialization.generation.generationId,
+        },
+        document: { kind: 'archive_summary' },
+      })
+    ).resolves.toMatchObject({
+      state: 'available',
+      lifecycle: { status: 'withdrawn', current: false },
+    });
+  });
+
+  it('labels an older explicit generation as superseded and inactive', async () => {
+    const client = new ReadSqlClient();
+    client.activeGenerationId = `local-private-trade-evaluation-generation:${'f'.repeat(64)}`;
+    const repository = createPostgresGovernedPrivateEvaluationReadRepository({
+      client,
+      artifactRepository: await retainedArtifacts(),
+      maximumArtifactBytes: 4 * 1024 * 1024,
+      principalId: 'firebase:registered-reader',
+      authorizeReader: async () => true,
+    });
+
+    await expect(
+      repository.read({
+        selector,
+        selection: {
+          kind: 'generation',
+          generationId: materialization.generation.generationId,
+        },
+        document: { kind: 'detail' },
+      })
+    ).resolves.toMatchObject({
+      state: 'available',
+      lifecycle: { status: 'superseded', current: false },
+    });
+  });
+
+  it('fails closed when any retained generation byte is altered', async () => {
+    const stored = await retainedArtifacts();
+    const tampered: AflTradeImmutableArtifactRepository = {
+      ...stored,
+      async loadExact(reference, maximumBytes) {
+        const result = await stored.loadExact(reference, maximumBytes);
+        if (
+          result === null ||
+          reference.artifactId !== materialization.projectionManifest.content.documents[1]?.artifact.artifactId
+        ) {
+          return result;
+        }
+        return { ...result, bytes: new TextEncoder().encode('{"tampered":true}') };
+      },
+    };
+    const repository = createPostgresGovernedPrivateEvaluationReadRepository({
+      client: new ReadSqlClient(),
+      artifactRepository: tampered,
+      maximumArtifactBytes: 4 * 1024 * 1024,
+      principalId: 'firebase:registered-reader',
+      authorizeReader: async () => true,
+    });
+
+    await expect(
+      repository.read({
+        selector,
+        selection: { kind: 'current' },
+        document: { kind: 'detail' },
+      })
+    ).resolves.toMatchObject({ state: 'unavailable', reason: 'authentication_failed' });
+  });
+
+  it('returns projection unavailable for an unsupported retained generation version', async () => {
+    const client = new ReadSqlClient();
+    client.generationJson = {
+      ...materialization.generation,
+      content: {
+        ...materialization.generation.content,
+        schemaVersion: 'local-private-trade-evaluation-generation/v999',
+      },
+    };
+    const artifacts = await retainedArtifacts();
+    const loadExact = vi.spyOn(artifacts, 'loadExact');
+    const repository = createPostgresGovernedPrivateEvaluationReadRepository({
+      client,
+      artifactRepository: artifacts,
+      maximumArtifactBytes: 4 * 1024 * 1024,
+      principalId: 'firebase:registered-reader',
+      authorizeReader: async () => true,
+    });
+
+    await expect(
+      repository.read({
+        selector,
+        selection: { kind: 'current' },
+        document: { kind: 'detail' },
+      })
+    ).resolves.toEqual({
+      state: 'unavailable',
+      selector,
+      selection: { kind: 'current' },
+      document: { kind: 'detail' },
+      reason: 'projection_unavailable',
+    });
+    expect(loadExact).not.toHaveBeenCalled();
+  });
+
+  it('returns projection unavailable for an unsupported retained manifest version', async () => {
+    const unsupportedManifest = {
+      ...materialization.projectionManifest,
+      content: {
+        ...materialization.projectionManifest.content,
+        schemaVersion: 'governed-private-evaluation-projection-manifest/v999',
+      },
+    };
+    const manifestBytes = new TextEncoder().encode(
+      canonicalizeAflTradeJson(unsupportedManifest)
+    );
+    const manifestArtifact = createAflTradeByteArtifactRef(
+      manifestBytes,
+      'application/json',
+      generatedAt
+    );
+    const generationContent = {
+      ...materialization.generation.content,
+      projectionManifestArtifact: manifestArtifact,
+    };
+    const generation = {
+      generationId: createAflTradeContentAddress(
+        'local-private-trade-evaluation-generation',
+        generationContent
+      ),
+      content: generationContent,
+    };
+    const generationArtifact = createAflTradeCanonicalJsonArtifactRef(
+      generation,
+      generatedAt
+    );
+    const artifacts = await retainedArtifacts();
+    await artifacts.putIfAbsent(manifestArtifact, manifestBytes);
+    await artifacts.putIfAbsent(
+      generationArtifact,
+      new TextEncoder().encode(canonicalizeAflTradeJson(generation))
+    );
+    const loadExact = vi.spyOn(artifacts, 'loadExact');
+    const client = new ReadSqlClient();
+    client.generationJson = generation;
+    const repository = createPostgresGovernedPrivateEvaluationReadRepository({
+      client,
+      artifactRepository: artifacts,
+      maximumArtifactBytes: 4 * 1024 * 1024,
+      principalId: 'firebase:registered-reader',
+      authorizeReader: async () => true,
+    });
+
+    await expect(
+      repository.read({
+        selector,
+        selection: { kind: 'current' },
+        document: { kind: 'detail' },
+      })
+    ).resolves.toMatchObject({ state: 'unavailable', reason: 'projection_unavailable' });
+    const loadedArtifactIds = loadExact.mock.calls.map(([reference]) => reference.artifactId);
+    for (const document of materialization.projectionManifest.content.documents) {
+      expect(loadedArtifactIds).not.toContain(document.artifact.artifactId);
+    }
+  });
+
+  it('denies an unauthorized principal before database or artifact access', async () => {
+    const client = new ReadSqlClient();
+    const artifacts = await retainedArtifacts();
+    const loadExact = vi.spyOn(artifacts, 'loadExact');
+    const authorizeReader = vi.fn(async () => false);
+    const repository = createPostgresGovernedPrivateEvaluationReadRepository({
+      client,
+      artifactRepository: artifacts,
+      maximumArtifactBytes: 4 * 1024 * 1024,
+      principalId: 'firebase:unauthorized-reader',
+      authorizeReader,
+    });
+
+    await expect(
+      repository.read({
+        selector,
+        selection: { kind: 'current' },
+        document: { kind: 'detail' },
+      })
+    ).resolves.toEqual({
+      state: 'unavailable',
+      selector,
+      selection: { kind: 'current' },
+      document: { kind: 'detail' },
+      reason: 'not_found',
+    });
+    expect(authorizeReader).toHaveBeenCalledWith({
+      principalId: 'firebase:unauthorized-reader',
+      selector,
+    });
+    expect(client.queryCount).toBe(0);
+    expect(loadExact).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-reconstruction.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-reconstruction.test.ts
@@ -1,0 +1,154 @@
+import type { AflTradeArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import type { AflTradeImmutableArtifactRepository } from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import { createAflTradeFixtureArtifactRepository } from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlQueryResult,
+  AflOutcomeSqlTransaction,
+} from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { createGovernedPrivateEvaluationGeneration } from '@/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration';
+import { createPostgresGovernedPrivateEvaluationReconstructionRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationReconstructionRepository';
+import { createGovernedPrivateEvaluationNarrativeFixture } from '../testUtils/governedPrivateEvaluationFixture';
+
+const selector = {
+  valuationScopeKey: 'afl-trade-history:test-fixture',
+  tradeId: 'trade:adelaide-st-kilda',
+};
+const verifiedAt = '2026-08-19T10:00:00.000Z';
+const generation = createGovernedPrivateEvaluationGeneration({
+  selector,
+  transitionIntentId: `private-evaluation-transition-intent:${'a'.repeat(64)}`,
+  generatedAt: verifiedAt,
+  narrative: createGovernedPrivateEvaluationNarrativeFixture(),
+});
+const request = {
+  selector,
+  inspectionId: `private-evaluation-inspection:${'b'.repeat(64)}`,
+  operationId: `private-evaluation-operation:${'c'.repeat(64)}`,
+  generationId: generation.generation.generationId,
+};
+
+class ReconstructionSqlClient implements AflOutcomeSqlClient {
+  readonly sql: string[] = [];
+  existing: { verification_json: unknown; artifact_id: string } | null = null;
+  trustedAt = verifiedAt;
+
+  async query<Row>(
+    statement: string
+  ): Promise<AflOutcomeSqlQueryResult<Row>> {
+    this.sql.push(statement);
+    if (statement.includes("date_trunc('milliseconds',clock_timestamp())")) {
+      return {
+        rows: [{ trusted_at: new Date(this.trustedAt) }],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (statement.includes('FROM outcome_private_evaluation_reconstruction_verification')) {
+      return {
+        rows: this.existing === null ? [] : [this.existing],
+        rowCount: this.existing === null ? 0 : 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (statement.includes('FROM outcome_private_evaluation_inspection_receipt')) {
+      return {
+        rows: [{ inspection_id: request.inspectionId }],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (statement.includes('FROM outcome_local_private_trade_evaluation_generation')) {
+      return {
+        rows: [{ generation_json: generation.generation }],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (statement.includes('INSERT INTO outcome_private_evaluation_reconstruction_verification')) {
+      return { rows: [], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+    }
+    throw new Error(`Unexpected SQL: ${statement}`);
+  }
+
+  async transaction<T>(
+    work: (transaction: AflOutcomeSqlTransaction) => Promise<T>
+  ): Promise<T> {
+    return work(this);
+  }
+}
+
+async function retainedArtifacts(): Promise<AflTradeImmutableArtifactRepository> {
+  const repository = createAflTradeFixtureArtifactRepository({
+    artifactClass: 'derived_private',
+  });
+  for (const artifact of generation.artifacts) {
+    await repository.putIfAbsent(artifact.reference, artifact.bytes);
+  }
+  return repository;
+}
+
+describe('PostgreSQL governed private evaluation reconstruction repository', () => {
+  it('authenticates every retained artifact and persists an exact replayable verification', async () => {
+    const client = new ReconstructionSqlClient();
+    const retained: { reference: AflTradeArtifactRef; bytes: Uint8Array }[] = [];
+    const repository = createPostgresGovernedPrivateEvaluationReconstructionRepository({
+      client,
+      artifactRepository: await retainedArtifacts(),
+      maximumArtifactBytes: 4 * 1024 * 1024,
+      retainArtifact: async (artifact) => {
+        retained.push(artifact);
+        return artifact.reference;
+      },
+    });
+
+    const first = await repository.verify(request);
+    expect(first).toMatchObject({
+      state: 'verified',
+      generationId: request.generationId,
+      exactMatch: true,
+      verifiedAt,
+    });
+    expect(retained).toHaveLength(1);
+    expect(
+      client.sql.some((sql) =>
+        sql.includes('INSERT INTO outcome_private_evaluation_reconstruction_verification')
+      )
+    ).toBe(true);
+
+    client.existing = {
+      verification_json: first.verification,
+      artifact_id: retained[0]!.reference.artifactId,
+    };
+    client.trustedAt = '2026-08-19T10:01:00.000Z';
+    await expect(repository.verify(request)).resolves.toMatchObject({
+      state: 'replayed',
+      verificationId: first.verificationId,
+      exactMatch: true,
+      verifiedAt,
+    });
+  });
+
+  it('does not retain a verification when reconstruction bytes are altered', async () => {
+    const stored = await retainedArtifacts();
+    const tampered: AflTradeImmutableArtifactRepository = {
+      ...stored,
+      async loadExact(reference, maximumBytes) {
+        const result = await stored.loadExact(reference, maximumBytes);
+        if (
+          result === null ||
+          reference.artifactId !== generation.projectionManifest.content.documents[0]?.artifact.artifactId
+        ) {
+          return result;
+        }
+        return { ...result, bytes: new TextEncoder().encode('{"tampered":true}') };
+      },
+    };
+    const retainArtifact = vi.fn();
+    const repository = createPostgresGovernedPrivateEvaluationReconstructionRepository({
+      client: new ReconstructionSqlClient(),
+      artifactRepository: tampered,
+      maximumArtifactBytes: 4 * 1024 * 1024,
+      retainArtifact,
+    });
+
+    await expect(repository.verify(request)).rejects.toThrow(/authentication|reconstruction/i);
+    expect(retainArtifact).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-staging.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-staging.test.ts
@@ -1,0 +1,211 @@
+import {
+  createAflTradeByteArtifactRef,
+  createAflTradeCanonicalJsonArtifactRef,
+  type AflTradeArtifactRef,
+} from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { createAflTradeFixtureArtifactRepository } from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlQueryResult,
+  AflOutcomeSqlTransaction,
+} from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { createGovernedPrivateEvaluationTransitionIntent } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle';
+import { createPostgresGovernedPrivateEvaluationStagingRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationStagingRepository';
+
+const selector = {
+  valuationScopeKey: 'afl-trade-history:test-fixture',
+  tradeId: 'trade:three-club:1',
+};
+const now = '2026-08-19T10:00:00.000Z';
+
+class StagingSqlClient implements AflOutcomeSqlClient {
+  readonly sql: string[] = [];
+  readonly custodyParameters: readonly unknown[][] = [];
+  intentParameters: readonly unknown[] | null = null;
+  private readonly artifacts = new Map<string, AflTradeArtifactRef>();
+
+  constructor(
+    private readonly retainedIntent: unknown,
+    private readonly retainedIntentArtifact: AflTradeArtifactRef
+  ) {
+    this.expectArtifact(retainedIntentArtifact);
+  }
+
+  expectArtifact(artifact: AflTradeArtifactRef): void {
+    this.artifacts.set(artifact.artifactId, artifact);
+  }
+
+  async query<Row>(
+    statement: string,
+    parameters: readonly unknown[] = []
+  ): Promise<AflOutcomeSqlQueryResult<Row>> {
+    this.sql.push(statement);
+    if (statement.includes("date_trunc('milliseconds',transaction_timestamp())")) {
+      return {
+        rows: [{ trusted_at: new Date(now) }],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (statement.includes('INSERT INTO outcome_artifact_custody')) {
+      this.custodyParameters.push(parameters);
+      return { rows: [], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (statement.includes('FROM outcome_artifact_custody')) {
+      const artifact = this.artifacts.get(String(parameters[0]));
+      if (artifact === undefined) throw new Error('Unexpected artifact custody read.');
+      return {
+        rows: [
+          {
+            artifact_id: artifact.artifactId,
+            content_sha256: artifact.contentSha256,
+            storage_uri: artifact.storageUri,
+            media_type: artifact.mediaType,
+            byte_length: artifact.byteLength,
+          },
+        ],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (statement.includes('INSERT INTO outcome_private_evaluation_transition_intent')) {
+      this.intentParameters = parameters;
+      return { rows: [], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (statement.includes('FROM outcome_private_evaluation_transition_intent')) {
+      return {
+        rows: [
+          {
+            intent_json: this.retainedIntent,
+            artifact_id: this.retainedIntentArtifact.artifactId,
+          },
+        ],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    throw new Error(`Unexpected SQL: ${statement}`);
+  }
+
+  async transaction<T>(
+    work: (transaction: AflOutcomeSqlTransaction) => Promise<T>
+  ): Promise<T> {
+    return work(this);
+  }
+}
+
+function withdrawalIntent() {
+  return createGovernedPrivateEvaluationTransitionIntent({
+    selector,
+    inspectionId: `private-evaluation-inspection:${'a'.repeat(64)}`,
+    authoritySnapshotId: null,
+    operationId: `private-evaluation-operation:${'b'.repeat(64)}`,
+    action: { kind: 'withdraw', reason: 'Operator safety withdrawal.' },
+    expectedHead: {
+      status: 'active',
+      revision: 1,
+      generationId: `local-private-trade-evaluation-generation:${'c'.repeat(64)}`,
+    },
+    review: {
+      principalId: 'firebase:operator-1',
+      rationale: 'Withdraw the active fixture generation.',
+    },
+    requestedAt: now,
+    expiresAt: '2026-08-19T10:05:00.000Z',
+  });
+}
+
+describe('PostgreSQL governed private evaluation staging repository', () => {
+  it('retains, reads back, registers, and stages an exact transition intent', async () => {
+    const intent = withdrawalIntent();
+    const intentArtifact = createAflTradeCanonicalJsonArtifactRef(intent, now);
+    const client = new StagingSqlClient(intent, intentArtifact);
+    const artifacts = createAflTradeFixtureArtifactRepository({
+      artifactClass: 'derived_private',
+    });
+    const repository = createPostgresGovernedPrivateEvaluationStagingRepository({
+      client,
+      artifactRepository: artifacts,
+      maximumArtifactBytes: 1_000_000,
+    });
+
+    await expect(repository.stage({ intent, intentArtifact })).resolves.toEqual({
+      transitionIntentId: intent.transitionIntentId,
+      generationId: null,
+    });
+    const retained = await artifacts.loadExact(intentArtifact, 1_000_000);
+    expect(new TextDecoder().decode(retained?.bytes)).toBe(canonicalizeAflTradeJson(intent));
+    expect(client.sql.some((sql) => sql.includes('INSERT INTO outcome_artifact_custody'))).toBe(
+      true
+    );
+    expect(
+      client.sql.some((sql) =>
+        sql.includes('authority_snapshot_id')
+      )
+    ).toBe(true);
+    expect(client.intentParameters?.[2]).toBeNull();
+    expect(client.custodyParameters[0]?.[6]).toBe(now);
+
+    const receiptBytes = new TextEncoder().encode('{"receipt":true}');
+    const receiptArtifact = createAflTradeByteArtifactRef(
+      receiptBytes,
+      'application/json',
+      now
+    );
+    client.expectArtifact(receiptArtifact);
+    await expect(
+      repository.retainArtifact({
+        reference: receiptArtifact,
+        bytes: receiptBytes,
+      })
+    ).resolves.toEqual(receiptArtifact);
+    expect(client.custodyParameters.at(-1)?.[6]).toBe(now);
+    await expect(artifacts.loadExact(receiptArtifact, 1_000_000)).resolves.toMatchObject({
+      reference: receiptArtifact,
+    });
+  });
+
+  it('refuses to stage construction without one complete verified generation', async () => {
+    const withdrawal = withdrawalIntent();
+    const intent = createGovernedPrivateEvaluationTransitionIntent({
+      ...withdrawal.content,
+      authoritySnapshotId: `private-evaluation-authority-snapshot:${'d'.repeat(64)}`,
+      operationId: `private-evaluation-operation:${'e'.repeat(64)}`,
+      action: { kind: 'construct_and_activate' },
+    });
+    const artifact = createAflTradeCanonicalJsonArtifactRef(intent, now);
+    const repository = createPostgresGovernedPrivateEvaluationStagingRepository({
+      client: new StagingSqlClient(intent, artifact),
+      artifactRepository: createAflTradeFixtureArtifactRepository({
+        artifactClass: 'derived_private',
+      }),
+      maximumArtifactBytes: 1_000_000,
+    });
+
+    await expect(repository.stage({ intent, intentArtifact: artifact })).rejects.toThrow(
+      /complete verified generation/i
+    );
+  });
+
+  it('registers local private artifact custody as non-production rather than fixture data', async () => {
+    const intent = withdrawalIntent();
+    const artifact = createAflTradeCanonicalJsonArtifactRef(intent, now);
+    const client = new StagingSqlClient(intent, artifact);
+    const fixtureRepository = createAflTradeFixtureArtifactRepository({
+      artifactClass: 'derived_private',
+    });
+    const repository = createPostgresGovernedPrivateEvaluationStagingRepository({
+      client,
+      artifactRepository: {
+        ...fixtureRepository,
+        assurance: 'local_non_production_filesystem',
+      },
+      maximumArtifactBytes: 1_000_000,
+    });
+
+    await repository.retainArtifact({
+      reference: artifact,
+      bytes: new TextEncoder().encode(canonicalizeAflTradeJson(intent)),
+    });
+
+    expect(client.custodyParameters[0]?.[5]).toBe('non_production');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-postgres-governed-valuation-component-run.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-valuation-component-run.test.ts
@@ -1,0 +1,150 @@
+import {
+  createAflTradeCanonicalJsonArtifactRef,
+  type AflTradeArtifactRef,
+} from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import {
+  createAflTradeFixtureArtifactRepository,
+  type AflTradeImmutableArtifactRepository,
+} from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlQueryResult,
+  AflOutcomeSqlTransaction,
+} from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { createGovernedValuationComponentRunManifest } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest';
+import { PostgresGovernedValuationComponentRunRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationComponentRunRepository';
+
+const retainedAt = '2026-08-20T09:00:00.000Z';
+const registeredAt = '2026-08-20T10:00:00.000Z';
+const id = (kind: string, marker: string) => `${kind}:${marker.repeat(64)}`;
+
+class ComponentRunSqlClient implements AflOutcomeSqlClient {
+  row: Record<string, unknown> | null = null;
+
+  constructor(private readonly manifestArtifact: AflTradeArtifactRef) {}
+
+  async query<Row>(
+    sql: string,
+    parameters: readonly unknown[] = []
+  ): Promise<AflOutcomeSqlQueryResult<Row>> {
+    if (sql.includes('pg_advisory_xact_lock')) return { rows: [], rowCount: 1 };
+    if (sql.includes('SELECT') && sql.includes('outcome_governed_valuation_component_run')) {
+      return {
+        rows: this.row === null ? [] : [this.row as Row],
+        rowCount: this.row === null ? 0 : 1,
+      };
+    }
+    if (sql.includes('INSERT INTO outcome_governed_valuation_component_run')) {
+      const artifact = this.manifestArtifact;
+      expect(parameters[4]).toBe(artifact.artifactId);
+      this.row = {
+        run_id: parameters[0],
+        role: parameters[1],
+        native_execution_kind: parameters[2],
+        native_execution_id: parameters[3],
+        artifact_id: artifact.artifactId,
+        native_execution_artifact_id: parameters[5],
+        protocol_id: parameters[6],
+        protocol_artifact_id: parameters[7],
+        dataset_id: parameters[8],
+        dataset_artifact_id: parameters[9],
+        dataset_admission_id: parameters[10],
+        dataset_admission_artifact_id: parameters[11],
+        dataset_admission_gate_ledger_revision: parameters[12],
+        registered_at: parameters[13],
+        content_sha256: parameters[14],
+        content_canonical_json: parameters[15],
+        manifest_json: JSON.parse(String(parameters[16])),
+        artifact_content_sha256: artifact.contentSha256,
+        artifact_storage_uri: artifact.storageUri,
+        artifact_media_type: artifact.mediaType,
+        artifact_byte_length: artifact.byteLength,
+        artifact_created_at: artifact.createdAt,
+      };
+      return { rows: [], rowCount: 1 };
+    }
+    throw new Error(`Unexpected SQL: ${sql}`);
+  }
+
+  transaction<T>(work: (transaction: AflOutcomeSqlTransaction) => Promise<T>): Promise<T> {
+    return work(this);
+  }
+}
+
+async function retained(
+  repository: AflTradeImmutableArtifactRepository,
+  value: unknown,
+  createdAt = retainedAt
+) {
+  const reference = createAflTradeCanonicalJsonArtifactRef(value, createdAt);
+  const bytes = new TextEncoder().encode(canonicalizeAflTradeJson(value));
+  await repository.putIfAbsent(reference, bytes);
+  return reference;
+}
+
+async function fixture() {
+  const artifacts = createAflTradeFixtureArtifactRepository({ artifactClass: 'derived_private' });
+  const nativeExecution = await retained(artifacts, { kind: 'pick-run' });
+  const protocol = await retained(artifacts, { kind: 'pick-protocol' });
+  const dataset = await retained(artifacts, { kind: 'pick-dataset' });
+  const admission = await retained(artifacts, { kind: 'pick-admission' });
+  const manifest = createGovernedValuationComponentRunManifest({
+    environment: 'non_production',
+    role: 'draft_pick_and_future_pick_distribution',
+    nativeExecution: {
+      kind: 'pick_pav_model_execution',
+      executionId: id('pick-pav-model-execution', '1'),
+      artifact: nativeExecution,
+    },
+    protocolId: id('model-protocol', '2'),
+    protocolArtifact: protocol,
+    datasetId: id('dataset', '3'),
+    datasetArtifact: dataset,
+    datasetAdmissionId: id('dataset-admission', '4'),
+    datasetAdmissionArtifact: admission,
+    datasetAdmissionGateLedgerRevision: 12,
+    registeredAt,
+  });
+  const manifestArtifact = await retained(artifacts, manifest, registeredAt);
+  return { artifacts, manifest, manifestArtifact, nativeExecution };
+}
+
+describe('PostgreSQL governed valuation component-run repository', () => {
+  it('registers, exactly replays, and rejects substituted physical evidence', async () => {
+    const value = await fixture();
+    const client = new ComponentRunSqlClient(value.manifestArtifact);
+    const repository = new PostgresGovernedValuationComponentRunRepository({
+      client,
+      artifactRepository: value.artifacts,
+      maximumArtifactBytes: 1024 * 1024,
+    });
+
+    await expect(
+      repository.register({ manifest: value.manifest, artifact: value.manifestArtifact })
+    ).resolves.toEqual({ manifest: value.manifest, artifact: value.manifestArtifact });
+    await expect(repository.loadExact(value.manifest.runId)).resolves.toEqual({
+      manifest: value.manifest,
+      artifact: value.manifestArtifact,
+    });
+    await expect(
+      repository.register({ manifest: value.manifest, artifact: value.manifestArtifact })
+    ).resolves.toEqual({ manifest: value.manifest, artifact: value.manifestArtifact });
+
+    const substituted: AflTradeImmutableArtifactRepository = {
+      ...value.artifacts,
+      loadExact: async (reference, maximumBytes) =>
+        reference.artifactId === value.nativeExecution.artifactId
+          ? { reference, bytes: new TextEncoder().encode('substituted') }
+          : value.artifacts.loadExact(reference, maximumBytes),
+    };
+    const rejecting = new PostgresGovernedValuationComponentRunRepository({
+      client,
+      artifactRepository: substituted,
+      maximumArtifactBytes: 1024 * 1024,
+    });
+    await expect(rejecting.loadExact(value.manifest.runId)).rejects.toThrow(
+      /artifact|bytes|custody|evidence/i
+    );
+  });
+});

--- a/tests/unit/afl-trade-intelligence-prepared-valuation-input-set.test.ts
+++ b/tests/unit/afl-trade-intelligence-prepared-valuation-input-set.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import {
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import {
   AFL_TRADE_PREPARED_VALUATION_INPUT_SET_SCHEMA_VERSION,
+  AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V2_SCHEMA_VERSION,
+  AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V3_SCHEMA_VERSION,
   createAflTradePreparedValuationInputSet,
 } from '@/server/aflTradeIntelligence/valuation/preparedValuationInputSet';
+import { PostgresAflTradePreparedValuationInputSetStore } from '@/server/aflTradeIntelligence/valuation/postgresPreparedValuationInputSetStore';
 
 const digest = (character: string) => character.repeat(64);
 type PreparedInput = Parameters<typeof createAflTradePreparedValuationInputSet>[0];
@@ -71,7 +77,121 @@ function content() {
   };
 }
 
+function v2Content() {
+  return {
+    ...content(),
+    schemaVersion: AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V2_SCHEMA_VERSION,
+    preparationAuthority: 'authenticated_calculation_evidence_snapshot' as const,
+    valuationInputBundleId: `valuation-input-bundle:${digest('9')}`,
+    valuationInputBundleArtifact: artifact('a'),
+    entries: [
+      {
+        tradeId: 'trade-a',
+        state: 'ready' as const,
+        calculationInputPackageId: `valuation-calculation-input:${digest('b')}`,
+        calculationInputArtifact: artifact('c'),
+        inputTraceId: `private-evaluation-input-trace:${digest('d')}`,
+        inputTraceArtifact: artifact('e'),
+      },
+      {
+        tradeId: 'trade-b',
+        state: 'blocked' as const,
+        blockers: [
+          {
+            code: 'lineage_unresolved' as const,
+            subject: { kind: 'lineage' as const, id: 'asset:pick-12' },
+            evidenceRefs: [artifact('f')],
+          },
+        ],
+      },
+    ],
+    readyCount: 1,
+    blockedCount: 1,
+  };
+}
+
+function v3Content() {
+  return {
+    ...v2Content(),
+    schemaVersion: AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V3_SCHEMA_VERSION,
+    entries: [
+      {
+        tradeId: 'trade-a',
+        state: 'ready' as const,
+        materializationManifestId: `private-evaluation-materialization-manifest:${digest('7')}`,
+        materializationManifestArtifact: artifact('b'),
+      },
+      v2Content().entries[1]!,
+    ],
+  };
+}
+
 describe('AFL trade prepared valuation input set', () => {
+  it('keeps current prepared authority behind explicit CAS and coherent read methods', () => {
+    const store = new PostgresAflTradePreparedValuationInputSetStore({
+      query: async () => ({ rows: [], rowCount: 0 }),
+      transaction: async (work) =>
+        work({ query: async () => ({ rows: [], rowCount: 0 }) }),
+    });
+
+    expect(store.activateCurrent).toEqual(expect.any(Function));
+    expect(store.loadCurrent).toEqual(expect.any(Function));
+    expect(store.loadCurrentTrade).toEqual(expect.any(Function));
+  });
+
+  it('rejects relational ancestry that disagrees with finalized v3 bytes', async () => {
+    const prepared = createAflTradePreparedValuationInputSet(v3Content());
+    let queryIndex = 0;
+    const store = new PostgresAflTradePreparedValuationInputSetStore({
+      async query() {
+        queryIndex += 1;
+        if (queryIndex === 1) {
+          return {
+            rows: [
+              {
+                schema_version: AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V2_SCHEMA_VERSION,
+                environment: prepared.content.environment,
+                scope_key: prepared.content.scopeKey,
+                factual_release_scope_key: prepared.content.factualReleaseScopeKey,
+                factual_release_id: prepared.content.factualReleaseId,
+                qualification_report_id: prepared.content.qualificationReportId,
+                prepared_at: prepared.content.preparedAt,
+                prepared_set_json: prepared,
+                content_canonical_json: canonicalizeAflTradeJson(prepared.content),
+                prepared_set_canonical_json: canonicalizeAflTradeJson(prepared),
+                finalized_at: prepared.content.preparedAt,
+                trade_count: prepared.content.tradeCount,
+                ready_count: prepared.content.readyCount,
+                blocked_count: prepared.content.blockedCount,
+                actual_count: prepared.content.tradeCount,
+                actual_ready_count: prepared.content.readyCount,
+                actual_blocked_count: prepared.content.blockedCount,
+              },
+            ],
+            rowCount: 1,
+          };
+        }
+        return {
+          rows: prepared.content.entries.map((entry, index) => ({
+            ordinal: index + 1,
+            trade_id: entry.tradeId,
+            state: entry.state,
+            entry_canonical_json: canonicalizeAflTradeJson(entry),
+            entry_json: entry,
+          })),
+          rowCount: prepared.content.entries.length,
+        };
+      },
+      async transaction(work) {
+        return work(this);
+      },
+    });
+
+    await expect(store.loadExact(prepared.preparedInputSetId)).rejects.toMatchObject({
+      code: 'INTEGRITY_MISMATCH',
+    });
+  });
+
   it('classifies every factual-release trade exactly once as blocked preflight evidence', () => {
     const prepared = createAflTradePreparedValuationInputSet(content());
 
@@ -137,6 +257,49 @@ describe('AFL trade prepared valuation input set', () => {
       createAflTradePreparedValuationInputSet(invalid as unknown as PreparedInput)
     ).toThrow(
       'accepts only exact source-policy blockers'
+    );
+  });
+
+  it('v2 classifies every release trade as authenticated ready or factual blocked', () => {
+    const prepared = createAflTradePreparedValuationInputSet(v2Content());
+
+    expect(prepared.content.schemaVersion).toBe(
+      AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V2_SCHEMA_VERSION
+    );
+    expect(prepared.content.readyCount).toBe(1);
+    expect(prepared.content.blockedCount).toBe(1);
+    expect(prepared.content.entries[0]).toMatchObject({
+      state: 'ready',
+      calculationInputPackageId: `valuation-calculation-input:${digest('b')}`,
+      inputTraceId: `private-evaluation-input-trace:${digest('d')}`,
+    });
+  });
+
+  it('v2 rejects a ready entry whose semantic input and trace share retained bytes', () => {
+    const input = v2Content();
+    const ready = input.entries[0];
+    if (ready?.state !== 'ready') throw new Error('Expected ready fixture entry.');
+    ready.inputTraceArtifact = ready.calculationInputArtifact;
+
+    expect(() => createAflTradePreparedValuationInputSet(input)).toThrow(
+      'Calculation input and trace must be distinct immutable artifacts.'
+    );
+  });
+
+  it('v3 classifies each trade through one bounded materialization manifest or blocker', () => {
+    const prepared = createAflTradePreparedValuationInputSet(v3Content());
+
+    expect(prepared.content.schemaVersion).toBe(
+      AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V3_SCHEMA_VERSION
+    );
+    expect(prepared.content.entries[0]).toEqual({
+      tradeId: 'trade-a',
+      state: 'ready',
+      materializationManifestId: `private-evaluation-materialization-manifest:${digest('7')}`,
+      materializationManifestArtifact: artifact('b'),
+    });
+    expect(prepared.content.readyCount + prepared.content.blockedCount).toBe(
+      prepared.content.tradeCount
     );
   });
 });

--- a/tests/unit/afl-trade-intelligence-prepared-valuation-input-v2-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-prepared-valuation-input-v2-migration.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const sql = readFileSync(
+  join(
+    process.cwd(),
+    'prisma/afl-trade-outcomes/migrations/0059_authenticated_prepared_valuation_inputs/migration.sql'
+  ),
+  'utf8'
+);
+
+describe('authenticated prepared valuation input v2 migration', () => {
+  it('extends 0048 through a forward version-specific migration', () => {
+    expect(sql).toContain('afl-trade-prepared-valuation-input-set/v1');
+    expect(sql).toContain('afl-trade-prepared-valuation-input-set/v2');
+    expect(sql).toMatch(/WHEN \(NEW\."schema_version"='afl-trade-prepared-valuation-input-set\/v1'\)/);
+    expect(sql).toContain('validate_outcome_prepared_valuation_input_set_v2_insert');
+  });
+
+  it('admits exact ready and blocked classifications only for v2', () => {
+    expect(sql).toMatch(/"state" IN \('ready','blocked'\)/);
+    expect(sql).toContain('"trade_count" = "ready_count" + "blocked_count"');
+    expect(sql).toContain("content->'releaseTradeIds' IS DISTINCT FROM expected_trade_ids");
+    expect(sql).toContain('authenticated_calculation_evidence_snapshot');
+  });
+
+  it('authenticates every retained v2 artifact against immutable custody', () => {
+    expect(sql).toContain('validate_outcome_prepared_valuation_input_v2_artifact');
+    expect(sql).toContain("content->'valuationInputBundleArtifact'");
+    expect(sql).toContain("NEW.\"entry_json\"->'calculationInputArtifact'");
+    expect(sql).toContain("NEW.\"entry_json\"->'inputTraceArtifact'");
+    expect(sql).toContain("blocker->'evidenceRefs'");
+    expect(sql).toContain('outcome_artifact_custody');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-prepared-valuation-input-v3-ancestry-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-prepared-valuation-input-v3-ancestry-migration.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const migrationPath =
+  'prisma/afl-trade-outcomes/migrations/0062_authenticated_prepared_v3_ancestry/migration.sql';
+
+describe('authenticated prepared valuation input v3 ancestry migration', () => {
+  const sql = readFileSync(migrationPath, 'utf8');
+
+  it('hardens v3 through a new forward migration', () => {
+    expect(sql).toContain(
+      'CREATE OR REPLACE FUNCTION "validate_outcome_prepared_valuation_input_set_v3_insert"'
+    );
+    expect(sql).not.toContain('ALTER TABLE');
+    expect(sql).not.toContain('DROP TABLE');
+  });
+
+  it('authenticates relational identity and exact factual ancestry', () => {
+    expect(sql).toContain('FROM "outcome_release_manifest"');
+    expect(sql).toContain('FROM "outcome_valuation_source_qualification_report"');
+    expect(sql.match(/FOR KEY SHARE/g)?.length).toBeGreaterThanOrEqual(2);
+    for (const field of [
+      "content->>'schemaVersion' IS DISTINCT FROM NEW.\"schema_version\"",
+      "content->>'environment' IS DISTINCT FROM NEW.\"environment\"::text",
+      "content->>'scopeKey' IS DISTINCT FROM NEW.\"scope_key\"",
+      "content->>'factualReleaseScopeKey' IS DISTINCT FROM NEW.\"factual_release_scope_key\"",
+      "content->>'factualReleaseId' IS DISTINCT FROM NEW.\"factual_release_id\"",
+      "content->>'qualificationReportId' IS DISTINCT FROM NEW.\"qualification_report_id\"",
+      "content->>'preparedAt'",
+    ]) {
+      expect(sql).toContain(field);
+    }
+    expect(sql).toContain("'eligible_for_dataset_admission'");
+    expect(sql).toContain("content->'releaseTradeIds' IS DISTINCT FROM expected_trade_ids");
+  });
+
+  it('verifies retained parent bytes and temporal custody', () => {
+    expect(sql).toContain("content->'factualReleaseArtifact'->>'contentSha256'");
+    expect(sql).toContain("content->'releaseMembershipArtifact'->>'contentSha256'");
+    expect(sql).toContain("content->'qualificationReportArtifact'->>'contentSha256'");
+    expect(sql).toContain(
+      '"validate_outcome_prepared_valuation_input_v2_artifact"(\n       content->\'valuationInputBundleArtifact\''
+    );
+    expect(sql).toContain(
+      "(content->'valuationInputBundleArtifact'->>'createdAt')::timestamptz>NEW.\"prepared_at\""
+    );
+    expect(sql).toContain('EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-prepared-valuation-input-v3-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-prepared-valuation-input-v3-migration.test.ts
@@ -1,0 +1,50 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const migrationPath =
+  'prisma/afl-trade-outcomes/migrations/0060_materialization_manifest_prepared_inputs/migration.sql';
+
+function migration(): string {
+  return readFileSync(join(process.cwd(), migrationPath), 'utf8');
+}
+
+describe('materialization-manifest prepared valuation input v3 migration', () => {
+  it('adds v3 through a forward migration while retaining v1 and v2', () => {
+    expect(existsSync(join(process.cwd(), migrationPath))).toBe(true);
+    const sql = migration();
+
+    expect(sql).toContain('afl-trade-prepared-valuation-input-set/v1');
+    expect(sql).toContain('afl-trade-prepared-valuation-input-set/v2');
+    expect(sql).toContain('afl-trade-prepared-valuation-input-set/v3');
+    expect(sql).toContain('validate_outcome_prepared_valuation_input_set_v3_insert');
+  });
+
+  it('authenticates exact retained manifest bytes for each ready v3 trade', () => {
+    const sql = migration();
+
+    expect(sql).toContain('outcome_private_evaluation_materialization_manifest');
+    expect(sql).toContain('materialization_manifest_id');
+    expect(sql).toContain("NEW.\"entry_json\"->'materializationManifestArtifact'");
+    expect(sql).toContain('validate_outcome_prepared_valuation_input_v2_artifact');
+    expect(sql).toContain('Private evaluation materialization manifests are append-only');
+    expect(sql).toContain('SELECT evidence.reference');
+    expect(sql).toContain('AS evidence(reference)');
+  });
+
+  it('selects one current prepared set per valuation scope through a CAS head', () => {
+    const sql = migration();
+
+    expect(sql).toContain('outcome_current_prepared_valuation_input_set');
+    expect(sql).toMatch(/PRIMARY KEY \("scope_key"\)/u);
+    expect(sql).toContain('expected_revision');
+    expect(sql).toContain('revision=revision+1');
+    expect(sql).toContain('Prepared valuation input heads require compare-and-swap');
+    expect(sql).toContain('target_is_finalized_v3');
+    expect(sql.indexOf('target_is_finalized_v3')).toBeLessThan(
+      sql.indexOf('SELECT revision INTO current_revision'),
+    );
+    expect(sql).toContain('outcome_private_evaluation_materialization_selector_idx');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-private-governed-exact-export-route.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-governed-exact-export-route.test.ts
@@ -1,0 +1,100 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { loadExactJsonExportMock } = vi.hoisted(() => ({
+  loadExactJsonExportMock: vi.fn(),
+}));
+
+vi.mock('@/server/aflTradeIntelligence/development/privateLocalWorkbookReads', () => ({
+  privateLocalWorkbookReads: { loadExactJsonExport: loadExactJsonExportMock },
+}));
+
+import { GET } from '@/app/api/dev/afl-trade-evaluation/[tradeId]/export/route';
+
+const tradeId = 'trade:carlton-fremantle-gold-coast';
+
+describe('GET /api/dev/afl-trade-evaluation/[tradeId]/export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects an invalid trade id before private reads', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost/api/dev/afl-trade-evaluation/bad/export'),
+      { params: Promise.resolve({ tradeId: '../bad' }) }
+    );
+
+    expect(response.status).toBe(400);
+    expect(loadExactJsonExportMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['a concealed reader', null],
+    [
+      'an unavailable generation',
+      {
+        state: 'unavailable',
+        selector: { valuationScopeKey: 'afl-men:2025-trades', tradeId },
+        selection: { kind: 'current' },
+        document: { kind: 'json_export' },
+        reason: 'withdrawn',
+      },
+    ],
+  ])('returns no private bytes for %s', async (_label, result) => {
+    loadExactJsonExportMock.mockResolvedValue(result);
+
+    const response = await GET(
+      new NextRequest(
+        `http://localhost/api/dev/afl-trade-evaluation/${encodeURIComponent(tradeId)}/export`
+      ),
+      { params: Promise.resolve({ tradeId: encodeURIComponent(tradeId) }) }
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+  });
+
+  it('streams the retained JSON bytes unchanged with their generation identities', async () => {
+    const bytes = new TextEncoder().encode('{"exact":true,"clubs":3}\n');
+    loadExactJsonExportMock.mockResolvedValue({
+      state: 'available',
+      selector: { valuationScopeKey: 'afl-men:2025-trades', tradeId },
+      selection: { kind: 'current' },
+      generationId: `local-private-trade-evaluation-generation:${'a'.repeat(64)}`,
+      projectionManifestId: `private-evaluation-projection-manifest:${'b'.repeat(64)}`,
+      lifecycle: { status: 'active', current: true },
+      document: {
+        kind: 'json_export',
+        artifact: {
+          artifactId: `artifact:${'c'.repeat(64)}`,
+          mediaType: 'application/json',
+          byteLength: bytes.byteLength,
+          sha256: 'd'.repeat(64),
+          createdAt: '2026-08-19T00:00:00.000Z',
+        },
+      },
+      bytes,
+    });
+
+    const response = await GET(
+      new NextRequest(
+        `http://localhost/api/dev/afl-trade-evaluation/${encodeURIComponent(tradeId)}/export`
+      ),
+      { params: Promise.resolve({ tradeId: encodeURIComponent(tradeId) }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(Array.from(new Uint8Array(await response.arrayBuffer()))).toEqual(Array.from(bytes));
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(response.headers.get('Content-Disposition')).toContain(
+      'trade-carlton-fremantle-gold-coast'
+    );
+    expect(response.headers.get('X-Statly-Generation-Id')).toBe(
+      `local-private-trade-evaluation-generation:${'a'.repeat(64)}`
+    );
+    expect(response.headers.get('X-Statly-Projection-Manifest-Id')).toBe(
+      `private-evaluation-projection-manifest:${'b'.repeat(64)}`
+    );
+  });
+});

--- a/tests/unit/afl-trade-intelligence-private-local-workbook-reads.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-local-workbook-reads.test.ts
@@ -8,7 +8,9 @@ import type { LocalAflTradeValuationReadiness } from '@/server/aflTradeIntellige
 import type {
   LocalWorkbookEvaluationArchive,
   LocalWorkbookEvaluationService,
+  LocalWorkbookTradeEvaluation,
 } from '@/server/aflTradeIntelligence/development/localWorkbookEvaluation';
+import type { GovernedPrivateEvaluationReadResult } from '@/server/aflTradeIntelligence/valuation/governedPrivateEvaluationWorkspace';
 
 const admittedEnvironment: PrivateLocalWorkbookReadEnvironment = {
   NODE_ENV: 'development',
@@ -18,10 +20,43 @@ const admittedEnvironment: PrivateLocalWorkbookReadEnvironment = {
   AFL_OUTCOMES_DEV_WORKBOOK_SHA256: 'a'.repeat(64),
   AFL_OUTCOMES_DATABASE_URL:
     'postgresql://postgres:postgres@127.0.0.1:55432/statly_outcomes_test?sslmode=disable',
+  AFL_TRADE_LOCAL_ARTIFACT_ROOT: '/private/statly-artifacts',
   STATLY_LOCAL_OUTCOMES_RUNTIME_NONCE: 'b'.repeat(64),
 };
 
 const archive = { year: 2025, publicationEligible: false } as LocalWorkbookEvaluationArchive;
+const tradeEvaluation = {
+  detail: { trade: { tradeId: 'trade:carlton-fremantle-gold-coast', year: 2025 } },
+  publicationEligible: false,
+} as LocalWorkbookTradeEvaluation;
+
+function governedRead(
+  kind: 'detail' | 'json_export',
+  bytes: Uint8Array
+): GovernedPrivateEvaluationReadResult {
+  return {
+    state: 'available',
+    selector: {
+      valuationScopeKey: 'afl-men:2025-trades',
+      tradeId: 'trade:carlton-fremantle-gold-coast',
+    },
+    selection: { kind: 'current' },
+    generationId: `local-private-trade-evaluation-generation:${'c'.repeat(64)}`,
+    projectionManifestId: `private-evaluation-projection-manifest:${'d'.repeat(64)}`,
+    lifecycle: { status: 'active', current: true },
+    document: {
+      kind,
+      artifact: {
+        artifactId: `artifact:${'e'.repeat(64)}`,
+        mediaType: 'application/json',
+        byteLength: bytes.byteLength,
+        sha256: 'f'.repeat(64),
+        createdAt: '2026-08-19T00:00:00.000Z',
+      },
+    },
+    bytes,
+  };
+}
 
 const readinessFixture: LocalAflTradeValuationReadiness = {
   state: 'blocked',
@@ -60,6 +95,10 @@ function dependencies(input?: {
     environment: PrivateLocalWorkbookReadEnvironment
   ) => Promise<string>;
   environment?: () => PrivateLocalWorkbookReadEnvironment;
+  readGovernedEvaluation?: Parameters<
+    typeof createPrivateLocalWorkbookReads
+  >[0]['readGovernedEvaluation'];
+  trade?: LocalWorkbookTradeEvaluation | null;
 }) {
   const inspectValuationReadiness =
     input?.inspectValuationReadiness ?? vi.fn().mockResolvedValue(readinessFixture);
@@ -73,7 +112,7 @@ function dependencies(input?: {
         readiness: await inspect('afl-men:2025-trades'),
       },
     })),
-    loadTrade: vi.fn().mockResolvedValue(null),
+    loadTrade: vi.fn().mockResolvedValue(input?.trade ?? null),
   };
   return {
     evaluation,
@@ -84,6 +123,7 @@ function dependencies(input?: {
       authenticateRuntime: input?.authenticateRuntime ?? vi.fn().mockResolvedValue(undefined),
       inspectValuationReadiness,
       readValuationReadinessGeneration,
+      readGovernedEvaluation: input?.readGovernedEvaluation,
       environment: input?.environment ?? (() => admittedEnvironment),
       evaluation,
     }),
@@ -134,6 +174,19 @@ describe('private local workbook reads', () => {
       vi.mocked(evaluation.loadArchive).mock.calls[0]?.[1],
       'afl-men:2025-trades'
     );
+  });
+
+  it('keeps legacy archive and detail reads available without governed artifact custody', async () => {
+    const environment = { ...admittedEnvironment, AFL_TRADE_LOCAL_ARTIFACT_ROOT: undefined };
+    const { reads } = dependencies({
+      environment: () => environment,
+      trade: tradeEvaluation,
+    });
+
+    await expect(reads.loadArchive({ year: 2025 })).resolves.toMatchObject(archive);
+    await expect(
+      reads.loadTrade('trade:carlton-fremantle-gold-coast')
+    ).resolves.toMatchObject({ detail: tradeEvaluation.detail });
   });
 
   it('does not read workbook data when PostgreSQL rejects the runtime nonce', async () => {
@@ -217,6 +270,86 @@ describe('private local workbook reads', () => {
 
     expect(inspectValuationReadiness).toHaveBeenCalledTimes(2);
   });
+
+  it('derives the governed selector from the real transaction and returns authenticated detail bytes', async () => {
+    const detailBytes = new TextEncoder().encode('{"detail":"retained"}');
+    const readGovernedEvaluation = vi
+      .fn()
+      .mockResolvedValue(governedRead('detail', detailBytes));
+    const { reads } = dependencies({ trade: tradeEvaluation, readGovernedEvaluation });
+
+    await expect(
+      reads.loadTrade('trade:carlton-fremantle-gold-coast')
+    ).resolves.toMatchObject({
+      detail: tradeEvaluation.detail,
+      governedEvaluation: {
+        state: 'available',
+        document: { kind: 'detail' },
+        bytes: detailBytes,
+      },
+    });
+    expect(readGovernedEvaluation).toHaveBeenCalledWith(
+      expect.objectContaining({ AFL_TRADE_LOCAL_ARTIFACT_ROOT: '/private/statly-artifacts' }),
+      'statly-dev-tester',
+      {
+        selector: {
+          valuationScopeKey: 'afl-men:2025-trades',
+          tradeId: 'trade:carlton-fremantle-gold-coast',
+        },
+        selection: { kind: 'current' },
+        document: { kind: 'detail' },
+      }
+    );
+  });
+
+  it('returns the retained JSON export bytes exactly and conceals them from a non-operator', async () => {
+    const exportBytes = new TextEncoder().encode('{"exact":true}\n');
+    const readGovernedEvaluation = vi
+      .fn()
+      .mockResolvedValue(governedRead('json_export', exportBytes));
+    const { reads } = dependencies({ trade: tradeEvaluation, readGovernedEvaluation });
+
+    const exported = await reads.loadExactJsonExport(
+      'trade:carlton-fremantle-gold-coast'
+    );
+    expect(exported).toMatchObject({
+      state: 'available',
+      document: { kind: 'json_export' },
+    });
+    expect(exported?.state === 'available' ? exported.bytes : null).toBe(exportBytes);
+
+    const concealed = dependencies({
+      trade: tradeEvaluation,
+      readGovernedEvaluation,
+      authenticate: vi.fn().mockResolvedValue('another-authenticated-user'),
+    });
+    await expect(
+      concealed.reads.loadExactJsonExport('trade:carlton-fremantle-gold-coast')
+    ).resolves.toBeNull();
+  });
+
+  it.each([undefined, 'relative/artifacts'])(
+    'fails closed for governed reads with invalid artifact custody (%s)',
+    async (artifactRoot) => {
+      const readGovernedEvaluation = vi.fn();
+      const { reads } = dependencies({
+        environment: () => ({
+          ...admittedEnvironment,
+          AFL_TRADE_LOCAL_ARTIFACT_ROOT: artifactRoot,
+        }),
+        trade: tradeEvaluation,
+        readGovernedEvaluation,
+      });
+
+      await expect(
+        reads.loadTrade('trade:carlton-fremantle-gold-coast')
+      ).rejects.toThrow('Governed private evaluation artifact configuration is invalid.');
+      await expect(
+        reads.loadExactJsonExport('trade:carlton-fremantle-gold-coast')
+      ).rejects.toThrow('Governed private evaluation artifact configuration is invalid.');
+      expect(readGovernedEvaluation).not.toHaveBeenCalled();
+    }
+  );
 
   it.each([
     ['production mode', { NODE_ENV: 'production' }],

--- a/tests/unit/afl-trade-intelligence-trade-calculation-narrative.test.ts
+++ b/tests/unit/afl-trade-intelligence-trade-calculation-narrative.test.ts
@@ -1,0 +1,402 @@
+import { describe, expect, it } from 'vitest';
+
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import type { AflTradeAssetLineageNarrativeEvidence } from '@/server/aflTradeIntelligence/valuation/assetLineageNarrativeEvidence';
+import type {
+  AflTradePickCalculationEvidence,
+  AflTradePlayerCalculationEvidence,
+} from '@/server/aflTradeIntelligence/valuation/calculationNarrativeEvidence';
+import {
+  createAflTradeCalculationNarrative,
+  type AflTradeCalculationNarrativeInput,
+} from '@/server/aflTradeIntelligence/valuation/tradeCalculationNarrative';
+import type {
+  AflTradeValuationAssetContribution,
+  AflTradeValuationExplanationDocument,
+} from '@/server/aflTradeIntelligence/valuation/tradeValuationExplanation';
+import {
+  createGovernedPrivateEvaluationGeneration,
+  decodeGovernedPrivateEvaluationDetailDocument,
+  verifyGovernedPrivateEvaluationGeneration,
+} from '@/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration';
+
+const addressed = (kind: string, marker: string) => `${kind}:${marker.repeat(64)}`;
+const views = ['at_trade', 'realized', 'remaining', 'current'] as const;
+
+function asset(
+  assetId: string,
+  assetKind: 'player' | 'current_pick',
+  label: string,
+  fromClubId: string,
+  toClubId: string,
+  value: number,
+  view: (typeof views)[number]
+): AflTradeValuationAssetContribution {
+  return {
+    assetId,
+    assetKind,
+    label,
+    fromClubId,
+    toClubId,
+    additiveMean: value,
+    distribution: { mean: value, median: value, p10: value - 1, p90: value + 1 },
+    currentComponents:
+      view === 'current'
+        ? assetId === 'asset:player-a'
+          ? { realizedMean: 72, remainingMean: 20 }
+          : { realizedMean: 0, remainingMean: 70 }
+        : null,
+    layers: {
+      grossMean: value,
+      listSpotAdjustedMean: value,
+      scarcityAdjustedMean: value,
+      listSpotDelta: 0,
+      scarcityDelta: 0,
+    },
+    evidenceState: 'complete',
+  };
+}
+
+function explanation(): AflTradeValuationExplanationDocument {
+  const values = {
+    at_trade: { player: 80, pick: 70 },
+    realized: { player: 72, pick: 0 },
+    remaining: { player: 20, pick: 70 },
+    current: { player: 92, pick: 70 },
+  } as const;
+  const content = {
+    schemaVersion: 'afl-trade-valuation-explanation/v1' as const,
+    tradeId: 'trade:adelaide-st-kilda',
+    defaultView: 'current' as const,
+    authority: {
+      kind: 'private_synthetic' as const,
+      assumptionSetId: addressed('artifact', 'a'),
+      publicationProhibited: true as const,
+      warning: 'Fabricated rank-based test values — not real AFL data.' as const,
+    },
+    valueUnitId: 'fixed_horizon_pav',
+    valuationBundleId: addressed('valuation-bundle', 'b'),
+    valuationCaseId: addressed('valuation-case', 'c'),
+    valuationCalculationId: addressed('valuation-calculation', 'd'),
+    effectiveAt: '2026-08-19T00:00:00.000Z',
+    effectiveThrough: '2026-08-19T23:59:59.999Z',
+    coverage: { status: 'complete' as const, ratio: 1 as const },
+    confidenceLevel: 'high' as const,
+    selectedLayer: 'scarcityAdjusted' as const,
+    views: views.map((view) => {
+      const player = asset(
+        'asset:player-a',
+        'player',
+        'Player A',
+        'afl-club:st-kilda',
+        'afl-club:adelaide',
+        values[view].player,
+        view
+      );
+      const pick = asset(
+        'asset:pick-14',
+        'current_pick',
+        'Pick 14',
+        'afl-club:adelaide',
+        'afl-club:st-kilda',
+        values[view].pick,
+        view
+      );
+      const net = player.additiveMean - pick.additiveMean;
+      const club = (
+        aflClubId: string,
+        clubName: string,
+        received: AflTradeValuationAssetContribution,
+        givenUp: AflTradeValuationAssetContribution,
+        sign: 1 | -1
+      ) => ({
+        aflClubId,
+        clubName,
+        received: {
+          assets: [received],
+          additiveMean: received.additiveMean,
+          distribution: received.distribution,
+        },
+        givenUp: {
+          assets: [givenUp],
+          additiveMean: givenUp.additiveMean,
+          distribution: givenUp.distribution,
+        },
+        net: {
+          additiveMean: sign * net,
+          distribution: {
+            mean: sign * net,
+            median: sign * net,
+            p10: sign * net - 1,
+            p90: sign * net + 1,
+          },
+        },
+        finishAheadProbability: sign === 1 ? 0.8 : 0.1,
+        grade: {
+          grade: sign === 1 ? ('A+' as const) : ('D' as const),
+          state: 'provisional' as const,
+          reasonCode: 'complete_high_confidence_development_preview',
+        },
+      });
+      return {
+        view,
+        practicalEquivalenceProbability: 0.1,
+        verdict: { kind: 'favours_club' as const, aflClubIds: ['afl-club:adelaide'] },
+        clubs: [
+          club('afl-club:adelaide', 'Adelaide', player, pick, 1),
+          club('afl-club:st-kilda', 'St Kilda', pick, player, -1),
+        ],
+      };
+    }),
+    methodology: {
+      additiveStatistic: 'probability_weighted_mean' as const,
+      uncertaintyStatistic: 'joint_draw_weighted_quantiles' as const,
+      packageMedianIsAdditive: false as const,
+      assetGradeTreatment: 'prohibited' as const,
+      currentIdentity: 'realized_plus_remaining' as const,
+      practicalEquivalenceBasis: 'Fixture threshold.',
+      practicalEquivalencePolicy: {
+        assumptionSetId: addressed('artifact', 'a'),
+        valueUnitId: 'fixed_horizon_pav',
+        bandByView: { at_trade: 1, realized: 1, remaining: 1, current: 1 },
+      },
+    },
+  };
+  return {
+    explanationId: createAflTradeContentAddress('valuation-explanation', content),
+    ...content,
+  };
+}
+
+function lineage(assetId: string, assetType: 'player' | 'current_pick_entitlement') {
+  return {
+    lineageGraphId: addressed('lineage-graph', assetId === 'asset:player-a' ? 'e' : 'f'),
+    rootAssetId: assetId,
+    cutoff: {
+      effectiveAsOf: '2026-08-19T00:00:00.000Z',
+      knowledgeCutoffAt: '2026-08-19T00:00:00.000Z',
+    },
+    nodes: [
+      {
+        assetId,
+        assetType,
+        label: assetId === 'asset:player-a' ? 'Player A' : 'Pick 14',
+        depth: 0,
+      effectiveFrom: '2020-10-10T00:00:00.000Z',
+        evidenceId: `evidence:${assetId}`,
+      },
+    ],
+    transformations: [],
+    custodyHistory: [],
+    dispositions: [],
+    frontierAssetIds: [assetId],
+  } satisfies AflTradeAssetLineageNarrativeEvidence;
+}
+
+function input(): AflTradeCalculationNarrativeInput {
+  const playerEvidence: AflTradePlayerCalculationEvidence = {
+    kind: 'player',
+    state: 'mature_observed',
+    observationId: addressed('player-pav-observation', '1'),
+    releaseId: addressed('outcome-release', '2'),
+    playerId: 'asset:player-a',
+    acquisitionSpell: {
+      spellId: 'spell:player-a',
+      spellVersionId: addressed('acquisition-spell-version', '3'),
+      clubId: 'afl-club:adelaide',
+      effectiveFrom: '2020-10-10',
+      effectiveThrough: null,
+      recordedAt: '2020-10-10T00:00:00.000Z',
+    },
+    predictionSeason: 2020,
+    evidenceCutoffAt: '2026-08-19T00:00:00.000Z',
+    horizon: {
+      endsAt: '2026-12-31T23:59:59.999Z',
+      requiredSeasons: [2021, 2022, 2023, 2024, 2025, 2026],
+      observedSeasons: [2021, 2022, 2023, 2024, 2025, 2026],
+    },
+    seasons: [2021, 2022, 2023, 2024, 2025, 2026].map((seasonYear, index) => ({
+      seasonYear,
+      gamesPlayed: 25,
+      contribution: 12,
+      contributionPerGame: 0.48,
+      calculationId: addressed('hpn-pav-season', String(index + 1)),
+      calculationSha256: String(index + 1).repeat(64),
+      effectiveThrough: `${seasonYear}-09-30T23:59:59.000Z`,
+      sourceObservationIds: [`provider-row:player-a:${seasonYear}`],
+    })),
+    totals: { gamesPlayed: 150, contribution: 72, contributionPerGame: 0.48 },
+  };
+  const pickEvidence: AflTradePickCalculationEvidence = {
+    kind: 'pick',
+    benchmarkId: addressed('pick-pav-benchmark', '4'),
+    observationSetId: addressed('pick-pav-observation-set', '5'),
+    policyId: addressed('pick-pav-policy', '6'),
+    methodId: addressed('hpn-pav-method', '7'),
+    valueUnit: 'fixed_horizon_pav',
+    selectionNumber: 14,
+    cohort: {
+      minimumSelectionNumber: 12,
+      maximumSelectionNumber: 16,
+      observationCount: 48,
+      draftClassCount: 12,
+      sourceSelectionNumbers: [12, 13, 14, 15, 16],
+    },
+    expected: { contribution: 70, games: 82 },
+    centralRange: {
+      contribution: { p10: 20, p50: 65, p90: 130 },
+      games: { p10: 12, p50: 76, p90: 180 },
+    },
+    outcomeProbabilities: [],
+    empiricalSupportObservationIds: [addressed('pick-pav-observation', '8')],
+    fixedHorizonSeasons: 5,
+    limitation: 'Training-only mature cohort.',
+  };
+  return {
+    explanation: explanation(),
+    assets: [
+      { assetId: 'asset:player-a', modelEvidence: playerEvidence, lineage: lineage('asset:player-a', 'player') },
+      { assetId: 'asset:pick-14', modelEvidence: pickEvidence, lineage: lineage('asset:pick-14', 'current_pick_entitlement') },
+    ],
+  };
+}
+
+describe('trade calculation narrative', () => {
+  it('connects evidence and exact arithmetic to each club package without asset grades', () => {
+    const narrative = createAflTradeCalculationNarrative(input());
+    const atTrade = narrative.content.views.find(({ view }) => view === 'at_trade')!;
+    const adelaide = atTrade.clubs.find(({ aflClubId }) => aflClubId === 'afl-club:adelaide')!;
+
+    expect(adelaide.arithmetic).toEqual({
+      receivedMean: 80,
+      givenUpMean: 70,
+      estimatedAdvantageMean: 10,
+    });
+    expect(adelaide.summary).toContain('80 - 70 = +10 fixed_horizon_pav');
+    expect(adelaide.summary).toContain('provisional A+ package grade');
+    expect(narrative.content.assets).toEqual([
+      expect.objectContaining({
+        assetId: 'asset:pick-14',
+        story: expect.stringContaining('48 observations across 12 draft classes'),
+      }),
+      expect.objectContaining({
+        assetId: 'asset:player-a',
+        story: expect.stringContaining('150 games for 72 fixed_horizon_pav'),
+      }),
+    ]);
+    expect(JSON.stringify(narrative)).not.toMatch(/assetGrade|asset grade/i);
+    const pick = narrative.content.assets.find(({ assetId }) => assetId === 'asset:pick-14')!;
+    const player = narrative.content.assets.find(({ assetId }) => assetId === 'asset:player-a')!;
+    expect(pick.contributions.find(({ view }) => view === 'at_trade')?.story).toContain(
+      '70 fixed_horizon_pav expected from 48 observations across 12 draft classes'
+    );
+    expect(player.contributions.find(({ view }) => view === 'realized')?.story).toContain(
+      '72 fixed_horizon_pav from 150 games at 0.48 per game'
+    );
+    expect(player.contributions.find(({ view }) => view === 'remaining')?.story).toContain(
+      '20 fixed_horizon_pav remaining model estimate'
+    );
+    expect(player.contributions.find(({ view }) => view === 'current')?.story).toContain(
+      '92 = 72 realized + 20 remaining fixed_horizon_pav'
+    );
+  });
+
+  it('fails closed when package arithmetic drifts from its assets', () => {
+    const request = input();
+    request.explanation.views[0]!.clubs[0]!.received.additiveMean += 1;
+
+    expect(() => createAflTradeCalculationNarrative(request)).toThrow(/package arithmetic/i);
+  });
+
+  it('fails closed when a player headline total drifts from the retained seasons', () => {
+    const request = input();
+    const player = request.assets.find(({ assetId }) => assetId === 'asset:player-a')!;
+    if (player.modelEvidence.kind !== 'player' || player.modelEvidence.state === 'unavailable') {
+      throw new Error('Fixture player evidence must be numeric.');
+    }
+    const driftedRequest: AflTradeCalculationNarrativeInput = {
+      ...request,
+      assets: request.assets.map((entry) =>
+        entry.assetId === player.assetId
+          ? {
+              ...entry,
+              modelEvidence: {
+                ...player.modelEvidence,
+                totals: { ...player.modelEvidence.totals, contribution: 73 },
+              },
+            }
+          : entry
+      ),
+    };
+
+    expect(() => createAflTradeCalculationNarrative(driftedRequest)).toThrow(
+      /player evidence totals/i
+    );
+  });
+});
+
+describe('governed private evaluation generation', () => {
+  it('pins canonical reader documents and exact JSON export bytes without retaining runtime HTML', () => {
+    const narrative = createAflTradeCalculationNarrative(input());
+    const materialization = createGovernedPrivateEvaluationGeneration({
+      selector: {
+        valuationScopeKey: 'afl.mens.trade-value:test-fixture',
+        tradeId: narrative.content.tradeId,
+      },
+      transitionIntentId: addressed('private-evaluation-transition-intent', 'a'),
+      generatedAt: '2026-08-19T01:00:00.000Z',
+      narrative,
+    });
+
+    expect(materialization.projectionManifest.content.documents.map(({ kind }) => kind)).toEqual([
+      'archive_summary',
+      'detail',
+      'reader_api',
+      'json_export',
+    ]);
+    expect(materialization.generation.content.transitionIntentId).toBe(
+      addressed('private-evaluation-transition-intent', 'a')
+    );
+    const exportArtifact = materialization.artifacts.find(({ kind }) => kind === 'json_export')!;
+    const exportJson = new TextDecoder().decode(exportArtifact.bytes);
+    expect(exportJson.endsWith('\n')).toBe(true);
+    expect(JSON.parse(exportJson)).toMatchObject({
+      schemaVersion: 'governed-private-evaluation-reader-api/v1',
+      selector: materialization.generation.content.selector,
+      narrativeId: narrative.narrativeId,
+    });
+    expect(materialization.artifacts.map(({ bytes }) => new TextDecoder().decode(bytes)).join('')).not.toMatch(
+      /<html|__next|react/i
+    );
+    expect(verifyGovernedPrivateEvaluationGeneration(materialization)).toBe(true);
+    const detailArtifact = materialization.artifacts.find(({ kind }) => kind === 'detail')!;
+    expect(decodeGovernedPrivateEvaluationDetailDocument(detailArtifact.bytes)).toMatchObject({
+      selector: materialization.generation.content.selector,
+      narrativeId: narrative.narrativeId,
+      narrative: { tradeId: narrative.content.tradeId },
+    });
+    const alteredDetail = JSON.parse(new TextDecoder().decode(detailArtifact.bytes));
+    alteredDetail.narrative.defaultView = 'at_trade';
+    expect(() =>
+      decodeGovernedPrivateEvaluationDetailDocument(
+        new TextEncoder().encode(JSON.stringify(alteredDetail))
+      )
+    ).toThrow(/detail|narrative|authenticate/i);
+  });
+
+  it('rejects retained export-byte tampering', () => {
+    const materialization = createGovernedPrivateEvaluationGeneration({
+      selector: {
+        valuationScopeKey: 'afl.mens.trade-value:test-fixture',
+        tradeId: explanation().tradeId,
+      },
+      transitionIntentId: addressed('private-evaluation-transition-intent', 'b'),
+      generatedAt: '2026-08-19T01:00:00.000Z',
+      narrative: createAflTradeCalculationNarrative(input()),
+    });
+    const exportArtifact = materialization.artifacts.find(({ kind }) => kind === 'json_export')!;
+    exportArtifact.bytes[0] = exportArtifact.bytes[0]! ^ 1;
+
+    expect(verifyGovernedPrivateEvaluationGeneration(materialization)).toBe(false);
+  });
+});

--- a/tests/unit/afl-trade-intelligence-trade-valuation-explanation.test.ts
+++ b/tests/unit/afl-trade-intelligence-trade-valuation-explanation.test.ts
@@ -5,7 +5,11 @@ import { describe, expect, it } from 'vitest';
 import type { DraftTradeDetail } from '@/lib/draftTrades/firestore';
 import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import { prepareLocalWorkbookSyntheticValuation } from '@/server/aflTradeIntelligence/development/localWorkbookSyntheticValuation';
-import { createAflTradeValuationExplanation } from '@/server/aflTradeIntelligence/valuation/tradeValuationExplanation';
+import {
+  createAflTradeValuationExplanation,
+  createGovernedAflTradeValuationExplanation,
+} from '@/server/aflTradeIntelligence/valuation/tradeValuationExplanation';
+import { createGovernedPrivateEvaluationAuthenticatedCalculationFixture } from '../testUtils/governedPrivateEvaluationAuthenticatedCalculationFixture';
 
 const TRADE_ID = 'workbook-2025-explanation-test';
 const VALUATION_BUNDLE_ID = `valuation-bundle:${'c'.repeat(64)}`;
@@ -169,6 +173,48 @@ function explanationInput(scenario: ReturnType<typeof preparedScenario>) {
 }
 
 describe('AFL trade valuation explanation document', () => {
+  it('automatically calculates exact asymmetric multi-club package banks from authenticated inputs', () => {
+    const fixture = createGovernedPrivateEvaluationAuthenticatedCalculationFixture();
+    const result = createGovernedAflTradeValuationExplanation(fixture);
+
+    expect(result.state).toBe('available');
+    if (result.state !== 'available') throw new Error('Expected an available explanation.');
+    expect(result.document).toMatchObject({
+      tradeId: 'trade:authenticated-three-club',
+      authority: {
+        kind: 'authenticated_non_production',
+        inputTraceId: fixture.trace.inputTraceId,
+        explanationPolicyId: fixture.explanationPolicy.policyId,
+        publicationProhibited: true,
+      },
+      confidenceLevel: 'unavailable',
+    });
+    expect(result.document.valuationCalculationId).toMatch(
+      /^valuation-calculation:[a-f0-9]{64}$/
+    );
+    const current = result.document.views.find(({ view }) => view === 'current')!;
+    expect(current.clubs.map(({ aflClubId }) => aflClubId)).toEqual([
+      'club:alpha',
+      'club:bravo',
+      'club:charlie',
+    ]);
+    expect(current.clubs.find(({ aflClubId }) => aflClubId === 'club:alpha')).toMatchObject({
+      received: { assets: [{ assetId: 'asset:03' }, { assetId: 'asset:04' }] },
+      givenUp: { assets: [{ assetId: 'asset:01' }, { assetId: 'asset:02' }] },
+      grade: {
+        grade: null,
+        state: 'unavailable',
+        reasonCode: 'grade_confidence_authority_unavailable',
+      },
+    });
+    expect(
+      current.clubs.every(
+        ({ received, givenUp, grade }) =>
+          received.assets.length > 0 && givenUp.assets.length > 0 && grade.grade === null
+      )
+    ).toBe(true);
+  });
+
   it('reconciles additive asset contributions while retaining package uncertainty separately', () => {
     const result = createAflTradeValuationExplanation(explanationInput(preparedScenario()));
 

--- a/tests/unit/afl-trade-intelligence-valuation-calculation-input-package.test.ts
+++ b/tests/unit/afl-trade-intelligence-valuation-calculation-input-package.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import {
   AFL_TRADE_VALUATION_CALCULATION_INPUT_PACKAGE_SCHEMA_VERSION,
+  AFL_TRADE_VALUATION_CALCULATION_INPUT_PACKAGE_V2_SCHEMA_VERSION,
+  aflTradeValuationCalculationInputPackageSchema,
   createAflTradeValuationCalculationInputPackage,
   createAflTradeValuationCalculationInputPackageArtifact,
 } from '@/server/aflTradeIntelligence/valuation/valuationCalculationInputPackage';
@@ -116,5 +118,42 @@ describe('AFL trade valuation calculation input package', () => {
           'Calculation input only; not a result, model approval, publication approval, or activation authority.',
       })
     ).toThrow();
+  });
+
+  it('binds authenticated non-production kernel inputs to one exact input trace', () => {
+    const fixture = createFabricatedAflTradeValuationFixture('three_club_trade');
+    const valuationInputBundleId = `valuation-input-bundle:${'8'.repeat(64)}`;
+    const inputTraceId = `private-evaluation-input-trace:${'7'.repeat(64)}`;
+    const { valuationCase, componentDrawSet, realizedContributionLedger, packagePolicy } =
+      bindInputBundle(fixture, valuationInputBundleId);
+    const input = createAflTradeValuationCalculationInputPackage({
+      schemaVersion: AFL_TRADE_VALUATION_CALCULATION_INPUT_PACKAGE_V2_SCHEMA_VERSION,
+      authority: {
+        kind: 'authenticated_non_production',
+        inputTraceId,
+        publicationProhibited: true,
+      },
+      tradeId: fixture.valuationCase.content.tradeId,
+      valuationInputBundleId,
+      valuationCase,
+      componentDrawSet,
+      realizedContributionLedger,
+      packagePolicy,
+      createdAt: '2026-08-15T03:00:00.000Z',
+      publicationEligible: false,
+      limitation:
+        'Calculation input only; not a result, model approval, publication approval, or activation authority.',
+    });
+
+    expect(input.content).toMatchObject({
+      schemaVersion: AFL_TRADE_VALUATION_CALCULATION_INPUT_PACKAGE_V2_SCHEMA_VERSION,
+      authority: { kind: 'authenticated_non_production', inputTraceId },
+    });
+    expect(aflTradeValuationCalculationInputPackageSchema.parse(input)).toEqual(input);
+
+    const tampered = structuredClone(input);
+    tampered.content.authority.inputTraceId =
+      `private-evaluation-input-trace:${'6'.repeat(64)}`;
+    expect(() => aflTradeValuationCalculationInputPackageSchema.parse(tampered)).toThrow();
   });
 });

--- a/tests/unit/local-workbook-trade-evaluation-page.test.tsx
+++ b/tests/unit/local-workbook-trade-evaluation-page.test.tsx
@@ -2,6 +2,9 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createGovernedPrivateEvaluationGeneration } from '@/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration';
+import { createGovernedPrivateEvaluationNarrativeFixture } from '../testUtils/governedPrivateEvaluationFixture';
+
 const { loadTradeMock, notFoundMock } = vi.hoisted(() => ({
   loadTradeMock: vi.fn(),
   notFoundMock: vi.fn(() => {
@@ -300,6 +303,44 @@ function evaluationFixture() {
   };
 }
 
+function governedEvaluationFixture() {
+  const narrative = createGovernedPrivateEvaluationNarrativeFixture();
+  const selector = {
+    valuationScopeKey: 'afl-men:2025-trades',
+    tradeId: narrative.content.tradeId,
+  };
+  const materialization = createGovernedPrivateEvaluationGeneration({
+    selector,
+    transitionIntentId: `private-evaluation-transition-intent:${'e'.repeat(64)}`,
+    generatedAt: '2026-08-19T00:00:00.000Z',
+    narrative,
+  });
+  const detailArtifact = materialization.artifacts.find(({ kind }) => kind === 'detail')!;
+  const evaluation = evaluationFixture();
+  return {
+    ...evaluation,
+    detail: {
+      ...evaluation.detail,
+      trade: {
+        ...evaluation.detail.trade,
+        tradeId: selector.tradeId,
+        title: 'Adelaide and St Kilda package evaluation',
+        clubNames: ['Adelaide', 'St Kilda'],
+      },
+    },
+    governedEvaluation: {
+      state: 'available' as const,
+      selector,
+      selection: { kind: 'current' as const },
+      generationId: materialization.generation.generationId,
+      projectionManifestId: materialization.projectionManifest.projectionManifestId,
+      lifecycle: { status: 'active' as const, current: true as const },
+      document: { kind: 'detail' as const, artifact: detailArtifact.reference },
+      bytes: detailArtifact.bytes,
+    },
+  };
+}
+
 describe('private local workbook trade evaluation page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -389,5 +430,33 @@ describe('private local workbook trade evaluation page', () => {
       })
     ).rejects.toThrow('NEXT_NOT_FOUND');
     expect(notFoundMock).toHaveBeenCalledOnce();
+  });
+
+  it('renders the authenticated package calculation and exact evidence export as one transaction', async () => {
+    const evaluation = governedEvaluationFixture();
+    loadTradeMock.mockResolvedValueOnce(evaluation);
+
+    render(
+      await LocalWorkbookTradeEvaluationPage({
+        params: Promise.resolve({ tradeId: evaluation.detail.trade.tradeId }),
+      })
+    );
+
+    const governed = screen.getByRole('region', {
+      name: 'Automatic governed package calculation',
+    });
+    expect(within(governed).getAllByRole('article')).toHaveLength(2);
+    expect(within(governed).getByRole('article', { name: 'Adelaide package' })).toBeVisible();
+    expect(within(governed).getByRole('article', { name: 'St Kilda package' })).toBeVisible();
+    expect(within(governed).getByText(/92 - 70 = \+22 fixed_horizon_pav/u)).toBeVisible();
+    fireEvent.click(within(governed).getAllByText('Pick 14 calculation and lineage')[0]!);
+    expect(within(governed).getAllByText(/48 observations across 12 draft classes/u)).not.toHaveLength(0);
+    expect(within(governed).getByRole('link', { name: 'Download exact JSON evidence' })).toHaveAttribute(
+      'href',
+      `/api/dev/afl-trade-evaluation/${encodeURIComponent(
+        evaluation.detail.trade.tradeId
+      )}/export`
+    );
+    expect(within(governed).queryByText(/asset grade/iu)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What

- adds the isolated PostgreSQL schema and forward migrations for governed private evaluation custody
- adds the deep workspace lifecycle for inspect, execute, stage, activate, replay, withdraw, recover, and verify
- exposes authenticated private read surfaces while preserving unavailable and publication-prohibited states
- documents the foundation and its authority boundaries

## Why

This delivers the reusable governed private-evaluation foundation required before automated model qualification and cohort calculation can be implemented safely. The work is intentionally limited to foundation behavior; it does not add automated qualification, cohort preparation, scheduling, or publication authority.

## Authority and compatibility

- remains local, non-production, and publication-prohibited
- authenticates retained snapshot and inspection bytes before lifecycle CAS decisions
- binds scope, selector, predecessor transition, heads, validity windows, and snapshot identity before writes
- preserves unavailable states rather than coercing missing evidence into a value
- uses forward-only isolated AFL outcomes migrations and does not alter existing migrations
- keeps current public publication authority unchanged

## Verification

Passed locally:

- npm run outcomes:prisma:validate
- npm run docs:check
- npm run lint:ci
- npm run typecheck
- npm run test:unit
- npm run test:outcomes:int — 19 files, 69 tests passed against disposable PostgreSQL, including the 783-trade seed and governed lifecycle
- git diff --check origin/main...HEAD
- independent specification and engineering-standards reviews after fixes: no remaining actionable findings

Environment-limited checks:

- npm run test:int stops in global setup because DATABASE_URL_TEST is not configured; no integration test files are discovered in this checkout
- npm run build stops in prebuild because Firebase auth-worker production settings are absent: apiKey, authDomain, projectId, and appId
- npm run test:e2e passed the public/auth shell case, then existing commissioner and draft-room navigation timed out; the run was stopped after the repeated route-level timeout pattern (1 passed, 2 failed, 1 interrupted, 22 not run). This PR does not modify those UI routes.

## Residual risk

The main residual risk is operational composition that belongs to later tickets: automated release qualification, current-cohort preparation, atomic batch visibility, durable retries, and weekly/ad-hoc orchestration are deliberately not claimed here.

Closes #533
Part of #532