### PR TITLE
Automate player-and-pick model qualification

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,7 +31,7 @@ const nextCommand = [
   `NEXT_PUBLIC_SOCKET_DISABLED=${useSocketWebServer ? 'false' : 'true'}`,
   `NEXT_PUBLIC_SOCKET_URL=${socketURL}`,
   `NEXT_PUBLIC_SOCKET_IO_URL=${socketURL}`,
-  './node_modules/.bin/next dev --turbopack',
+  './node_modules/.bin/next dev --webpack',
   `-p ${port}`,
 ].join(' ');
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -100,7 +100,7 @@ export default defineConfig({
   },
   webServer: {
     command: webServerCommand,
-    url: baseURL,
+    url: `${baseURL}/api/ping`,
     reuseExistingServer: false,
     timeout: 120_000,
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,7 +31,7 @@ const nextCommand = [
   `NEXT_PUBLIC_SOCKET_DISABLED=${useSocketWebServer ? 'false' : 'true'}`,
   `NEXT_PUBLIC_SOCKET_URL=${socketURL}`,
   `NEXT_PUBLIC_SOCKET_IO_URL=${socketURL}`,
-  './node_modules/.bin/next dev --webpack',
+  './node_modules/.bin/next dev --turbopack',
   `-p ${port}`,
 ].join(' ');
 
@@ -100,7 +100,7 @@ export default defineConfig({
   },
   webServer: {
     command: webServerCommand,
-    url: `${baseURL}/api/ping`,
+    url: useDraftWorkerWebServer ? `${baseURL}/api/ping` : baseURL,
     reuseExistingServer: false,
     timeout: 120_000,
   },

--- a/prisma/afl-trade-outcomes/migrations/0064_automated_model_pair_qualification/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0064_automated_model_pair_qualification/migration.sql
@@ -227,6 +227,13 @@ CREATE OR REPLACE FUNCTION "validate_outcome_governed_model_qualification_insert
 RETURNS TRIGGER LANGUAGE plpgsql AS $$
 DECLARE
   content JSONB := NEW."qualification_json"->'content';
+  policy JSONB;
+  player_evidence JSONB;
+  pick_evidence JSONB;
+  pick_metrics JSONB;
+  expected_failure_codes JSONB := '[]'::JSONB;
+  player_failed BOOLEAN := FALSE;
+  pick_failed BOOLEAN := FALSE;
   player_run RECORD;
   pick_run RECORD;
 BEGIN
@@ -234,15 +241,77 @@ BEGIN
    WHERE "run_id"=NEW."player_run_id" FOR KEY SHARE;
   SELECT * INTO STRICT pick_run FROM "outcome_governed_valuation_component_run"
    WHERE "run_id"=NEW."pick_run_id" FOR KEY SHARE;
+  policy:=content->'policy';
+  player_evidence:=content->'player'->'validationEvidence';
+  pick_evidence:=content->'pick'->'validationEvidence';
+  pick_metrics:=pick_evidence->'metrics';
+  IF (player_evidence->>'comparableObservationCount')::INTEGER <
+       (policy->'player'->>'minimumComparableObservations')::INTEGER THEN
+    expected_failure_codes:=expected_failure_codes || jsonb_build_array('player_observation_count_below_minimum');
+    player_failed:=TRUE;
+  END IF;
+  IF player_evidence->>'acceptanceOutcome' IS DISTINCT FROM
+       policy->'player'->>'requiredAcceptanceOutcome' THEN
+    expected_failure_codes:=expected_failure_codes || jsonb_build_array('player_acceptance_outcome_not_met');
+    player_failed:=TRUE;
+  END IF;
+  IF player_evidence->>'relativeMaeImprovement' IS NULL OR
+     (player_evidence->>'relativeMaeImprovement')::NUMERIC <
+       (policy->'player'->>'minimumRelativeMaeImprovement')::NUMERIC THEN
+    expected_failure_codes:=expected_failure_codes || jsonb_build_array('player_mae_improvement_below_minimum');
+    player_failed:=TRUE;
+  END IF;
+  IF player_evidence->>'relativeRmseImprovement' IS NULL OR
+     (player_evidence->>'relativeRmseImprovement')::NUMERIC <
+       (policy->'player'->>'minimumRelativeRmseImprovement')::NUMERIC THEN
+    expected_failure_codes:=expected_failure_codes || jsonb_build_array('player_rmse_improvement_below_minimum');
+    player_failed:=TRUE;
+  END IF;
+  IF pick_evidence->>'evaluationStatus' IS DISTINCT FROM 'scored_not_approved' THEN
+    expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_evaluation_not_scored');
+    pick_failed:=TRUE;
+  END IF;
+  IF (pick_evidence->>'observationCount')::INTEGER <
+       (policy->'pick'->>'minimumObservations')::INTEGER THEN
+    expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_observation_count_below_minimum');
+    pick_failed:=TRUE;
+  END IF;
+  IF pick_metrics IS NULL OR pick_metrics='null'::JSONB THEN
+    expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_metrics_unavailable');
+    pick_failed:=TRUE;
+  ELSE
+    IF (pick_metrics->>'multiclassBrierScore')::NUMERIC > (policy->'pick'->>'maximumMulticlassBrierScore')::NUMERIC THEN expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_brier_score_above_maximum'); pick_failed:=TRUE; END IF;
+    IF (pick_metrics->>'rankedProbabilityScore')::NUMERIC > (policy->'pick'->>'maximumRankedProbabilityScore')::NUMERIC THEN expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_ranked_probability_score_above_maximum'); pick_failed:=TRUE; END IF;
+    IF (pick_metrics->>'contributionCrps')::NUMERIC > (policy->'pick'->>'maximumContributionCrps')::NUMERIC THEN expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_contribution_crps_above_maximum'); pick_failed:=TRUE; END IF;
+    IF (pick_metrics->>'meanAbsoluteContributionError')::NUMERIC > (policy->'pick'->>'maximumMeanAbsoluteContributionError')::NUMERIC THEN expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_contribution_mae_above_maximum'); pick_failed:=TRUE; END IF;
+    IF (pick_metrics->>'rootMeanSquaredContributionError')::NUMERIC > (policy->'pick'->>'maximumRootMeanSquaredContributionError')::NUMERIC THEN expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_contribution_rmse_above_maximum'); pick_failed:=TRUE; END IF;
+    IF (pick_metrics->>'meanAbsoluteGamesError')::NUMERIC > (policy->'pick'->>'maximumMeanAbsoluteGamesError')::NUMERIC THEN expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_games_mae_above_maximum'); pick_failed:=TRUE; END IF;
+    IF (pick_metrics->>'rootMeanSquaredGamesError')::NUMERIC > (policy->'pick'->>'maximumRootMeanSquaredGamesError')::NUMERIC THEN expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_games_rmse_above_maximum'); pick_failed:=TRUE; END IF;
+    IF (pick_metrics->>'meanEmpiricalIntervalWidth')::NUMERIC > (policy->'pick'->>'maximumMeanEmpiricalIntervalWidth')::NUMERIC THEN expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_interval_width_above_maximum'); pick_failed:=TRUE; END IF;
+    IF (pick_metrics->>'zeroProbabilityObservationCount')::INTEGER > (policy->'pick'->>'maximumZeroProbabilityObservationCount')::INTEGER THEN expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_zero_probability_count_above_maximum'); pick_failed:=TRUE; END IF;
+    IF pick_metrics->>'multiclassLogLoss' IS NULL THEN expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_log_loss_unavailable'); pick_failed:=TRUE;
+    ELSIF (pick_metrics->>'multiclassLogLoss')::NUMERIC > (policy->'pick'->>'maximumMulticlassLogLoss')::NUMERIC THEN expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_log_loss_above_maximum'); pick_failed:=TRUE; END IF;
+    IF (pick_metrics->>'empiricalP10P90Coverage')::NUMERIC < (policy->'pick'->>'minimumEmpiricalP10P90Coverage')::NUMERIC THEN expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_coverage_below_minimum'); pick_failed:=TRUE; END IF;
+    IF (pick_metrics->>'empiricalP10P90Coverage')::NUMERIC > (policy->'pick'->>'maximumEmpiricalP10P90Coverage')::NUMERIC THEN expected_failure_codes:=expected_failure_codes || jsonb_build_array('pick_coverage_above_maximum'); pick_failed:=TRUE; END IF;
+  END IF;
   IF NEW."qualification_json"->>'qualificationId' IS DISTINCT FROM NEW."qualification_id"
     OR content->>'schemaVersion' IS DISTINCT FROM 'governed-valuation-model-qualification/v1'
     OR content->>'environment' IS DISTINCT FROM 'non_production'
     OR content->>'scopeKey' IS DISTINCT FROM NEW."scope_key"
     OR content->>'outcome' IS DISTINCT FROM NEW."outcome"
+    OR content->'failureCodes' IS DISTINCT FROM expected_failure_codes
+    OR (content->'player'->>'passed')::BOOLEAN IS DISTINCT FROM (NOT player_failed)
+    OR (content->'pick'->>'passed')::BOOLEAN IS DISTINCT FROM (NOT pick_failed)
+    OR content->>'outcome' IS DISTINCT FROM
+      (CASE WHEN player_failed OR pick_failed THEN 'failed' ELSE 'qualified' END)
     OR content->>'publicationEligible' IS DISTINCT FROM 'false'
     OR content->'player'->>'runId' IS DISTINCT FROM NEW."player_run_id"
     OR content->'pick'->>'runId' IS DISTINCT FROM NEW."pick_run_id"
     OR content->'policyArtifact'->>'artifactId' IS DISTINCT FROM NEW."policy_artifact_id"
+    OR policy->>'policyVersion' IS DISTINCT FROM 'model-qualification-policy:' || encode(sha256(convert_to(
+      outcome_afl_trade_canonical_json(jsonb_build_object('player',policy->'player','pick',policy->'pick')),'UTF8')),'hex')
+    OR NEW."policy_artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+      outcome_afl_trade_canonical_json(policy),'UTF8')),'hex')
     OR content->'player'->'criteriaArtifact'->>'artifactId'
       IS DISTINCT FROM NEW."player_criteria_artifact_id"
     OR content->'pick'->'criteriaArtifact'->>'artifactId'
@@ -251,6 +320,14 @@ BEGIN
       IS DISTINCT FROM NEW."player_evidence_artifact_id"
     OR content->'pick'->'validationEvidenceArtifact'->>'artifactId'
       IS DISTINCT FROM NEW."pick_evidence_artifact_id"
+    OR NEW."player_criteria_artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+      outcome_afl_trade_canonical_json(policy->'player'),'UTF8')),'hex')
+    OR NEW."pick_criteria_artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+      outcome_afl_trade_canonical_json(policy->'pick'),'UTF8')),'hex')
+    OR NEW."player_evidence_artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+      outcome_afl_trade_canonical_json(player_evidence),'UTF8')),'hex')
+    OR NEW."pick_evidence_artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+      outcome_afl_trade_canonical_json(pick_evidence),'UTF8')),'hex')
     OR (content->>'evaluatedAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."evaluated_at"
     OR NEW."content_sha256" IS DISTINCT FROM substring(NEW."qualification_id" FROM 21)
     OR NEW."content_canonical_json" IS DISTINCT FROM outcome_afl_trade_canonical_json(content)
@@ -361,6 +438,14 @@ BEGIN
   IF qualification."outcome"<>'qualified' OR qualification."scope_key"<>target_scope_key
     OR work."qualification_id"<>qualification."qualification_id"
     OR work."scope_key"<>target_scope_key OR work."status"<>'pending'
+    OR work."available_at" IS DISTINCT FROM target_advanced_at
+    OR work."work_json"->'content'->>'scopeKey' IS DISTINCT FROM target_scope_key
+    OR work."work_json"->'content'->>'qualificationId' IS DISTINCT FROM qualification."qualification_id"
+    OR work."work_json"->'content'->>'playerRunId' IS DISTINCT FROM qualification."player_run_id"
+    OR work."work_json"->'content'->>'pickRunId' IS DISTINCT FROM qualification."pick_run_id"
+    OR work."work_json"->'content'->>'playerGate3DecisionId' IS DISTINCT FROM player_decision."decision_id"
+    OR work."work_json"->'content'->>'pickGate3DecisionId' IS DISTINCT FROM pick_decision."decision_id"
+    OR (work."work_json"->'content'->>'availableAt')::TIMESTAMPTZ IS DISTINCT FROM target_advanced_at
     OR work."player_gate3_decision_id"<>player_decision."decision_id"
     OR work."pick_gate3_decision_id"<>pick_decision."decision_id"
     OR player_decision."state"<>'approved' OR pick_decision."state"<>'approved'
@@ -368,8 +453,15 @@ BEGIN
     OR pick_decision."gate"<>'gate_3_model_validity'
     OR player_decision."environment"<>'non_production'::"OutcomeEnvironment"
     OR pick_decision."environment"<>'non_production'::"OutcomeEnvironment"
+    OR player_decision."decision_json"->'content'->'scope'->>'scopeKey' IS DISTINCT FROM target_scope_key
+    OR pick_decision."decision_json"->'content'->'scope'->>'scopeKey' IS DISTINCT FROM target_scope_key
     OR player_decision."decision_json"->'content'->>'authorityKind'<>'automated_validation_record'
     OR pick_decision."decision_json"->'content'->>'authorityKind'<>'automated_validation_record'
+    OR NOT (player_decision."decision_json"->'content'->'authorityEvidenceIds' ? qualification."artifact_id")
+    OR NOT (pick_decision."decision_json"->'content'->'authorityEvidenceIds' ? qualification."artifact_id")
+    OR target_advanced_at<qualification."evaluated_at"
+    OR target_advanced_at<player_decision."effective_at"
+    OR target_advanced_at<pick_decision."effective_at"
     OR NOT EXISTS (
       SELECT 1 FROM jsonb_array_elements(
         player_decision."decision_json"->'content'->'affectedArtifacts'

--- a/prisma/afl-trade-outcomes/migrations/0064_automated_model_pair_qualification/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0064_automated_model_pair_qualification/migration.sql
@@ -6,7 +6,10 @@ RETURNS TRIGGER LANGUAGE plpgsql AS $$
 DECLARE
   content JSONB := NEW."manifest_json"->'content';
   pending_state_valid BOOLEAN;
+  component_artifact RECORD;
 BEGIN
+  SELECT * INTO component_artifact FROM "outcome_artifact_custody"
+   WHERE "artifact_id"=NEW."artifact_id" FOR KEY SHARE;
   pending_state_valid :=
     (content->>'schemaVersion'='governed-valuation-component-run/v1'
       AND content->>'approvalState'='gate_3_review_required'
@@ -16,6 +19,23 @@ BEGIN
       AND content->>'qualificationState'='automated_qualification_pending'
       AND NOT content ? 'approvalState');
   IF NEW."manifest_json"->>'runId' IS DISTINCT FROM NEW."run_id"
+    OR NEW."content_sha256" IS DISTINCT FROM
+       substring(NEW."run_id" FROM length('model-run:') + 1)
+    OR NEW."content_canonical_json" IS DISTINCT FROM outcome_afl_trade_canonical_json(content)
+    OR NEW."run_id" IS DISTINCT FROM 'model-run:' || encode(sha256(convert_to(
+       NEW."content_canonical_json",'UTF8')),'hex')
+    OR NEW."artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+       outcome_afl_trade_canonical_json(NEW."manifest_json"),'UTF8')),'hex')
+    OR component_artifact."content_sha256" IS DISTINCT FROM
+       substring(NEW."artifact_id" FROM length('artifact:') + 1)
+    OR component_artifact."storage_uri" IS DISTINCT FROM 'artifact://sha256/' ||
+       component_artifact."content_sha256"
+    OR component_artifact."media_type" IS DISTINCT FROM 'application/json'
+    OR component_artifact."byte_length" IS DISTINCT FROM octet_length(convert_to(
+       outcome_afl_trade_canonical_json(NEW."manifest_json"),'UTF8'))
+    OR component_artifact."environment" IS DISTINCT FROM
+       'non_production'::"OutcomeEnvironment"
+    OR component_artifact."created_at" IS DISTINCT FROM NEW."registered_at"
     OR NOT pending_state_valid
     OR content->>'environment' IS DISTINCT FROM 'non_production'
     OR content->>'role' IS DISTINCT FROM NEW."role"
@@ -34,6 +54,24 @@ BEGIN
     OR (content->>'datasetAdmissionGateLedgerRevision')::INTEGER
       IS DISTINCT FROM NEW."dataset_admission_gate_ledger_revision"
     OR (content->>'registeredAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."registered_at"
+    OR validate_outcome_prepared_valuation_input_v2_artifact(
+         content->'nativeExecution'->'artifact','non_production'::"OutcomeEnvironment"
+       ) IS DISTINCT FROM TRUE
+    OR validate_outcome_prepared_valuation_input_v2_artifact(
+         content->'protocolArtifact','non_production'::"OutcomeEnvironment"
+       ) IS DISTINCT FROM TRUE
+    OR validate_outcome_prepared_valuation_input_v2_artifact(
+         content->'datasetArtifact','non_production'::"OutcomeEnvironment"
+       ) IS DISTINCT FROM TRUE
+    OR validate_outcome_prepared_valuation_input_v2_artifact(
+         content->'datasetAdmissionArtifact','non_production'::"OutcomeEnvironment"
+       ) IS DISTINCT FROM TRUE
+    OR (content->'nativeExecution'->'artifact'->>'createdAt')::TIMESTAMPTZ>
+       NEW."registered_at"
+    OR (content->'protocolArtifact'->>'createdAt')::TIMESTAMPTZ>NEW."registered_at"
+    OR (content->'datasetArtifact'->>'createdAt')::TIMESTAMPTZ>NEW."registered_at"
+    OR (content->'datasetAdmissionArtifact'->>'createdAt')::TIMESTAMPTZ>
+       NEW."registered_at"
   THEN
     RAISE EXCEPTION 'Governed valuation component-run columns disagree with manifest JSON';
   END IF;
@@ -192,6 +230,11 @@ BEGIN
         WHERE "qualification_id"=automated_qualification_id FOR KEY SHARE;
       IF qualification_row."outcome"<>'qualified'
         OR qualification_row."scope_key" IS DISTINCT FROM content->'scope'->>'scopeKey'
+        OR proposal_row."proposed_at"<qualification_row."evaluated_at"
+        OR NEW."decided_at" IS NULL
+        OR NEW."decided_at"<qualification_row."evaluated_at"
+        OR NEW."effective_at" IS NULL
+        OR NEW."effective_at"<qualification_row."evaluated_at"
         OR content->'scope' IS DISTINCT FROM proposal_row."proposal_json"->'content'->'scope'
         OR automated_model_run_id NOT IN (
           qualification_row."player_run_id", qualification_row."pick_run_id"
@@ -277,6 +320,513 @@ RETURNS BOOLEAN LANGUAGE SQL IMMUTABLE AS $$
     AND document->>'createdAt' IS NOT NULL
 $$;
 
+CREATE TABLE "outcome_governed_component_validation_evidence" (
+  "run_id" TEXT NOT NULL PRIMARY KEY,
+  "role" TEXT NOT NULL,
+  "native_execution_artifact_id" TEXT NOT NULL,
+  "validation_report_id" TEXT NOT NULL,
+  "validation_report_artifact_id" TEXT,
+  "native_execution_json" JSONB NOT NULL,
+  "validation_report_json" JSONB NOT NULL,
+  "recorded_at" TIMESTAMPTZ(3) NOT NULL,
+  FOREIGN KEY ("run_id") REFERENCES "outcome_governed_valuation_component_run"("run_id") ON DELETE RESTRICT,
+  FOREIGN KEY ("native_execution_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+  FOREIGN KEY ("validation_report_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+  CONSTRAINT "outcome_governed_component_validation_evidence_role_check" CHECK (
+    "role" IN ('player_contribution_and_availability','draft_pick_and_future_pick_distribution')
+  )
+);
+
+CREATE OR REPLACE FUNCTION "validate_outcome_governed_player_validation_metrics"(report JSONB)
+RETURNS BOOLEAN LANGUAGE plpgsql AS $$
+DECLARE
+  content JSONB := report->'content';
+  metrics JSONB := report->'content'->'metrics';
+  candidate_mae DOUBLE PRECISION;
+  candidate_rmse DOUBLE PRECISION;
+  games_mae DOUBLE PRECISION;
+  games_rmse DOUBLE PRECISION;
+  relative_mae DOUBLE PRECISION;
+  relative_rmse DOUBLE PRECISION;
+  expected_outcome TEXT;
+BEGIN
+  candidate_mae := (metrics->'candidate'->>'meanAbsoluteError')::DOUBLE PRECISION;
+  candidate_rmse := (metrics->'candidate'->>'rootMeanSquaredError')::DOUBLE PRECISION;
+  games_mae := (metrics->'gamesOnly'->>'meanAbsoluteError')::DOUBLE PRECISION;
+  games_rmse := (metrics->'gamesOnly'->>'rootMeanSquaredError')::DOUBLE PRECISION;
+  IF candidate_mae<0 OR candidate_rmse<0 OR games_mae<0 OR games_rmse<0
+    OR jsonb_array_length(content->'comparableObservationIds')<
+       (content->'config'->>'minimumComparableObservations')::INTEGER
+    OR abs((metrics->'candidateMinusGamesOnly'->>'meanAbsoluteError')::DOUBLE PRECISION-
+       (candidate_mae-games_mae))>1e-10
+    OR abs((metrics->'candidateMinusGamesOnly'->>'rootMeanSquaredError')::DOUBLE PRECISION-
+       (candidate_rmse-games_rmse))>1e-10
+  THEN RETURN FALSE;
+  END IF;
+  IF games_mae=0 THEN
+    IF candidate_mae=0 THEN relative_mae := 0;
+    ELSIF metrics->'relativeImprovement'->'meanAbsoluteError' IS DISTINCT FROM 'null'::JSONB
+      THEN RETURN FALSE;
+    END IF;
+  ELSE relative_mae := (games_mae-candidate_mae)/games_mae;
+  END IF;
+  IF games_rmse=0 THEN
+    IF candidate_rmse=0 THEN relative_rmse := 0;
+    ELSIF metrics->'relativeImprovement'->'rootMeanSquaredError' IS DISTINCT FROM 'null'::JSONB
+      THEN RETURN FALSE;
+    END IF;
+  ELSE relative_rmse := (games_rmse-candidate_rmse)/games_rmse;
+  END IF;
+  IF (relative_mae IS NOT NULL AND (
+       jsonb_typeof(metrics->'relativeImprovement'->'meanAbsoluteError') IS DISTINCT FROM 'number'
+       OR abs((metrics->'relativeImprovement'->>'meanAbsoluteError')::DOUBLE PRECISION-
+         relative_mae)>1e-10))
+    OR (relative_rmse IS NOT NULL AND (
+       jsonb_typeof(metrics->'relativeImprovement'->'rootMeanSquaredError') IS DISTINCT FROM 'number'
+       OR abs((metrics->'relativeImprovement'->>'rootMeanSquaredError')::DOUBLE PRECISION-
+         relative_rmse)>1e-10))
+  THEN RETURN FALSE;
+  END IF;
+  expected_outcome := CASE WHEN relative_mae IS NOT NULL AND relative_rmse IS NOT NULL
+      AND relative_mae>=(content->'config'->>'minimumRelativeMaeImprovement')::DOUBLE PRECISION
+      AND relative_rmse>=(content->'config'->>'minimumRelativeRmseImprovement')::DOUBLE PRECISION
+    THEN 'meets_declared_predictive_thresholds'
+    ELSE 'does_not_meet_declared_predictive_thresholds' END;
+  RETURN content->>'acceptanceOutcome' IS NOT DISTINCT FROM expected_outcome;
+EXCEPTION WHEN OTHERS THEN
+  RETURN FALSE;
+END $$;
+
+CREATE OR REPLACE FUNCTION "validate_outcome_governed_pick_final_test_metrics"(report JSONB)
+RETURNS BOOLEAN LANGUAGE plpgsql AS $$
+DECLARE
+  content JSONB := report->'content';
+  final_scope JSONB;
+  prediction JSONB;
+  probability JSONB;
+  support_left JSONB;
+  support_right JSONB;
+  metrics JSONB;
+  final_count INTEGER := 0;
+  observed_index INTEGER;
+  probability_index INTEGER;
+  observed_probability DOUBLE PRECISION;
+  predicted_cumulative DOUBLE PRECISION;
+  support_count INTEGER;
+  first_crps DOUBLE PRECISION;
+  pairwise_crps DOUBLE PRECISION;
+  brier DOUBLE PRECISION := 0;
+  log_loss DOUBLE PRECISION := 0;
+  ranked_score DOUBLE PRECISION := 0;
+  contribution_crps DOUBLE PRECISION := 0;
+  absolute_contribution_error DOUBLE PRECISION := 0;
+  squared_contribution_error DOUBLE PRECISION := 0;
+  absolute_games_error DOUBLE PRECISION := 0;
+  squared_games_error DOUBLE PRECISION := 0;
+  coverage DOUBLE PRECISION := 0;
+  interval_width DOUBLE PRECISION := 0;
+  probability_total DOUBLE PRECISION;
+  zero_probability_count INTEGER := 0;
+  all_zero_probability_count INTEGER;
+  expected_evaluation_status TEXT;
+  expected_ids JSONB;
+  category_order TEXT[] := ARRAY[
+    'no_afl_game','short_career','replacement_level','regular_contributor','high_quality','elite'
+  ];
+BEGIN
+  IF jsonb_typeof(content->'predictions') IS DISTINCT FROM 'array'
+    OR jsonb_typeof(content->'excludedObservations') IS DISTINCT FROM 'array'
+    OR (content->>'inputObservationCount')::INTEGER IS DISTINCT FROM
+       jsonb_array_length(content->'predictions') +
+       jsonb_array_length(content->'excludedObservations')
+    OR (SELECT count(*) FROM (
+         SELECT entry->>'observationId' AS observation_id
+           FROM jsonb_array_elements(content->'predictions') entry
+         UNION ALL
+         SELECT entry->>'observationId'
+           FROM jsonb_array_elements(content->'excludedObservations') entry
+       ) identifiers) IS DISTINCT FROM
+       (SELECT count(DISTINCT observation_id) FROM (
+         SELECT entry->>'observationId' AS observation_id
+           FROM jsonb_array_elements(content->'predictions') entry
+         UNION ALL
+         SELECT entry->>'observationId'
+           FROM jsonb_array_elements(content->'excludedObservations') entry
+       ) identifiers)
+  THEN RETURN FALSE;
+  END IF;
+
+  IF EXISTS (
+       SELECT 1 FROM jsonb_array_elements(content->'predictions') prediction_entry
+        WHERE (SELECT count(*) FROM jsonb_array_elements(
+          prediction_entry->'categoryProbabilities') probability_entry
+          WHERE probability_entry->>'category'=prediction_entry->>'observedCategory')<>1
+     )
+  THEN RETURN FALSE;
+  END IF;
+  SELECT count(*) INTO all_zero_probability_count
+    FROM jsonb_array_elements(content->'predictions') prediction_entry
+   WHERE EXISTS (
+     SELECT 1 FROM jsonb_array_elements(
+       prediction_entry->'categoryProbabilities') probability_entry
+      WHERE probability_entry->>'category'=prediction_entry->>'observedCategory'
+        AND (probability_entry->>'probability')::DOUBLE PRECISION=0
+   );
+  expected_evaluation_status := CASE
+    WHEN jsonb_array_length(content->'predictions')<
+         (content->'config'->>'minimumEligibleObservations')::INTEGER
+      OR EXISTS (
+        SELECT 1 FROM (VALUES ('calibration'),('validation'),('final_test')) partition(name)
+         WHERE (SELECT count(*) FROM jsonb_array_elements(content->'predictions') entry
+           WHERE entry->>'partition'=partition.name)<
+           (content->'config'->>'minimumPartitionObservations')::INTEGER
+      )
+      THEN 'insufficient_eligible_observations_not_approved'
+    WHEN all_zero_probability_count>0 THEN 'invalid_zero_probability_not_approved'
+    ELSE 'scored_not_approved'
+  END;
+  IF content->>'evaluationStatus' IS DISTINCT FROM expected_evaluation_status THEN
+    RETURN FALSE;
+  END IF;
+
+  SELECT scope INTO STRICT final_scope
+    FROM jsonb_array_elements(content->'scoreScopes') scope
+   WHERE scope->>'scope'='final_test';
+  metrics := final_scope->'metrics';
+  SELECT count(*),COALESCE(jsonb_agg(to_jsonb(entry->>'observationId')
+      ORDER BY entry->>'observationId'),'[]'::JSONB)
+    INTO final_count,expected_ids
+    FROM jsonb_array_elements(content->'predictions') entry
+   WHERE entry->>'partition'='final_test';
+  IF (final_scope->>'observationCount')::INTEGER IS DISTINCT FROM final_count
+    OR final_scope->'observationIds' IS DISTINCT FROM expected_ids
+    OR (final_count=0 AND metrics IS NOT NULL)
+    OR (final_count>0 AND jsonb_typeof(metrics) IS DISTINCT FROM 'object')
+  THEN RETURN FALSE;
+  END IF;
+  IF final_count=0 THEN RETURN TRUE;
+  END IF;
+
+  FOR prediction IN
+    SELECT entry FROM jsonb_array_elements(content->'predictions') entry
+     WHERE entry->>'partition'='final_test'
+  LOOP
+    observed_index := array_position(category_order,prediction->>'observedCategory');
+    IF observed_index IS NULL
+      OR jsonb_array_length(prediction->'categoryProbabilities')<>array_length(category_order,1)
+      OR jsonb_array_length(prediction->'empiricalSupport')=0
+    THEN RETURN FALSE;
+    END IF;
+    observed_probability := NULL;
+    predicted_cumulative := 0;
+    probability_total := 0;
+    FOR probability,probability_index IN
+      SELECT entry,ordinality::INTEGER
+        FROM jsonb_array_elements(prediction->'categoryProbabilities') WITH ORDINALITY value(entry,ordinality)
+       ORDER BY ordinality
+    LOOP
+      IF probability->>'category' IS DISTINCT FROM category_order[probability_index]
+        OR (probability->>'probability')::DOUBLE PRECISION NOT BETWEEN 0 AND 1
+      THEN RETURN FALSE;
+      END IF;
+      brier := brier + power((probability->>'probability')::DOUBLE PRECISION -
+        CASE WHEN probability_index=observed_index THEN 1 ELSE 0 END,2);
+      probability_total := probability_total +
+        (probability->>'probability')::DOUBLE PRECISION;
+      IF probability_index=observed_index THEN
+        observed_probability := (probability->>'probability')::DOUBLE PRECISION;
+      END IF;
+      IF probability_index<array_length(category_order,1) THEN
+        predicted_cumulative := predicted_cumulative +
+          (probability->>'probability')::DOUBLE PRECISION;
+        ranked_score := ranked_score + power(predicted_cumulative -
+          CASE WHEN observed_index<=probability_index THEN 1 ELSE 0 END,2) /
+          (array_length(category_order,1)-1);
+      END IF;
+    END LOOP;
+    IF abs(probability_total-1)>1e-10
+      OR (prediction->>'supportObservationCount')::INTEGER IS DISTINCT FROM
+         jsonb_array_length(prediction->'empiricalSupport')
+      OR jsonb_array_length(prediction->'empiricalSupport') IS DISTINCT FROM
+         (SELECT count(DISTINCT entry->>'observationId')
+            FROM jsonb_array_elements(prediction->'empiricalSupport') entry)
+      OR (prediction->>'p10Contribution')::DOUBLE PRECISION>
+         (prediction->>'p50Contribution')::DOUBLE PRECISION
+      OR (prediction->>'p50Contribution')::DOUBLE PRECISION>
+         (prediction->>'p90Contribution')::DOUBLE PRECISION
+      OR (prediction->>'p10Games')::DOUBLE PRECISION>
+         (prediction->>'p50Games')::DOUBLE PRECISION
+      OR (prediction->>'p50Games')::DOUBLE PRECISION>
+         (prediction->>'p90Games')::DOUBLE PRECISION
+    THEN RETURN FALSE;
+    END IF;
+    IF observed_probability=0 THEN zero_probability_count := zero_probability_count + 1;
+    ELSE log_loss := log_loss - ln(observed_probability);
+    END IF;
+
+    support_count := jsonb_array_length(prediction->'empiricalSupport');
+    first_crps := 0;
+    pairwise_crps := 0;
+    FOR support_left IN SELECT value FROM jsonb_array_elements(prediction->'empiricalSupport')
+    LOOP
+      first_crps := first_crps + abs((support_left->>'contribution')::DOUBLE PRECISION -
+        (prediction->>'observedContribution')::DOUBLE PRECISION);
+      FOR support_right IN SELECT value FROM jsonb_array_elements(prediction->'empiricalSupport')
+      LOOP
+        pairwise_crps := pairwise_crps + abs(
+          (support_left->>'contribution')::DOUBLE PRECISION -
+          (support_right->>'contribution')::DOUBLE PRECISION);
+      END LOOP;
+    END LOOP;
+    contribution_crps := contribution_crps + first_crps/support_count -
+      pairwise_crps/(2*power(support_count,2));
+    absolute_contribution_error := absolute_contribution_error + abs(
+      (prediction->>'predictedExpectedContribution')::DOUBLE PRECISION -
+      (prediction->>'observedContribution')::DOUBLE PRECISION);
+    squared_contribution_error := squared_contribution_error + power(
+      (prediction->>'predictedExpectedContribution')::DOUBLE PRECISION -
+      (prediction->>'observedContribution')::DOUBLE PRECISION,2);
+    absolute_games_error := absolute_games_error + abs(
+      (prediction->>'predictedExpectedGames')::DOUBLE PRECISION -
+      (prediction->>'observedGames')::DOUBLE PRECISION);
+    squared_games_error := squared_games_error + power(
+      (prediction->>'predictedExpectedGames')::DOUBLE PRECISION -
+      (prediction->>'observedGames')::DOUBLE PRECISION,2);
+    IF (prediction->>'observedContribution')::DOUBLE PRECISION BETWEEN
+       (prediction->>'p10Contribution')::DOUBLE PRECISION AND
+       (prediction->>'p90Contribution')::DOUBLE PRECISION
+    THEN coverage := coverage + 1;
+    END IF;
+    interval_width := interval_width +
+      (prediction->>'p90Contribution')::DOUBLE PRECISION -
+      (prediction->>'p10Contribution')::DOUBLE PRECISION;
+  END LOOP;
+
+  RETURN abs((metrics->>'multiclassBrierScore')::DOUBLE PRECISION-brier/final_count)<=1e-10
+    AND ((zero_probability_count>0 AND metrics->'multiclassLogLoss'='null'::JSONB) OR
+      (zero_probability_count=0 AND abs((metrics->>'multiclassLogLoss')::DOUBLE PRECISION-
+        log_loss/final_count)<=1e-10))
+    AND abs((metrics->>'rankedProbabilityScore')::DOUBLE PRECISION-
+      ranked_score/final_count)<=1e-10
+    AND abs((metrics->>'contributionCrps')::DOUBLE PRECISION-
+      contribution_crps/final_count)<=1e-10
+    AND abs((metrics->>'meanAbsoluteContributionError')::DOUBLE PRECISION-
+      absolute_contribution_error/final_count)<=1e-10
+    AND abs((metrics->>'rootMeanSquaredContributionError')::DOUBLE PRECISION-
+      sqrt(squared_contribution_error/final_count))<=1e-10
+    AND abs((metrics->>'meanAbsoluteGamesError')::DOUBLE PRECISION-
+      absolute_games_error/final_count)<=1e-10
+    AND abs((metrics->>'rootMeanSquaredGamesError')::DOUBLE PRECISION-
+      sqrt(squared_games_error/final_count))<=1e-10
+    AND abs((metrics->>'empiricalP10P90Coverage')::DOUBLE PRECISION-
+      coverage/final_count)<=1e-10
+    AND abs((metrics->>'meanEmpiricalIntervalWidth')::DOUBLE PRECISION-
+      interval_width/final_count)<=1e-10
+    AND (metrics->>'zeroProbabilityObservationCount')::INTEGER=zero_probability_count;
+EXCEPTION WHEN OTHERS THEN
+  RETURN FALSE;
+END $$;
+
+CREATE OR REPLACE FUNCTION "validate_outcome_governed_component_validation_evidence"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  component RECORD;
+  execution_content JSONB := NEW."native_execution_json"->'content';
+  report_content JSONB := NEW."validation_report_json"->'content';
+  report_artifact RECORD;
+  player_execution RECORD;
+  pick_execution RECORD;
+BEGIN
+  SELECT * INTO STRICT component
+    FROM "outcome_governed_valuation_component_run"
+   WHERE "run_id"=NEW."run_id" FOR KEY SHARE;
+  IF component."role" IS DISTINCT FROM NEW."role"
+    OR component."native_execution_artifact_id" IS DISTINCT FROM
+       NEW."native_execution_artifact_id"
+    OR NEW."native_execution_artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+       outcome_afl_trade_canonical_json(NEW."native_execution_json"),'UTF8')),'hex')
+    OR validate_outcome_prepared_valuation_input_v2_artifact(
+         component."manifest_json"->'content'->'nativeExecution'->'artifact',
+         'non_production'::"OutcomeEnvironment"
+       ) IS DISTINCT FROM TRUE
+    OR outcome_afl_trade_jsonb_has_exact_keys(
+         NEW."validation_report_json",ARRAY['content','validationReportId']) IS DISTINCT FROM TRUE
+    OR NEW."validation_report_json"->>'validationReportId' IS DISTINCT FROM
+       NEW."validation_report_id"
+    OR NEW."recorded_at"<component."registered_at"
+  THEN RAISE EXCEPTION 'Governed component validation evidence ancestry mismatch';
+  END IF;
+
+  IF NEW."role"='player_contribution_and_availability' THEN
+    SELECT * INTO player_execution FROM "outcome_valuation_model_run"
+     WHERE "run_id"=component."native_execution_id" FOR KEY SHARE;
+    SELECT * INTO STRICT report_artifact FROM "outcome_artifact_custody"
+     WHERE "artifact_id"=NEW."validation_report_artifact_id" FOR KEY SHARE;
+    IF player_execution."run_id" IS NULL
+      OR player_execution."status" IS DISTINCT FROM 'succeeded'
+      OR player_execution."run_json" IS DISTINCT FROM NEW."native_execution_json"
+      OR component."native_execution_kind" IS DISTINCT FROM 'admitted_player_model_run'
+      OR NEW."native_execution_json"->>'runId' IS DISTINCT FROM
+         component."native_execution_id"
+      OR NEW."native_execution_json"->>'runId' IS DISTINCT FROM 'model-run:' ||
+         encode(sha256(convert_to(outcome_afl_trade_canonical_json(execution_content),'UTF8')),'hex')
+      OR execution_content->>'schemaVersion' IS DISTINCT FROM 'afl-trade-model-run/v3'
+      OR execution_content->'outcome'->>'status' IS DISTINCT FROM 'succeeded'
+      OR execution_content->>'datasetId' IS DISTINCT FROM component."dataset_id"
+      OR execution_content->>'datasetAdmissionId' IS DISTINCT FROM
+         component."dataset_admission_id"
+      OR execution_content->>'modelProtocolId' IS DISTINCT FROM component."protocol_id"
+      OR execution_content->'outcome'->'validationReportArtifact'->>'artifactId'
+         IS DISTINCT FROM NEW."validation_report_artifact_id"
+      OR validate_outcome_prepared_valuation_input_v2_artifact(
+           execution_content->'outcome'->'validationReportArtifact',
+           'non_production'::"OutcomeEnvironment"
+         ) IS DISTINCT FROM TRUE
+      OR NEW."validation_report_artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+         outcome_afl_trade_canonical_json(NEW."validation_report_json"),'UTF8')),'hex')
+      OR report_artifact."content_sha256" IS DISTINCT FROM
+         substring(NEW."validation_report_artifact_id" FROM length('artifact:') + 1)
+      OR report_artifact."media_type" IS DISTINCT FROM 'application/json'
+      OR report_artifact."byte_length" IS DISTINCT FROM octet_length(convert_to(
+         outcome_afl_trade_canonical_json(NEW."validation_report_json"),'UTF8'))
+      OR report_artifact."environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+      OR report_artifact."created_at" IS DISTINCT FROM
+         (execution_content->'outcome'->'validationReportArtifact'->>'createdAt')::TIMESTAMPTZ
+      OR report_artifact."created_at"<(execution_content->>'finalTestEvaluatedAt')::TIMESTAMPTZ
+      OR report_artifact."created_at">(execution_content->>'finishedAt')::TIMESTAMPTZ
+      OR NEW."recorded_at"<report_artifact."created_at"
+      OR NEW."validation_report_id" IS DISTINCT FROM 'player-validation-report:' ||
+         encode(sha256(convert_to(outcome_afl_trade_canonical_json(report_content),'UTF8')),'hex')
+      OR outcome_afl_trade_jsonb_has_exact_keys(report_content,ARRAY[
+           'acceptanceOutcome','baselineFitId','candidateModelId','comparableObservationIds',
+           'config','evaluatedPartition','evidenceLimitation','excludedObservations','metrics',
+           'observationSetId','predictionSetId','publicIdentityBoundary','schemaVersion','valueUnitId'
+         ]) IS DISTINCT FROM TRUE
+      OR outcome_afl_trade_jsonb_has_exact_keys(report_content->'metrics',ARRAY[
+           'candidate','candidateMinusGamesOnly','gamesOnly','relativeImprovement'
+         ]) IS DISTINCT FROM TRUE
+      OR outcome_afl_trade_jsonb_has_exact_keys(
+           report_content->'metrics'->'relativeImprovement',
+           ARRAY['meanAbsoluteError','rootMeanSquaredError']
+         ) IS DISTINCT FROM TRUE
+      OR report_content->>'schemaVersion' IS DISTINCT FROM
+         'afl-trade-player-validation-report/v1'
+      OR report_content->>'publicIdentityBoundary' IS DISTINCT FROM
+         'source_native_no_fantasy_ownership'
+      OR report_content->>'evaluatedPartition' IS DISTINCT FROM 'final_test'
+      OR report_content->>'observationSetId' IS DISTINCT FROM
+         execution_content->>'observationSetId'
+      OR report_content->>'candidateModelId' IS DISTINCT FROM execution_content->>'modelId'
+      OR jsonb_typeof(report_content->'comparableObservationIds') IS DISTINCT FROM 'array'
+      OR jsonb_array_length(report_content->'comparableObservationIds') NOT BETWEEN 1 AND 100000
+      OR EXISTS (SELECT 1 FROM jsonb_array_elements(
+           report_content->'comparableObservationIds') entry
+         WHERE jsonb_typeof(entry) IS DISTINCT FROM 'string' OR entry#>>'{}'='')
+      OR jsonb_array_length(report_content->'comparableObservationIds') IS DISTINCT FROM
+         (SELECT count(DISTINCT entry#>>'{}') FROM jsonb_array_elements(
+           report_content->'comparableObservationIds') entry)
+      OR report_content->>'acceptanceOutcome' IS NULL
+      OR report_content->>'acceptanceOutcome' NOT IN (
+         'meets_declared_predictive_thresholds','does_not_meet_declared_predictive_thresholds')
+      OR report_content->'config'->>'schemaVersion' IS DISTINCT FROM
+         'afl-trade-player-validation-config/v1'
+      OR report_content->'config'->>'acceptanceRule' IS DISTINCT FROM
+         'candidate_improves_both_mae_and_rmse'
+      OR report_content->'config'->>'incompletePredictionCoverage' IS DISTINCT FROM 'fail_closed'
+      OR report_content->'config'->>'governanceEffect' IS DISTINCT FROM
+         'evidence_only_no_gate_or_source_approval'
+      OR report_content->>'evidenceLimitation' IS DISTINCT FROM
+         'report_is_reproducible_evidence_not_source_approval_gate_approval_or_production_readiness'
+      OR validate_outcome_governed_player_validation_metrics(
+           NEW."validation_report_json") IS DISTINCT FROM TRUE
+      OR jsonb_typeof(report_content->'metrics'->'relativeImprovement'->'meanAbsoluteError')
+         NOT IN ('number','null')
+      OR jsonb_typeof(report_content->'metrics'->'relativeImprovement'->'rootMeanSquaredError')
+         NOT IN ('number','null')
+    THEN RAISE EXCEPTION 'Governed player validation evidence mismatch';
+    END IF;
+  ELSE
+    SELECT * INTO pick_execution FROM "outcome_governed_pick_pav_model_execution"
+     WHERE "execution_id"=component."native_execution_id" FOR KEY SHARE;
+    IF pick_execution."execution_id" IS NULL
+      OR pick_execution."execution_json" IS DISTINCT FROM NEW."native_execution_json"
+      OR component."native_execution_kind" IS DISTINCT FROM
+       'governed_pick_pav_model_execution'
+      OR NEW."validation_report_artifact_id" IS NOT NULL
+      OR NEW."native_execution_json"->>'executionId' IS DISTINCT FROM
+         component."native_execution_id"
+      OR NEW."native_execution_json"->>'executionId' IS DISTINCT FROM
+         'pick-pav-model-execution:' || encode(sha256(convert_to(
+           outcome_afl_trade_canonical_json(execution_content),'UTF8')),'hex')
+      OR execution_content->>'schemaVersion' IS DISTINCT FROM
+         'afl-trade-pick-pav-model-execution/v3'
+      OR execution_content->>'datasetId' IS DISTINCT FROM component."dataset_id"
+      OR execution_content->>'datasetAdmissionId' IS DISTINCT FROM
+         component."dataset_admission_id"
+      OR (execution_content->>'datasetAdmissionGateLedgerRevision')::INTEGER
+         IS DISTINCT FROM component."dataset_admission_gate_ledger_revision"
+      OR execution_content->>'protocolId' IS DISTINCT FROM component."protocol_id"
+      OR execution_content->'validationReport' IS DISTINCT FROM NEW."validation_report_json"
+      OR report_content->>'environment' IS DISTINCT FROM execution_content->>'environment'
+      OR report_content->>'competition' IS DISTINCT FROM execution_content->>'competition'
+      OR report_content->>'observationSetId' IS DISTINCT FROM
+         execution_content->>'observationSetId'
+      OR report_content->>'benchmarkId' IS DISTINCT FROM
+         execution_content->'benchmark'->>'benchmarkId'
+      OR report_content->'config' IS DISTINCT FROM execution_content->'validationConfig'
+      OR report_content->>'releaseId' IS DISTINCT FROM execution_content->>'releaseId'
+      OR report_content->>'policyId' IS DISTINCT FROM execution_content->>'policyId'
+      OR report_content->>'methodId' IS DISTINCT FROM execution_content->>'methodId'
+      OR report_content->>'valueUnit' IS DISTINCT FROM execution_content->>'valueUnit'
+      OR report_content->'fixedHorizonSeasons' IS DISTINCT FROM
+         execution_content->'observationSet'->'content'->'policy'->'content'->'fixedHorizonSeasons'
+      OR NEW."validation_report_id" IS DISTINCT FROM 'pick-pav-validation-report:' ||
+         encode(sha256(convert_to(outcome_afl_trade_canonical_json(report_content),'UTF8')),'hex')
+      OR outcome_afl_trade_jsonb_has_exact_keys(report_content,ARRAY[
+           'approvalStatus','authorityBoundary','benchmarkId','competition','config','environment',
+           'evaluationStatus','excludedObservations','fixedHorizonSeasons','inputObservationCount',
+           'limitation','methodId','observationSetId','policyId','predictions','publicationEligible',
+           'releaseId','schemaVersion','scoreScopes','valueUnit'
+         ]) IS DISTINCT FROM TRUE
+      OR report_content->>'schemaVersion' IS DISTINCT FROM
+         'afl-trade-pick-pav-validation-report/v1'
+      OR report_content->>'authorityBoundary' IS DISTINCT FROM
+         'private_temporal_pick_pav_benchmark_evaluation_not_model_approval_grade_publication_or_fantasy_ownership'
+      OR report_content->'publicationEligible' IS DISTINCT FROM 'false'::JSONB
+      OR report_content->>'approvalStatus' IS DISTINCT FROM
+         'not_assessed_by_validation_harness'
+      OR report_content->>'limitation' IS DISTINCT FROM
+         'Validation evidence is not Gate approval, deployment approval, a grade, or public numerical authority.'
+      OR report_content->'config'->>'schemaVersion' IS DISTINCT FROM
+         'afl-trade-pick-pav-validation-config/v1'
+      OR (report_content->'config'->>'nominalIntervalCoverage')::DOUBLE PRECISION
+         IS DISTINCT FROM 0.8::DOUBLE PRECISION
+      OR report_content->>'evaluationStatus' IS NULL
+      OR report_content->>'evaluationStatus' NOT IN (
+         'scored_not_approved','insufficient_eligible_observations_not_approved',
+         'invalid_zero_probability_not_approved')
+      OR jsonb_typeof(report_content->'scoreScopes') IS DISTINCT FROM 'array'
+      OR (SELECT count(*) FROM jsonb_array_elements(report_content->'scoreScopes') scope
+           WHERE scope->>'scope'='final_test')<>1
+      OR validate_outcome_governed_pick_final_test_metrics(
+           NEW."validation_report_json") IS DISTINCT FROM TRUE
+    THEN RAISE EXCEPTION 'Governed pick validation evidence mismatch';
+    END IF;
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_governed_component_validation_evidence_validate"
+BEFORE INSERT ON "outcome_governed_component_validation_evidence"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_governed_component_validation_evidence"();
+
+CREATE OR REPLACE FUNCTION "reject_outcome_governed_component_validation_evidence_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN RAISE EXCEPTION 'Governed component validation evidence is immutable'; END $$;
+CREATE TRIGGER "outcome_governed_component_validation_evidence_append_only"
+BEFORE UPDATE OR DELETE ON "outcome_governed_component_validation_evidence"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_governed_component_validation_evidence_mutation"();
+
 CREATE OR REPLACE FUNCTION "validate_outcome_governed_model_qualification_insert"()
 RETURNS TRIGGER LANGUAGE plpgsql AS $$
 DECLARE
@@ -290,12 +840,25 @@ DECLARE
   pick_failed BOOLEAN := FALSE;
   player_run RECORD;
   pick_run RECORD;
+  player_native RECORD;
+  pick_native RECORD;
+  pick_final_test JSONB;
   qualification_artifact RECORD;
 BEGIN
   SELECT * INTO STRICT player_run FROM "outcome_governed_valuation_component_run"
    WHERE "run_id"=NEW."player_run_id" FOR KEY SHARE;
   SELECT * INTO STRICT pick_run FROM "outcome_governed_valuation_component_run"
    WHERE "run_id"=NEW."pick_run_id" FOR KEY SHARE;
+  SELECT * INTO player_native FROM "outcome_governed_component_validation_evidence"
+   WHERE "run_id"=NEW."player_run_id" FOR KEY SHARE;
+  SELECT * INTO pick_native FROM "outcome_governed_component_validation_evidence"
+   WHERE "run_id"=NEW."pick_run_id" FOR KEY SHARE;
+  IF player_native."run_id" IS NULL OR pick_native."run_id" IS NULL THEN
+    RAISE EXCEPTION 'Governed model qualification native evidence mismatch';
+  END IF;
+  SELECT scope INTO STRICT pick_final_test
+    FROM jsonb_array_elements(pick_native."validation_report_json"->'content'->'scoreScopes') scope
+   WHERE scope->>'scope'='final_test';
   SELECT * INTO STRICT qualification_artifact FROM "outcome_artifact_custody"
    WHERE "artifact_id"=NEW."artifact_id" FOR KEY SHARE;
   policy:=content->'policy';
@@ -355,6 +918,26 @@ BEGIN
     OR content->'player'->>'role' IS DISTINCT FROM 'player_contribution_and_availability'
     OR content->'pick'->>'role' IS DISTINCT FROM
        'draft_pick_and_future_pick_distribution'
+    OR player_native."role" IS DISTINCT FROM content->'player'->>'role'
+    OR pick_native."role" IS DISTINCT FROM content->'pick'->>'role'
+    OR player_native."recorded_at">NEW."evaluated_at"
+    OR pick_native."recorded_at">NEW."evaluated_at"
+    OR player_evidence->>'validationReportId' IS DISTINCT FROM
+       player_native."validation_report_id"
+    OR (player_evidence->>'comparableObservationCount')::INTEGER IS DISTINCT FROM
+       jsonb_array_length(player_native."validation_report_json"->'content'->'comparableObservationIds')
+    OR player_evidence->>'acceptanceOutcome' IS DISTINCT FROM
+       player_native."validation_report_json"->'content'->>'acceptanceOutcome'
+    OR player_evidence->'relativeMaeImprovement' IS DISTINCT FROM
+       player_native."validation_report_json"->'content'->'metrics'->'relativeImprovement'->'meanAbsoluteError'
+    OR player_evidence->'relativeRmseImprovement' IS DISTINCT FROM
+       player_native."validation_report_json"->'content'->'metrics'->'relativeImprovement'->'rootMeanSquaredError'
+    OR pick_evidence->>'validationReportId' IS DISTINCT FROM pick_native."validation_report_id"
+    OR pick_evidence->>'evaluationStatus' IS DISTINCT FROM
+       pick_native."validation_report_json"->'content'->>'evaluationStatus'
+    OR (pick_evidence->>'observationCount')::INTEGER IS DISTINCT FROM
+       (pick_final_test->>'observationCount')::INTEGER
+    OR pick_evidence->'metrics' IS DISTINCT FROM pick_final_test->'metrics'
     OR policy->'player'->>'requiredAcceptanceOutcome' IS DISTINCT FROM
        'meets_declared_predictive_thresholds'
     OR player_evidence->>'acceptanceOutcome' IS NULL
@@ -379,7 +962,7 @@ BEGIN
     OR player_evidence->>'validationReportId' !~ '^player-validation-report:[a-f0-9]{64}$'
     OR jsonb_typeof(pick_evidence->'validationReportId') IS DISTINCT FROM 'string'
     OR pick_evidence->>'validationReportId' !~ '^pick-pav-validation-report:[a-f0-9]{64}$'
-  THEN RAISE EXCEPTION 'Governed model qualification nested contract mismatch';
+  THEN RAISE EXCEPTION 'Governed model qualification nested or native evidence contract mismatch';
   END IF;
   IF EXISTS (
        SELECT 1 FROM jsonb_array_elements(jsonb_build_array(

--- a/prisma/afl-trade-outcomes/migrations/0064_automated_model_pair_qualification/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0064_automated_model_pair_qualification/migration.sql
@@ -1,0 +1,424 @@
+-- Automated model-pair qualification is non-production model-validity authority only. Legacy
+-- review-pending execution records retain their original schema and meaning.
+
+CREATE OR REPLACE FUNCTION "validate_outcome_governed_valuation_component_run_insert"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  content JSONB := NEW."manifest_json"->'content';
+  pending_state_valid BOOLEAN;
+BEGIN
+  pending_state_valid :=
+    (content->>'schemaVersion'='governed-valuation-component-run/v1'
+      AND content->>'approvalState'='gate_3_review_required'
+      AND NOT content ? 'qualificationState')
+    OR
+    (content->>'schemaVersion'='governed-valuation-component-run/v2'
+      AND content->>'qualificationState'='automated_qualification_pending'
+      AND NOT content ? 'approvalState');
+  IF NEW."manifest_json"->>'runId' IS DISTINCT FROM NEW."run_id"
+    OR NOT pending_state_valid
+    OR content->>'environment' IS DISTINCT FROM 'non_production'
+    OR content->>'role' IS DISTINCT FROM NEW."role"
+    OR content->>'publicationEligible' IS DISTINCT FROM 'false'
+    OR content->'nativeExecution'->>'kind' IS DISTINCT FROM NEW."native_execution_kind"
+    OR content->'nativeExecution'->>'executionId' IS DISTINCT FROM NEW."native_execution_id"
+    OR content->'nativeExecution'->'artifact'->>'artifactId'
+      IS DISTINCT FROM NEW."native_execution_artifact_id"
+    OR content->>'protocolId' IS DISTINCT FROM NEW."protocol_id"
+    OR content->'protocolArtifact'->>'artifactId' IS DISTINCT FROM NEW."protocol_artifact_id"
+    OR content->>'datasetId' IS DISTINCT FROM NEW."dataset_id"
+    OR content->'datasetArtifact'->>'artifactId' IS DISTINCT FROM NEW."dataset_artifact_id"
+    OR content->>'datasetAdmissionId' IS DISTINCT FROM NEW."dataset_admission_id"
+    OR content->'datasetAdmissionArtifact'->>'artifactId'
+      IS DISTINCT FROM NEW."dataset_admission_artifact_id"
+    OR (content->>'datasetAdmissionGateLedgerRevision')::INTEGER
+      IS DISTINCT FROM NEW."dataset_admission_gate_ledger_revision"
+    OR (content->>'registeredAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."registered_at"
+  THEN
+    RAISE EXCEPTION 'Governed valuation component-run columns disagree with manifest JSON';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE OR REPLACE FUNCTION "validate_outcome_governed_pick_pav_model_execution_insert"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  content JSONB := NEW."execution_json"->'content';
+  observation_row RECORD;
+  dataset_row RECORD;
+  admission_row RECORD;
+  protocol_row RECORD;
+  pending_state_valid BOOLEAN;
+BEGIN
+  SELECT * INTO observation_row FROM "outcome_pick_pav_observation_set"
+   WHERE "observation_set_id"=NEW."observation_set_id" FOR SHARE;
+  SELECT * INTO dataset_row FROM "outcome_valuation_dataset_candidate"
+   WHERE "dataset_id"=NEW."dataset_id" FOR SHARE;
+  SELECT * INTO admission_row FROM "outcome_valuation_dataset_admission"
+   WHERE "admission_id"=NEW."dataset_admission_id" FOR SHARE;
+  SELECT * INTO protocol_row FROM "outcome_valuation_model_protocol"
+   WHERE "protocol_id"=NEW."protocol_id" FOR SHARE;
+  pending_state_valid :=
+    (content->>'schemaVersion'='afl-trade-pick-pav-model-execution/v2'
+      AND content->>'approvalStatus'='gate_3_review_required'
+      AND NOT content ? 'qualificationStatus')
+    OR
+    (content->>'schemaVersion'='afl-trade-pick-pav-model-execution/v3'
+      AND content->>'qualificationStatus'='automated_qualification_pending'
+      AND NOT content ? 'approvalStatus');
+
+  IF NEW."execution_json"->>'executionId' IS DISTINCT FROM NEW."execution_id"
+    OR NEW."content_sha256" IS DISTINCT FROM
+      substring(NEW."execution_id" FROM length('pick-pav-model-execution:') + 1)
+    OR NEW."content_canonical_json" IS DISTINCT FROM outcome_afl_trade_canonical_json(content)
+    OR NEW."execution_id" IS DISTINCT FROM 'pick-pav-model-execution:' ||
+      encode(sha256(convert_to(NEW."content_canonical_json",'UTF8')),'hex')
+    OR NOT pending_state_valid
+    OR content->>'environment' IS DISTINCT FROM 'non_production'
+    OR content->>'publicationEligible' IS DISTINCT FROM 'false'
+    OR content->>'observationSetId' IS DISTINCT FROM NEW."observation_set_id"
+    OR content->>'datasetId' IS DISTINCT FROM NEW."dataset_id"
+    OR content->'datasetArtifact'->>'artifactId' IS DISTINCT FROM NEW."dataset_artifact_id"
+    OR content->>'datasetAdmissionId' IS DISTINCT FROM NEW."dataset_admission_id"
+    OR content->'datasetAdmissionArtifact'->>'artifactId'
+      IS DISTINCT FROM NEW."dataset_admission_artifact_id"
+    OR (content->>'datasetAdmissionGateLedgerRevision')::INTEGER
+      IS DISTINCT FROM NEW."dataset_admission_gate_ledger_revision"
+    OR content->>'protocolId' IS DISTINCT FROM NEW."protocol_id"
+    OR content->'protocolArtifact'->>'artifactId' IS DISTINCT FROM NEW."protocol_artifact_id"
+    OR (content->>'finalTestEvaluationStartedAt')::TIMESTAMPTZ
+      IS DISTINCT FROM NEW."final_test_evaluation_started_at"
+    OR (content->>'completedAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."completed_at"
+    OR observation_row."status" IS DISTINCT FROM 'finalized'
+    OR observation_row."environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR dataset_row."status" IS DISTINCT FROM 'finalized'
+    OR dataset_row."environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR admission_row."status" IS DISTINCT FROM 'finalized'
+    OR admission_row."environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR admission_row."dataset_id" IS DISTINCT FROM NEW."dataset_id"
+    OR admission_row."gate_ledger_revision"
+      IS DISTINCT FROM NEW."dataset_admission_gate_ledger_revision"
+    OR protocol_row."environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR protocol_row."dataset_id" IS DISTINCT FROM NEW."dataset_id"
+    OR protocol_row."admission_id" IS DISTINCT FROM NEW."dataset_admission_id"
+    OR NEW."dataset_artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+      outcome_afl_trade_canonical_json(dataset_row."dataset_json"),'UTF8')),'hex')
+    OR NEW."dataset_admission_artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+      outcome_afl_trade_canonical_json(admission_row."admission_json"),'UTF8')),'hex')
+    OR NEW."protocol_artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+      outcome_afl_trade_canonical_json(protocol_row."protocol_json"),'UTF8')),'hex')
+    OR observation_row."release_id" IS DISTINCT FROM
+      dataset_row."dataset_json"->'content'->'factualParent'->>'factualReleaseId'
+    OR observation_row."release_id" IS DISTINCT FROM
+      admission_row."admission_json"->'content'->>'factualReleaseId'
+  THEN
+    RAISE EXCEPTION 'Governed pick-PAV execution authority or ancestry mismatch';
+  END IF;
+  RETURN NEW;
+END $$;
+
+ALTER TABLE "outcome_gate_decision"
+  DROP CONSTRAINT "outcome_gate_decision_approval_expiry_check";
+ALTER TABLE "outcome_gate_decision"
+  ADD CONSTRAINT "outcome_gate_decision_approval_expiry_check" CHECK (
+    "state" <> 'approved'
+    OR (
+      "decision_json"->'content'->>'authorityKind'='automated_validation_record'
+      AND "gate"='gate_3_model_validity'
+      AND "environment"='non_production'::"OutcomeEnvironment"
+      AND "revalidate_at" IS NULL
+    )
+    OR (
+      "decision_json"->'content'->>'authorityKind'<>'automated_validation_record'
+      AND "revalidate_at" IS NOT NULL
+      AND "revalidate_at">"effective_at"
+    )
+  );
+
+CREATE OR REPLACE FUNCTION "validate_outcome_gate_decision_insert"() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+    proposal_row "outcome_gate_proposal"%ROWTYPE;
+    predecessor "outcome_gate_decision"%ROWTYPE;
+    content JSONB := NEW."decision_json"->'content';
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtextextended(
+        'afl-trade-gate:' || NEW."gate" || ':' || NEW."environment"::TEXT || ':' || NEW."decision_key",
+        0
+    ));
+    SELECT * INTO STRICT proposal_row FROM "outcome_gate_proposal"
+     WHERE "proposal_id"=NEW."proposal_id";
+    IF proposal_row."gate"<>NEW."gate" OR proposal_row."decision_key"<>NEW."decision_key"
+       OR proposal_row."version"<>NEW."version" OR proposal_row."environment"<>NEW."environment"
+    THEN RAISE EXCEPTION 'Gate decision identity does not match its proposal'; END IF;
+    IF NEW."version"=1 THEN
+      IF NEW."supersedes_decision_id" IS NOT NULL
+      THEN RAISE EXCEPTION 'The first Gate decision cannot supersede another decision'; END IF;
+    ELSE
+      IF NEW."supersedes_decision_id" IS NULL
+      THEN RAISE EXCEPTION 'A later Gate decision must supersede the current decision'; END IF;
+      SELECT * INTO STRICT predecessor FROM "outcome_gate_decision"
+       WHERE "decision_id"=NEW."supersedes_decision_id";
+      IF predecessor."gate"<>NEW."gate" OR predecessor."environment"<>NEW."environment"
+         OR predecessor."decision_key"<>NEW."decision_key" OR predecessor."version"<>NEW."version"-1
+         OR predecessor."effective_at">NEW."effective_at"
+         OR EXISTS (SELECT 1 FROM "outcome_gate_decision"
+                     WHERE "supersedes_decision_id"=predecessor."decision_id")
+      THEN RAISE EXCEPTION 'Gate decisions must form one chronological linear chain'; END IF;
+    END IF;
+    IF content->>'authorityKind'='automated_validation_record' AND (
+      NEW."gate"<>'gate_3_model_validity'
+      OR NEW."environment"<>'non_production'::"OutcomeEnvironment"
+      OR content->>'state'<>'approved'
+      OR jsonb_array_length(content->'reviewers')<>0
+      OR (SELECT count(*) FROM jsonb_array_elements(content->'affectedArtifacts') artifact
+           WHERE artifact->>'kind'='model_run')<>1
+      OR (SELECT count(*) FROM jsonb_array_elements(content->'affectedArtifacts') artifact
+           WHERE artifact->>'kind'='model_qualification')<>1
+    ) THEN
+      RAISE EXCEPTION 'Automated validation authority is limited to non-production Gate 3';
+    END IF;
+    IF NEW."state"='approved' AND NEW."environment"='production'::"OutcomeEnvironment"
+       AND content->>'authorityKind'<>'external_human_record'
+    THEN RAISE EXCEPTION 'Production Gate approval requires external human authority'; END IF;
+    RETURN NEW;
+END $$;
+
+CREATE TABLE "outcome_governed_valuation_model_qualification" (
+  "qualification_id" TEXT NOT NULL PRIMARY KEY,
+  "scope_key" TEXT NOT NULL,
+  "outcome" TEXT NOT NULL,
+  "artifact_id" TEXT NOT NULL UNIQUE,
+  "player_run_id" TEXT NOT NULL,
+  "pick_run_id" TEXT NOT NULL,
+  "policy_artifact_id" TEXT NOT NULL,
+  "player_criteria_artifact_id" TEXT NOT NULL,
+  "pick_criteria_artifact_id" TEXT NOT NULL,
+  "player_evidence_artifact_id" TEXT NOT NULL,
+  "pick_evidence_artifact_id" TEXT NOT NULL,
+  "evaluated_at" TIMESTAMPTZ(3) NOT NULL,
+  "content_sha256" CHAR(64) NOT NULL,
+  "content_canonical_json" TEXT NOT NULL,
+  "qualification_json" JSONB NOT NULL,
+  "recorded_at" TIMESTAMPTZ(3) NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT "outcome_governed_model_qualification_id_check"
+    CHECK ("qualification_id" ~ '^model-qualification:[a-f0-9]{64}$'),
+  CONSTRAINT "outcome_governed_model_qualification_outcome_check"
+    CHECK ("outcome" IN ('qualified','failed')),
+  CONSTRAINT "outcome_governed_model_qualification_artifact_fkey"
+    FOREIGN KEY ("artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+  CONSTRAINT "outcome_governed_model_qualification_player_run_fkey"
+    FOREIGN KEY ("player_run_id") REFERENCES "outcome_governed_valuation_component_run"("run_id") ON DELETE RESTRICT,
+  CONSTRAINT "outcome_governed_model_qualification_pick_run_fkey"
+    FOREIGN KEY ("pick_run_id") REFERENCES "outcome_governed_valuation_component_run"("run_id") ON DELETE RESTRICT,
+  CONSTRAINT "outcome_governed_model_qualification_policy_artifact_fkey"
+    FOREIGN KEY ("policy_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+  CONSTRAINT "outcome_governed_model_qualification_player_criteria_fkey"
+    FOREIGN KEY ("player_criteria_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+  CONSTRAINT "outcome_governed_model_qualification_pick_criteria_fkey"
+    FOREIGN KEY ("pick_criteria_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+  CONSTRAINT "outcome_governed_model_qualification_player_evidence_fkey"
+    FOREIGN KEY ("player_evidence_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT,
+  CONSTRAINT "outcome_governed_model_qualification_pick_evidence_fkey"
+    FOREIGN KEY ("pick_evidence_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT
+);
+
+CREATE OR REPLACE FUNCTION "validate_outcome_governed_model_qualification_insert"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  content JSONB := NEW."qualification_json"->'content';
+  player_run RECORD;
+  pick_run RECORD;
+BEGIN
+  SELECT * INTO STRICT player_run FROM "outcome_governed_valuation_component_run"
+   WHERE "run_id"=NEW."player_run_id" FOR KEY SHARE;
+  SELECT * INTO STRICT pick_run FROM "outcome_governed_valuation_component_run"
+   WHERE "run_id"=NEW."pick_run_id" FOR KEY SHARE;
+  IF NEW."qualification_json"->>'qualificationId' IS DISTINCT FROM NEW."qualification_id"
+    OR content->>'schemaVersion' IS DISTINCT FROM 'governed-valuation-model-qualification/v1'
+    OR content->>'environment' IS DISTINCT FROM 'non_production'
+    OR content->>'scopeKey' IS DISTINCT FROM NEW."scope_key"
+    OR content->>'outcome' IS DISTINCT FROM NEW."outcome"
+    OR content->>'publicationEligible' IS DISTINCT FROM 'false'
+    OR content->'player'->>'runId' IS DISTINCT FROM NEW."player_run_id"
+    OR content->'pick'->>'runId' IS DISTINCT FROM NEW."pick_run_id"
+    OR content->'policyArtifact'->>'artifactId' IS DISTINCT FROM NEW."policy_artifact_id"
+    OR content->'player'->'criteriaArtifact'->>'artifactId'
+      IS DISTINCT FROM NEW."player_criteria_artifact_id"
+    OR content->'pick'->'criteriaArtifact'->>'artifactId'
+      IS DISTINCT FROM NEW."pick_criteria_artifact_id"
+    OR content->'player'->'validationEvidenceArtifact'->>'artifactId'
+      IS DISTINCT FROM NEW."player_evidence_artifact_id"
+    OR content->'pick'->'validationEvidenceArtifact'->>'artifactId'
+      IS DISTINCT FROM NEW."pick_evidence_artifact_id"
+    OR (content->>'evaluatedAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."evaluated_at"
+    OR NEW."content_sha256" IS DISTINCT FROM substring(NEW."qualification_id" FROM 21)
+    OR NEW."content_canonical_json" IS DISTINCT FROM outcome_afl_trade_canonical_json(content)
+    OR NEW."qualification_id" IS DISTINCT FROM 'model-qualification:' ||
+      encode(sha256(convert_to(NEW."content_canonical_json",'UTF8')),'hex')
+    OR NEW."artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
+      outcome_afl_trade_canonical_json(NEW."qualification_json"),'UTF8')),'hex')
+    OR player_run."role"<>'player_contribution_and_availability'
+    OR pick_run."role"<>'draft_pick_and_future_pick_distribution'
+    OR player_run."artifact_id" IS DISTINCT FROM content->'player'->'runArtifact'->>'artifactId'
+    OR pick_run."artifact_id" IS DISTINCT FROM content->'pick'->'runArtifact'->>'artifactId'
+    OR player_run."protocol_id" IS DISTINCT FROM content->'player'->>'protocolId'
+    OR pick_run."protocol_id" IS DISTINCT FROM content->'pick'->>'protocolId'
+    OR player_run."protocol_artifact_id"
+      IS DISTINCT FROM content->'player'->'protocolArtifact'->>'artifactId'
+    OR pick_run."protocol_artifact_id"
+      IS DISTINCT FROM content->'pick'->'protocolArtifact'->>'artifactId'
+  THEN RAISE EXCEPTION 'Governed model qualification ancestry or retained JSON mismatch'; END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_governed_model_qualification_validate_insert"
+BEFORE INSERT ON "outcome_governed_valuation_model_qualification"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_governed_model_qualification_insert"();
+
+CREATE OR REPLACE FUNCTION "reject_outcome_governed_model_qualification_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN RAISE EXCEPTION 'Governed valuation model qualifications are append-only'; END $$;
+CREATE TRIGGER "outcome_governed_model_qualification_append_only"
+BEFORE UPDATE OR DELETE ON "outcome_governed_valuation_model_qualification"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_governed_model_qualification_mutation"();
+
+CREATE TABLE "outcome_governed_model_qualification_work" (
+  "work_id" TEXT NOT NULL PRIMARY KEY,
+  "scope_key" TEXT NOT NULL,
+  "qualification_id" TEXT NOT NULL UNIQUE,
+  "player_gate3_decision_id" TEXT NOT NULL,
+  "pick_gate3_decision_id" TEXT NOT NULL,
+  "available_at" TIMESTAMPTZ(3) NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'pending',
+  "work_json" JSONB NOT NULL,
+  "recorded_at" TIMESTAMPTZ(3) NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT "outcome_governed_model_qualification_work_id_check"
+    CHECK ("work_id" ~ '^model-qualification-work:[a-f0-9]{64}$'),
+  CONSTRAINT "outcome_governed_model_qualification_work_status_check"
+    CHECK ("status" IN ('pending','claimed','completed','superseded')),
+  FOREIGN KEY ("qualification_id") REFERENCES "outcome_governed_valuation_model_qualification"("qualification_id") ON DELETE RESTRICT,
+  FOREIGN KEY ("player_gate3_decision_id") REFERENCES "outcome_gate_decision"("decision_id") ON DELETE RESTRICT,
+  FOREIGN KEY ("pick_gate3_decision_id") REFERENCES "outcome_gate_decision"("decision_id") ON DELETE RESTRICT
+);
+
+CREATE OR REPLACE FUNCTION "reject_outcome_governed_model_qualification_work_delete"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN RAISE EXCEPTION 'Governed model qualification work is durable'; END $$;
+CREATE TRIGGER "outcome_governed_model_qualification_work_no_delete"
+BEFORE DELETE ON "outcome_governed_model_qualification_work"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_governed_model_qualification_work_delete"();
+
+CREATE TABLE "outcome_current_governed_valuation_model_pair" (
+  "scope_key" TEXT NOT NULL PRIMARY KEY,
+  "revision" INTEGER NOT NULL,
+  "qualification_id" TEXT NOT NULL UNIQUE,
+  "player_run_id" TEXT NOT NULL,
+  "pick_run_id" TEXT NOT NULL,
+  "player_gate3_decision_id" TEXT NOT NULL UNIQUE,
+  "pick_gate3_decision_id" TEXT NOT NULL UNIQUE,
+  "work_id" TEXT NOT NULL UNIQUE,
+  "advanced_at" TIMESTAMPTZ(3) NOT NULL,
+  CONSTRAINT "outcome_current_governed_model_pair_revision_check" CHECK ("revision">0),
+  FOREIGN KEY ("qualification_id") REFERENCES "outcome_governed_valuation_model_qualification"("qualification_id") ON DELETE RESTRICT,
+  FOREIGN KEY ("player_run_id") REFERENCES "outcome_governed_valuation_component_run"("run_id") ON DELETE RESTRICT,
+  FOREIGN KEY ("pick_run_id") REFERENCES "outcome_governed_valuation_component_run"("run_id") ON DELETE RESTRICT,
+  FOREIGN KEY ("player_gate3_decision_id") REFERENCES "outcome_gate_decision"("decision_id") ON DELETE RESTRICT,
+  FOREIGN KEY ("pick_gate3_decision_id") REFERENCES "outcome_gate_decision"("decision_id") ON DELETE RESTRICT,
+  FOREIGN KEY ("work_id") REFERENCES "outcome_governed_model_qualification_work"("work_id") ON DELETE RESTRICT
+);
+
+CREATE OR REPLACE FUNCTION "advance_outcome_current_governed_valuation_model_pair"(
+  target_scope_key TEXT,
+  target_qualification_id TEXT,
+  target_player_gate3_decision_id TEXT,
+  target_pick_gate3_decision_id TEXT,
+  target_work_id TEXT,
+  expected_revision INTEGER,
+  target_advanced_at TIMESTAMPTZ
+) RETURNS INTEGER LANGUAGE plpgsql AS $$
+DECLARE
+  current_revision INTEGER;
+  qualification RECORD;
+  work RECORD;
+  player_decision RECORD;
+  pick_decision RECORD;
+  next_revision INTEGER;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended('governed-model-pair:' || target_scope_key,0));
+  SELECT revision INTO current_revision FROM "outcome_current_governed_valuation_model_pair"
+   WHERE "scope_key"=target_scope_key FOR UPDATE;
+  current_revision:=COALESCE(current_revision,0);
+  IF current_revision<>expected_revision THEN RAISE EXCEPTION 'Stale current model-pair revision'; END IF;
+  SELECT * INTO STRICT qualification FROM "outcome_governed_valuation_model_qualification"
+   WHERE "qualification_id"=target_qualification_id FOR KEY SHARE;
+  SELECT * INTO STRICT work FROM "outcome_governed_model_qualification_work"
+   WHERE "work_id"=target_work_id FOR KEY SHARE;
+  SELECT * INTO STRICT player_decision FROM "outcome_gate_decision"
+   WHERE "decision_id"=target_player_gate3_decision_id FOR KEY SHARE;
+  SELECT * INTO STRICT pick_decision FROM "outcome_gate_decision"
+   WHERE "decision_id"=target_pick_gate3_decision_id FOR KEY SHARE;
+  IF qualification."outcome"<>'qualified' OR qualification."scope_key"<>target_scope_key
+    OR work."qualification_id"<>qualification."qualification_id"
+    OR work."scope_key"<>target_scope_key OR work."status"<>'pending'
+    OR work."player_gate3_decision_id"<>player_decision."decision_id"
+    OR work."pick_gate3_decision_id"<>pick_decision."decision_id"
+    OR player_decision."state"<>'approved' OR pick_decision."state"<>'approved'
+    OR player_decision."gate"<>'gate_3_model_validity'
+    OR pick_decision."gate"<>'gate_3_model_validity'
+    OR player_decision."environment"<>'non_production'::"OutcomeEnvironment"
+    OR pick_decision."environment"<>'non_production'::"OutcomeEnvironment"
+    OR player_decision."decision_json"->'content'->>'authorityKind'<>'automated_validation_record'
+    OR pick_decision."decision_json"->'content'->>'authorityKind'<>'automated_validation_record'
+    OR NOT EXISTS (
+      SELECT 1 FROM jsonb_array_elements(
+        player_decision."decision_json"->'content'->'affectedArtifacts'
+      ) artifact
+      WHERE artifact->>'kind'='model_run'
+        AND artifact->>'artifactId'=qualification."player_run_id"
+    )
+    OR NOT EXISTS (
+      SELECT 1 FROM jsonb_array_elements(
+        player_decision."decision_json"->'content'->'affectedArtifacts'
+      ) artifact
+      WHERE artifact->>'kind'='model_qualification'
+        AND artifact->>'artifactId'=qualification."qualification_id"
+    )
+    OR NOT EXISTS (
+      SELECT 1 FROM jsonb_array_elements(
+        pick_decision."decision_json"->'content'->'affectedArtifacts'
+      ) artifact
+      WHERE artifact->>'kind'='model_run'
+        AND artifact->>'artifactId'=qualification."pick_run_id"
+    )
+    OR NOT EXISTS (
+      SELECT 1 FROM jsonb_array_elements(
+        pick_decision."decision_json"->'content'->'affectedArtifacts'
+      ) artifact
+      WHERE artifact->>'kind'='model_qualification'
+        AND artifact->>'artifactId'=qualification."qualification_id"
+    )
+    OR EXISTS (SELECT 1 FROM "outcome_gate_decision" successor
+                WHERE successor."supersedes_decision_id" IN
+                  (player_decision."decision_id",pick_decision."decision_id"))
+  THEN RAISE EXCEPTION 'Current governed valuation model pairs require a passing qualification'; END IF;
+  next_revision:=current_revision+1;
+  INSERT INTO "outcome_current_governed_valuation_model_pair"
+    ("scope_key","revision","qualification_id","player_run_id","pick_run_id",
+     "player_gate3_decision_id","pick_gate3_decision_id","work_id","advanced_at")
+  VALUES (target_scope_key,next_revision,qualification."qualification_id",
+          qualification."player_run_id",qualification."pick_run_id",
+          player_decision."decision_id",pick_decision."decision_id",work."work_id",target_advanced_at)
+  ON CONFLICT ("scope_key") DO UPDATE SET
+    "revision"=EXCLUDED."revision","qualification_id"=EXCLUDED."qualification_id",
+    "player_run_id"=EXCLUDED."player_run_id","pick_run_id"=EXCLUDED."pick_run_id",
+    "player_gate3_decision_id"=EXCLUDED."player_gate3_decision_id",
+    "pick_gate3_decision_id"=EXCLUDED."pick_gate3_decision_id",
+    "work_id"=EXCLUDED."work_id","advanced_at"=EXCLUDED."advanced_at";
+  RETURN next_revision;
+END $$;
+
+CREATE INDEX "outcome_governed_model_qualification_scope_idx"
+  ON "outcome_governed_valuation_model_qualification"("scope_key","evaluated_at","qualification_id");
+CREATE INDEX "outcome_governed_model_qualification_work_pending_idx"
+  ON "outcome_governed_model_qualification_work"("status","available_at","scope_key");

--- a/prisma/afl-trade-outcomes/migrations/0064_automated_model_pair_qualification/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0064_automated_model_pair_qualification/migration.sql
@@ -358,6 +358,21 @@ BEGIN
     OR pick_evidence->>'evaluationStatus' NOT IN (
        'scored_not_approved','insufficient_eligible_observations_not_approved',
        'invalid_zero_probability_not_approved')
+    OR jsonb_typeof(content->'publicationEligible') IS DISTINCT FROM 'boolean'
+    OR content->'publicationEligible' IS DISTINCT FROM 'false'::JSONB
+    OR jsonb_typeof(content->'player'->'passed') IS DISTINCT FROM 'boolean'
+    OR jsonb_typeof(content->'pick'->'passed') IS DISTINCT FROM 'boolean'
+    OR jsonb_typeof(content->'failureCodes') IS DISTINCT FROM 'array'
+    OR jsonb_typeof(content->'scopeKey') IS DISTINCT FROM 'string'
+    OR length(content->>'scopeKey') NOT BETWEEN 1 AND 200
+    OR content->>'scopeKey' !~ '^[a-zA-Z0-9][a-zA-Z0-9._:-]*$'
+    OR jsonb_typeof(content->'evaluatedAt') IS DISTINCT FROM 'string'
+    OR content->>'evaluatedAt' !~
+       '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$'
+    OR jsonb_typeof(player_evidence->'validationReportId') IS DISTINCT FROM 'string'
+    OR player_evidence->>'validationReportId' !~ '^player-validation-report:[a-f0-9]{64}$'
+    OR jsonb_typeof(pick_evidence->'validationReportId') IS DISTINCT FROM 'string'
+    OR pick_evidence->>'validationReportId' !~ '^pick-pav-validation-report:[a-f0-9]{64}$'
   THEN RAISE EXCEPTION 'Governed model qualification nested contract mismatch';
   END IF;
   IF EXISTS (
@@ -466,6 +481,9 @@ BEGIN
          content->'pick'->'validationEvidenceArtifact'
        )) reference
        WHERE outcome_afl_trade_jsonb_is_artifact_ref(reference) IS DISTINCT FROM TRUE
+         OR "validate_outcome_prepared_valuation_input_v2_artifact"(
+              reference, 'non_production'::"OutcomeEnvironment"
+            ) IS DISTINCT FROM TRUE
      )
     OR EXISTS (
        SELECT 1 FROM jsonb_array_elements(jsonb_build_array(
@@ -536,11 +554,11 @@ BEGIN
     OR content->>'scopeKey' IS DISTINCT FROM NEW."scope_key"
     OR content->>'outcome' IS DISTINCT FROM NEW."outcome"
     OR content->'failureCodes' IS DISTINCT FROM expected_failure_codes
-    OR (content->'player'->>'passed')::BOOLEAN IS DISTINCT FROM (NOT player_failed)
-    OR (content->'pick'->>'passed')::BOOLEAN IS DISTINCT FROM (NOT pick_failed)
+    OR content->'player'->'passed' IS DISTINCT FROM to_jsonb(NOT player_failed)
+    OR content->'pick'->'passed' IS DISTINCT FROM to_jsonb(NOT pick_failed)
     OR content->>'outcome' IS DISTINCT FROM
       (CASE WHEN player_failed OR pick_failed THEN 'failed' ELSE 'qualified' END)
-    OR content->>'publicationEligible' IS DISTINCT FROM 'false'
+    OR content->'publicationEligible' IS DISTINCT FROM 'false'::JSONB
     OR content->'player'->>'runId' IS DISTINCT FROM NEW."player_run_id"
     OR content->'pick'->>'runId' IS DISTINCT FROM NEW."pick_run_id"
     OR content->'policyArtifact'->>'artifactId' IS DISTINCT FROM NEW."policy_artifact_id"
@@ -588,6 +606,57 @@ END $$;
 CREATE TRIGGER "outcome_governed_model_qualification_validate_insert"
 BEFORE INSERT ON "outcome_governed_valuation_model_qualification"
 FOR EACH ROW EXECUTE FUNCTION "validate_outcome_governed_model_qualification_insert"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_automated_gate_pair_commit"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  automated_qualification_id TEXT;
+  qualification_row RECORD;
+  decision_count INTEGER;
+  player_count INTEGER;
+  pick_count INTEGER;
+BEGIN
+  IF NEW."decision_json"->'content'->>'authorityKind'<>'automated_validation_record' THEN
+    RETURN NEW;
+  END IF;
+  SELECT artifact->>'artifactId' INTO STRICT automated_qualification_id
+    FROM jsonb_array_elements(NEW."decision_json"->'content'->'affectedArtifacts') artifact
+    WHERE artifact->>'kind'='model_qualification';
+  SELECT * INTO STRICT qualification_row
+    FROM "outcome_governed_valuation_model_qualification"
+    WHERE "qualification_id"=automated_qualification_id;
+  SELECT count(*),
+         count(*) FILTER (WHERE EXISTS (
+           SELECT 1
+             FROM jsonb_array_elements(decision."decision_json"->'content'->'affectedArtifacts') artifact
+            WHERE artifact->>'kind'='model_run'
+              AND artifact->>'artifactId'=qualification_row."player_run_id"
+         )),
+         count(*) FILTER (WHERE EXISTS (
+           SELECT 1
+             FROM jsonb_array_elements(decision."decision_json"->'content'->'affectedArtifacts') artifact
+            WHERE artifact->>'kind'='model_run'
+              AND artifact->>'artifactId'=qualification_row."pick_run_id"
+         ))
+    INTO decision_count,player_count,pick_count
+    FROM "outcome_gate_decision" decision
+   WHERE decision."decision_json"->'content'->>'authorityKind'='automated_validation_record'
+     AND EXISTS (
+       SELECT 1
+         FROM jsonb_array_elements(decision."decision_json"->'content'->'affectedArtifacts') artifact
+        WHERE artifact->>'kind'='model_qualification'
+          AND artifact->>'artifactId'=automated_qualification_id
+     );
+  IF decision_count<>2 OR player_count<>1 OR pick_count<>1 THEN
+    RAISE EXCEPTION 'Automated Gate 3 authority requires one atomic role-specific decision pair';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE CONSTRAINT TRIGGER "outcome_automated_gate_pair_commit_guard"
+AFTER INSERT ON "outcome_gate_decision"
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_automated_gate_pair_commit"();
 
 CREATE OR REPLACE FUNCTION "reject_outcome_governed_model_qualification_mutation"()
 RETURNS TRIGGER LANGUAGE plpgsql AS $$

--- a/prisma/afl-trade-outcomes/migrations/0064_automated_model_pair_qualification/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0064_automated_model_pair_qualification/migration.sql
@@ -140,6 +140,9 @@ LANGUAGE plpgsql AS $$
 DECLARE
     proposal_row "outcome_gate_proposal"%ROWTYPE;
     predecessor "outcome_gate_decision"%ROWTYPE;
+    qualification_row RECORD;
+    automated_qualification_id TEXT;
+    automated_model_run_id TEXT;
     content JSONB := NEW."decision_json"->'content';
 BEGIN
     PERFORM pg_advisory_xact_lock(hashtextextended(
@@ -166,17 +169,39 @@ BEGIN
                      WHERE "supersedes_decision_id"=predecessor."decision_id")
       THEN RAISE EXCEPTION 'Gate decisions must form one chronological linear chain'; END IF;
     END IF;
-    IF content->>'authorityKind'='automated_validation_record' AND (
-      NEW."gate"<>'gate_3_model_validity'
-      OR NEW."environment"<>'non_production'::"OutcomeEnvironment"
-      OR content->>'state'<>'approved'
-      OR jsonb_array_length(content->'reviewers')<>0
-      OR (SELECT count(*) FROM jsonb_array_elements(content->'affectedArtifacts') artifact
-           WHERE artifact->>'kind'='model_run')<>1
-      OR (SELECT count(*) FROM jsonb_array_elements(content->'affectedArtifacts') artifact
-           WHERE artifact->>'kind'='model_qualification')<>1
-    ) THEN
-      RAISE EXCEPTION 'Automated validation authority is limited to non-production Gate 3';
+    IF content->>'authorityKind'='automated_validation_record' THEN
+      IF NEW."gate"<>'gate_3_model_validity'
+        OR NEW."environment"<>'non_production'::"OutcomeEnvironment"
+        OR content->>'state'<>'approved'
+        OR content->'revalidateAt'<>'null'::JSONB
+        OR jsonb_array_length(content->'reviewers')<>0
+        OR (SELECT count(*) FROM jsonb_array_elements(content->'affectedArtifacts') artifact
+             WHERE artifact->>'kind'='model_run')<>1
+        OR (SELECT count(*) FROM jsonb_array_elements(content->'affectedArtifacts') artifact
+             WHERE artifact->>'kind'='model_qualification')<>1
+      THEN RAISE EXCEPTION 'Automated validation authority is limited to non-production Gate 3';
+      END IF;
+      SELECT artifact->>'artifactId' INTO STRICT automated_qualification_id
+        FROM jsonb_array_elements(content->'affectedArtifacts') artifact
+        WHERE artifact->>'kind'='model_qualification';
+      SELECT artifact->>'artifactId' INTO STRICT automated_model_run_id
+        FROM jsonb_array_elements(content->'affectedArtifacts') artifact
+        WHERE artifact->>'kind'='model_run';
+      SELECT * INTO STRICT qualification_row
+        FROM "outcome_governed_valuation_model_qualification"
+        WHERE "qualification_id"=automated_qualification_id FOR KEY SHARE;
+      IF qualification_row."outcome"<>'qualified'
+        OR qualification_row."scope_key" IS DISTINCT FROM content->'scope'->>'scopeKey'
+        OR content->'scope' IS DISTINCT FROM proposal_row."proposal_json"->'content'->'scope'
+        OR automated_model_run_id NOT IN (
+          qualification_row."player_run_id", qualification_row."pick_run_id"
+        )
+        OR NOT (content->'authorityEvidenceIds' ? qualification_row."artifact_id")
+        OR NOT (
+          proposal_row."proposal_json"->'content'->'evidenceIds' ? qualification_row."artifact_id"
+        )
+      THEN RAISE EXCEPTION 'Automated Gate 3 requires its exact retained passing qualification';
+      END IF;
     END IF;
     IF NEW."state"='approved' AND NEW."environment"='production'::"OutcomeEnvironment"
        AND content->>'authorityKind'<>'external_human_record'
@@ -223,6 +248,32 @@ CREATE TABLE "outcome_governed_valuation_model_qualification" (
     FOREIGN KEY ("pick_evidence_artifact_id") REFERENCES "outcome_artifact_custody"("artifact_id") ON DELETE RESTRICT
 );
 
+CREATE OR REPLACE FUNCTION "outcome_afl_trade_jsonb_has_exact_keys"(
+  document JSONB,
+  expected_keys TEXT[]
+) RETURNS BOOLEAN LANGUAGE SQL IMMUTABLE AS $$
+  SELECT jsonb_typeof(document)='object'
+    AND ARRAY(SELECT key FROM jsonb_object_keys(document) key ORDER BY key)
+      = ARRAY(SELECT key FROM unnest(expected_keys) key ORDER BY key)
+$$;
+
+CREATE OR REPLACE FUNCTION "outcome_afl_trade_jsonb_is_artifact_ref"(document JSONB)
+RETURNS BOOLEAN LANGUAGE SQL IMMUTABLE AS $$
+  SELECT outcome_afl_trade_jsonb_has_exact_keys(
+      document,
+      ARRAY['artifactId','byteLength','contentSha256','createdAt','mediaType','storageUri']
+    )
+    AND document->>'artifactId' ~ '^artifact:[a-f0-9]{64}$'
+    AND document->>'contentSha256' ~ '^[a-f0-9]{64}$'
+    AND document->>'artifactId' = ('artifact:' || (document->>'contentSha256'))
+    AND document->>'storageUri' = ('artifact://sha256/' || (document->>'contentSha256'))
+    AND length(document->>'mediaType') BETWEEN 1 AND 160
+    AND jsonb_typeof(document->'byteLength')='number'
+    AND (document->>'byteLength')::NUMERIC >= 0
+    AND (document->>'byteLength')::NUMERIC = trunc((document->>'byteLength')::NUMERIC)
+    AND document->>'createdAt' IS NOT NULL
+$$;
+
 CREATE OR REPLACE FUNCTION "validate_outcome_governed_model_qualification_insert"()
 RETURNS TRIGGER LANGUAGE plpgsql AS $$
 DECLARE
@@ -245,6 +296,191 @@ BEGIN
   player_evidence:=content->'player'->'validationEvidence';
   pick_evidence:=content->'pick'->'validationEvidence';
   pick_metrics:=pick_evidence->'metrics';
+  IF outcome_afl_trade_jsonb_has_exact_keys(
+       NEW."qualification_json", ARRAY['content','qualificationId'])
+       IS DISTINCT FROM TRUE
+    OR outcome_afl_trade_jsonb_has_exact_keys(
+       content, ARRAY['environment','evaluatedAt','failureCodes','outcome','pick',
+         'player','policy','policyArtifact','publicationEligible','schemaVersion','scopeKey'])
+       IS DISTINCT FROM TRUE
+    OR outcome_afl_trade_jsonb_has_exact_keys(
+       policy, ARRAY['pick','player','policyVersion','schemaVersion']) IS DISTINCT FROM TRUE
+    OR outcome_afl_trade_jsonb_has_exact_keys(
+       policy->'player', ARRAY['minimumComparableObservations','minimumRelativeMaeImprovement',
+         'minimumRelativeRmseImprovement','requiredAcceptanceOutcome','schemaVersion'])
+       IS DISTINCT FROM TRUE
+    OR outcome_afl_trade_jsonb_has_exact_keys(
+       policy->'pick', ARRAY['evaluatedScope','maximumContributionCrps',
+         'maximumEmpiricalP10P90Coverage','maximumMeanAbsoluteContributionError',
+         'maximumMeanAbsoluteGamesError','maximumMeanEmpiricalIntervalWidth',
+         'maximumMulticlassBrierScore','maximumMulticlassLogLoss',
+         'maximumRankedProbabilityScore','maximumRootMeanSquaredContributionError',
+         'maximumRootMeanSquaredGamesError','maximumZeroProbabilityObservationCount',
+         'minimumEmpiricalP10P90Coverage','minimumObservations','schemaVersion'])
+       IS DISTINCT FROM TRUE
+    OR outcome_afl_trade_jsonb_has_exact_keys(
+       content->'player', ARRAY['criteriaArtifact','passed','protocolArtifact','protocolId','role',
+         'runArtifact','runId','validationEvidence','validationEvidenceArtifact'])
+       IS DISTINCT FROM TRUE
+    OR outcome_afl_trade_jsonb_has_exact_keys(
+       content->'pick', ARRAY['criteriaArtifact','passed','protocolArtifact','protocolId','role',
+         'runArtifact','runId','validationEvidence','validationEvidenceArtifact'])
+       IS DISTINCT FROM TRUE
+    OR outcome_afl_trade_jsonb_has_exact_keys(
+       player_evidence, ARRAY['acceptanceOutcome','comparableObservationCount',
+         'relativeMaeImprovement','relativeRmseImprovement','schemaVersion','validationReportId'])
+       IS DISTINCT FROM TRUE
+    OR outcome_afl_trade_jsonb_has_exact_keys(
+       pick_evidence, ARRAY['evaluationStatus','metrics','observationCount','schemaVersion','scope',
+         'validationReportId']) IS DISTINCT FROM TRUE
+    OR content->>'schemaVersion' IS DISTINCT FROM 'governed-valuation-model-qualification/v1'
+    OR policy->>'schemaVersion' IS DISTINCT FROM
+       'governed-valuation-model-qualification-policy/v1'
+    OR policy->'player'->>'schemaVersion' IS DISTINCT FROM
+       'governed-player-model-qualification-criteria/v1'
+    OR policy->'pick'->>'schemaVersion' IS DISTINCT FROM
+       'governed-pick-model-qualification-criteria/v1'
+    OR policy->'pick'->>'evaluatedScope' IS DISTINCT FROM 'final_test'
+    OR player_evidence->>'schemaVersion' IS DISTINCT FROM
+       'governed-player-model-qualification-evidence/v1'
+    OR pick_evidence->>'schemaVersion' IS DISTINCT FROM
+       'governed-pick-model-qualification-evidence/v1'
+    OR pick_evidence->>'scope' IS DISTINCT FROM 'final_test'
+    OR content->'player'->>'role' IS DISTINCT FROM 'player_contribution_and_availability'
+    OR content->'pick'->>'role' IS DISTINCT FROM
+       'draft_pick_and_future_pick_distribution'
+    OR policy->'player'->>'requiredAcceptanceOutcome' IS DISTINCT FROM
+       'meets_declared_predictive_thresholds'
+    OR player_evidence->>'acceptanceOutcome' IS NULL
+    OR player_evidence->>'acceptanceOutcome' NOT IN (
+       'meets_declared_predictive_thresholds','does_not_meet_declared_predictive_thresholds')
+    OR pick_evidence->>'evaluationStatus' IS NULL
+    OR pick_evidence->>'evaluationStatus' NOT IN (
+       'scored_not_approved','insufficient_eligible_observations_not_approved',
+       'invalid_zero_probability_not_approved')
+  THEN RAISE EXCEPTION 'Governed model qualification nested contract mismatch';
+  END IF;
+  IF EXISTS (
+       SELECT 1 FROM jsonb_array_elements(jsonb_build_array(
+         policy->'player'->'minimumComparableObservations',
+         policy->'player'->'minimumRelativeMaeImprovement',
+         policy->'player'->'minimumRelativeRmseImprovement',
+         policy->'pick'->'minimumObservations',
+         policy->'pick'->'maximumMulticlassBrierScore',
+         policy->'pick'->'maximumMulticlassLogLoss',
+         policy->'pick'->'maximumRankedProbabilityScore',
+         policy->'pick'->'maximumContributionCrps',
+         policy->'pick'->'maximumMeanAbsoluteContributionError',
+         policy->'pick'->'maximumRootMeanSquaredContributionError',
+         policy->'pick'->'maximumMeanAbsoluteGamesError',
+         policy->'pick'->'maximumRootMeanSquaredGamesError',
+         policy->'pick'->'minimumEmpiricalP10P90Coverage',
+         policy->'pick'->'maximumEmpiricalP10P90Coverage',
+         policy->'pick'->'maximumMeanEmpiricalIntervalWidth',
+         policy->'pick'->'maximumZeroProbabilityObservationCount',
+         player_evidence->'comparableObservationCount',
+         pick_evidence->'observationCount'
+       )) value WHERE jsonb_typeof(value)<>'number'
+     )
+    OR jsonb_typeof(player_evidence->'relativeMaeImprovement') NOT IN ('number','null')
+    OR jsonb_typeof(player_evidence->'relativeRmseImprovement') NOT IN ('number','null')
+    OR (policy->'player'->>'minimumComparableObservations')::NUMERIC NOT BETWEEN 1 AND 100000
+    OR (policy->'player'->>'minimumComparableObservations')::NUMERIC <>
+       trunc((policy->'player'->>'minimumComparableObservations')::NUMERIC)
+    OR (policy->'player'->>'minimumRelativeMaeImprovement')::NUMERIC NOT BETWEEN 0 AND 1
+    OR (policy->'player'->>'minimumRelativeMaeImprovement')::NUMERIC = 0
+    OR (policy->'player'->>'minimumRelativeRmseImprovement')::NUMERIC NOT BETWEEN 0 AND 1
+    OR (policy->'player'->>'minimumRelativeRmseImprovement')::NUMERIC = 0
+    OR (policy->'pick'->>'minimumObservations')::NUMERIC NOT BETWEEN 1 AND 100000
+    OR (policy->'pick'->>'minimumObservations')::NUMERIC <>
+       trunc((policy->'pick'->>'minimumObservations')::NUMERIC)
+    OR (player_evidence->>'comparableObservationCount')::NUMERIC NOT BETWEEN 0 AND 100000
+    OR (player_evidence->>'comparableObservationCount')::NUMERIC <>
+       trunc((player_evidence->>'comparableObservationCount')::NUMERIC)
+    OR (pick_evidence->>'observationCount')::NUMERIC NOT BETWEEN 0 AND 100000
+    OR (pick_evidence->>'observationCount')::NUMERIC <>
+       trunc((pick_evidence->>'observationCount')::NUMERIC)
+    OR (policy->'pick'->>'minimumEmpiricalP10P90Coverage')::NUMERIC NOT BETWEEN 0 AND 1
+    OR (policy->'pick'->>'maximumEmpiricalP10P90Coverage')::NUMERIC NOT BETWEEN 0 AND 1
+    OR (policy->'pick'->>'maximumEmpiricalP10P90Coverage')::NUMERIC <
+       (policy->'pick'->>'minimumEmpiricalP10P90Coverage')::NUMERIC
+    OR EXISTS (
+       SELECT 1 FROM jsonb_array_elements(jsonb_build_array(
+         policy->'pick'->'maximumMulticlassBrierScore',
+         policy->'pick'->'maximumMulticlassLogLoss',
+         policy->'pick'->'maximumRankedProbabilityScore',
+         policy->'pick'->'maximumContributionCrps',
+         policy->'pick'->'maximumMeanAbsoluteContributionError',
+         policy->'pick'->'maximumRootMeanSquaredContributionError',
+         policy->'pick'->'maximumMeanAbsoluteGamesError',
+         policy->'pick'->'maximumRootMeanSquaredGamesError',
+         policy->'pick'->'maximumMeanEmpiricalIntervalWidth'
+       )) value WHERE (value#>>'{}')::NUMERIC < 0
+     )
+    OR (policy->'pick'->>'maximumZeroProbabilityObservationCount')::NUMERIC < 0
+    OR (policy->'pick'->>'maximumZeroProbabilityObservationCount')::NUMERIC <>
+       trunc((policy->'pick'->>'maximumZeroProbabilityObservationCount')::NUMERIC)
+  THEN RAISE EXCEPTION 'Governed model qualification numeric contract mismatch';
+  END IF;
+  IF pick_metrics IS NOT NULL AND pick_metrics<>'null'::JSONB THEN
+    IF outcome_afl_trade_jsonb_has_exact_keys(
+         pick_metrics, ARRAY['contributionCrps','empiricalP10P90Coverage',
+           'meanAbsoluteContributionError','meanAbsoluteGamesError','meanEmpiricalIntervalWidth',
+           'multiclassBrierScore','multiclassLogLoss','rankedProbabilityScore',
+           'rootMeanSquaredContributionError','rootMeanSquaredGamesError',
+           'zeroProbabilityObservationCount']) IS DISTINCT FROM TRUE
+      OR EXISTS (
+        SELECT 1 FROM jsonb_array_elements(jsonb_build_array(
+          pick_metrics->'multiclassBrierScore', pick_metrics->'rankedProbabilityScore',
+          pick_metrics->'contributionCrps', pick_metrics->'meanAbsoluteContributionError',
+          pick_metrics->'rootMeanSquaredContributionError', pick_metrics->'meanAbsoluteGamesError',
+          pick_metrics->'rootMeanSquaredGamesError', pick_metrics->'empiricalP10P90Coverage',
+          pick_metrics->'meanEmpiricalIntervalWidth',
+          pick_metrics->'zeroProbabilityObservationCount'
+        )) value WHERE jsonb_typeof(value)<>'number'
+      )
+      OR NOT (pick_metrics ? 'multiclassLogLoss')
+      OR jsonb_typeof(pick_metrics->'multiclassLogLoss') NOT IN ('number','null')
+      OR (pick_metrics->>'multiclassBrierScore')::NUMERIC < 0
+      OR (pick_metrics->>'rankedProbabilityScore')::NUMERIC < 0
+      OR (pick_metrics->>'contributionCrps')::NUMERIC < 0
+      OR (pick_metrics->>'meanAbsoluteContributionError')::NUMERIC < 0
+      OR (pick_metrics->>'rootMeanSquaredContributionError')::NUMERIC < 0
+      OR (pick_metrics->>'meanAbsoluteGamesError')::NUMERIC < 0
+      OR (pick_metrics->>'rootMeanSquaredGamesError')::NUMERIC < 0
+      OR (pick_metrics->>'empiricalP10P90Coverage')::NUMERIC NOT BETWEEN 0 AND 1
+      OR (pick_metrics->>'meanEmpiricalIntervalWidth')::NUMERIC < 0
+      OR (pick_metrics->>'zeroProbabilityObservationCount')::NUMERIC < 0
+      OR (pick_metrics->>'zeroProbabilityObservationCount')::NUMERIC <>
+         trunc((pick_metrics->>'zeroProbabilityObservationCount')::NUMERIC)
+      OR (pick_metrics->>'multiclassLogLoss')::NUMERIC < 0
+    THEN RAISE EXCEPTION 'Governed model qualification metric contract mismatch';
+    END IF;
+  END IF;
+  IF EXISTS (
+       SELECT 1 FROM jsonb_array_elements(jsonb_build_array(
+         content->'policyArtifact', content->'player'->'runArtifact',
+         content->'player'->'protocolArtifact', content->'player'->'criteriaArtifact',
+         content->'player'->'validationEvidenceArtifact', content->'pick'->'runArtifact',
+         content->'pick'->'protocolArtifact', content->'pick'->'criteriaArtifact',
+         content->'pick'->'validationEvidenceArtifact'
+       )) reference
+       WHERE outcome_afl_trade_jsonb_is_artifact_ref(reference) IS DISTINCT FROM TRUE
+     )
+    OR EXISTS (
+       SELECT 1 FROM jsonb_array_elements(jsonb_build_array(
+         content->'policyArtifact', content->'player'->'runArtifact',
+         content->'player'->'protocolArtifact', content->'player'->'criteriaArtifact',
+         content->'player'->'validationEvidenceArtifact', content->'pick'->'runArtifact',
+         content->'pick'->'protocolArtifact', content->'pick'->'criteriaArtifact',
+         content->'pick'->'validationEvidenceArtifact'
+       )) reference
+       WHERE (reference->>'createdAt')::TIMESTAMPTZ > (content->>'evaluatedAt')::TIMESTAMPTZ
+     )
+    OR content->'player'->>'runId'=content->'pick'->>'runId'
+    OR content->'player'->>'protocolId'=content->'pick'->>'protocolId'
+  THEN RAISE EXCEPTION 'Governed model qualification lineage contract mismatch';
+  END IF;
   IF (player_evidence->>'comparableObservationCount')::INTEGER <
        (policy->'player'->>'minimumComparableObservations')::INTEGER THEN
     expected_failure_codes:=expected_failure_codes || jsonb_build_array('player_observation_count_below_minimum');

--- a/prisma/afl-trade-outcomes/migrations/0064_automated_model_pair_qualification/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0064_automated_model_pair_qualification/migration.sql
@@ -196,6 +196,9 @@ BEGIN
         OR automated_model_run_id NOT IN (
           qualification_row."player_run_id", qualification_row."pick_run_id"
         )
+        OR NEW."decision_key" IS DISTINCT FROM content->'scope'->>'scopeKey' || ':' ||
+          (CASE WHEN automated_model_run_id=qualification_row."player_run_id"
+             THEN 'player-model-validity' ELSE 'pick-model-validity' END)
         OR NOT (content->'authorityEvidenceIds' ? qualification_row."artifact_id")
         OR NOT (
           proposal_row."proposal_json"->'content'->'evidenceIds' ? qualification_row."artifact_id"
@@ -287,11 +290,14 @@ DECLARE
   pick_failed BOOLEAN := FALSE;
   player_run RECORD;
   pick_run RECORD;
+  qualification_artifact RECORD;
 BEGIN
   SELECT * INTO STRICT player_run FROM "outcome_governed_valuation_component_run"
    WHERE "run_id"=NEW."player_run_id" FOR KEY SHARE;
   SELECT * INTO STRICT pick_run FROM "outcome_governed_valuation_component_run"
    WHERE "run_id"=NEW."pick_run_id" FOR KEY SHARE;
+  SELECT * INTO STRICT qualification_artifact FROM "outcome_artifact_custody"
+   WHERE "artifact_id"=NEW."artifact_id" FOR KEY SHARE;
   policy:=content->'policy';
   player_evidence:=content->'player'->'validationEvidence';
   pick_evidence:=content->'pick'->'validationEvidence';
@@ -497,6 +503,25 @@ BEGIN
      )
     OR content->'player'->>'runId'=content->'pick'->>'runId'
     OR content->'player'->>'protocolId'=content->'pick'->>'protocolId'
+    OR content->'policyArtifact'->>'mediaType' IS DISTINCT FROM 'application/json'
+    OR (content->'policyArtifact'->>'byteLength')::BIGINT IS DISTINCT FROM
+       octet_length(convert_to(outcome_afl_trade_canonical_json(policy),'UTF8'))
+    OR content->'player'->'criteriaArtifact'->>'mediaType' IS DISTINCT FROM 'application/json'
+    OR (content->'player'->'criteriaArtifact'->>'byteLength')::BIGINT IS DISTINCT FROM
+       octet_length(convert_to(outcome_afl_trade_canonical_json(policy->'player'),'UTF8'))
+    OR content->'pick'->'criteriaArtifact'->>'mediaType' IS DISTINCT FROM 'application/json'
+    OR (content->'pick'->'criteriaArtifact'->>'byteLength')::BIGINT IS DISTINCT FROM
+       octet_length(convert_to(outcome_afl_trade_canonical_json(policy->'pick'),'UTF8'))
+    OR content->'player'->'validationEvidenceArtifact'->>'mediaType'
+       IS DISTINCT FROM 'application/json'
+    OR (content->'player'->'validationEvidenceArtifact'->>'byteLength')::BIGINT
+       IS DISTINCT FROM octet_length(convert_to(
+         outcome_afl_trade_canonical_json(player_evidence),'UTF8'))
+    OR content->'pick'->'validationEvidenceArtifact'->>'mediaType'
+       IS DISTINCT FROM 'application/json'
+    OR (content->'pick'->'validationEvidenceArtifact'->>'byteLength')::BIGINT
+       IS DISTINCT FROM octet_length(convert_to(
+         outcome_afl_trade_canonical_json(pick_evidence),'UTF8'))
   THEN RAISE EXCEPTION 'Governed model qualification lineage contract mismatch';
   END IF;
   IF (player_evidence->>'comparableObservationCount')::INTEGER <
@@ -589,6 +614,16 @@ BEGIN
       encode(sha256(convert_to(NEW."content_canonical_json",'UTF8')),'hex')
     OR NEW."artifact_id" IS DISTINCT FROM 'artifact:' || encode(sha256(convert_to(
       outcome_afl_trade_canonical_json(NEW."qualification_json"),'UTF8')),'hex')
+    OR qualification_artifact."content_sha256" IS DISTINCT FROM
+       substring(NEW."artifact_id" FROM length('artifact:') + 1)
+    OR qualification_artifact."storage_uri" IS DISTINCT FROM
+       'artifact://sha256/' || qualification_artifact."content_sha256"
+    OR qualification_artifact."media_type" IS DISTINCT FROM 'application/json'
+    OR qualification_artifact."byte_length" IS DISTINCT FROM
+       octet_length(convert_to(outcome_afl_trade_canonical_json(NEW."qualification_json"),'UTF8'))
+    OR qualification_artifact."environment" IS DISTINCT FROM
+       'non_production'::"OutcomeEnvironment"
+    OR qualification_artifact."created_at" IS DISTINCT FROM NEW."evaluated_at"
     OR player_run."role"<>'player_contribution_and_availability'
     OR pick_run."role"<>'draft_pick_and_future_pick_distribution'
     OR player_run."artifact_id" IS DISTINCT FROM content->'player'->'runArtifact'->>'artifactId'
@@ -622,6 +657,9 @@ BEGIN
   SELECT artifact->>'artifactId' INTO STRICT automated_qualification_id
     FROM jsonb_array_elements(NEW."decision_json"->'content'->'affectedArtifacts') artifact
     WHERE artifact->>'kind'='model_qualification';
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    'automated-gate-pair:' || automated_qualification_id,0
+  ));
   SELECT * INTO STRICT qualification_row
     FROM "outcome_governed_valuation_model_qualification"
     WHERE "qualification_id"=automated_qualification_id;
@@ -658,6 +696,23 @@ AFTER INSERT ON "outcome_gate_decision"
 DEFERRABLE INITIALLY DEFERRED
 FOR EACH ROW EXECUTE FUNCTION "validate_outcome_automated_gate_pair_commit"();
 
+CREATE OR REPLACE FUNCTION "outcome_automated_gate_artifact_id"(
+  decision_document JSONB,
+  artifact_kind TEXT
+) RETURNS TEXT LANGUAGE SQL IMMUTABLE STRICT AS $$
+  SELECT artifact->>'artifactId'
+    FROM jsonb_array_elements(decision_document->'content'->'affectedArtifacts') artifact
+   WHERE artifact->>'kind'=artifact_kind
+   LIMIT 1
+$$;
+
+CREATE UNIQUE INDEX "outcome_automated_gate_qualification_run_unique"
+ON "outcome_gate_decision" (
+  outcome_automated_gate_artifact_id("decision_json",'model_qualification'),
+  outcome_automated_gate_artifact_id("decision_json",'model_run')
+)
+WHERE "decision_json"->'content'->>'authorityKind'='automated_validation_record';
+
 CREATE OR REPLACE FUNCTION "reject_outcome_governed_model_qualification_mutation"()
 RETURNS TRIGGER LANGUAGE plpgsql AS $$
 BEGIN RAISE EXCEPTION 'Governed valuation model qualifications are append-only'; END $$;
@@ -683,6 +738,106 @@ CREATE TABLE "outcome_governed_model_qualification_work" (
   FOREIGN KEY ("player_gate3_decision_id") REFERENCES "outcome_gate_decision"("decision_id") ON DELETE RESTRICT,
   FOREIGN KEY ("pick_gate3_decision_id") REFERENCES "outcome_gate_decision"("decision_id") ON DELETE RESTRICT
 );
+
+CREATE OR REPLACE FUNCTION "validate_outcome_governed_model_qualification_work"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  content JSONB := NEW."work_json"->'content';
+  qualification RECORD;
+BEGIN
+  IF TG_OP='UPDATE' THEN
+    IF NEW."work_id" IS DISTINCT FROM OLD."work_id"
+      OR NEW."scope_key" IS DISTINCT FROM OLD."scope_key"
+      OR NEW."qualification_id" IS DISTINCT FROM OLD."qualification_id"
+      OR NEW."player_gate3_decision_id" IS DISTINCT FROM OLD."player_gate3_decision_id"
+      OR NEW."pick_gate3_decision_id" IS DISTINCT FROM OLD."pick_gate3_decision_id"
+      OR NEW."available_at" IS DISTINCT FROM OLD."available_at"
+      OR NEW."work_json" IS DISTINCT FROM OLD."work_json"
+      OR NEW."recorded_at" IS DISTINCT FROM OLD."recorded_at"
+    THEN RAISE EXCEPTION 'Governed model qualification work evidence is immutable';
+    END IF;
+    IF NOT (
+      NEW."status"=OLD."status"
+      OR (OLD."status"='pending' AND NEW."status" IN ('claimed','superseded'))
+      OR (OLD."status"='claimed' AND NEW."status" IN ('pending','completed','superseded'))
+    ) THEN RAISE EXCEPTION 'Invalid governed model qualification work status transition';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  SELECT * INTO STRICT qualification
+    FROM "outcome_governed_valuation_model_qualification"
+   WHERE "qualification_id"=NEW."qualification_id" FOR KEY SHARE;
+  IF outcome_afl_trade_jsonb_has_exact_keys(NEW."work_json",ARRAY['content','workId'])
+       IS DISTINCT FROM TRUE
+    OR outcome_afl_trade_jsonb_has_exact_keys(content,ARRAY[
+         'availableAt','cause','environment','pickGate3DecisionId','pickRunId',
+         'playerGate3DecisionId','playerRunId','publicationEligible','qualificationId',
+         'schemaVersion','scopeKey','status'
+       ]) IS DISTINCT FROM TRUE
+    OR NEW."work_json"->>'workId' IS DISTINCT FROM NEW."work_id"
+    OR content->>'schemaVersion' IS DISTINCT FROM
+       'governed-valuation-model-qualification-work/v1'
+    OR content->>'environment' IS DISTINCT FROM 'non_production'
+    OR content->>'cause' IS DISTINCT FROM 'current_qualified_model_pair_advanced'
+    OR content->>'status' IS DISTINCT FROM 'pending'
+    OR jsonb_typeof(content->'publicationEligible') IS DISTINCT FROM 'boolean'
+    OR content->'publicationEligible' IS DISTINCT FROM 'false'::JSONB
+    OR jsonb_typeof(content->'scopeKey') IS DISTINCT FROM 'string'
+    OR length(content->>'scopeKey') NOT BETWEEN 1 AND 200
+    OR content->>'scopeKey' !~ '^[a-zA-Z0-9][a-zA-Z0-9._:-]*$'
+    OR content->>'qualificationId' !~ '^model-qualification:[a-f0-9]{64}$'
+    OR content->>'playerRunId' !~ '^model-run:[a-f0-9]{64}$'
+    OR content->>'pickRunId' !~ '^model-run:[a-f0-9]{64}$'
+    OR content->>'playerGate3DecisionId' !~ '^gate-decision:[a-f0-9]{64}$'
+    OR content->>'pickGate3DecisionId' !~ '^gate-decision:[a-f0-9]{64}$'
+    OR jsonb_typeof(content->'availableAt') IS DISTINCT FROM 'string'
+    OR content->>'availableAt' !~
+       '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$'
+    OR NEW."work_id" IS DISTINCT FROM 'model-qualification-work:' || encode(sha256(convert_to(
+       outcome_afl_trade_canonical_json(content),'UTF8')),'hex')
+    OR NEW."scope_key" IS DISTINCT FROM content->>'scopeKey'
+    OR NEW."qualification_id" IS DISTINCT FROM content->>'qualificationId'
+    OR NEW."player_gate3_decision_id" IS DISTINCT FROM content->>'playerGate3DecisionId'
+    OR NEW."pick_gate3_decision_id" IS DISTINCT FROM content->>'pickGate3DecisionId'
+    OR NEW."available_at" IS DISTINCT FROM (content->>'availableAt')::TIMESTAMPTZ
+    OR NEW."status" IS DISTINCT FROM 'pending'
+    OR qualification."outcome" IS DISTINCT FROM 'qualified'
+    OR qualification."scope_key" IS DISTINCT FROM NEW."scope_key"
+    OR qualification."player_run_id" IS DISTINCT FROM content->>'playerRunId'
+    OR qualification."pick_run_id" IS DISTINCT FROM content->>'pickRunId'
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_gate_decision" decision
+       WHERE decision."decision_id"=NEW."player_gate3_decision_id"
+         AND EXISTS (SELECT 1 FROM jsonb_array_elements(
+           decision."decision_json"->'content'->'affectedArtifacts') artifact
+           WHERE artifact->>'kind'='model_run'
+             AND artifact->>'artifactId'=qualification."player_run_id")
+         AND EXISTS (SELECT 1 FROM jsonb_array_elements(
+           decision."decision_json"->'content'->'affectedArtifacts') artifact
+           WHERE artifact->>'kind'='model_qualification'
+             AND artifact->>'artifactId'=qualification."qualification_id")
+    )
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_gate_decision" decision
+       WHERE decision."decision_id"=NEW."pick_gate3_decision_id"
+         AND EXISTS (SELECT 1 FROM jsonb_array_elements(
+           decision."decision_json"->'content'->'affectedArtifacts') artifact
+           WHERE artifact->>'kind'='model_run'
+             AND artifact->>'artifactId'=qualification."pick_run_id")
+         AND EXISTS (SELECT 1 FROM jsonb_array_elements(
+           decision."decision_json"->'content'->'affectedArtifacts') artifact
+           WHERE artifact->>'kind'='model_qualification'
+             AND artifact->>'artifactId'=qualification."qualification_id")
+    )
+  THEN RAISE EXCEPTION 'Governed model qualification work contract mismatch';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_governed_model_qualification_work_validate"
+BEFORE INSERT OR UPDATE ON "outcome_governed_model_qualification_work"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_governed_model_qualification_work"();
 
 CREATE OR REPLACE FUNCTION "reject_outcome_governed_model_qualification_work_delete"()
 RETURNS TRIGGER LANGUAGE plpgsql AS $$

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -4948,6 +4948,57 @@ model OutcomeGovernedValuationComponentRun {
   @@map("outcome_governed_valuation_component_run")
 }
 
+model OutcomeGovernedValuationModelQualification {
+  qualificationId          String   @id @map("qualification_id") @outcomes.Text
+  scopeKey                 String   @map("scope_key") @outcomes.Text
+  outcome                  String   @outcomes.Text
+  artifactId               String   @unique @map("artifact_id") @outcomes.Text
+  playerRunId              String   @map("player_run_id") @outcomes.Text
+  pickRunId                String   @map("pick_run_id") @outcomes.Text
+  policyArtifactId         String   @map("policy_artifact_id") @outcomes.Text
+  playerCriteriaArtifactId String   @map("player_criteria_artifact_id") @outcomes.Text
+  pickCriteriaArtifactId   String   @map("pick_criteria_artifact_id") @outcomes.Text
+  playerEvidenceArtifactId String   @map("player_evidence_artifact_id") @outcomes.Text
+  pickEvidenceArtifactId   String   @map("pick_evidence_artifact_id") @outcomes.Text
+  evaluatedAt              DateTime @map("evaluated_at") @outcomes.Timestamptz(3)
+  contentSha256            String   @map("content_sha256") @outcomes.Char(64)
+  contentCanonicalJson     String   @map("content_canonical_json") @outcomes.Text
+  qualificationJson        Json     @map("qualification_json")
+  recordedAt               DateTime @default(dbgenerated("clock_timestamp()")) @map("recorded_at") @outcomes.Timestamptz(3)
+
+  @@index([scopeKey, evaluatedAt, qualificationId], map: "outcome_governed_model_qualification_scope_idx")
+  @@map("outcome_governed_valuation_model_qualification")
+}
+
+model OutcomeGovernedModelQualificationWork {
+  workId                String   @id @map("work_id") @outcomes.Text
+  scopeKey              String   @map("scope_key") @outcomes.Text
+  qualificationId       String   @unique @map("qualification_id") @outcomes.Text
+  playerGate3DecisionId String   @map("player_gate3_decision_id") @outcomes.Text
+  pickGate3DecisionId   String   @map("pick_gate3_decision_id") @outcomes.Text
+  availableAt           DateTime @map("available_at") @outcomes.Timestamptz(3)
+  status                String   @default("pending") @outcomes.Text
+  workJson              Json     @map("work_json")
+  recordedAt            DateTime @default(dbgenerated("clock_timestamp()")) @map("recorded_at") @outcomes.Timestamptz(3)
+
+  @@index([status, availableAt, scopeKey], map: "outcome_governed_model_qualification_work_pending_idx")
+  @@map("outcome_governed_model_qualification_work")
+}
+
+model OutcomeCurrentGovernedValuationModelPair {
+  scopeKey              String   @id @map("scope_key") @outcomes.Text
+  revision              Int
+  qualificationId       String   @unique @map("qualification_id") @outcomes.Text
+  playerRunId           String   @map("player_run_id") @outcomes.Text
+  pickRunId             String   @map("pick_run_id") @outcomes.Text
+  playerGate3DecisionId String   @unique @map("player_gate3_decision_id") @outcomes.Text
+  pickGate3DecisionId   String   @unique @map("pick_gate3_decision_id") @outcomes.Text
+  workId                String   @unique @map("work_id") @outcomes.Text
+  advancedAt            DateTime @map("advanced_at") @outcomes.Timestamptz(3)
+
+  @@map("outcome_current_governed_valuation_model_pair")
+}
+
 model OutcomePrivateEvaluationAuthoritySnapshot {
   snapshotId               String                                        @id @map("snapshot_id") @outcomes.Text
   valuationScopeKey        String                                        @map("valuation_scope_key") @outcomes.Text

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -282,15 +282,17 @@ model OutcomeArtifactCustody {
   privateEvaluationProjectionManifestArtifacts OutcomeLocalPrivateTradeEvaluationGeneration[]       @relation("PrivateEvaluationProjectionManifestArtifact")
   privateEvaluationTransitionReceipts          OutcomePrivateEvaluationTransitionReceipt[]          @relation("PrivateEvaluationTransitionReceiptArtifact")
   privateEvaluationReconstructionVerifications OutcomePrivateEvaluationReconstructionVerification[] @relation("PrivateEvaluationReconstructionVerificationArtifact")
-  governedComponentRunManifests                OutcomeGovernedValuationComponentRun[]                @relation("GovernedValuationComponentRunManifestArtifact")
-  governedComponentRunNativeExecutions         OutcomeGovernedValuationComponentRun[]                @relation("GovernedValuationComponentRunNativeArtifact")
-  governedComponentRunProtocols                OutcomeGovernedValuationComponentRun[]                @relation("GovernedValuationComponentRunProtocolArtifact")
-  governedComponentRunDatasets                 OutcomeGovernedValuationComponentRun[]                @relation("GovernedValuationComponentRunDatasetArtifact")
-  governedComponentRunAdmissions               OutcomeGovernedValuationComponentRun[]                @relation("GovernedValuationComponentRunAdmissionArtifact")
-  governedPickExecutionArtifacts               OutcomeGovernedPickPavModelExecution[]                @relation("GovernedPickExecutionArtifact")
-  governedPickDatasetArtifacts                 OutcomeGovernedPickPavModelExecution[]                @relation("GovernedPickDatasetArtifact")
-  governedPickAdmissionArtifacts               OutcomeGovernedPickPavModelExecution[]                @relation("GovernedPickAdmissionArtifact")
-  governedPickProtocolArtifacts                OutcomeGovernedPickPavModelExecution[]                @relation("GovernedPickProtocolArtifact")
+  governedComponentRunManifests                OutcomeGovernedValuationComponentRun[]               @relation("GovernedValuationComponentRunManifestArtifact")
+  governedComponentRunNativeExecutions         OutcomeGovernedValuationComponentRun[]               @relation("GovernedValuationComponentRunNativeArtifact")
+  governedComponentRunProtocols                OutcomeGovernedValuationComponentRun[]               @relation("GovernedValuationComponentRunProtocolArtifact")
+  governedComponentRunDatasets                 OutcomeGovernedValuationComponentRun[]               @relation("GovernedValuationComponentRunDatasetArtifact")
+  governedComponentRunAdmissions               OutcomeGovernedValuationComponentRun[]               @relation("GovernedValuationComponentRunAdmissionArtifact")
+  governedComponentValidationNativeExecutions  OutcomeGovernedComponentValidationEvidence[]         @relation("GovernedComponentValidationNativeArtifact")
+  governedComponentValidationReports           OutcomeGovernedComponentValidationEvidence[]         @relation("GovernedComponentValidationReportArtifact")
+  governedPickExecutionArtifacts               OutcomeGovernedPickPavModelExecution[]               @relation("GovernedPickExecutionArtifact")
+  governedPickDatasetArtifacts                 OutcomeGovernedPickPavModelExecution[]               @relation("GovernedPickDatasetArtifact")
+  governedPickAdmissionArtifacts               OutcomeGovernedPickPavModelExecution[]               @relation("GovernedPickAdmissionArtifact")
+  governedPickProtocolArtifacts                OutcomeGovernedPickPavModelExecution[]               @relation("GovernedPickProtocolArtifact")
 
   @@unique([artifactClass, contentSha256], map: "outcome_artifact_class_sha256_key")
   @@index([environment, artifactClass, createdAt], map: "outcome_artifact_environment_class_created_idx")
@@ -1731,23 +1733,23 @@ model OutcomePickPavSelectionAccess {
 }
 
 model OutcomePickPavObservationSet {
-  observationSetId            String                            @id @map("observation_set_id")
-  observationSetSha256        String                            @unique @map("observation_set_sha256") @outcomes.Char(64)
+  observationSetId            String                                 @id @map("observation_set_id")
+  observationSetSha256        String                                 @unique @map("observation_set_sha256") @outcomes.Char(64)
   environment                 OutcomeEnvironment
   competition                 String
-  releaseId                   String                            @map("release_id")
-  policyId                    String                            @map("policy_id")
-  createdAt                   DateTime                          @map("created_at") @outcomes.Timestamptz(3)
-  knowledgeCutoffAt           DateTime                          @map("knowledge_cutoff_at") @outcomes.Timestamptz(3)
+  releaseId                   String                                 @map("release_id")
+  policyId                    String                                 @map("policy_id")
+  createdAt                   DateTime                               @map("created_at") @outcomes.Timestamptz(3)
+  knowledgeCutoffAt           DateTime                               @map("knowledge_cutoff_at") @outcomes.Timestamptz(3)
   status                      String
-  calculationCount            Int                               @map("calculation_count")
-  draftClassCount             Int                               @map("draft_class_count")
-  observationCount            Int                               @map("observation_count")
-  observationSetCanonicalJson String                            @map("observation_set_canonical_json") @outcomes.Text
-  observationSetJson          Json                              @map("observation_set_json")
-  finalizedAt                 DateTime?                         @map("finalized_at") @outcomes.Timestamptz(3)
-  release                     OutcomeReleaseManifest            @relation(fields: [releaseId], references: [releaseId], onDelete: Restrict)
-  policy                      OutcomePickPavPolicy              @relation(fields: [policyId], references: [policyId], onDelete: Restrict)
+  calculationCount            Int                                    @map("calculation_count")
+  draftClassCount             Int                                    @map("draft_class_count")
+  observationCount            Int                                    @map("observation_count")
+  observationSetCanonicalJson String                                 @map("observation_set_canonical_json") @outcomes.Text
+  observationSetJson          Json                                   @map("observation_set_json")
+  finalizedAt                 DateTime?                              @map("finalized_at") @outcomes.Timestamptz(3)
+  release                     OutcomeReleaseManifest                 @relation(fields: [releaseId], references: [releaseId], onDelete: Restrict)
+  policy                      OutcomePickPavPolicy                   @relation(fields: [policyId], references: [policyId], onDelete: Restrict)
   calculations                OutcomePickPavCalculationMember[]
   draftClasses                OutcomePickPavDraftClass[]
   observations                OutcomePickPavObservation[]
@@ -1887,30 +1889,30 @@ model OutcomePickPavModelExecution {
 }
 
 model OutcomeGovernedPickPavModelExecution {
-  executionId                           String                           @id @map("execution_id") @outcomes.Text
-  observationSetId                      String                           @map("observation_set_id") @outcomes.Text
-  datasetId                             String                           @map("dataset_id") @outcomes.Text
-  datasetArtifactId                     String                           @map("dataset_artifact_id") @outcomes.Text
-  datasetAdmissionId                    String                           @map("dataset_admission_id") @outcomes.Text
-  datasetAdmissionArtifactId            String                           @map("dataset_admission_artifact_id") @outcomes.Text
-  datasetAdmissionGateLedgerRevision    Int                              @map("dataset_admission_gate_ledger_revision")
-  protocolId                            String                           @map("protocol_id") @outcomes.Text
-  protocolArtifactId                    String                           @map("protocol_artifact_id") @outcomes.Text
-  executionArtifactId                   String                           @unique @map("execution_artifact_id") @outcomes.Text
-  finalTestEvaluationStartedAt          DateTime                         @map("final_test_evaluation_started_at") @outcomes.Timestamptz(3)
-  completedAt                           DateTime                         @map("completed_at") @outcomes.Timestamptz(3)
-  contentSha256                         String                           @map("content_sha256") @outcomes.Char(64)
-  contentCanonicalJson                  String                           @map("content_canonical_json") @outcomes.Text
-  executionJson                         Json                             @map("execution_json")
-  recordedAt                            DateTime                         @default(dbgenerated("clock_timestamp()")) @map("recorded_at") @outcomes.Timestamptz(3)
-  recordedBy                            String                           @default(dbgenerated("CURRENT_USER")) @map("recorded_by") @outcomes.Text
-  observationSet                        OutcomePickPavObservationSet     @relation(fields: [observationSetId], references: [observationSetId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_observation_fkey")
-  dataset                               OutcomeValuationDatasetCandidate @relation(fields: [datasetId], references: [datasetId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_dataset_fkey")
-  datasetAdmission                      OutcomeValuationDatasetAdmission @relation(fields: [datasetAdmissionId], references: [admissionId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_admission_fkey")
-  executionArtifact                     OutcomeArtifactCustody           @relation("GovernedPickExecutionArtifact", fields: [executionArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_artifact_fkey")
-  datasetArtifact                       OutcomeArtifactCustody           @relation("GovernedPickDatasetArtifact", fields: [datasetArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_dataset_artifact_fkey")
-  datasetAdmissionArtifact              OutcomeArtifactCustody           @relation("GovernedPickAdmissionArtifact", fields: [datasetAdmissionArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_pick_exec_admission_artifact_fkey")
-  protocolArtifact                      OutcomeArtifactCustody           @relation("GovernedPickProtocolArtifact", fields: [protocolArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_pick_exec_protocol_artifact_fkey")
+  executionId                        String                           @id @map("execution_id") @outcomes.Text
+  observationSetId                   String                           @map("observation_set_id") @outcomes.Text
+  datasetId                          String                           @map("dataset_id") @outcomes.Text
+  datasetArtifactId                  String                           @map("dataset_artifact_id") @outcomes.Text
+  datasetAdmissionId                 String                           @map("dataset_admission_id") @outcomes.Text
+  datasetAdmissionArtifactId         String                           @map("dataset_admission_artifact_id") @outcomes.Text
+  datasetAdmissionGateLedgerRevision Int                              @map("dataset_admission_gate_ledger_revision")
+  protocolId                         String                           @map("protocol_id") @outcomes.Text
+  protocolArtifactId                 String                           @map("protocol_artifact_id") @outcomes.Text
+  executionArtifactId                String                           @unique @map("execution_artifact_id") @outcomes.Text
+  finalTestEvaluationStartedAt       DateTime                         @map("final_test_evaluation_started_at") @outcomes.Timestamptz(3)
+  completedAt                        DateTime                         @map("completed_at") @outcomes.Timestamptz(3)
+  contentSha256                      String                           @map("content_sha256") @outcomes.Char(64)
+  contentCanonicalJson               String                           @map("content_canonical_json") @outcomes.Text
+  executionJson                      Json                             @map("execution_json")
+  recordedAt                         DateTime                         @default(dbgenerated("clock_timestamp()")) @map("recorded_at") @outcomes.Timestamptz(3)
+  recordedBy                         String                           @default(dbgenerated("CURRENT_USER")) @map("recorded_by") @outcomes.Text
+  observationSet                     OutcomePickPavObservationSet     @relation(fields: [observationSetId], references: [observationSetId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_observation_fkey")
+  dataset                            OutcomeValuationDatasetCandidate @relation(fields: [datasetId], references: [datasetId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_dataset_fkey")
+  datasetAdmission                   OutcomeValuationDatasetAdmission @relation(fields: [datasetAdmissionId], references: [admissionId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_admission_fkey")
+  executionArtifact                  OutcomeArtifactCustody           @relation("GovernedPickExecutionArtifact", fields: [executionArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_artifact_fkey")
+  datasetArtifact                    OutcomeArtifactCustody           @relation("GovernedPickDatasetArtifact", fields: [datasetArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_pick_pav_model_execution_dataset_artifact_fkey")
+  datasetAdmissionArtifact           OutcomeArtifactCustody           @relation("GovernedPickAdmissionArtifact", fields: [datasetAdmissionArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_pick_exec_admission_artifact_fkey")
+  protocolArtifact                   OutcomeArtifactCustody           @relation("GovernedPickProtocolArtifact", fields: [protocolArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_pick_exec_protocol_artifact_fkey")
 
   @@index([datasetId, datasetAdmissionId, protocolId, completedAt], map: "outcome_governed_pick_pav_model_execution_ancestry_idx")
   @@map("outcome_governed_pick_pav_model_execution")
@@ -4420,16 +4422,16 @@ model OutcomePreparedValuationInputEntry {
 
 model OutcomePrivateEvaluationMaterializationManifest {
   materializationManifestId String                 @id @map("materialization_manifest_id") @outcomes.Text
-  contentSha256              String                 @map("content_sha256") @outcomes.Char(64)
-  valuationScopeKey          String                 @map("valuation_scope_key") @outcomes.Text
-  tradeId                    String                 @map("trade_id") @outcomes.Text
-  artifactId                 String                 @unique @map("artifact_id") @outcomes.Text
-  createdAt                  DateTime               @map("created_at") @outcomes.Timestamptz(3)
-  contentCanonicalJson       String                 @map("content_canonical_json") @outcomes.Text
-  manifestCanonicalJson      String                 @map("manifest_canonical_json") @outcomes.Text
-  manifestJson               Json                   @map("manifest_json")
-  registeredAt               DateTime               @default(dbgenerated("transaction_timestamp()")) @map("registered_at") @outcomes.Timestamptz(3)
-  artifact                   OutcomeArtifactCustody @relation("PrivateEvaluationMaterializationManifestArtifact", fields: [artifactId], references: [artifactId], onDelete: Restrict)
+  contentSha256             String                 @map("content_sha256") @outcomes.Char(64)
+  valuationScopeKey         String                 @map("valuation_scope_key") @outcomes.Text
+  tradeId                   String                 @map("trade_id") @outcomes.Text
+  artifactId                String                 @unique @map("artifact_id") @outcomes.Text
+  createdAt                 DateTime               @map("created_at") @outcomes.Timestamptz(3)
+  contentCanonicalJson      String                 @map("content_canonical_json") @outcomes.Text
+  manifestCanonicalJson     String                 @map("manifest_canonical_json") @outcomes.Text
+  manifestJson              Json                   @map("manifest_json")
+  registeredAt              DateTime               @default(dbgenerated("transaction_timestamp()")) @map("registered_at") @outcomes.Timestamptz(3)
+  artifact                  OutcomeArtifactCustody @relation("PrivateEvaluationMaterializationManifestArtifact", fields: [artifactId], references: [artifactId], onDelete: Restrict)
 
   @@index([valuationScopeKey, tradeId, createdAt], map: "outcome_private_evaluation_materialization_selector_idx")
   @@map("outcome_private_evaluation_materialization_manifest")
@@ -4918,34 +4920,51 @@ model OutcomeWorkbookTransactionReviewHead {
 }
 
 model OutcomeGovernedValuationComponentRun {
-  runId                              String                 @id @map("run_id") @outcomes.Text
-  role                               String                 @outcomes.Text
-  nativeExecutionKind                String                 @map("native_execution_kind") @outcomes.Text
-  nativeExecutionId                  String                 @map("native_execution_id") @outcomes.Text
-  artifactId                         String                 @unique @map("artifact_id") @outcomes.Text
-  nativeExecutionArtifactId          String                 @map("native_execution_artifact_id") @outcomes.Text
-  protocolId                         String                 @map("protocol_id") @outcomes.Text
-  protocolArtifactId                 String                 @map("protocol_artifact_id") @outcomes.Text
-  datasetId                          String                 @map("dataset_id") @outcomes.Text
-  datasetArtifactId                  String                 @map("dataset_artifact_id") @outcomes.Text
-  datasetAdmissionId                 String                 @map("dataset_admission_id") @outcomes.Text
-  datasetAdmissionArtifactId         String                 @map("dataset_admission_artifact_id") @outcomes.Text
-  datasetAdmissionGateLedgerRevision Int                    @map("dataset_admission_gate_ledger_revision")
-  registeredAt                       DateTime               @map("registered_at") @outcomes.Timestamptz(3)
-  contentSha256                      String                 @map("content_sha256") @outcomes.Char(64)
-  contentCanonicalJson               String                 @map("content_canonical_json") @outcomes.Text
-  manifestJson                       Json                   @map("manifest_json")
-  recordedAt                         DateTime               @default(dbgenerated("clock_timestamp()")) @map("recorded_at") @outcomes.Timestamptz(3)
-  artifact                           OutcomeArtifactCustody @relation("GovernedValuationComponentRunManifestArtifact", fields: [artifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_run_artifact_fkey")
-  nativeExecutionArtifact            OutcomeArtifactCustody @relation("GovernedValuationComponentRunNativeArtifact", fields: [nativeExecutionArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_native_artifact_fkey")
-  protocolArtifact                   OutcomeArtifactCustody @relation("GovernedValuationComponentRunProtocolArtifact", fields: [protocolArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_protocol_artifact_fkey")
-  datasetArtifact                    OutcomeArtifactCustody @relation("GovernedValuationComponentRunDatasetArtifact", fields: [datasetArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_dataset_artifact_fkey")
-  datasetAdmissionArtifact           OutcomeArtifactCustody @relation("GovernedValuationComponentRunAdmissionArtifact", fields: [datasetAdmissionArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_admission_artifact_fkey")
+  runId                              String                                      @id @map("run_id") @outcomes.Text
+  role                               String                                      @outcomes.Text
+  nativeExecutionKind                String                                      @map("native_execution_kind") @outcomes.Text
+  nativeExecutionId                  String                                      @map("native_execution_id") @outcomes.Text
+  artifactId                         String                                      @unique @map("artifact_id") @outcomes.Text
+  nativeExecutionArtifactId          String                                      @map("native_execution_artifact_id") @outcomes.Text
+  protocolId                         String                                      @map("protocol_id") @outcomes.Text
+  protocolArtifactId                 String                                      @map("protocol_artifact_id") @outcomes.Text
+  datasetId                          String                                      @map("dataset_id") @outcomes.Text
+  datasetArtifactId                  String                                      @map("dataset_artifact_id") @outcomes.Text
+  datasetAdmissionId                 String                                      @map("dataset_admission_id") @outcomes.Text
+  datasetAdmissionArtifactId         String                                      @map("dataset_admission_artifact_id") @outcomes.Text
+  datasetAdmissionGateLedgerRevision Int                                         @map("dataset_admission_gate_ledger_revision")
+  registeredAt                       DateTime                                    @map("registered_at") @outcomes.Timestamptz(3)
+  contentSha256                      String                                      @map("content_sha256") @outcomes.Char(64)
+  contentCanonicalJson               String                                      @map("content_canonical_json") @outcomes.Text
+  manifestJson                       Json                                        @map("manifest_json")
+  recordedAt                         DateTime                                    @default(dbgenerated("clock_timestamp()")) @map("recorded_at") @outcomes.Timestamptz(3)
+  artifact                           OutcomeArtifactCustody                      @relation("GovernedValuationComponentRunManifestArtifact", fields: [artifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_run_artifact_fkey")
+  nativeExecutionArtifact            OutcomeArtifactCustody                      @relation("GovernedValuationComponentRunNativeArtifact", fields: [nativeExecutionArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_native_artifact_fkey")
+  protocolArtifact                   OutcomeArtifactCustody                      @relation("GovernedValuationComponentRunProtocolArtifact", fields: [protocolArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_protocol_artifact_fkey")
+  datasetArtifact                    OutcomeArtifactCustody                      @relation("GovernedValuationComponentRunDatasetArtifact", fields: [datasetArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_dataset_artifact_fkey")
+  datasetAdmissionArtifact           OutcomeArtifactCustody                      @relation("GovernedValuationComponentRunAdmissionArtifact", fields: [datasetAdmissionArtifactId], references: [artifactId], onDelete: Restrict, map: "outcome_governed_valuation_component_admission_artifact_fkey")
+  validationEvidence                 OutcomeGovernedComponentValidationEvidence?
 
   @@unique([nativeExecutionKind, nativeExecutionId], map: "outcome_governed_valuation_component_run_native_key")
   @@index([role, registeredAt, runId], map: "outcome_governed_valuation_component_run_role_idx")
   @@index([datasetId, datasetAdmissionId, protocolId], map: "outcome_governed_valuation_component_run_ancestry_idx")
   @@map("outcome_governed_valuation_component_run")
+}
+
+model OutcomeGovernedComponentValidationEvidence {
+  runId                      String                               @id @map("run_id") @outcomes.Text
+  role                       String                               @outcomes.Text
+  nativeExecutionArtifactId  String                               @map("native_execution_artifact_id") @outcomes.Text
+  validationReportId         String                               @map("validation_report_id") @outcomes.Text
+  validationReportArtifactId String?                              @map("validation_report_artifact_id") @outcomes.Text
+  nativeExecutionJson        Json                                 @map("native_execution_json")
+  validationReportJson       Json                                 @map("validation_report_json")
+  recordedAt                 DateTime                             @map("recorded_at") @outcomes.Timestamptz(3)
+  componentRun               OutcomeGovernedValuationComponentRun @relation(fields: [runId], references: [runId], onDelete: Restrict)
+  nativeExecutionArtifact    OutcomeArtifactCustody               @relation("GovernedComponentValidationNativeArtifact", fields: [nativeExecutionArtifactId], references: [artifactId], onDelete: Restrict)
+  validationReportArtifact   OutcomeArtifactCustody?              @relation("GovernedComponentValidationReportArtifact", fields: [validationReportArtifactId], references: [artifactId], onDelete: Restrict)
+
+  @@map("outcome_governed_component_validation_evidence")
 }
 
 model OutcomeGovernedValuationModelQualification {

--- a/src/server/aflTradeIntelligence/governance/gateDecisionLedger.ts
+++ b/src/server/aflTradeIntelligence/governance/gateDecisionLedger.ts
@@ -515,9 +515,15 @@ export function resolveAflTradeGateEligibility(
     return { status: 'blocked', decision, blockers: [stateBlockers[decision.content.state]] };
   }
 
+  const nonExpiringAutomatedGate3 =
+    decision.content.authorityKind === 'automated_validation_record' &&
+    decision.content.environment === 'non_production' &&
+    decision.content.gate === 'gate_3_model_validity' &&
+    decision.content.revalidateAt === null;
   if (
-    decision.content.revalidateAt === null ||
-    Date.parse(decision.content.revalidateAt) <= evaluatedAt
+    !nonExpiringAutomatedGate3 &&
+    (decision.content.revalidateAt === null ||
+      Date.parse(decision.content.revalidateAt) <= evaluatedAt)
   ) {
     return {
       status: 'blocked',

--- a/src/server/aflTradeIntelligence/governance/gateDecisionTypes.ts
+++ b/src/server/aflTradeIntelligence/governance/gateDecisionTypes.ts
@@ -40,6 +40,7 @@ export const AFL_TRADE_GOVERNED_ARTIFACT_KINDS = [
   'dataset',
   'model_protocol',
   'model_run',
+  'model_qualification',
   'valuation_bundle',
   'publication',
   'projection',
@@ -62,6 +63,7 @@ const governedArtifactPrefixes = {
   dataset: 'dataset',
   model_protocol: 'model-protocol',
   model_run: 'model-run',
+  model_qualification: 'model-qualification',
   valuation_bundle: 'valuation-bundle',
   publication: 'publication',
   projection: 'projection',
@@ -252,7 +254,7 @@ const aflTradeGateDecisionRecordContentBaseSchema = z
     environment: z.enum(AFL_TRADE_DECISION_ENVIRONMENTS),
     scope: aflTradeGateScopeSchema,
     state: z.enum(AFL_TRADE_GATE_DECISION_STATES),
-    authorityKind: z.enum(['fixture', 'external_human_record']),
+    authorityKind: z.enum(['fixture', 'external_human_record', 'automated_validation_record']),
     accountableOwner: publicIdSchema,
     decidedBy: publicIdSchema.nullable(),
     reviewers: z.array(reviewerSchema).max(20),
@@ -345,13 +347,18 @@ function refineApprovedDecisionRecord(
   decision: AflTradeGateDecisionRecordContent,
   context: z.RefinementCtx
 ) {
-  if (decision.revalidateAt === null) {
+  const isNonExpiringAutomatedGate3 =
+    decision.authorityKind === 'automated_validation_record' &&
+    decision.environment === 'non_production' &&
+    decision.gate === 'gate_3_model_validity';
+  if (decision.revalidateAt === null && !isNonExpiringAutomatedGate3) {
     context.addIssue({
       code: 'custom',
       path: ['revalidateAt'],
       message: 'Approved decisions require a revalidation time.',
     });
   } else if (
+    decision.revalidateAt !== null &&
     decision.effectiveAt !== null &&
     Date.parse(decision.revalidateAt) <= Date.parse(decision.effectiveAt)
   ) {
@@ -366,6 +373,31 @@ function refineApprovedDecisionRecord(
       code: 'custom',
       path: ['authorityKind'],
       message: 'Production approval requires an externally recorded human decision.',
+    });
+  }
+}
+
+function refineAutomatedValidationRecord(
+  decision: AflTradeGateDecisionRecordContent,
+  context: z.RefinementCtx
+) {
+  if (decision.authorityKind !== 'automated_validation_record') return;
+  const modelRuns = decision.affectedArtifacts.filter(({ kind }) => kind === 'model_run');
+  const qualifications = decision.affectedArtifacts.filter(
+    ({ kind }) => kind === 'model_qualification'
+  );
+  if (
+    decision.gate !== 'gate_3_model_validity' ||
+    decision.environment !== 'non_production' ||
+    decision.reviewers.length !== 0 ||
+    modelRuns.length !== 1 ||
+    qualifications.length !== 1
+  ) {
+    context.addIssue({
+      code: 'custom',
+      path: ['authorityKind'],
+      message:
+        'Automated validation authority is limited to one qualified non-production Gate 3 model run.',
     });
   }
 }
@@ -393,6 +425,7 @@ export const aflTradeGateDecisionRecordContentSchema =
     refineFinalizedDecisionRecord(decision, context);
     if (decision.state === 'approved') refineApprovedDecisionRecord(decision, context);
     if (decision.state === 'withdrawn') refineWithdrawnDecisionRecord(decision, context);
+    refineAutomatedValidationRecord(decision, context);
   });
 
 export const aflTradeGateDecisionRecordSchema = z

--- a/src/server/aflTradeIntelligence/governance/gateDecisionTypes.ts
+++ b/src/server/aflTradeIntelligence/governance/gateDecisionTypes.ts
@@ -389,6 +389,8 @@ function refineAutomatedValidationRecord(
   if (
     decision.gate !== 'gate_3_model_validity' ||
     decision.environment !== 'non_production' ||
+    decision.state !== 'approved' ||
+    decision.revalidateAt !== null ||
     decision.reviewers.length !== 0 ||
     modelRuns.length !== 1 ||
     qualifications.length !== 1

--- a/src/server/aflTradeIntelligence/governance/gateDecisionTypes.ts
+++ b/src/server/aflTradeIntelligence/governance/gateDecisionTypes.ts
@@ -422,6 +422,7 @@ export const aflTradeGateDecisionRecordContentSchema =
     refineDecisionRecordUniqueness(decision, context);
     if (decision.state === 'pending') {
       refinePendingDecisionRecord(decision, context);
+      refineAutomatedValidationRecord(decision, context);
       return;
     }
     refineFinalizedDecisionRecord(decision, context);

--- a/src/server/aflTradeIntelligence/governance/postgresGateDecisionLedgerRepository.ts
+++ b/src/server/aflTradeIntelligence/governance/postgresGateDecisionLedgerRepository.ts
@@ -241,18 +241,16 @@ async function loadLedger(
   );
   if (head.rows.length !== 1) throw invalidStored('The Gate ledger head is unavailable.');
 
-  const [proposalRows, decisionRows] = await Promise.all([
-    transaction.query<ProposalRow>(
-      `SELECT proposal_json
-       FROM outcome_gate_proposal
-       ORDER BY proposed_at, gate, decision_key, version, proposal_id`
-    ),
-    transaction.query<DecisionRow>(
-      `SELECT decision_json
-       FROM outcome_gate_decision
-       ORDER BY version, gate, decision_key, decision_id`
-    ),
-  ]);
+  const proposalRows = await transaction.query<ProposalRow>(
+    `SELECT proposal_json
+     FROM outcome_gate_proposal
+     ORDER BY proposed_at, gate, decision_key, version, proposal_id`
+  );
+  const decisionRows = await transaction.query<DecisionRow>(
+    `SELECT decision_json
+     FROM outcome_gate_decision
+     ORDER BY version, gate, decision_key, decision_id`
+  );
   const ledger = {
     proposals: proposalRows.rows.map((row) => parseProposal(row.proposal_json)),
     decisions: decisionRows.rows.map((row) => parseDecision(row.decision_json)),
@@ -378,6 +376,69 @@ async function insertDecision(
       decision,
     ]
   );
+}
+
+export async function appendNewAflTradeGateDecisionsWithinTransaction(
+  transaction: AflOutcomeSqlTransaction,
+  input: Readonly<{
+    expectedRevision: number;
+    records: readonly Readonly<{
+      proposal: AflTradeGateDecisionProposal;
+      decision: AflTradeGateDecisionRecord;
+    }>[];
+    updatedAt: string;
+  }>
+): Promise<AflTradeStoredGateLedger> {
+  if (input.records.length === 0) {
+    throw new AflTradeGateLedgerRepositoryError(
+      'INVALID_APPEND',
+      'A transaction-scoped Gate append requires at least one decision.'
+    );
+  }
+  const records = input.records.map((record) =>
+    parseDecisionAppendInput({ ...record, expectedRevision: input.expectedRevision })
+  );
+  const stored = await loadLedger(transaction, true);
+  if (stored.revision !== input.expectedRevision) {
+    throw new AflTradeGateLedgerRepositoryError(
+      'STALE_REVISION',
+      'The Gate ledger revision changed before the transaction-scoped append.'
+    );
+  }
+  let ledger = stored.ledger;
+  for (const record of records) {
+    if (findReplay(stored, record) !== 'none') {
+      throw new AflTradeGateLedgerRepositoryError(
+        'CONFLICTING_REPLAY',
+        'A transaction-scoped Gate append requires new proposal and decision identities.'
+      );
+    }
+    try {
+      ledger = appendAflTradeGateDecision(ledger, record.proposal, record.decision);
+    } catch (cause) {
+      throw new AflTradeGateLedgerRepositoryError(
+        'INVALID_APPEND',
+        'A Gate decision does not validly extend the transaction-scoped batch.',
+        { cause }
+      );
+    }
+    await insertProposal(transaction, record.proposal);
+    await insertDecision(transaction, record.decision);
+  }
+  const revision = stored.revision + records.length;
+  const updated = await transaction.query(
+    `UPDATE outcome_gate_ledger_head
+     SET revision=$1,updated_at=$2
+     WHERE singleton_id=1 AND revision=$3`,
+    [revision, input.updatedAt, stored.revision]
+  );
+  if (updated.rowCount !== 1) {
+    throw new AflTradeGateLedgerRepositoryError(
+      'STALE_REVISION',
+      'The locked Gate ledger head could not be advanced for the transaction-scoped batch.'
+    );
+  }
+  return { revision, ledger };
 }
 
 class PostgresAflTradeGateDecisionLedgerRepository implements AflTradeGateDecisionLedgerRepository {

--- a/src/server/aflTradeIntelligence/governance/postgresGateDecisionLedgerRepository.ts
+++ b/src/server/aflTradeIntelligence/governance/postgresGateDecisionLedgerRepository.ts
@@ -481,9 +481,10 @@ class PostgresAflTradeGateDecisionLedgerRepository implements AflTradeGateDecisi
           'A Gate batch proposal or decision identity already names different content.'
         );
       }
-      const rightsExist = await Promise.all(
-        input.records.map((record) => requireExactSourceRights(transaction, record.sourceRights))
-      );
+      const rightsExist: boolean[] = [];
+      for (const record of input.records) {
+        rightsExist.push(await requireExactSourceRights(transaction, record.sourceRights));
+      }
       if (replayStates.every((state) => state === 'exact')) {
         if (rightsExist.some((exists) => !exists)) {
           throw invalidStored('An exact Gate batch replay is missing source-rights records.');
@@ -609,6 +610,12 @@ class PostgresAflTradeGateDecisionLedgerRepository implements AflTradeGateDecisi
     unparsedInput: AflTradeGateLedgerDecisionAppendInput
   ): Promise<AflTradeGateLedgerAppendResult> {
     const input = parseDecisionAppendInput(unparsedInput);
+    if (input.decision.content.authorityKind === 'automated_validation_record') {
+      throw new AflTradeGateLedgerRepositoryError(
+        'INVALID_APPEND',
+        'Automated model-validity records must use the governed qualification boundary.'
+      );
+    }
     return this.client.transaction(async (transaction) => {
       const stored = await loadLedger(transaction, true);
       const replay = findReplay(stored, input);

--- a/src/server/aflTradeIntelligence/governance/postgresGateDecisionLedgerRepository.ts
+++ b/src/server/aflTradeIntelligence/governance/postgresGateDecisionLedgerRepository.ts
@@ -149,6 +149,15 @@ function parseAppendInput(input: AflTradeGateLedgerAppendInput): AflTradeGateLed
     );
   }
   if (
+    proposal.data.content.gate !== 'gate_0a_permission_to_evaluate' ||
+    decision.data.content.gate !== 'gate_0a_permission_to_evaluate'
+  ) {
+    throw new AflTradeGateLedgerRepositoryError(
+      'INVALID_APPEND',
+      'The source-rights append boundary accepts only Gate 0A decisions.'
+    );
+  }
+  if (
     !proposal.data.content.affectedArtifacts.some(
       (artifact) =>
         artifact.kind === 'source_rights' &&
@@ -382,6 +391,11 @@ export async function appendNewAflTradeGateDecisionsWithinTransaction(
   transaction: AflOutcomeSqlTransaction,
   input: Readonly<{
     expectedRevision: number;
+    scopeKey: string;
+    qualificationId: string;
+    qualificationArtifactId: string;
+    playerRunId: string;
+    pickRunId: string;
     records: readonly Readonly<{
       proposal: AflTradeGateDecisionProposal;
       decision: AflTradeGateDecisionRecord;
@@ -389,15 +403,54 @@ export async function appendNewAflTradeGateDecisionsWithinTransaction(
     updatedAt: string;
   }>
 ): Promise<AflTradeStoredGateLedger> {
-  if (input.records.length === 0) {
+  if (input.records.length !== 2) {
     throw new AflTradeGateLedgerRepositoryError(
       'INVALID_APPEND',
-      'A transaction-scoped Gate append requires at least one decision.'
+      'Governed model qualification requires exactly two linked Gate decisions.'
     );
   }
   const records = input.records.map((record) =>
     parseDecisionAppendInput({ ...record, expectedRevision: input.expectedRevision })
   );
+  const expectedRunIds = [input.playerRunId, input.pickRunId] as const;
+  for (const [index, record] of records.entries()) {
+    const proposal = record.proposal.content;
+    const decision = record.decision.content;
+    const proposalModelRuns = proposal.affectedArtifacts.filter(
+      ({ kind }) => kind === 'model_run'
+    );
+    const decisionModelRuns = decision.affectedArtifacts.filter(
+      ({ kind }) => kind === 'model_run'
+    );
+    const proposalQualifications = proposal.affectedArtifacts.filter(
+      ({ kind }) => kind === 'model_qualification'
+    );
+    const decisionQualifications = decision.affectedArtifacts.filter(
+      ({ kind }) => kind === 'model_qualification'
+    );
+    if (
+      proposal.gate !== 'gate_3_model_validity' ||
+      decision.gate !== 'gate_3_model_validity' ||
+      decision.authorityKind !== 'automated_validation_record' ||
+      proposal.scope.scopeKey !== input.scopeKey ||
+      decision.scope.scopeKey !== input.scopeKey ||
+      !proposal.evidenceIds.includes(input.qualificationArtifactId) ||
+      !decision.authorityEvidenceIds.includes(input.qualificationArtifactId) ||
+      proposalModelRuns.length !== 1 ||
+      proposalModelRuns[0]?.artifactId !== expectedRunIds[index] ||
+      decisionModelRuns.length !== 1 ||
+      decisionModelRuns[0]?.artifactId !== expectedRunIds[index] ||
+      proposalQualifications.length !== 1 ||
+      proposalQualifications[0]?.artifactId !== input.qualificationId ||
+      decisionQualifications.length !== 1 ||
+      decisionQualifications[0]?.artifactId !== input.qualificationId
+    ) {
+      throw new AflTradeGateLedgerRepositoryError(
+        'INVALID_APPEND',
+        'Transaction-scoped automated Gate decisions must bind the exact role-specific qualified pair.'
+      );
+    }
+  }
   const stored = await loadLedger(transaction, true);
   if (stored.revision !== input.expectedRevision) {
     throw new AflTradeGateLedgerRepositoryError(

--- a/src/server/aflTradeIntelligence/modeling/governedPickPavModelExecution.ts
+++ b/src/server/aflTradeIntelligence/modeling/governedPickPavModelExecution.ts
@@ -20,19 +20,19 @@ import {
   validateAflTradePickPavDistributionBenchmark,
 } from './pickPavDistributionValidation';
 
-const SCHEMA_VERSION = 'afl-trade-pick-pav-model-execution/v2' as const;
-const AUTHORITY_BOUNDARY =
+const LEGACY_AUTHORITY_BOUNDARY =
   'authenticated_non_production_pick_model_candidate_no_gate_3_approval_grade_publication_or_fantasy_ownership' as const;
-const LIMITATION =
+const LEGACY_LIMITATION =
   'This retained non-production execution is eligible for independent Gate 3 review only; it is not an approval, trade grade, or public numerical authority.' as const;
+const AUTHORITY_BOUNDARY =
+  'authenticated_non_production_pick_model_candidate_pending_automated_qualification_no_grade_publication_or_fantasy_ownership' as const;
+const LIMITATION =
+  'This retained non-production execution is pending automated model-pair qualification; it is not a trade grade or public numerical authority.' as const;
 const instantSchema = z.iso.datetime({ offset: true });
 
-const governedExecutionContentSchema = z
+const sharedGovernedExecutionContentSchema = z
   .object({
-    schemaVersion: z.literal(SCHEMA_VERSION),
-    authorityBoundary: z.literal(AUTHORITY_BOUNDARY),
     publicationEligible: z.literal(false),
-    approvalStatus: z.literal('gate_3_review_required'),
     environment: z.literal('non_production'),
     competition: z.literal('AFLM'),
     datasetId: aflTradeContentAddressedIdSchema('dataset'),
@@ -55,10 +55,13 @@ const governedExecutionContentSchema = z
     validationConfig: aflTradePickPavValidationConfigSchema,
     benchmark: aflTradePickPavDistributionBenchmarkSchema,
     validationReport: aflTradePickPavValidationReportSchema,
-    limitation: z.literal(LIMITATION),
   })
-  .strict()
-  .superRefine((execution, context) => {
+  .strict();
+
+function refineGovernedExecution(
+  execution: z.infer<typeof sharedGovernedExecutionContentSchema>,
+  context: z.RefinementCtx
+) {
     const observationSet = execution.observationSet;
     if (
       execution.observationSetId !== observationSet.observationSetId ||
@@ -146,12 +149,32 @@ const governedExecutionContentSchema = z
             : 'Governed pick execution outputs could not be re-derived.',
       });
     }
-  });
+}
+
+const legacyGovernedExecutionContentSchema = sharedGovernedExecutionContentSchema
+  .extend({
+    schemaVersion: z.literal('afl-trade-pick-pav-model-execution/v2'),
+    authorityBoundary: z.literal(LEGACY_AUTHORITY_BOUNDARY),
+    approvalStatus: z.literal('gate_3_review_required'),
+    limitation: z.literal(LEGACY_LIMITATION),
+  })
+  .strict()
+  .superRefine(refineGovernedExecution);
+
+const governedExecutionContentSchema = sharedGovernedExecutionContentSchema
+  .extend({
+    schemaVersion: z.literal('afl-trade-pick-pav-model-execution/v3'),
+    authorityBoundary: z.literal(AUTHORITY_BOUNDARY),
+    qualificationStatus: z.literal('automated_qualification_pending'),
+    limitation: z.literal(LIMITATION),
+  })
+  .strict()
+  .superRefine(refineGovernedExecution);
 
 export const governedAflTradePickPavModelExecutionSchema = z
   .object({
     executionId: aflTradeContentAddressedIdSchema('pick-pav-model-execution'),
-    content: governedExecutionContentSchema,
+    content: z.union([legacyGovernedExecutionContentSchema, governedExecutionContentSchema]),
   })
   .strict()
   .superRefine((execution, context) => {
@@ -183,10 +206,10 @@ export function createGovernedAflTradePickPavModelExecution(input: {
 }): GovernedAflTradePickPavModelExecution {
   const observationSet = aflTradePickPavObservationSetSchema.parse(input.outputs.observationSet);
   const content = governedExecutionContentSchema.parse({
-    schemaVersion: SCHEMA_VERSION,
+    schemaVersion: 'afl-trade-pick-pav-model-execution/v3',
     authorityBoundary: AUTHORITY_BOUNDARY,
     publicationEligible: false,
-    approvalStatus: 'gate_3_review_required',
+    qualificationStatus: 'automated_qualification_pending',
     environment: 'non_production',
     competition: observationSet.content.competition,
     ...input.authority,

--- a/src/server/aflTradeIntelligence/valuation/internal/governedNativeComponentExecution.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedNativeComponentExecution.ts
@@ -1,10 +1,25 @@
 import {
   doAflTradeArtifactRefsExactlyMatch,
   doesAflTradeArtifactRefMatchBytes,
+  type AflTradeArtifactRef,
 } from '../../artifacts/artifactReference';
-import { aflTradeModelRunManifestV3Schema } from '../../artifacts/modelRunManifest';
+import {
+  aflTradeModelRunManifestV3Schema,
+  type AflTradeModelRunManifestV3,
+} from '../../artifacts/modelRunManifest';
 import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
-import { governedAflTradePickPavModelExecutionSchema } from '../../modeling/governedPickPavModelExecution';
+import {
+  governedAflTradePickPavModelExecutionSchema,
+  type GovernedAflTradePickPavModelExecution,
+} from '../../modeling/governedPickPavModelExecution';
+import {
+  aflTradePickPavValidationReportSchema,
+  type AflTradePickPavValidationReport,
+} from '../../modeling/pickPavDistributionValidation';
+import {
+  aflTradePlayerValidationReportSchema,
+  type AflTradePlayerValidationReport,
+} from '../../modeling/playerContributionValidation';
 import type { GovernedValuationComponentRunManifest } from './governedValuationComponentRunManifest';
 
 export class GovernedNativeComponentExecutionError extends Error {
@@ -14,16 +29,13 @@ export class GovernedNativeComponentExecutionError extends Error {
   }
 }
 
-async function loadNativeDocument(input: {
-  readonly manifest: GovernedValuationComponentRunManifest;
+async function loadExactJsonDocument(input: {
+  readonly reference: AflTradeArtifactRef;
   readonly artifactRepository: AflTradeImmutableArtifactRepository;
   readonly maximumArtifactBytes: number;
 }): Promise<unknown> {
-  const reference = input.manifest.content.nativeExecution.artifact;
-  const loaded = await input.artifactRepository.loadExact(
-    reference,
-    input.maximumArtifactBytes
-  );
+  const reference = input.reference;
+  const loaded = await input.artifactRepository.loadExact(reference, input.maximumArtifactBytes);
   if (
     loaded === null ||
     !doAflTradeArtifactRefsExactlyMatch(loaded.reference, reference) ||
@@ -42,11 +54,24 @@ async function loadNativeDocument(input: {
   }
 }
 
-export async function authenticateGovernedNativeComponentExecution(input: {
+export type GovernedNativeComponentValidationReport =
+  | Readonly<{
+      kind: 'player_contribution_and_availability';
+      execution: AflTradeModelRunManifestV3;
+      validationReport: AflTradePlayerValidationReport;
+      validationReportArtifact: AflTradeArtifactRef;
+    }>
+  | Readonly<{
+      kind: 'draft_pick_and_future_pick_distribution';
+      execution: GovernedAflTradePickPavModelExecution;
+      validationReport: AflTradePickPavValidationReport;
+    }>;
+
+export async function loadGovernedNativeComponentValidationReport(input: {
   readonly manifest: GovernedValuationComponentRunManifest;
   readonly artifactRepository: AflTradeImmutableArtifactRepository;
   readonly maximumArtifactBytes: number;
-}): Promise<void> {
+}): Promise<GovernedNativeComponentValidationReport> {
   if (
     input.artifactRepository.artifactClass !== 'derived_private' ||
     !Number.isSafeInteger(input.maximumArtifactBytes) ||
@@ -55,7 +80,11 @@ export async function authenticateGovernedNativeComponentExecution(input: {
     throw new TypeError('Native component authentication requires bounded private custody.');
   }
   const content = input.manifest.content;
-  const document = await loadNativeDocument(input);
+  const document = await loadExactJsonDocument({
+    reference: content.nativeExecution.artifact,
+    artifactRepository: input.artifactRepository,
+    maximumArtifactBytes: input.maximumArtifactBytes,
+  });
   if (content.nativeExecution.kind === 'admitted_player_model_run') {
     const parsed = aflTradeModelRunManifestV3Schema.safeParse(document);
     if (
@@ -71,7 +100,32 @@ export async function authenticateGovernedNativeComponentExecution(input: {
         'Governed player native execution ancestry is invalid or unsuccessful.'
       );
     }
-    return;
+    const validationDocument = await loadExactJsonDocument({
+      reference: parsed.data.content.outcome.validationReportArtifact,
+      artifactRepository: input.artifactRepository,
+      maximumArtifactBytes: input.maximumArtifactBytes,
+    });
+    const validationReport = aflTradePlayerValidationReportSchema.safeParse(validationDocument);
+    const reportArtifact = parsed.data.content.outcome.validationReportArtifact;
+    if (
+      !validationReport.success ||
+      validationReport.data.content.evaluatedPartition !== 'final_test' ||
+      validationReport.data.content.observationSetId !== parsed.data.content.observationSetId ||
+      validationReport.data.content.candidateModelId !== parsed.data.content.modelId ||
+      parsed.data.content.finalTestEvaluatedAt === null ||
+      Date.parse(reportArtifact.createdAt) < Date.parse(parsed.data.content.finalTestEvaluatedAt) ||
+      Date.parse(reportArtifact.createdAt) > Date.parse(parsed.data.content.finishedAt)
+    ) {
+      throw new GovernedNativeComponentExecutionError(
+        'Governed player native validation report ancestry or chronology is invalid.'
+      );
+    }
+    return {
+      kind: 'player_contribution_and_availability',
+      execution: parsed.data,
+      validationReport: validationReport.data,
+      validationReportArtifact: reportArtifact,
+    };
   }
   if (content.nativeExecution.kind !== 'governed_pick_pav_model_execution') {
     throw new GovernedNativeComponentExecutionError(
@@ -104,4 +158,19 @@ export async function authenticateGovernedNativeComponentExecution(input: {
       'Governed pick native execution ancestry is invalid.'
     );
   }
+  return {
+    kind: 'draft_pick_and_future_pick_distribution',
+    execution: parsed.data,
+    validationReport: aflTradePickPavValidationReportSchema.parse(
+      parsed.data.content.validationReport
+    ),
+  };
+}
+
+export async function authenticateGovernedNativeComponentExecution(input: {
+  readonly manifest: GovernedValuationComponentRunManifest;
+  readonly artifactRepository: AflTradeImmutableArtifactRepository;
+  readonly maximumArtifactBytes: number;
+}): Promise<void> {
+  await loadGovernedNativeComponentValidationReport(input);
 }

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationAuthoritySnapshot.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationAuthoritySnapshot.ts
@@ -151,6 +151,25 @@ const readyComponentSchema = z
     }
   });
 
+const qualifiedReadyComponentSchema = readyComponentSchema.superRefine(
+  (component, context) => {
+    if (
+      component.qualificationId === undefined ||
+      component.qualificationPolicyVersion === undefined
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['qualificationId'],
+        message: 'New ready authority requires exact model-pair qualification custody.',
+      });
+    }
+  }
+);
+
+const qualifiedReadyComponentsSchema = z
+  .array(qualifiedReadyComponentSchema)
+  .length(componentRoles.length);
+
 function refineSharedReadyQualification(
   components: readonly z.output<typeof readyComponentSchema>[],
   context: z.RefinementCtx
@@ -621,7 +640,7 @@ type ReadyCreationInput = Readonly<{
   inputTraceId: string;
   inputTraceArtifact: z.input<typeof aflTradeArtifactRefSchema>;
   gateLedgerRevision: number;
-  components: readonly z.input<typeof readyComponentSchema>[];
+  components: readonly z.input<typeof qualifiedReadyComponentSchema>[];
 }>;
 
 type ReadyV3CreationInput = Readonly<{
@@ -642,7 +661,7 @@ type ReadyV3CreationInput = Readonly<{
   valuationInputBundleId: string;
   valuationInputBundleArtifact: z.input<typeof aflTradeArtifactRefSchema>;
   gateLedgerRevision: number;
-  components: readonly z.input<typeof readyComponentSchema>[];
+  components: readonly z.input<typeof qualifiedReadyComponentSchema>[];
 }>;
 
 function resultOf(retained: z.output<typeof retainedSchema>) {
@@ -812,6 +831,7 @@ export function createReadyFixtureGovernedPrivateEvaluationAuthorityInspection(
 export function createReadyGovernedPrivateEvaluationAuthorityInspection(
   input: ReadyCreationInput
 ) {
+  const components = qualifiedReadyComponentsSchema.parse(input.components);
   const common = {
     environment: 'non_production' as const,
     publicationProhibited: true as const,
@@ -832,7 +852,7 @@ export function createReadyGovernedPrivateEvaluationAuthorityInspection(
       inputTraceId: input.inputTraceId,
       inputTraceArtifact: input.inputTraceArtifact,
       gateLedgerRevision: input.gateLedgerRevision,
-      components: input.components,
+      components,
     },
     blockers: [] as const,
     limitation: READY_NON_PRODUCTION_LIMITATION,
@@ -867,6 +887,7 @@ export function createReadyGovernedPrivateEvaluationAuthorityInspection(
 export function createReadyGovernedPrivateEvaluationAuthorityInspectionV3(
   input: ReadyV3CreationInput
 ) {
+  const components = qualifiedReadyComponentsSchema.parse(input.components);
   const common = {
     environment: 'non_production' as const,
     publicationProhibited: true as const,
@@ -889,7 +910,7 @@ export function createReadyGovernedPrivateEvaluationAuthorityInspectionV3(
       valuationInputBundleId: input.valuationInputBundleId,
       valuationInputBundleArtifact: input.valuationInputBundleArtifact,
       gateLedgerRevision: input.gateLedgerRevision,
-      components: input.components,
+      components,
     },
     blockers: [] as const,
     limitation: READY_NON_PRODUCTION_LIMITATION,

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationAuthoritySnapshot.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationAuthoritySnapshot.ts
@@ -132,8 +132,41 @@ const readyComponentSchema = z
     datasetAdmissionGateLedgerRevision: z.number().int().positive(),
     gate3DecisionId: aflTradeContentAddressedIdSchema('gate-decision'),
     gate3DecisionVersion: z.number().int().positive(),
+    qualificationId: aflTradeContentAddressedIdSchema('model-qualification').optional(),
+    qualificationPolicyVersion: aflTradeContentAddressedIdSchema(
+      'model-qualification-policy'
+    ).optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((component, context) => {
+    if (
+      (component.qualificationId === undefined) !==
+      (component.qualificationPolicyVersion === undefined)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['qualificationId'],
+        message: 'Ready component qualification identity and policy version must travel together.',
+      });
+    }
+  });
+
+function refineSharedReadyQualification(
+  components: readonly z.output<typeof readyComponentSchema>[],
+  context: z.RefinementCtx
+): void {
+  const qualificationIds = new Set(components.map(({ qualificationId }) => qualificationId));
+  const policyVersions = new Set(
+    components.map(({ qualificationPolicyVersion }) => qualificationPolicyVersion)
+  );
+  if (qualificationIds.size !== 1 || policyVersions.size !== 1) {
+    context.addIssue({
+      code: 'custom',
+      path: ['components'],
+      message: 'Ready components must share one exact model-pair qualification and policy version.',
+    });
+  }
+}
 
 const readyCalculationAuthoritySchema = z
   .object({
@@ -154,6 +187,7 @@ const readyCalculationAuthoritySchema = z
   })
   .strict()
   .superRefine((authority, context) => {
+    refineSharedReadyQualification(authority.components, context);
     if (
       canonicalizeAflTradeJson(authority.components.map(({ role }) => role)) !==
       canonicalizeAflTradeJson(componentRoles)
@@ -229,6 +263,7 @@ const readyCalculationAuthorityV3Schema = z
   })
   .strict()
   .superRefine((authority, context) => {
+    refineSharedReadyQualification(authority.components, context);
     if (
       canonicalizeAflTradeJson(authority.components.map(({ role }) => role)) !==
       canonicalizeAflTradeJson(componentRoles)

--- a/src/server/aflTradeIntelligence/valuation/internal/governedReadyComponentAuthority.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedReadyComponentAuthority.ts
@@ -90,6 +90,7 @@ function requireExactAncestry(input: {
 function requireCurrentGate3(input: {
   readonly runId: string;
   readonly qualificationId: string;
+  readonly qualificationScopeKey: string;
   readonly decision: AflTradeGateDecisionRecord;
   readonly isCurrent: boolean;
   readonly capturedAt: string;
@@ -108,6 +109,7 @@ function requireCurrentGate3(input: {
     decision.authorityKind !== 'automated_validation_record' ||
     decision.effectiveAt === null ||
     decision.revalidateAt !== null ||
+    decision.scope.scopeKey !== input.qualificationScopeKey ||
     !decision.affectedArtifacts.some(
       ({ kind, artifactId }) => kind === 'model_run' && artifactId === input.runId
     ) ||
@@ -192,6 +194,7 @@ export function authenticateGovernedReadyComponentAuthority(input: {
   requireCurrentGate3({
     runId: input.run.manifest.runId,
     qualificationId: qualification.qualificationId,
+    qualificationScopeKey: qualification.content.scopeKey,
     decision: gate3Decision,
     isCurrent: input.gate3IsCurrent,
     capturedAt: input.capturedAt,

--- a/src/server/aflTradeIntelligence/valuation/internal/governedReadyComponentAuthority.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedReadyComponentAuthority.ts
@@ -8,6 +8,10 @@ import {
   type AflTradeGateDecisionRecord,
 } from '../../governance/gateDecisionTypes';
 import type { GovernedPrivateEvaluationInputTrace } from './governedPrivateEvaluationInputTrace';
+import {
+  governedValuationModelQualificationSchema,
+  type GovernedValuationModelQualification,
+} from './governedValuationModelQualification';
 import type { RetainedGovernedValuationComponentRun } from './postgresGovernedValuationComponentRunRepository';
 
 type TraceComponent = GovernedPrivateEvaluationInputTrace['content']['components'][number];
@@ -21,11 +25,18 @@ export type GovernedReadyComponentAuthority = Readonly<{
   datasetAdmissionGateLedgerRevision: number;
   gate3DecisionId: string;
   gate3DecisionVersion: number;
+  qualificationId: string;
+  qualificationPolicyVersion: string;
 }>;
 
 export class GovernedReadyComponentAuthorityError extends Error {
   constructor(
-    readonly code: 'ANCESTRY_MISMATCH' | 'NOT_CURRENT' | 'NOT_APPROVED' | 'EXPIRED',
+    readonly code:
+      | 'ANCESTRY_MISMATCH'
+      | 'NOT_CURRENT'
+      | 'NOT_APPROVED'
+      | 'NOT_QUALIFIED'
+      | 'QUALIFICATION_MISMATCH',
     message: string
   ) {
     super(message);
@@ -78,6 +89,7 @@ function requireExactAncestry(input: {
 
 function requireCurrentGate3(input: {
   readonly runId: string;
+  readonly qualificationId: string;
   readonly decision: AflTradeGateDecisionRecord;
   readonly isCurrent: boolean;
   readonly capturedAt: string;
@@ -93,25 +105,70 @@ function requireCurrentGate3(input: {
     decision.gate !== 'gate_3_model_validity' ||
     decision.environment !== 'non_production' ||
     decision.state !== 'approved' ||
-    decision.authorityKind !== 'external_human_record' ||
+    decision.authorityKind !== 'automated_validation_record' ||
     decision.effectiveAt === null ||
-    decision.revalidateAt === null ||
+    decision.revalidateAt !== null ||
     !decision.affectedArtifacts.some(
       ({ kind, artifactId }) => kind === 'model_run' && artifactId === input.runId
+    ) ||
+    !decision.affectedArtifacts.some(
+      ({ kind, artifactId }) =>
+        kind === 'model_qualification' && artifactId === input.qualificationId
     )
   ) {
     throw new GovernedReadyComponentAuthorityError(
       'NOT_APPROVED',
-      'Ready component authority requires an external human Gate 3 approval for the exact run.'
+      'Ready component authority requires the automated Gate 3 decision for the exact run and qualification.'
+    );
+  }
+  if (Date.parse(decision.effectiveAt) > Date.parse(input.capturedAt)) {
+    throw new GovernedReadyComponentAuthorityError(
+      'NOT_CURRENT',
+      'Gate 3 component authority is not yet effective at the captured authority time.'
+    );
+  }
+}
+
+function requireExactQualification(input: {
+  readonly qualification: GovernedValuationModelQualification;
+  readonly qualificationArtifact: AflTradeArtifactRef;
+  readonly currentQualificationId: string;
+  readonly traceComponent: TraceComponent;
+  readonly run: RetainedGovernedValuationComponentRun;
+}): void {
+  const qualification = input.qualification;
+  if (qualification.content.outcome !== 'qualified') {
+    throw new GovernedReadyComponentAuthorityError(
+      'NOT_QUALIFIED',
+      'Ready component authority requires a passing retained model-pair qualification.'
     );
   }
   if (
-    Date.parse(decision.effectiveAt) > Date.parse(input.capturedAt) ||
-    Date.parse(decision.revalidateAt) <= Date.parse(input.capturedAt)
+    qualification.qualificationId !== input.currentQualificationId ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(input.qualificationArtifact, qualification)
   ) {
     throw new GovernedReadyComponentAuthorityError(
-      'EXPIRED',
-      'Gate 3 component authority is outside its current revalidation window.'
+      'NOT_CURRENT',
+      'Retained model-pair qualification is not the exact current qualification.'
+    );
+  }
+  const component =
+    input.traceComponent.role === 'player_contribution_and_availability'
+      ? qualification.content.player
+      : qualification.content.pick;
+  if (
+    !component.passed ||
+    component.runId !== input.run.manifest.runId ||
+    component.protocolId !== input.run.manifest.content.protocolId ||
+    !doAflTradeArtifactRefsExactlyMatch(component.runArtifact, input.run.artifact) ||
+    !doAflTradeArtifactRefsExactlyMatch(
+      component.protocolArtifact,
+      input.run.manifest.content.protocolArtifact
+    )
+  ) {
+    throw new GovernedReadyComponentAuthorityError(
+      'QUALIFICATION_MISMATCH',
+      'Current model-pair qualification does not authenticate this exact component run and protocol.'
     );
   }
 }
@@ -124,11 +181,17 @@ export function authenticateGovernedReadyComponentAuthority(input: {
   readonly gate3IsCurrent: boolean;
   readonly gateLedgerRevision: number;
   readonly capturedAt: string;
+  readonly qualification: unknown;
+  readonly qualificationArtifact: AflTradeArtifactRef;
+  readonly currentQualificationId: string;
 }): GovernedReadyComponentAuthority {
   const gate3Decision = aflTradeGateDecisionRecordSchema.parse(input.gate3Decision);
+  const qualification = governedValuationModelQualificationSchema.parse(input.qualification);
   requireExactAncestry({ ...input, gate3Decision });
+  requireExactQualification({ ...input, qualification });
   requireCurrentGate3({
     runId: input.run.manifest.runId,
+    qualificationId: qualification.qualificationId,
     decision: gate3Decision,
     isCurrent: input.gate3IsCurrent,
     capturedAt: input.capturedAt,
@@ -153,5 +216,7 @@ export function authenticateGovernedReadyComponentAuthority(input: {
     datasetAdmissionGateLedgerRevision: admissionRevision,
     gate3DecisionId: gate3Decision.decisionId,
     gate3DecisionVersion: gate3Decision.content.version,
+    qualificationId: qualification.qualificationId,
+    qualificationPolicyVersion: qualification.content.policy.policyVersion,
   };
 }

--- a/src/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest.ts
@@ -7,9 +7,10 @@ import {
   createAflTradeContentAddress,
 } from '../../artifacts/contentAddress';
 
-const SCHEMA_VERSION = 'governed-valuation-component-run/v1' as const;
-const LIMITATION =
+const LEGACY_LIMITATION =
   'Authenticated non-production component-run candidate only; Gate 3 approval, grades, production use, and publication remain prohibited.' as const;
+const LIMITATION =
+  'Authenticated non-production component-run candidate pending automated model-pair qualification; grades, production use, and publication remain prohibited.' as const;
 const instantSchema = z.iso.datetime({ offset: true });
 
 const nativeExecutionSchema = z.discriminatedUnion('kind', [
@@ -36,9 +37,8 @@ const nativeExecutionSchema = z.discriminatedUnion('kind', [
     .strict(),
 ]);
 
-export const governedValuationComponentRunManifestContentSchema = z
+const governedValuationComponentRunInputSchema = z
   .object({
-    schemaVersion: z.literal(SCHEMA_VERSION),
     environment: z.literal('non_production'),
     role: z.enum([
       'player_contribution_and_availability',
@@ -53,12 +53,13 @@ export const governedValuationComponentRunManifestContentSchema = z
     datasetAdmissionArtifact: aflTradeArtifactRefSchema,
     datasetAdmissionGateLedgerRevision: z.number().int().positive(),
     registeredAt: instantSchema,
-    approvalState: z.literal('gate_3_review_required'),
-    publicationEligible: z.literal(false),
-    limitation: z.literal(LIMITATION),
   })
-  .strict()
-  .superRefine((manifest, context) => {
+  .strict();
+
+function refineComponentRunManifest(
+  manifest: z.infer<typeof governedValuationComponentRunInputSchema>,
+  context: z.RefinementCtx
+) {
     const roleMatchesNativeExecution =
       manifest.role === 'player_contribution_and_availability'
         ? manifest.nativeExecution.kind === 'admitted_player_model_run'
@@ -94,7 +95,34 @@ export const governedValuationComponentRunManifestContentSchema = z
         message: 'Every component-run evidence artifact must exist before registration.',
       });
     }
-  });
+}
+
+const legacyGovernedValuationComponentRunManifestContentSchema =
+  governedValuationComponentRunInputSchema
+    .extend({
+      schemaVersion: z.literal('governed-valuation-component-run/v1'),
+      approvalState: z.literal('gate_3_review_required'),
+      publicationEligible: z.literal(false),
+      limitation: z.literal(LEGACY_LIMITATION),
+    })
+    .strict()
+    .superRefine(refineComponentRunManifest);
+
+const successorGovernedValuationComponentRunManifestContentSchema =
+  governedValuationComponentRunInputSchema
+    .extend({
+      schemaVersion: z.literal('governed-valuation-component-run/v2'),
+      qualificationState: z.literal('automated_qualification_pending'),
+      publicationEligible: z.literal(false),
+      limitation: z.literal(LIMITATION),
+    })
+    .strict()
+    .superRefine(refineComponentRunManifest);
+
+export const governedValuationComponentRunManifestContentSchema = z.union([
+  legacyGovernedValuationComponentRunManifestContentSchema,
+  successorGovernedValuationComponentRunManifestContentSchema,
+]);
 
 export const governedValuationComponentRunManifestSchema = z
   .object({
@@ -113,15 +141,12 @@ export type GovernedValuationComponentRunManifest = z.infer<
 >;
 
 export function createGovernedValuationComponentRunManifest(
-  input: Omit<
-    z.input<typeof governedValuationComponentRunManifestContentSchema>,
-    'schemaVersion' | 'approvalState' | 'publicationEligible' | 'limitation'
-  >
+  input: z.input<typeof governedValuationComponentRunInputSchema>
 ): GovernedValuationComponentRunManifest {
-  const content = governedValuationComponentRunManifestContentSchema.parse({
-    schemaVersion: SCHEMA_VERSION,
+  const content = successorGovernedValuationComponentRunManifestContentSchema.parse({
+    schemaVersion: 'governed-valuation-component-run/v2',
     ...input,
-    approvalState: 'gate_3_review_required',
+    qualificationState: 'automated_qualification_pending',
     publicationEligible: false,
     limitation: LIMITATION,
   });

--- a/src/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification.ts
@@ -1,0 +1,485 @@
+import { z } from 'zod';
+
+import {
+  aflTradeArtifactRefSchema,
+  doesAflTradeArtifactRefMatchCanonicalJson,
+} from '../../artifacts/artifactReference';
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  createAflTradeContentAddress,
+} from '../../artifacts/contentAddress';
+import {
+  aflTradeGateDecisionProposalSchema,
+  aflTradeGateDecisionRecordSchema,
+  type AflTradeGateDecisionProposal,
+  type AflTradeGateDecisionRecord,
+} from '../../governance/gateDecisionTypes';
+
+const SCHEMA_VERSION = 'governed-valuation-model-qualification/v1' as const;
+const POLICY_SCHEMA_VERSION = 'governed-valuation-model-qualification-policy/v1' as const;
+const instantSchema = z.iso.datetime({ offset: true });
+const finiteNonNegative = z.number().finite().nonnegative();
+const probability = z.number().finite().min(0).max(1);
+const publicIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(200)
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9._:-]*$/u);
+
+export const governedPlayerModelQualificationCriteriaSchema = z
+  .object({
+    schemaVersion: z.literal('governed-player-model-qualification-criteria/v1'),
+    minimumComparableObservations: z.number().int().positive().max(100_000),
+    minimumRelativeMaeImprovement: probability.gt(0),
+    minimumRelativeRmseImprovement: probability.gt(0),
+    requiredAcceptanceOutcome: z.literal('meets_declared_predictive_thresholds'),
+  })
+  .strict();
+
+export const governedPickModelQualificationCriteriaSchema = z
+  .object({
+    schemaVersion: z.literal('governed-pick-model-qualification-criteria/v1'),
+    evaluatedScope: z.literal('final_test'),
+    minimumObservations: z.number().int().positive().max(100_000),
+    maximumMulticlassBrierScore: finiteNonNegative,
+    maximumMulticlassLogLoss: finiteNonNegative,
+    maximumRankedProbabilityScore: finiteNonNegative,
+    maximumContributionCrps: finiteNonNegative,
+    maximumMeanAbsoluteContributionError: finiteNonNegative,
+    maximumRootMeanSquaredContributionError: finiteNonNegative,
+    maximumMeanAbsoluteGamesError: finiteNonNegative,
+    maximumRootMeanSquaredGamesError: finiteNonNegative,
+    minimumEmpiricalP10P90Coverage: probability,
+    maximumEmpiricalP10P90Coverage: probability,
+    maximumMeanEmpiricalIntervalWidth: finiteNonNegative,
+    maximumZeroProbabilityObservationCount: z.number().int().nonnegative(),
+  })
+  .strict()
+  .superRefine((criteria, context) => {
+    if (
+      criteria.maximumEmpiricalP10P90Coverage < criteria.minimumEmpiricalP10P90Coverage
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['maximumEmpiricalP10P90Coverage'],
+        message: 'Maximum empirical coverage cannot be below the declared minimum.',
+      });
+    }
+  });
+
+export const governedValuationModelQualificationPolicySchema = z
+  .object({
+    schemaVersion: z.literal(POLICY_SCHEMA_VERSION),
+    policyVersion: publicIdSchema,
+    player: governedPlayerModelQualificationCriteriaSchema,
+    pick: governedPickModelQualificationCriteriaSchema,
+  })
+  .strict();
+
+const playerEvidenceSchema = z
+  .object({
+    schemaVersion: z.literal('governed-player-model-qualification-evidence/v1'),
+    validationReportId: aflTradeContentAddressedIdSchema('player-validation-report'),
+    comparableObservationCount: z.number().int().nonnegative().max(100_000),
+    acceptanceOutcome: z.enum([
+      'meets_declared_predictive_thresholds',
+      'does_not_meet_declared_predictive_thresholds',
+    ]),
+    relativeMaeImprovement: z.number().finite().nullable(),
+    relativeRmseImprovement: z.number().finite().nullable(),
+  })
+  .strict();
+
+const pickMetricsSchema = z
+  .object({
+    multiclassBrierScore: finiteNonNegative,
+    multiclassLogLoss: finiteNonNegative.nullable(),
+    rankedProbabilityScore: finiteNonNegative,
+    contributionCrps: finiteNonNegative,
+    meanAbsoluteContributionError: finiteNonNegative,
+    rootMeanSquaredContributionError: finiteNonNegative,
+    meanAbsoluteGamesError: finiteNonNegative,
+    rootMeanSquaredGamesError: finiteNonNegative,
+    empiricalP10P90Coverage: probability,
+    meanEmpiricalIntervalWidth: finiteNonNegative,
+    zeroProbabilityObservationCount: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const pickEvidenceSchema = z
+  .object({
+    schemaVersion: z.literal('governed-pick-model-qualification-evidence/v1'),
+    validationReportId: aflTradeContentAddressedIdSchema('pick-pav-validation-report'),
+    evaluationStatus: z.enum([
+      'scored_not_approved',
+      'insufficient_eligible_observations_not_approved',
+      'invalid_zero_probability_not_approved',
+    ]),
+    scope: z.literal('final_test'),
+    observationCount: z.number().int().nonnegative().max(100_000),
+    metrics: pickMetricsSchema.nullable(),
+  })
+  .strict();
+
+const commonComponentSchema = z.object({
+  runId: aflTradeContentAddressedIdSchema('model-run'),
+  runArtifact: aflTradeArtifactRefSchema,
+  protocolId: aflTradeContentAddressedIdSchema('model-protocol'),
+  protocolArtifact: aflTradeArtifactRefSchema,
+  criteriaArtifact: aflTradeArtifactRefSchema,
+  validationEvidenceArtifact: aflTradeArtifactRefSchema,
+});
+
+const playerComponentInputSchema = commonComponentSchema
+  .extend({
+    role: z.literal('player_contribution_and_availability'),
+    validationEvidence: playerEvidenceSchema,
+  })
+  .strict();
+
+const pickComponentInputSchema = commonComponentSchema
+  .extend({
+    role: z.literal('draft_pick_and_future_pick_distribution'),
+    validationEvidence: pickEvidenceSchema,
+  })
+  .strict();
+
+const qualificationInputSchema = z
+  .object({
+    environment: z.literal('non_production'),
+    scopeKey: publicIdSchema,
+    evaluatedAt: instantSchema,
+    policy: governedValuationModelQualificationPolicySchema,
+    policyArtifact: aflTradeArtifactRefSchema,
+    components: z
+      .object({
+        player: playerComponentInputSchema,
+        pick: pickComponentInputSchema,
+      })
+      .strict(),
+  })
+  .strict();
+
+export const GOVERNED_VALUATION_MODEL_QUALIFICATION_FAILURE_CODES = [
+  'player_observation_count_below_minimum',
+  'player_acceptance_outcome_not_met',
+  'player_mae_improvement_below_minimum',
+  'player_rmse_improvement_below_minimum',
+  'pick_evaluation_not_scored',
+  'pick_observation_count_below_minimum',
+  'pick_metrics_unavailable',
+  'pick_brier_score_above_maximum',
+  'pick_log_loss_unavailable',
+  'pick_log_loss_above_maximum',
+  'pick_ranked_probability_score_above_maximum',
+  'pick_contribution_crps_above_maximum',
+  'pick_contribution_mae_above_maximum',
+  'pick_contribution_rmse_above_maximum',
+  'pick_games_mae_above_maximum',
+  'pick_games_rmse_above_maximum',
+  'pick_coverage_below_minimum',
+  'pick_coverage_above_maximum',
+  'pick_interval_width_above_maximum',
+  'pick_zero_probability_count_above_maximum',
+] as const;
+
+const failureCodeSchema = z.enum(GOVERNED_VALUATION_MODEL_QUALIFICATION_FAILURE_CODES);
+type FailureCode = z.infer<typeof failureCodeSchema>;
+
+function playerFailures(
+  criteria: z.infer<typeof governedPlayerModelQualificationCriteriaSchema>,
+  evidence: z.infer<typeof playerEvidenceSchema>
+): FailureCode[] {
+  const failures: FailureCode[] = [];
+  if (evidence.comparableObservationCount < criteria.minimumComparableObservations) {
+    failures.push('player_observation_count_below_minimum');
+  }
+  if (evidence.acceptanceOutcome !== criteria.requiredAcceptanceOutcome) {
+    failures.push('player_acceptance_outcome_not_met');
+  }
+  if (
+    evidence.relativeMaeImprovement === null ||
+    evidence.relativeMaeImprovement < criteria.minimumRelativeMaeImprovement
+  ) {
+    failures.push('player_mae_improvement_below_minimum');
+  }
+  if (
+    evidence.relativeRmseImprovement === null ||
+    evidence.relativeRmseImprovement < criteria.minimumRelativeRmseImprovement
+  ) {
+    failures.push('player_rmse_improvement_below_minimum');
+  }
+  return failures;
+}
+
+function pickFailures(
+  criteria: z.infer<typeof governedPickModelQualificationCriteriaSchema>,
+  evidence: z.infer<typeof pickEvidenceSchema>
+): FailureCode[] {
+  const failures: FailureCode[] = [];
+  if (evidence.evaluationStatus !== 'scored_not_approved') {
+    failures.push('pick_evaluation_not_scored');
+  }
+  if (evidence.observationCount < criteria.minimumObservations) {
+    failures.push('pick_observation_count_below_minimum');
+  }
+  const metrics = evidence.metrics;
+  if (metrics === null) return [...failures, 'pick_metrics_unavailable'];
+  const upperBounds: ReadonlyArray<readonly [boolean, FailureCode]> = [
+    [metrics.multiclassBrierScore > criteria.maximumMulticlassBrierScore, 'pick_brier_score_above_maximum'],
+    [metrics.rankedProbabilityScore > criteria.maximumRankedProbabilityScore, 'pick_ranked_probability_score_above_maximum'],
+    [metrics.contributionCrps > criteria.maximumContributionCrps, 'pick_contribution_crps_above_maximum'],
+    [metrics.meanAbsoluteContributionError > criteria.maximumMeanAbsoluteContributionError, 'pick_contribution_mae_above_maximum'],
+    [metrics.rootMeanSquaredContributionError > criteria.maximumRootMeanSquaredContributionError, 'pick_contribution_rmse_above_maximum'],
+    [metrics.meanAbsoluteGamesError > criteria.maximumMeanAbsoluteGamesError, 'pick_games_mae_above_maximum'],
+    [metrics.rootMeanSquaredGamesError > criteria.maximumRootMeanSquaredGamesError, 'pick_games_rmse_above_maximum'],
+    [metrics.meanEmpiricalIntervalWidth > criteria.maximumMeanEmpiricalIntervalWidth, 'pick_interval_width_above_maximum'],
+    [metrics.zeroProbabilityObservationCount > criteria.maximumZeroProbabilityObservationCount, 'pick_zero_probability_count_above_maximum'],
+  ];
+  for (const [failed, code] of upperBounds) if (failed) failures.push(code);
+  if (metrics.multiclassLogLoss === null) failures.push('pick_log_loss_unavailable');
+  else if (metrics.multiclassLogLoss > criteria.maximumMulticlassLogLoss) {
+    failures.push('pick_log_loss_above_maximum');
+  }
+  if (metrics.empiricalP10P90Coverage < criteria.minimumEmpiricalP10P90Coverage) {
+    failures.push('pick_coverage_below_minimum');
+  }
+  if (metrics.empiricalP10P90Coverage > criteria.maximumEmpiricalP10P90Coverage) {
+    failures.push('pick_coverage_above_maximum');
+  }
+  return failures;
+}
+
+const qualifiedComponentSchema = commonComponentSchema
+  .extend({
+    role: z.enum([
+      'player_contribution_and_availability',
+      'draft_pick_and_future_pick_distribution',
+    ]),
+    validationEvidence: z.union([playerEvidenceSchema, pickEvidenceSchema]),
+    passed: z.boolean(),
+  })
+  .strict();
+
+export const governedValuationModelQualificationContentSchema = z
+  .object({
+    schemaVersion: z.literal(SCHEMA_VERSION),
+    environment: z.literal('non_production'),
+    scopeKey: publicIdSchema,
+    evaluatedAt: instantSchema,
+    policy: governedValuationModelQualificationPolicySchema,
+    policyArtifact: aflTradeArtifactRefSchema,
+    player: qualifiedComponentSchema.extend({
+      role: z.literal('player_contribution_and_availability'),
+      validationEvidence: playerEvidenceSchema,
+    }),
+    pick: qualifiedComponentSchema.extend({
+      role: z.literal('draft_pick_and_future_pick_distribution'),
+      validationEvidence: pickEvidenceSchema,
+    }),
+    outcome: z.enum(['qualified', 'failed']),
+    failureCodes: z.array(failureCodeSchema).max(GOVERNED_VALUATION_MODEL_QUALIFICATION_FAILURE_CODES.length),
+    publicationEligible: z.literal(false),
+  })
+  .strict()
+  .superRefine((qualification, context) => {
+    const player = playerFailures(qualification.policy.player, qualification.player.validationEvidence);
+    const pick = pickFailures(qualification.policy.pick, qualification.pick.validationEvidence);
+    const expectedFailures = [...player, ...pick];
+    const artifactChecks: ReadonlyArray<readonly [boolean, (string | number)[], string]> = [
+      [doesAflTradeArtifactRefMatchCanonicalJson(qualification.policyArtifact, qualification.policy), ['policyArtifact'], 'Qualification policy artifact does not authenticate the declared policy.'],
+      [doesAflTradeArtifactRefMatchCanonicalJson(qualification.player.criteriaArtifact, qualification.policy.player), ['player', 'criteriaArtifact'], 'Player criteria artifact does not authenticate the declared criteria.'],
+      [doesAflTradeArtifactRefMatchCanonicalJson(qualification.pick.criteriaArtifact, qualification.policy.pick), ['pick', 'criteriaArtifact'], 'Pick criteria artifact does not authenticate the declared criteria.'],
+      [doesAflTradeArtifactRefMatchCanonicalJson(qualification.player.validationEvidenceArtifact, qualification.player.validationEvidence), ['player', 'validationEvidenceArtifact'], 'Player validation evidence artifact does not authenticate the retained evidence.'],
+      [doesAflTradeArtifactRefMatchCanonicalJson(qualification.pick.validationEvidenceArtifact, qualification.pick.validationEvidence), ['pick', 'validationEvidenceArtifact'], 'Pick validation evidence artifact does not authenticate the retained evidence.'],
+    ];
+    for (const [valid, path, message] of artifactChecks) {
+      if (!valid) context.addIssue({ code: 'custom', path, message });
+    }
+    if (
+      qualification.player.runId === qualification.pick.runId ||
+      qualification.player.protocolId === qualification.pick.protocolId
+    ) {
+      context.addIssue({ code: 'custom', path: ['pick'], message: 'Player and pick qualification require distinct run and protocol lineage.' });
+    }
+    if (
+      qualification.player.passed !== (player.length === 0) ||
+      qualification.pick.passed !== (pick.length === 0) ||
+      qualification.outcome !== (expectedFailures.length === 0 ? 'qualified' : 'failed') ||
+      JSON.stringify(qualification.failureCodes) !== JSON.stringify(expectedFailures)
+    ) {
+      context.addIssue({ code: 'custom', path: ['outcome'], message: 'Qualification result must equal the recomputed criteria outcome.' });
+    }
+    const latestArtifactTime = Math.max(
+      ...[
+        qualification.policyArtifact,
+        qualification.player.runArtifact,
+        qualification.player.protocolArtifact,
+        qualification.player.criteriaArtifact,
+        qualification.player.validationEvidenceArtifact,
+        qualification.pick.runArtifact,
+        qualification.pick.protocolArtifact,
+        qualification.pick.criteriaArtifact,
+        qualification.pick.validationEvidenceArtifact,
+      ].map(({ createdAt }) => Date.parse(createdAt))
+    );
+    if (latestArtifactTime > Date.parse(qualification.evaluatedAt)) {
+      context.addIssue({ code: 'custom', path: ['evaluatedAt'], message: 'Qualification cannot predate retained authority or validation evidence.' });
+    }
+  });
+
+export const governedValuationModelQualificationSchema = z
+  .object({
+    qualificationId: aflTradeContentAddressedIdSchema('model-qualification'),
+    content: governedValuationModelQualificationContentSchema,
+  })
+  .strict()
+  .superRefine((qualification, context) => {
+    addAflTradeContentAddressIssue('model-qualification', qualification.qualificationId, qualification.content, context, ['qualificationId']);
+  });
+
+export type GovernedValuationModelQualification = z.infer<
+  typeof governedValuationModelQualificationSchema
+>;
+
+export function createGovernedValuationModelQualification(
+  rawInput: z.input<typeof qualificationInputSchema>
+): GovernedValuationModelQualification {
+  const input = qualificationInputSchema.parse(rawInput);
+  const playerFailureCodes = playerFailures(input.policy.player, input.components.player.validationEvidence);
+  const pickFailureCodes = pickFailures(input.policy.pick, input.components.pick.validationEvidence);
+  const failureCodes = [...playerFailureCodes, ...pickFailureCodes];
+  const content = governedValuationModelQualificationContentSchema.parse({
+    schemaVersion: SCHEMA_VERSION,
+    environment: input.environment,
+    scopeKey: input.scopeKey,
+    evaluatedAt: input.evaluatedAt,
+    policy: input.policy,
+    policyArtifact: input.policyArtifact,
+    player: { ...input.components.player, passed: playerFailureCodes.length === 0 },
+    pick: { ...input.components.pick, passed: pickFailureCodes.length === 0 },
+    outcome: failureCodes.length === 0 ? 'qualified' : 'failed',
+    failureCodes,
+    publicationEligible: false,
+  });
+  return governedValuationModelQualificationSchema.parse({
+    qualificationId: createAflTradeContentAddress('model-qualification', content),
+    content,
+  });
+}
+
+export function authenticateGovernedValuationModelQualification(
+  input: unknown
+): GovernedValuationModelQualification {
+  return governedValuationModelQualificationSchema.parse(input);
+}
+
+export type GovernedValuationModelQualificationGateRecord = Readonly<{
+  proposal: AflTradeGateDecisionProposal;
+  decision: AflTradeGateDecisionRecord;
+}>;
+
+export function createGovernedValuationModelQualificationGateRecords(input: {
+  readonly qualification: GovernedValuationModelQualification;
+  readonly qualificationArtifact: z.input<typeof aflTradeArtifactRefSchema>;
+  readonly decidedAt: string;
+  readonly automationPrincipal: string;
+  readonly accountableOwner: string;
+  readonly versions: Readonly<{ player: number; pick: number }>;
+  readonly supersedes: Readonly<{ player: string | null; pick: string | null }>;
+}): readonly [
+  GovernedValuationModelQualificationGateRecord,
+  GovernedValuationModelQualificationGateRecord,
+] {
+  const qualification = governedValuationModelQualificationSchema.parse(input.qualification);
+  const qualificationArtifact = aflTradeArtifactRefSchema.parse(input.qualificationArtifact);
+  const decidedAt = instantSchema.parse(input.decidedAt);
+  const automationPrincipal = publicIdSchema.parse(input.automationPrincipal);
+  const accountableOwner = publicIdSchema.parse(input.accountableOwner);
+  if (
+    qualification.content.outcome !== 'qualified' ||
+    !doesAflTradeArtifactRefMatchCanonicalJson(qualificationArtifact, qualification) ||
+    Date.parse(qualificationArtifact.createdAt) > Date.parse(decidedAt)
+  ) {
+    throw new RangeError(
+      'Automated Gate 3 records require a passing exact qualification retained before decision.'
+    );
+  }
+
+  const createRecord = (
+    component: 'player' | 'pick'
+  ): GovernedValuationModelQualificationGateRecord => {
+    const qualifiedComponent = qualification.content[component];
+    const version = z.number().int().positive().parse(input.versions[component]);
+    const supersedesDecisionId = input.supersedes[component];
+    const decisionKey = `${qualification.content.scopeKey}:${component}-model-validity`;
+    const affectedArtifacts = [
+      { kind: 'model_run' as const, artifactId: qualifiedComponent.runId },
+      {
+        kind: 'model_qualification' as const,
+        artifactId: qualification.qualificationId,
+      },
+    ];
+    const proposalContent = {
+      schemaVersion: 'afl-trade-gate-proposal/v1' as const,
+      gate: 'gate_3_model_validity' as const,
+      decisionKey,
+      version,
+      environment: 'non_production' as const,
+      scope: {
+        scopeKey: qualification.content.scopeKey,
+        description: `Automated ${component} model validity for one exact qualified pair.`,
+        dimensions: [{ name: 'qualification', values: [qualification.qualificationId] }],
+        exclusions: ['Production use, publication, and trade grades'],
+      },
+      proposal: `Apply the exact retained ${component} result from the shared model-pair qualification.`,
+      alternativesConsidered: ['Retain the candidate without advancing current model authority.'],
+      accountableOwner,
+      reviewRequirement: 'accountable_owner_only' as const,
+      requiredReviewerRoles: [],
+      conditions: [],
+      evidenceIds: [qualificationArtifact.artifactId],
+      affectedArtifacts,
+      proposedAt: decidedAt,
+      proposedBy: automationPrincipal,
+      proposalOrigin: 'agent_assisted' as const,
+    };
+    const proposal = aflTradeGateDecisionProposalSchema.parse({
+      proposalId: createAflTradeContentAddress('gate-proposal', proposalContent),
+      content: proposalContent,
+    });
+    const decisionContent = {
+      schemaVersion: 'afl-trade-gate-decision/v1' as const,
+      proposalId: proposal.proposalId,
+      gate: proposal.content.gate,
+      decisionKey,
+      version,
+      environment: 'non_production' as const,
+      scope: proposal.content.scope,
+      state: 'approved' as const,
+      authorityKind: 'automated_validation_record' as const,
+      accountableOwner,
+      decidedBy: automationPrincipal,
+      reviewers: [],
+      authorityEvidenceIds: [qualificationArtifact.artifactId],
+      conditionResults: [],
+      rationale: `The shared exact model-pair qualification passed every declared ${component} criterion.`,
+      limitations: ['Private non-production model validity only.'],
+      decidedAt,
+      effectiveAt: decidedAt,
+      revalidateAt: null,
+      supersedesDecisionId,
+      affectedArtifacts,
+      withdrawalActions: [],
+    };
+    const decision = aflTradeGateDecisionRecordSchema.parse({
+      decisionId: createAflTradeContentAddress('gate-decision', decisionContent),
+      content: decisionContent,
+    });
+    return { proposal, decision };
+  };
+
+  return [createRecord('player'), createRecord('pick')];
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification.ts
@@ -15,6 +15,8 @@ import {
   type AflTradeGateDecisionProposal,
   type AflTradeGateDecisionRecord,
 } from '../../governance/gateDecisionTypes';
+import type { AflTradePickPavValidationReport } from '../../modeling/pickPavDistributionValidation';
+import type { AflTradePlayerValidationReport } from '../../modeling/playerContributionValidation';
 
 const SCHEMA_VERSION = 'governed-valuation-model-qualification/v1' as const;
 const POLICY_SCHEMA_VERSION = 'governed-valuation-model-qualification-policy/v1' as const;
@@ -58,9 +60,7 @@ export const governedPickModelQualificationCriteriaSchema = z
   })
   .strict()
   .superRefine((criteria, context) => {
-    if (
-      criteria.maximumEmpiricalP10P90Coverage < criteria.minimumEmpiricalP10P90Coverage
-    ) {
+    if (criteria.maximumEmpiricalP10P90Coverage < criteria.minimumEmpiricalP10P90Coverage) {
       context.addIssue({
         code: 'custom',
         path: ['maximumEmpiricalP10P90Coverage'],
@@ -104,7 +104,7 @@ export function createGovernedValuationModelQualificationPolicy(
   });
 }
 
-const playerEvidenceSchema = z
+export const governedPlayerModelQualificationEvidenceSchema = z
   .object({
     schemaVersion: z.literal('governed-player-model-qualification-evidence/v1'),
     validationReportId: aflTradeContentAddressedIdSchema('player-validation-report'),
@@ -134,7 +134,7 @@ const pickMetricsSchema = z
   })
   .strict();
 
-const pickEvidenceSchema = z
+export const governedPickModelQualificationEvidenceSchema = z
   .object({
     schemaVersion: z.literal('governed-pick-model-qualification-evidence/v1'),
     validationReportId: aflTradeContentAddressedIdSchema('pick-pav-validation-report'),
@@ -149,6 +149,36 @@ const pickEvidenceSchema = z
   })
   .strict();
 
+export function deriveGovernedPlayerModelQualificationEvidence(
+  report: AflTradePlayerValidationReport
+): z.infer<typeof governedPlayerModelQualificationEvidenceSchema> {
+  return governedPlayerModelQualificationEvidenceSchema.parse({
+    schemaVersion: 'governed-player-model-qualification-evidence/v1',
+    validationReportId: report.validationReportId,
+    comparableObservationCount: report.content.comparableObservationIds.length,
+    acceptanceOutcome: report.content.acceptanceOutcome,
+    relativeMaeImprovement: report.content.metrics.relativeImprovement.meanAbsoluteError,
+    relativeRmseImprovement: report.content.metrics.relativeImprovement.rootMeanSquaredError,
+  });
+}
+
+export function deriveGovernedPickModelQualificationEvidence(
+  report: AflTradePickPavValidationReport
+): z.infer<typeof governedPickModelQualificationEvidenceSchema> {
+  const finalTest = report.content.scoreScopes.find(({ scope }) => scope === 'final_test');
+  if (finalTest === undefined) {
+    throw new RangeError('Pick validation report must contain final-test evidence.');
+  }
+  return governedPickModelQualificationEvidenceSchema.parse({
+    schemaVersion: 'governed-pick-model-qualification-evidence/v1',
+    validationReportId: report.validationReportId,
+    evaluationStatus: report.content.evaluationStatus,
+    scope: finalTest.scope,
+    observationCount: finalTest.observationCount,
+    metrics: finalTest.metrics,
+  });
+}
+
 const commonComponentSchema = z.object({
   runId: aflTradeContentAddressedIdSchema('model-run'),
   runArtifact: aflTradeArtifactRefSchema,
@@ -161,14 +191,14 @@ const commonComponentSchema = z.object({
 const playerComponentInputSchema = commonComponentSchema
   .extend({
     role: z.literal('player_contribution_and_availability'),
-    validationEvidence: playerEvidenceSchema,
+    validationEvidence: governedPlayerModelQualificationEvidenceSchema,
   })
   .strict();
 
 const pickComponentInputSchema = commonComponentSchema
   .extend({
     role: z.literal('draft_pick_and_future_pick_distribution'),
-    validationEvidence: pickEvidenceSchema,
+    validationEvidence: governedPickModelQualificationEvidenceSchema,
   })
   .strict();
 
@@ -216,7 +246,7 @@ type FailureCode = z.infer<typeof failureCodeSchema>;
 
 function playerFailures(
   criteria: z.infer<typeof governedPlayerModelQualificationCriteriaSchema>,
-  evidence: z.infer<typeof playerEvidenceSchema>
+  evidence: z.infer<typeof governedPlayerModelQualificationEvidenceSchema>
 ): FailureCode[] {
   const failures: FailureCode[] = [];
   if (evidence.comparableObservationCount < criteria.minimumComparableObservations) {
@@ -242,7 +272,7 @@ function playerFailures(
 
 function pickFailures(
   criteria: z.infer<typeof governedPickModelQualificationCriteriaSchema>,
-  evidence: z.infer<typeof pickEvidenceSchema>
+  evidence: z.infer<typeof governedPickModelQualificationEvidenceSchema>
 ): FailureCode[] {
   const failures: FailureCode[] = [];
   if (evidence.evaluationStatus !== 'scored_not_approved') {
@@ -254,15 +284,42 @@ function pickFailures(
   const metrics = evidence.metrics;
   if (metrics === null) return [...failures, 'pick_metrics_unavailable'];
   const upperBounds: ReadonlyArray<readonly [boolean, FailureCode]> = [
-    [metrics.multiclassBrierScore > criteria.maximumMulticlassBrierScore, 'pick_brier_score_above_maximum'],
-    [metrics.rankedProbabilityScore > criteria.maximumRankedProbabilityScore, 'pick_ranked_probability_score_above_maximum'],
-    [metrics.contributionCrps > criteria.maximumContributionCrps, 'pick_contribution_crps_above_maximum'],
-    [metrics.meanAbsoluteContributionError > criteria.maximumMeanAbsoluteContributionError, 'pick_contribution_mae_above_maximum'],
-    [metrics.rootMeanSquaredContributionError > criteria.maximumRootMeanSquaredContributionError, 'pick_contribution_rmse_above_maximum'],
-    [metrics.meanAbsoluteGamesError > criteria.maximumMeanAbsoluteGamesError, 'pick_games_mae_above_maximum'],
-    [metrics.rootMeanSquaredGamesError > criteria.maximumRootMeanSquaredGamesError, 'pick_games_rmse_above_maximum'],
-    [metrics.meanEmpiricalIntervalWidth > criteria.maximumMeanEmpiricalIntervalWidth, 'pick_interval_width_above_maximum'],
-    [metrics.zeroProbabilityObservationCount > criteria.maximumZeroProbabilityObservationCount, 'pick_zero_probability_count_above_maximum'],
+    [
+      metrics.multiclassBrierScore > criteria.maximumMulticlassBrierScore,
+      'pick_brier_score_above_maximum',
+    ],
+    [
+      metrics.rankedProbabilityScore > criteria.maximumRankedProbabilityScore,
+      'pick_ranked_probability_score_above_maximum',
+    ],
+    [
+      metrics.contributionCrps > criteria.maximumContributionCrps,
+      'pick_contribution_crps_above_maximum',
+    ],
+    [
+      metrics.meanAbsoluteContributionError > criteria.maximumMeanAbsoluteContributionError,
+      'pick_contribution_mae_above_maximum',
+    ],
+    [
+      metrics.rootMeanSquaredContributionError > criteria.maximumRootMeanSquaredContributionError,
+      'pick_contribution_rmse_above_maximum',
+    ],
+    [
+      metrics.meanAbsoluteGamesError > criteria.maximumMeanAbsoluteGamesError,
+      'pick_games_mae_above_maximum',
+    ],
+    [
+      metrics.rootMeanSquaredGamesError > criteria.maximumRootMeanSquaredGamesError,
+      'pick_games_rmse_above_maximum',
+    ],
+    [
+      metrics.meanEmpiricalIntervalWidth > criteria.maximumMeanEmpiricalIntervalWidth,
+      'pick_interval_width_above_maximum',
+    ],
+    [
+      metrics.zeroProbabilityObservationCount > criteria.maximumZeroProbabilityObservationCount,
+      'pick_zero_probability_count_above_maximum',
+    ],
   ];
   for (const [failed, code] of upperBounds) if (failed) failures.push(code);
   if (metrics.multiclassLogLoss === null) failures.push('pick_log_loss_unavailable');
@@ -284,7 +341,10 @@ const qualifiedComponentSchema = commonComponentSchema
       'player_contribution_and_availability',
       'draft_pick_and_future_pick_distribution',
     ]),
-    validationEvidence: z.union([playerEvidenceSchema, pickEvidenceSchema]),
+    validationEvidence: z.union([
+      governedPlayerModelQualificationEvidenceSchema,
+      governedPickModelQualificationEvidenceSchema,
+    ]),
     passed: z.boolean(),
   })
   .strict();
@@ -299,27 +359,67 @@ export const governedValuationModelQualificationContentSchema = z
     policyArtifact: aflTradeArtifactRefSchema,
     player: qualifiedComponentSchema.extend({
       role: z.literal('player_contribution_and_availability'),
-      validationEvidence: playerEvidenceSchema,
+      validationEvidence: governedPlayerModelQualificationEvidenceSchema,
     }),
     pick: qualifiedComponentSchema.extend({
       role: z.literal('draft_pick_and_future_pick_distribution'),
-      validationEvidence: pickEvidenceSchema,
+      validationEvidence: governedPickModelQualificationEvidenceSchema,
     }),
     outcome: z.enum(['qualified', 'failed']),
-    failureCodes: z.array(failureCodeSchema).max(GOVERNED_VALUATION_MODEL_QUALIFICATION_FAILURE_CODES.length),
+    failureCodes: z
+      .array(failureCodeSchema)
+      .max(GOVERNED_VALUATION_MODEL_QUALIFICATION_FAILURE_CODES.length),
     publicationEligible: z.literal(false),
   })
   .strict()
   .superRefine((qualification, context) => {
-    const player = playerFailures(qualification.policy.player, qualification.player.validationEvidence);
+    const player = playerFailures(
+      qualification.policy.player,
+      qualification.player.validationEvidence
+    );
     const pick = pickFailures(qualification.policy.pick, qualification.pick.validationEvidence);
     const expectedFailures = [...player, ...pick];
     const artifactChecks: ReadonlyArray<readonly [boolean, (string | number)[], string]> = [
-      [doesAflTradeArtifactRefMatchCanonicalJson(qualification.policyArtifact, qualification.policy), ['policyArtifact'], 'Qualification policy artifact does not authenticate the declared policy.'],
-      [doesAflTradeArtifactRefMatchCanonicalJson(qualification.player.criteriaArtifact, qualification.policy.player), ['player', 'criteriaArtifact'], 'Player criteria artifact does not authenticate the declared criteria.'],
-      [doesAflTradeArtifactRefMatchCanonicalJson(qualification.pick.criteriaArtifact, qualification.policy.pick), ['pick', 'criteriaArtifact'], 'Pick criteria artifact does not authenticate the declared criteria.'],
-      [doesAflTradeArtifactRefMatchCanonicalJson(qualification.player.validationEvidenceArtifact, qualification.player.validationEvidence), ['player', 'validationEvidenceArtifact'], 'Player validation evidence artifact does not authenticate the retained evidence.'],
-      [doesAflTradeArtifactRefMatchCanonicalJson(qualification.pick.validationEvidenceArtifact, qualification.pick.validationEvidence), ['pick', 'validationEvidenceArtifact'], 'Pick validation evidence artifact does not authenticate the retained evidence.'],
+      [
+        doesAflTradeArtifactRefMatchCanonicalJson(
+          qualification.policyArtifact,
+          qualification.policy
+        ),
+        ['policyArtifact'],
+        'Qualification policy artifact does not authenticate the declared policy.',
+      ],
+      [
+        doesAflTradeArtifactRefMatchCanonicalJson(
+          qualification.player.criteriaArtifact,
+          qualification.policy.player
+        ),
+        ['player', 'criteriaArtifact'],
+        'Player criteria artifact does not authenticate the declared criteria.',
+      ],
+      [
+        doesAflTradeArtifactRefMatchCanonicalJson(
+          qualification.pick.criteriaArtifact,
+          qualification.policy.pick
+        ),
+        ['pick', 'criteriaArtifact'],
+        'Pick criteria artifact does not authenticate the declared criteria.',
+      ],
+      [
+        doesAflTradeArtifactRefMatchCanonicalJson(
+          qualification.player.validationEvidenceArtifact,
+          qualification.player.validationEvidence
+        ),
+        ['player', 'validationEvidenceArtifact'],
+        'Player validation evidence artifact does not authenticate the retained evidence.',
+      ],
+      [
+        doesAflTradeArtifactRefMatchCanonicalJson(
+          qualification.pick.validationEvidenceArtifact,
+          qualification.pick.validationEvidence
+        ),
+        ['pick', 'validationEvidenceArtifact'],
+        'Pick validation evidence artifact does not authenticate the retained evidence.',
+      ],
     ];
     for (const [valid, path, message] of artifactChecks) {
       if (!valid) context.addIssue({ code: 'custom', path, message });
@@ -328,7 +428,11 @@ export const governedValuationModelQualificationContentSchema = z
       qualification.player.runId === qualification.pick.runId ||
       qualification.player.protocolId === qualification.pick.protocolId
     ) {
-      context.addIssue({ code: 'custom', path: ['pick'], message: 'Player and pick qualification require distinct run and protocol lineage.' });
+      context.addIssue({
+        code: 'custom',
+        path: ['pick'],
+        message: 'Player and pick qualification require distinct run and protocol lineage.',
+      });
     }
     if (
       qualification.player.passed !== (player.length === 0) ||
@@ -336,7 +440,11 @@ export const governedValuationModelQualificationContentSchema = z
       qualification.outcome !== (expectedFailures.length === 0 ? 'qualified' : 'failed') ||
       JSON.stringify(qualification.failureCodes) !== JSON.stringify(expectedFailures)
     ) {
-      context.addIssue({ code: 'custom', path: ['outcome'], message: 'Qualification result must equal the recomputed criteria outcome.' });
+      context.addIssue({
+        code: 'custom',
+        path: ['outcome'],
+        message: 'Qualification result must equal the recomputed criteria outcome.',
+      });
     }
     const latestArtifactTime = Math.max(
       ...[
@@ -352,7 +460,11 @@ export const governedValuationModelQualificationContentSchema = z
       ].map(({ createdAt }) => Date.parse(createdAt))
     );
     if (latestArtifactTime > Date.parse(qualification.evaluatedAt)) {
-      context.addIssue({ code: 'custom', path: ['evaluatedAt'], message: 'Qualification cannot predate retained authority or validation evidence.' });
+      context.addIssue({
+        code: 'custom',
+        path: ['evaluatedAt'],
+        message: 'Qualification cannot predate retained authority or validation evidence.',
+      });
     }
   });
 
@@ -363,7 +475,13 @@ export const governedValuationModelQualificationSchema = z
   })
   .strict()
   .superRefine((qualification, context) => {
-    addAflTradeContentAddressIssue('model-qualification', qualification.qualificationId, qualification.content, context, ['qualificationId']);
+    addAflTradeContentAddressIssue(
+      'model-qualification',
+      qualification.qualificationId,
+      qualification.content,
+      context,
+      ['qualificationId']
+    );
   });
 
 export type GovernedValuationModelQualification = z.infer<
@@ -374,8 +492,14 @@ export function createGovernedValuationModelQualification(
   rawInput: z.input<typeof qualificationInputSchema>
 ): GovernedValuationModelQualification {
   const input = qualificationInputSchema.parse(rawInput);
-  const playerFailureCodes = playerFailures(input.policy.player, input.components.player.validationEvidence);
-  const pickFailureCodes = pickFailures(input.policy.pick, input.components.pick.validationEvidence);
+  const playerFailureCodes = playerFailures(
+    input.policy.player,
+    input.components.player.validationEvidence
+  );
+  const pickFailureCodes = pickFailures(
+    input.policy.pick,
+    input.components.pick.validationEvidence
+  );
   const failureCodes = [...playerFailureCodes, ...pickFailureCodes];
   const content = governedValuationModelQualificationContentSchema.parse({
     schemaVersion: SCHEMA_VERSION,

--- a/src/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification.ts
@@ -69,14 +69,40 @@ export const governedPickModelQualificationCriteriaSchema = z
     }
   });
 
-export const governedValuationModelQualificationPolicySchema = z
+const governedValuationModelQualificationThresholdsSchema = z
   .object({
-    schemaVersion: z.literal(POLICY_SCHEMA_VERSION),
-    policyVersion: publicIdSchema,
     player: governedPlayerModelQualificationCriteriaSchema,
     pick: governedPickModelQualificationCriteriaSchema,
   })
   .strict();
+
+export const governedValuationModelQualificationPolicySchema =
+  governedValuationModelQualificationThresholdsSchema
+    .extend({
+      schemaVersion: z.literal(POLICY_SCHEMA_VERSION),
+      policyVersion: aflTradeContentAddressedIdSchema('model-qualification-policy'),
+    })
+    .strict()
+    .superRefine((policy, context) => {
+      addAflTradeContentAddressIssue(
+        'model-qualification-policy',
+        policy.policyVersion,
+        { player: policy.player, pick: policy.pick },
+        context,
+        ['policyVersion']
+      );
+    });
+
+export function createGovernedValuationModelQualificationPolicy(
+  input: z.input<typeof governedValuationModelQualificationThresholdsSchema>
+): z.infer<typeof governedValuationModelQualificationPolicySchema> {
+  const thresholds = governedValuationModelQualificationThresholdsSchema.parse(input);
+  return governedValuationModelQualificationPolicySchema.parse({
+    schemaVersion: POLICY_SCHEMA_VERSION,
+    policyVersion: createAflTradeContentAddress('model-qualification-policy', thresholds),
+    ...thresholds,
+  });
+}
 
 const playerEvidenceSchema = z
   .object({

--- a/src/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualificationWork.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualificationWork.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  createAflTradeContentAddress,
+} from '../../artifacts/contentAddress';
+import type { GovernedValuationModelQualification } from './governedValuationModelQualification';
+
+const publicIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(200)
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9._:-]*$/u);
+
+export const governedValuationModelQualificationWorkContentSchema = z
+  .object({
+    schemaVersion: z.literal('governed-valuation-model-qualification-work/v1'),
+    environment: z.literal('non_production'),
+    scopeKey: publicIdSchema,
+    qualificationId: aflTradeContentAddressedIdSchema('model-qualification'),
+    playerRunId: aflTradeContentAddressedIdSchema('model-run'),
+    pickRunId: aflTradeContentAddressedIdSchema('model-run'),
+    playerGate3DecisionId: aflTradeContentAddressedIdSchema('gate-decision'),
+    pickGate3DecisionId: aflTradeContentAddressedIdSchema('gate-decision'),
+    availableAt: z.iso.datetime({ offset: true }),
+    cause: z.literal('current_qualified_model_pair_advanced'),
+    status: z.literal('pending'),
+    publicationEligible: z.literal(false),
+  })
+  .strict();
+
+export const governedValuationModelQualificationWorkSchema = z
+  .object({
+    workId: aflTradeContentAddressedIdSchema('model-qualification-work'),
+    content: governedValuationModelQualificationWorkContentSchema,
+  })
+  .strict()
+  .superRefine((work, context) => {
+    addAflTradeContentAddressIssue('model-qualification-work', work.workId, work.content, context, [
+      'workId',
+    ]);
+  });
+
+export type GovernedValuationModelQualificationWork = z.infer<
+  typeof governedValuationModelQualificationWorkSchema
+>;
+
+export function createGovernedValuationModelQualificationWork(input: {
+  readonly qualification: GovernedValuationModelQualification;
+  readonly playerGate3DecisionId: string;
+  readonly pickGate3DecisionId: string;
+  readonly availableAt: string;
+}): GovernedValuationModelQualificationWork {
+  if (input.qualification.content.outcome !== 'qualified') {
+    throw new RangeError('Immediate qualification work requires a passing model pair.');
+  }
+  const content = governedValuationModelQualificationWorkContentSchema.parse({
+    schemaVersion: 'governed-valuation-model-qualification-work/v1',
+    environment: 'non_production',
+    scopeKey: input.qualification.content.scopeKey,
+    qualificationId: input.qualification.qualificationId,
+    playerRunId: input.qualification.content.player.runId,
+    pickRunId: input.qualification.content.pick.runId,
+    playerGate3DecisionId: input.playerGate3DecisionId,
+    pickGate3DecisionId: input.pickGate3DecisionId,
+    availableAt: input.availableAt,
+    cause: 'current_qualified_model_pair_advanced',
+    status: 'pending',
+    publicationEligible: false,
+  });
+  return governedValuationModelQualificationWorkSchema.parse({
+    workId: createAflTradeContentAddress('model-qualification-work', content),
+    content,
+  });
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationCalculationAuthority.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationCalculationAuthority.ts
@@ -23,7 +23,8 @@ import { PostgresGovernedPrivateEvaluationMaterializationManifestRepository } fr
 
 const BLOCKER_MESSAGES = {
   source_blocked: 'The current factual source authority blocks this calculation.',
-  model_not_approved: 'The required model component has not received current external Gate 3 approval.',
+  model_not_approved:
+    'The required model component is not part of the exact current automated qualification.',
   insufficient_data: 'The prepared evidence is insufficient for this calculation.',
   identity_unresolved: 'A required trade or asset identity remains unresolved.',
   lineage_unresolved: 'A required asset lineage remains unresolved.',

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationComponentAuthority.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationComponentAuthority.ts
@@ -1,4 +1,5 @@
 import {
+  createAflTradeCanonicalJsonArtifactRef,
   doAflTradeArtifactRefsExactlyMatch,
   doesAflTradeArtifactRefMatchBytes,
   doesAflTradeArtifactRefMatchCanonicalJson,
@@ -21,6 +22,10 @@ import {
   GovernedValuationComponentRunRepositoryError,
   PostgresGovernedValuationComponentRunRepository,
 } from './postgresGovernedValuationComponentRunRepository';
+import {
+  governedValuationModelQualificationSchema,
+  type GovernedValuationModelQualification,
+} from './governedValuationModelQualification';
 
 interface GateHeadRow {
   readonly revision: number | string;
@@ -36,6 +41,16 @@ interface GateDecisionRow {
   readonly is_current: boolean;
 }
 
+interface CurrentQualificationRow {
+  readonly qualification_id: string;
+  readonly player_run_id: string;
+  readonly pick_run_id: string;
+  readonly player_gate3_decision_id: string;
+  readonly pick_gate3_decision_id: string;
+  readonly artifact_id: string;
+  readonly qualification_json: unknown;
+}
+
 type Unavailable = Readonly<{
   state: 'unavailable';
   blockers: readonly Readonly<{
@@ -49,7 +64,8 @@ const unavailable = (): Unavailable => ({
   blockers: [
     {
       code: 'model_not_approved',
-      message: 'Current external Gate 3 approval is unavailable for both governed model components.',
+      message:
+        'The exact current automated qualification is unavailable for both governed model components.',
     },
   ],
 });
@@ -123,6 +139,78 @@ async function loadGate3(input: {
   return { decision: parsed.data, artifact: input.artifact, isCurrent: row.is_current };
 }
 
+async function loadCurrentQualification(input: {
+  transaction: AflOutcomeSqlTransaction;
+  scopeKey: string;
+  artifactRepository: AflTradeImmutableArtifactRepository;
+  maximumArtifactBytes: number;
+}): Promise<
+  | null
+  | Readonly<{
+      qualification: GovernedValuationModelQualification;
+      artifact: ReturnType<typeof createAflTradeCanonicalJsonArtifactRef>;
+      playerRunId: string;
+      pickRunId: string;
+      playerGate3DecisionId: string;
+      pickGate3DecisionId: string;
+    }>
+> {
+  const result = await input.transaction.query<CurrentQualificationRow>(
+    `SELECT current_pair.qualification_id,current_pair.player_run_id,current_pair.pick_run_id,
+       current_pair.player_gate3_decision_id,current_pair.pick_gate3_decision_id,
+       qualification.artifact_id,qualification.qualification_json
+       FROM outcome_current_governed_valuation_model_pair current_pair
+       JOIN outcome_governed_valuation_model_qualification qualification
+         ON qualification.qualification_id=current_pair.qualification_id
+      WHERE current_pair.scope_key=$1`,
+    [input.scopeKey]
+  );
+  if (result.rows.length === 0) return null;
+  const row = result.rows[0];
+  if (result.rows.length !== 1 || row === undefined) {
+    throw new TypeError('Current governed model-pair identity is ambiguous.');
+  }
+  const qualification = governedValuationModelQualificationSchema.parse(row.qualification_json);
+  const artifact = createAflTradeCanonicalJsonArtifactRef(
+    qualification,
+    qualification.content.evaluatedAt
+  );
+  if (
+    qualification.qualificationId !== row.qualification_id ||
+    qualification.content.scopeKey !== input.scopeKey ||
+    qualification.content.player.runId !== row.player_run_id ||
+    qualification.content.pick.runId !== row.pick_run_id ||
+    artifact.artifactId !== row.artifact_id
+  ) {
+    throw new TypeError('Current governed model-pair SQL ancestry failed exact authentication.');
+  }
+  const retained = await input.artifactRepository.loadExact(artifact, input.maximumArtifactBytes);
+  if (
+    retained === null ||
+    !doAflTradeArtifactRefsExactlyMatch(retained.reference, artifact) ||
+    !doesAflTradeArtifactRefMatchBytes(artifact, retained.bytes)
+  ) {
+    throw new TypeError('Current governed model-pair retained bytes failed exact authentication.');
+  }
+  let physical: unknown;
+  try {
+    physical = JSON.parse(new TextDecoder().decode(retained.bytes));
+  } catch {
+    throw new TypeError('Current governed model-pair retained bytes are not valid JSON.');
+  }
+  if (canonicalizeAflTradeJson(physical) !== canonicalizeAflTradeJson(qualification)) {
+    throw new TypeError('Current governed model-pair SQL and retained bytes disagree.');
+  }
+  return {
+    qualification,
+    artifact,
+    playerRunId: row.player_run_id,
+    pickRunId: row.pick_run_id,
+    playerGate3DecisionId: row.player_gate3_decision_id,
+    pickGate3DecisionId: row.pick_gate3_decision_id,
+  };
+}
+
 export async function loadCurrentGovernedComponentAuthority(input: {
   transaction: AflOutcomeSqlTransaction;
   trace: GovernedPrivateEvaluationInputTrace;
@@ -149,6 +237,13 @@ export async function loadCurrentGovernedComponentAuthority(input: {
     throw new TypeError('Gate ledger head is unavailable or malformed.');
   }
   if (gateLedgerRevision === 0) return unavailable();
+  const currentQualification = await loadCurrentQualification({
+    transaction: input.transaction,
+    scopeKey: input.trace.content.selector.valuationScopeKey,
+    artifactRepository: input.artifactRepository,
+    maximumArtifactBytes: input.maximumArtifactBytes,
+  });
+  if (currentQualification === null) return unavailable();
   const repository = new PostgresGovernedValuationComponentRunRepository({
     client: transactionClient(input.transaction),
     artifactRepository: input.artifactRepository,
@@ -156,6 +251,22 @@ export async function loadCurrentGovernedComponentAuthority(input: {
   });
   const components: GovernedReadyComponentAuthority[] = [];
   for (const traceComponent of input.trace.content.components) {
+    const expected =
+      traceComponent.role === 'player_contribution_and_availability'
+        ? {
+            runId: currentQualification.playerRunId,
+            gate3DecisionId: currentQualification.playerGate3DecisionId,
+          }
+        : {
+            runId: currentQualification.pickRunId,
+            gate3DecisionId: currentQualification.pickGate3DecisionId,
+          };
+    if (
+      traceComponent.runId !== expected.runId ||
+      traceComponent.gate3DecisionId !== expected.gate3DecisionId
+    ) {
+      return unavailable();
+    }
     let run;
     try {
       run = await repository.loadExact(traceComponent.runId);
@@ -191,6 +302,9 @@ export async function loadCurrentGovernedComponentAuthority(input: {
           gate3IsCurrent: gate3.isCurrent,
           gateLedgerRevision,
           capturedAt: input.capturedAt,
+          qualification: currentQualification.qualification,
+          qualificationArtifact: currentQualification.artifact,
+          currentQualificationId: currentQualification.qualification.qualificationId,
         })
       );
     } catch (error) {

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
@@ -410,6 +410,214 @@ export type GovernedValuationModelQualificationRegistrationResult =
       idempotentReplay: boolean;
     }>;
 
+interface QualificationRegistrationInput {
+  readonly qualification: GovernedValuationModelQualification;
+  readonly qualificationArtifact: AflTradeArtifactRef;
+  readonly expectedGateLedgerRevision: number;
+  readonly expectedCurrentRevision: number;
+  readonly gateRecords?: readonly [
+    GovernedValuationModelQualificationGateRecord,
+    GovernedValuationModelQualificationGateRecord,
+  ];
+}
+
+function validateQualificationGateRecords(
+  qualification: GovernedValuationModelQualification,
+  qualificationArtifact: AflTradeArtifactRef,
+  gateRecords: readonly [
+    GovernedValuationModelQualificationGateRecord,
+    GovernedValuationModelQualificationGateRecord,
+  ]
+): string {
+  const expectedRunIds = [qualification.content.player.runId, qualification.content.pick.runId];
+  const qualificationRetainedAt = Date.parse(qualificationArtifact.createdAt);
+  const qualificationEvaluatedAt = Date.parse(qualification.content.evaluatedAt);
+  for (const [index, record] of gateRecords.entries()) {
+    const decision = record.decision.content;
+    const proposedAt = Date.parse(record.proposal.content.proposedAt);
+    const decidedAt = decision.decidedAt === null ? Number.NaN : Date.parse(decision.decidedAt);
+    const effectiveAt =
+      decision.effectiveAt === null ? Number.NaN : Date.parse(decision.effectiveAt);
+    if (
+      decision.authorityKind !== 'automated_validation_record' ||
+      decision.scope.scopeKey !== qualification.content.scopeKey ||
+      [proposedAt, decidedAt, effectiveAt].some(
+        (instant) =>
+          !Number.isFinite(instant) ||
+          instant < qualificationEvaluatedAt ||
+          instant < qualificationRetainedAt
+      ) ||
+      !decision.authorityEvidenceIds.includes(qualificationArtifact.artifactId) ||
+      !decision.affectedArtifacts.some(
+        ({ kind, artifactId }) => kind === 'model_run' && artifactId === expectedRunIds[index]
+      ) ||
+      !decision.affectedArtifacts.some(
+        ({ kind, artifactId }) =>
+          kind === 'model_qualification' && artifactId === qualification.qualificationId
+      )
+    ) {
+      throw new GovernedValuationModelQualificationRepositoryError(
+        'INTEGRITY_MISMATCH',
+        'Gate 3 records do not cite the exact role-specific run and shared qualification.'
+      );
+    }
+  }
+  return new Date(
+    Math.max(...gateRecords.map(({ decision }) => Date.parse(decision.content.effectiveAt!)))
+  ).toISOString();
+}
+
+async function appendQualificationGateRecords(
+  transaction: AflOutcomeSqlTransaction,
+  input: QualificationRegistrationInput & {
+    readonly gateRecords: readonly [
+      GovernedValuationModelQualificationGateRecord,
+      GovernedValuationModelQualificationGateRecord,
+    ];
+  },
+  authorityEffectiveAt: string
+): Promise<void> {
+  try {
+    await appendNewAflTradeGateDecisionsWithinTransaction(transaction, {
+      expectedRevision: input.expectedGateLedgerRevision,
+      scopeKey: input.qualification.content.scopeKey,
+      qualificationId: input.qualification.qualificationId,
+      qualificationArtifactId: input.qualificationArtifact.artifactId,
+      playerRunId: input.qualification.content.player.runId,
+      pickRunId: input.qualification.content.pick.runId,
+      records: input.gateRecords,
+      updatedAt: authorityEffectiveAt,
+    });
+  } catch (cause) {
+    if (cause instanceof AflTradeGateLedgerRepositoryError && cause.code === 'STALE_REVISION') {
+      throw new GovernedValuationModelQualificationRepositoryError(
+        'STALE_GATE_LEDGER',
+        'Gate ledger changed before the qualified pair could commit.',
+        { cause }
+      );
+    }
+    throw cause;
+  }
+}
+
+async function advanceQualifiedPair(
+  transaction: AflOutcomeSqlTransaction,
+  input: QualificationRegistrationInput & {
+    readonly gateRecords: readonly [
+      GovernedValuationModelQualificationGateRecord,
+      GovernedValuationModelQualificationGateRecord,
+    ];
+  },
+  work: GovernedValuationModelQualificationWork,
+  authorityEffectiveAt: string
+): Promise<GovernedCurrentValuationModelPair> {
+  let revisionResult;
+  try {
+    revisionResult = await transaction.query<{ revision: number }>(
+      `SELECT advance_outcome_current_governed_valuation_model_pair(
+         $1,$2,$3,$4,$5,$6,$7) AS revision`,
+      [
+        input.qualification.content.scopeKey,
+        input.qualification.qualificationId,
+        input.gateRecords[0].decision.decisionId,
+        input.gateRecords[1].decision.decisionId,
+        work.workId,
+        input.expectedCurrentRevision,
+        authorityEffectiveAt,
+      ]
+    );
+  } catch (cause) {
+    if (!(cause instanceof Error) || !cause.message.includes('Stale current model-pair revision')) {
+      throw cause;
+    }
+    throw new GovernedValuationModelQualificationRepositoryError(
+      'STALE_CURRENT_PAIR',
+      'Current model pair changed before the qualification could advance.',
+      { cause }
+    );
+  }
+  const current = await loadCurrentFrom(transaction, input.qualification.content.scopeKey);
+  if (
+    !current ||
+    current.revision !== Number(revisionResult.rows[0]?.revision) ||
+    current.qualificationId !== input.qualification.qualificationId
+  ) {
+    throw new GovernedValuationModelQualificationRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'Advanced current model pair failed exact readback.'
+    );
+  }
+  return current;
+}
+
+async function registerQualificationWithinTransaction(
+  transaction: AflOutcomeSqlTransaction,
+  input: QualificationRegistrationInput,
+  nativeEvidence: AuthenticatedQualificationArtifacts
+): Promise<GovernedValuationModelQualificationRegistrationResult> {
+  const { qualification } = input;
+  await retainNativeValidationEvidence(transaction, qualification, nativeEvidence);
+  const replay =
+    (await retainQualification(transaction, qualification, input.qualificationArtifact)) ===
+    'replayed';
+  const existingCurrent = await loadCurrentFrom(transaction, qualification.content.scopeKey);
+  if (qualification.content.outcome === 'failed') {
+    return {
+      status: 'failed_retained',
+      qualification,
+      current: existingCurrent,
+      idempotentReplay: replay,
+    };
+  }
+  if (!input.gateRecords) {
+    throw new GovernedValuationModelQualificationRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'A passing qualification requires both linked Gate 3 records.'
+    );
+  }
+  if (replay) {
+    if (existingCurrent?.qualificationId !== qualification.qualificationId) {
+      throw new GovernedValuationModelQualificationRepositoryError(
+        'STALE_CURRENT_PAIR',
+        'A retained qualification replay cannot replace a newer current pair.'
+      );
+    }
+    const workResult = await transaction.query<JsonRow>(
+      `SELECT work_json AS value FROM outcome_governed_model_qualification_work WHERE work_id=$1`,
+      [existingCurrent.workId]
+    );
+    const work = governedValuationModelQualificationWorkSchema.parse(workResult.rows[0]?.value);
+    return {
+      status: 'advanced',
+      qualification,
+      current: existingCurrent,
+      work,
+      idempotentReplay: true,
+    };
+  }
+  const qualifiedInput = { ...input, gateRecords: input.gateRecords };
+  const authorityEffectiveAt = validateQualificationGateRecords(
+    qualification,
+    input.qualificationArtifact,
+    qualifiedInput.gateRecords
+  );
+  await appendQualificationGateRecords(transaction, qualifiedInput, authorityEffectiveAt);
+  const work = createGovernedValuationModelQualificationWork({
+    qualification,
+    playerGate3DecisionId: qualifiedInput.gateRecords[0].decision.decisionId,
+    pickGate3DecisionId: qualifiedInput.gateRecords[1].decision.decisionId,
+    availableAt: authorityEffectiveAt,
+  });
+  await retainWork(transaction, work);
+  const current = await advanceQualifiedPair(
+    transaction,
+    qualifiedInput,
+    work,
+    authorityEffectiveAt
+  );
+  return { status: 'advanced', qualification, current, work, idempotentReplay: false };
+}
+
 export class PostgresGovernedValuationModelQualificationRepository {
   constructor(
     private readonly dependencies: {
@@ -427,16 +635,9 @@ export class PostgresGovernedValuationModelQualificationRepository {
     }
   }
 
-  async register(input: {
-    readonly qualification: GovernedValuationModelQualification;
-    readonly qualificationArtifact: AflTradeArtifactRef;
-    readonly expectedGateLedgerRevision: number;
-    readonly expectedCurrentRevision: number;
-    readonly gateRecords?: readonly [
-      GovernedValuationModelQualificationGateRecord,
-      GovernedValuationModelQualificationGateRecord,
-    ];
-  }): Promise<GovernedValuationModelQualificationRegistrationResult> {
+  async register(
+    input: QualificationRegistrationInput
+  ): Promise<GovernedValuationModelQualificationRegistrationResult> {
     const qualification = governedValuationModelQualificationSchema.parse(input.qualification);
     if (
       !doesAflTradeArtifactRefMatchCanonicalJson(input.qualificationArtifact, qualification) ||
@@ -453,168 +654,13 @@ export class PostgresGovernedValuationModelQualificationRepository {
       qualification,
       qualificationArtifact: input.qualificationArtifact,
     });
-    return this.dependencies.client.transaction(async (transaction) => {
-      await retainNativeValidationEvidence(transaction, qualification, nativeEvidence);
-      const replay =
-        (await retainQualification(transaction, qualification, input.qualificationArtifact)) ===
-        'replayed';
-      const existingCurrent = await loadCurrentFrom(transaction, qualification.content.scopeKey);
-      if (qualification.content.outcome === 'failed') {
-        return {
-          status: 'failed_retained',
-          qualification,
-          current: existingCurrent,
-          idempotentReplay: replay,
-        };
-      }
-      if (!input.gateRecords) {
-        throw new GovernedValuationModelQualificationRepositoryError(
-          'INTEGRITY_MISMATCH',
-          'A passing qualification requires both linked Gate 3 records.'
-        );
-      }
-      if (replay) {
-        if (existingCurrent?.qualificationId !== qualification.qualificationId) {
-          throw new GovernedValuationModelQualificationRepositoryError(
-            'STALE_CURRENT_PAIR',
-            'A retained qualification replay cannot replace a newer current pair.'
-          );
-        }
-        const workResult = await transaction.query<JsonRow>(
-          `SELECT work_json AS value FROM outcome_governed_model_qualification_work
-           WHERE work_id=$1`,
-          [existingCurrent.workId]
-        );
-        const work = governedValuationModelQualificationWorkSchema.parse(workResult.rows[0]?.value);
-        return {
-          status: 'advanced',
-          qualification,
-          current: existingCurrent,
-          work,
-          idempotentReplay: true,
-        };
-      }
-      const expectedRunIds = [
-        qualification.content.player.runId,
-        qualification.content.pick.runId,
-      ] as const;
-      for (const [index, record] of input.gateRecords.entries()) {
-        const decision = record.decision.content;
-        const qualificationRetainedAt = Date.parse(input.qualificationArtifact.createdAt);
-        const qualificationEvaluatedAt = Date.parse(qualification.content.evaluatedAt);
-        const proposedAt = Date.parse(record.proposal.content.proposedAt);
-        const decidedAt = decision.decidedAt === null ? Number.NaN : Date.parse(decision.decidedAt);
-        const effectiveAt =
-          decision.effectiveAt === null ? Number.NaN : Date.parse(decision.effectiveAt);
-        if (
-          decision.authorityKind !== 'automated_validation_record' ||
-          decision.scope.scopeKey !== qualification.content.scopeKey ||
-          !Number.isFinite(proposedAt) ||
-          !Number.isFinite(decidedAt) ||
-          !Number.isFinite(effectiveAt) ||
-          proposedAt < qualificationEvaluatedAt ||
-          proposedAt < qualificationRetainedAt ||
-          decidedAt < qualificationEvaluatedAt ||
-          decidedAt < qualificationRetainedAt ||
-          effectiveAt < qualificationEvaluatedAt ||
-          effectiveAt < qualificationRetainedAt ||
-          !decision.authorityEvidenceIds.includes(input.qualificationArtifact.artifactId) ||
-          !decision.affectedArtifacts.some(
-            ({ kind, artifactId }) => kind === 'model_run' && artifactId === expectedRunIds[index]
-          ) ||
-          !decision.affectedArtifacts.some(
-            ({ kind, artifactId }) =>
-              kind === 'model_qualification' && artifactId === qualification.qualificationId
-          )
-        ) {
-          throw new GovernedValuationModelQualificationRepositoryError(
-            'INTEGRITY_MISMATCH',
-            'Gate 3 records do not cite the exact role-specific run and shared qualification.'
-          );
-        }
-      }
-      const authorityEffectiveAt = new Date(
-        Math.max(
-          ...input.gateRecords.map(({ decision }) => {
-            if (decision.content.effectiveAt === null) {
-              throw new GovernedValuationModelQualificationRepositoryError(
-                'INTEGRITY_MISMATCH',
-                'Automated Gate 3 authority must have an effective time.'
-              );
-            }
-            return Date.parse(decision.content.effectiveAt);
-          })
-        )
-      ).toISOString();
-      try {
-        await appendNewAflTradeGateDecisionsWithinTransaction(transaction, {
-          expectedRevision: input.expectedGateLedgerRevision,
-          scopeKey: qualification.content.scopeKey,
-          qualificationId: qualification.qualificationId,
-          qualificationArtifactId: input.qualificationArtifact.artifactId,
-          playerRunId: qualification.content.player.runId,
-          pickRunId: qualification.content.pick.runId,
-          records: input.gateRecords,
-          updatedAt: authorityEffectiveAt,
-        });
-      } catch (cause) {
-        if (cause instanceof AflTradeGateLedgerRepositoryError && cause.code === 'STALE_REVISION') {
-          throw new GovernedValuationModelQualificationRepositoryError(
-            'STALE_GATE_LEDGER',
-            'Gate ledger changed before the qualified pair could commit.',
-            { cause }
-          );
-        }
-        throw cause;
-      }
-      const work = createGovernedValuationModelQualificationWork({
-        qualification,
-        playerGate3DecisionId: input.gateRecords[0].decision.decisionId,
-        pickGate3DecisionId: input.gateRecords[1].decision.decisionId,
-        availableAt: authorityEffectiveAt,
-      });
-      await retainWork(transaction, work);
-      let revisionResult;
-      try {
-        revisionResult = await transaction.query<{ revision: number }>(
-          `SELECT advance_outcome_current_governed_valuation_model_pair(
-             $1,$2,$3,$4,$5,$6,$7) AS revision`,
-          [
-            qualification.content.scopeKey,
-            qualification.qualificationId,
-            input.gateRecords[0].decision.decisionId,
-            input.gateRecords[1].decision.decisionId,
-            work.workId,
-            input.expectedCurrentRevision,
-            authorityEffectiveAt,
-          ]
-        );
-      } catch (cause) {
-        if (
-          !(cause instanceof Error) ||
-          !cause.message.includes('Stale current model-pair revision')
-        ) {
-          throw cause;
-        }
-        throw new GovernedValuationModelQualificationRepositoryError(
-          'STALE_CURRENT_PAIR',
-          'Current model pair changed before the qualification could advance.',
-          { cause }
-        );
-      }
-      const current = await loadCurrentFrom(transaction, qualification.content.scopeKey);
-      if (
-        !current ||
-        current.revision !== Number(revisionResult.rows[0]?.revision) ||
-        current.qualificationId !== qualification.qualificationId
-      ) {
-        throw new GovernedValuationModelQualificationRepositoryError(
-          'INTEGRITY_MISMATCH',
-          'Advanced current model pair failed exact readback.'
-        );
-      }
-      return { status: 'advanced', qualification, current, work, idempotentReplay: false };
-    });
+    return this.dependencies.client.transaction((transaction) =>
+      registerQualificationWithinTransaction(
+        transaction,
+        { ...input, qualification },
+        nativeEvidence
+      )
+    );
   }
 
   loadCurrent(scopeKey: string): Promise<GovernedCurrentValuationModelPair | null> {

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
@@ -1,4 +1,5 @@
 import {
+  doAflTradeArtifactRefsExactlyMatch,
   doesAflTradeArtifactRefMatchBytes,
   doesAflTradeArtifactRefMatchCanonicalJson,
   type AflTradeArtifactRef,
@@ -14,10 +15,17 @@ import type {
   AflOutcomeSqlTransaction,
 } from '../../outcomes/postgresOutcomeReleaseRepository';
 import {
+  deriveGovernedPickModelQualificationEvidence,
+  deriveGovernedPlayerModelQualificationEvidence,
   governedValuationModelQualificationSchema,
   type GovernedValuationModelQualification,
   type GovernedValuationModelQualificationGateRecord,
 } from './governedValuationModelQualification';
+import { governedValuationComponentRunManifestSchema } from './governedValuationComponentRunManifest';
+import {
+  loadGovernedNativeComponentValidationReport,
+  type GovernedNativeComponentValidationReport,
+} from './governedNativeComponentExecution';
 import {
   createGovernedValuationModelQualificationWork,
   governedValuationModelQualificationWorkSchema,
@@ -60,10 +68,7 @@ interface CurrentPairRow extends Record<string, unknown> {
 export class GovernedValuationModelQualificationRepositoryError extends Error {
   constructor(
     readonly code:
-      | 'INTEGRITY_MISMATCH'
-      | 'CONFLICTING_REPLAY'
-      | 'STALE_GATE_LEDGER'
-      | 'STALE_CURRENT_PAIR',
+      'INTEGRITY_MISMATCH' | 'CONFLICTING_REPLAY' | 'STALE_GATE_LEDGER' | 'STALE_CURRENT_PAIR',
     message: string,
     options?: ErrorOptions
   ) {
@@ -182,13 +187,108 @@ async function retainWork(
   );
 }
 
+interface NativeEvidenceRow extends Record<string, unknown> {
+  run_id: string;
+  role: string;
+  native_execution_artifact_id: string;
+  validation_report_id: string;
+  validation_report_artifact_id: string | null;
+  native_execution_json: unknown;
+  validation_report_json: unknown;
+  recorded_at: Date | string;
+}
+
+async function retainNativeValidationEvidence(
+  transaction: AflOutcomeSqlTransaction,
+  qualification: GovernedValuationModelQualification,
+  evidence: AuthenticatedQualificationArtifacts
+): Promise<void> {
+  const entries = [
+    {
+      runId: qualification.content.player.runId,
+      role: evidence.player.kind,
+      validationReportId: evidence.player.validationReport.validationReportId,
+      validationReportArtifactId: evidence.player.validationReportArtifact.artifactId,
+      nativeExecution: evidence.player.execution,
+      validationReport: evidence.player.validationReport,
+    },
+    {
+      runId: qualification.content.pick.runId,
+      role: evidence.pick.kind,
+      validationReportId: evidence.pick.validationReport.validationReportId,
+      validationReportArtifactId: null,
+      nativeExecution: evidence.pick.execution,
+      validationReport: evidence.pick.validationReport,
+    },
+  ] as const;
+  for (const entry of entries) {
+    await transaction.query(
+      `INSERT INTO outcome_governed_component_validation_evidence
+        (run_id,role,native_execution_artifact_id,validation_report_id,
+         validation_report_artifact_id,native_execution_json,validation_report_json,recorded_at)
+       SELECT run_id,$2,native_execution_artifact_id,$3,$4,$5::jsonb,$6::jsonb,$7
+         FROM outcome_governed_valuation_component_run WHERE run_id=$1
+       ON CONFLICT (run_id) DO NOTHING`,
+      [
+        entry.runId,
+        entry.role,
+        entry.validationReportId,
+        entry.validationReportArtifactId,
+        canonicalizeAflTradeJson(entry.nativeExecution),
+        canonicalizeAflTradeJson(entry.validationReport),
+        qualification.content.evaluatedAt,
+      ]
+    );
+    const retained = await transaction.query<NativeEvidenceRow>(
+      `SELECT run_id,role,native_execution_artifact_id,validation_report_id,
+          validation_report_artifact_id,native_execution_json,validation_report_json,recorded_at
+         FROM outcome_governed_component_validation_evidence WHERE run_id=$1`,
+      [entry.runId]
+    );
+    const row = retained.rows[0];
+    if (
+      retained.rows.length !== 1 ||
+      row === undefined ||
+      row.role !== entry.role ||
+      row.validation_report_id !== entry.validationReportId ||
+      row.validation_report_artifact_id !== entry.validationReportArtifactId ||
+      canonicalizeAflTradeJson(row.native_execution_json) !==
+        canonicalizeAflTradeJson(entry.nativeExecution) ||
+      canonicalizeAflTradeJson(row.validation_report_json) !==
+        canonicalizeAflTradeJson(entry.validationReport) ||
+      Date.parse(new Date(row.recorded_at).toISOString()) >
+        Date.parse(qualification.content.evaluatedAt)
+    ) {
+      throw new GovernedValuationModelQualificationRepositoryError(
+        'CONFLICTING_REPLAY',
+        'Component validation evidence conflicts with retained native authority.'
+      );
+    }
+  }
+}
+
+type PlayerNativeEvidence = Extract<
+  GovernedNativeComponentValidationReport,
+  { kind: 'player_contribution_and_availability' }
+>;
+type PickNativeEvidence = Extract<
+  GovernedNativeComponentValidationReport,
+  { kind: 'draft_pick_and_future_pick_distribution' }
+>;
+
+interface AuthenticatedQualificationArtifacts {
+  readonly player: PlayerNativeEvidence;
+  readonly pick: PickNativeEvidence;
+}
+
 async function authenticateArtifacts(input: {
   repository: AflTradeImmutableArtifactRepository;
   maximumBytes: number;
   qualification: GovernedValuationModelQualification;
   qualificationArtifact: AflTradeArtifactRef;
-}): Promise<void> {
+}): Promise<AuthenticatedQualificationArtifacts> {
   const content = input.qualification.content;
+  const documents = new Map<string, unknown>();
   const references = [
     input.qualificationArtifact,
     content.policyArtifact,
@@ -213,6 +313,85 @@ async function authenticateArtifacts(input: {
         `Qualification artifact custody failed for ${reference.artifactId}.`
       );
     }
+    if (
+      reference.artifactId === content.player.runArtifact.artifactId ||
+      reference.artifactId === content.pick.runArtifact.artifactId
+    ) {
+      try {
+        documents.set(reference.artifactId, JSON.parse(new TextDecoder().decode(loaded.bytes)));
+      } catch {
+        throw new GovernedValuationModelQualificationRepositoryError(
+          'INTEGRITY_MISMATCH',
+          `Qualification component run is not canonical JSON: ${reference.artifactId}.`
+        );
+      }
+    }
+  }
+  const playerRun = governedValuationComponentRunManifestSchema.safeParse(
+    documents.get(content.player.runArtifact.artifactId)
+  );
+  const pickRun = governedValuationComponentRunManifestSchema.safeParse(
+    documents.get(content.pick.runArtifact.artifactId)
+  );
+  if (
+    !playerRun.success ||
+    !pickRun.success ||
+    playerRun.data.runId !== content.player.runId ||
+    playerRun.data.content.role !== content.player.role ||
+    playerRun.data.content.protocolId !== content.player.protocolId ||
+    !doAflTradeArtifactRefsExactlyMatch(
+      playerRun.data.content.protocolArtifact,
+      content.player.protocolArtifact
+    ) ||
+    pickRun.data.runId !== content.pick.runId ||
+    pickRun.data.content.role !== content.pick.role ||
+    pickRun.data.content.protocolId !== content.pick.protocolId ||
+    !doAflTradeArtifactRefsExactlyMatch(
+      pickRun.data.content.protocolArtifact,
+      content.pick.protocolArtifact
+    )
+  ) {
+    throw new GovernedValuationModelQualificationRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'Qualification component-run evidence does not match the selected role and protocol.'
+    );
+  }
+  try {
+    const [playerNative, pickNative] = await Promise.all([
+      loadGovernedNativeComponentValidationReport({
+        manifest: playerRun.data,
+        artifactRepository: input.repository,
+        maximumArtifactBytes: input.maximumBytes,
+      }),
+      loadGovernedNativeComponentValidationReport({
+        manifest: pickRun.data,
+        artifactRepository: input.repository,
+        maximumArtifactBytes: input.maximumBytes,
+      }),
+    ]);
+    if (
+      playerNative.kind !== 'player_contribution_and_availability' ||
+      pickNative.kind !== 'draft_pick_and_future_pick_distribution' ||
+      canonicalizeAflTradeJson(
+        deriveGovernedPlayerModelQualificationEvidence(playerNative.validationReport)
+      ) !== canonicalizeAflTradeJson(content.player.validationEvidence) ||
+      canonicalizeAflTradeJson(
+        deriveGovernedPickModelQualificationEvidence(pickNative.validationReport)
+      ) !== canonicalizeAflTradeJson(content.pick.validationEvidence)
+    ) {
+      throw new GovernedValuationModelQualificationRepositoryError(
+        'INTEGRITY_MISMATCH',
+        'Qualification evidence does not equal the selected native validation reports.'
+      );
+    }
+    return { player: playerNative, pick: pickNative };
+  } catch (cause) {
+    if (cause instanceof GovernedValuationModelQualificationRepositoryError) throw cause;
+    throw new GovernedValuationModelQualificationRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'Qualification native validation evidence failed authentication.',
+      { cause }
+    );
   }
 }
 
@@ -268,13 +447,14 @@ export class PostgresGovernedValuationModelQualificationRepository {
         'Qualification artifact does not authenticate the exact evaluated record.'
       );
     }
-    await authenticateArtifacts({
+    const nativeEvidence = await authenticateArtifacts({
       repository: this.dependencies.artifactRepository,
       maximumBytes: this.dependencies.maximumArtifactBytes,
       qualification,
       qualificationArtifact: input.qualificationArtifact,
     });
     return this.dependencies.client.transaction(async (transaction) => {
+      await retainNativeValidationEvidence(transaction, qualification, nativeEvidence);
       const replay =
         (await retainQualification(transaction, qualification, input.qualificationArtifact)) ===
         'replayed';
@@ -306,7 +486,13 @@ export class PostgresGovernedValuationModelQualificationRepository {
           [existingCurrent.workId]
         );
         const work = governedValuationModelQualificationWorkSchema.parse(workResult.rows[0]?.value);
-        return { status: 'advanced', qualification, current: existingCurrent, work, idempotentReplay: true };
+        return {
+          status: 'advanced',
+          qualification,
+          current: existingCurrent,
+          work,
+          idempotentReplay: true,
+        };
       }
       const expectedRunIds = [
         qualification.content.player.runId,
@@ -314,13 +500,27 @@ export class PostgresGovernedValuationModelQualificationRepository {
       ] as const;
       for (const [index, record] of input.gateRecords.entries()) {
         const decision = record.decision.content;
+        const qualificationRetainedAt = Date.parse(input.qualificationArtifact.createdAt);
+        const qualificationEvaluatedAt = Date.parse(qualification.content.evaluatedAt);
+        const proposedAt = Date.parse(record.proposal.content.proposedAt);
+        const decidedAt = decision.decidedAt === null ? Number.NaN : Date.parse(decision.decidedAt);
+        const effectiveAt =
+          decision.effectiveAt === null ? Number.NaN : Date.parse(decision.effectiveAt);
         if (
           decision.authorityKind !== 'automated_validation_record' ||
           decision.scope.scopeKey !== qualification.content.scopeKey ||
+          !Number.isFinite(proposedAt) ||
+          !Number.isFinite(decidedAt) ||
+          !Number.isFinite(effectiveAt) ||
+          proposedAt < qualificationEvaluatedAt ||
+          proposedAt < qualificationRetainedAt ||
+          decidedAt < qualificationEvaluatedAt ||
+          decidedAt < qualificationRetainedAt ||
+          effectiveAt < qualificationEvaluatedAt ||
+          effectiveAt < qualificationRetainedAt ||
           !decision.authorityEvidenceIds.includes(input.qualificationArtifact.artifactId) ||
           !decision.affectedArtifacts.some(
-            ({ kind, artifactId }) =>
-              kind === 'model_run' && artifactId === expectedRunIds[index]
+            ({ kind, artifactId }) => kind === 'model_run' && artifactId === expectedRunIds[index]
           ) ||
           !decision.affectedArtifacts.some(
             ({ kind, artifactId }) =>
@@ -358,10 +558,7 @@ export class PostgresGovernedValuationModelQualificationRepository {
           updatedAt: authorityEffectiveAt,
         });
       } catch (cause) {
-        if (
-          cause instanceof AflTradeGateLedgerRepositoryError &&
-          cause.code === 'STALE_REVISION'
-        ) {
+        if (cause instanceof AflTradeGateLedgerRepositoryError && cause.code === 'STALE_REVISION') {
           throw new GovernedValuationModelQualificationRepositoryError(
             'STALE_GATE_LEDGER',
             'Gate ledger changed before the qualified pair could commit.',

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
@@ -6,14 +6,9 @@ import {
 import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
 import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
 import {
-  appendAflTradeGateDecision,
-  validateAflTradeGateDecisionLedger,
-  type AflTradeGateDecisionLedger,
-} from '../../governance/gateDecisionLedger';
-import {
-  aflTradeGateDecisionProposalSchema,
-  aflTradeGateDecisionRecordSchema,
-} from '../../governance/gateDecisionTypes';
+  AflTradeGateLedgerRepositoryError,
+  appendNewAflTradeGateDecisionsWithinTransaction,
+} from '../../governance/postgresGateDecisionLedgerRepository';
 import type {
   AflOutcomeSqlClient,
   AflOutcomeSqlTransaction,
@@ -28,10 +23,6 @@ import {
   governedValuationModelQualificationWorkSchema,
   type GovernedValuationModelQualificationWork,
 } from './governedValuationModelQualificationWork';
-
-interface GateHeadRow extends Record<string, unknown> {
-  revision: number;
-}
 
 interface JsonRow extends Record<string, unknown> {
   value: unknown;
@@ -115,80 +106,6 @@ async function loadCurrentFrom(
     );
   }
   return result.rows[0] ? currentPair(result.rows[0]) : null;
-}
-
-async function loadGateLedger(
-  transaction: AflOutcomeSqlTransaction
-): Promise<{ revision: number; ledger: AflTradeGateDecisionLedger }> {
-  const head = await transaction.query<GateHeadRow>(
-    `SELECT revision FROM outcome_gate_ledger_head WHERE singleton_id=1 FOR UPDATE`
-  );
-  const proposals = await transaction.query<JsonRow>(
-    `SELECT proposal_json AS value FROM outcome_gate_proposal
-     ORDER BY proposed_at,gate,decision_key,version,proposal_id`
-  );
-  const decisions = await transaction.query<JsonRow>(
-    `SELECT decision_json AS value FROM outcome_gate_decision
-     ORDER BY version,gate,decision_key,decision_id`
-  );
-  const ledger = {
-    proposals: proposals.rows.map(({ value }) => aflTradeGateDecisionProposalSchema.parse(value)),
-    decisions: decisions.rows.map(({ value }) => aflTradeGateDecisionRecordSchema.parse(value)),
-  };
-  if (
-    head.rows.length !== 1 ||
-    !validateAflTradeGateDecisionLedger(ledger).valid ||
-    head.rows[0]!.revision !== ledger.decisions.length
-  ) {
-    throw new GovernedValuationModelQualificationRepositoryError(
-      'INTEGRITY_MISMATCH',
-      'Stored Gate ledger failed exact authentication.'
-    );
-  }
-  return { revision: head.rows[0].revision, ledger };
-}
-
-async function insertGateRecord(
-  transaction: AflOutcomeSqlTransaction,
-  record: GovernedValuationModelQualificationGateRecord
-): Promise<void> {
-  const proposal = record.proposal;
-  const decision = record.decision;
-  await transaction.query(
-    `INSERT INTO outcome_gate_proposal
-      (proposal_id,gate,decision_key,version,environment,scope_key,proposed_at,proposal_json)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb)`,
-    [
-      proposal.proposalId,
-      proposal.content.gate,
-      proposal.content.decisionKey,
-      proposal.content.version,
-      proposal.content.environment,
-      proposal.content.scope.scopeKey,
-      proposal.content.proposedAt,
-      canonicalizeAflTradeJson(proposal),
-    ]
-  );
-  await transaction.query(
-    `INSERT INTO outcome_gate_decision
-      (decision_id,proposal_id,gate,decision_key,version,environment,state,decided_at,
-       effective_at,revalidate_at,supersedes_decision_id,decision_json)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
-    [
-      decision.decisionId,
-      decision.content.proposalId,
-      decision.content.gate,
-      decision.content.decisionKey,
-      decision.content.version,
-      decision.content.environment,
-      decision.content.state,
-      decision.content.decidedAt,
-      decision.content.effectiveAt,
-      decision.content.revalidateAt,
-      decision.content.supersedesDecisionId,
-      canonicalizeAflTradeJson(decision),
-    ]
-  );
 }
 
 async function retainQualification(
@@ -391,14 +308,6 @@ export class PostgresGovernedValuationModelQualificationRepository {
         const work = governedValuationModelQualificationWorkSchema.parse(workResult.rows[0]?.value);
         return { status: 'advanced', qualification, current: existingCurrent, work, idempotentReplay: true };
       }
-      const gate = await loadGateLedger(transaction);
-      if (gate.revision !== input.expectedGateLedgerRevision) {
-        throw new GovernedValuationModelQualificationRepositoryError(
-          'STALE_GATE_LEDGER',
-          'Gate ledger changed before the qualified pair could commit.'
-        );
-      }
-      let candidate = gate.ledger;
       const expectedRunIds = [
         qualification.content.player.runId,
         qualification.content.pick.runId,
@@ -407,6 +316,8 @@ export class PostgresGovernedValuationModelQualificationRepository {
         const decision = record.decision.content;
         if (
           decision.authorityKind !== 'automated_validation_record' ||
+          decision.scope.scopeKey !== qualification.content.scopeKey ||
+          !decision.authorityEvidenceIds.includes(input.qualificationArtifact.artifactId) ||
           !decision.affectedArtifacts.some(
             ({ kind, artifactId }) =>
               kind === 'model_run' && artifactId === expectedRunIds[index]
@@ -421,25 +332,44 @@ export class PostgresGovernedValuationModelQualificationRepository {
             'Gate 3 records do not cite the exact role-specific run and shared qualification.'
           );
         }
-        candidate = appendAflTradeGateDecision(candidate, record.proposal, record.decision);
-        await insertGateRecord(transaction, record);
       }
-      const updatedHead = await transaction.query(
-        `UPDATE outcome_gate_ledger_head SET revision=$1,updated_at=$2
-         WHERE singleton_id=1 AND revision=$3`,
-        [gate.revision + 2, qualification.content.evaluatedAt, gate.revision]
-      );
-      if (updatedHead.rowCount !== 1) {
-        throw new GovernedValuationModelQualificationRepositoryError(
-          'STALE_GATE_LEDGER',
-          'Gate ledger head changed before the qualified pair could commit.'
-        );
+      const authorityEffectiveAt = new Date(
+        Math.max(
+          ...input.gateRecords.map(({ decision }) => {
+            if (decision.content.effectiveAt === null) {
+              throw new GovernedValuationModelQualificationRepositoryError(
+                'INTEGRITY_MISMATCH',
+                'Automated Gate 3 authority must have an effective time.'
+              );
+            }
+            return Date.parse(decision.content.effectiveAt);
+          })
+        )
+      ).toISOString();
+      try {
+        await appendNewAflTradeGateDecisionsWithinTransaction(transaction, {
+          expectedRevision: input.expectedGateLedgerRevision,
+          records: input.gateRecords,
+          updatedAt: authorityEffectiveAt,
+        });
+      } catch (cause) {
+        if (
+          cause instanceof AflTradeGateLedgerRepositoryError &&
+          cause.code === 'STALE_REVISION'
+        ) {
+          throw new GovernedValuationModelQualificationRepositoryError(
+            'STALE_GATE_LEDGER',
+            'Gate ledger changed before the qualified pair could commit.',
+            { cause }
+          );
+        }
+        throw cause;
       }
       const work = createGovernedValuationModelQualificationWork({
         qualification,
         playerGate3DecisionId: input.gateRecords[0].decision.decisionId,
         pickGate3DecisionId: input.gateRecords[1].decision.decisionId,
-        availableAt: qualification.content.evaluatedAt,
+        availableAt: authorityEffectiveAt,
       });
       await retainWork(transaction, work);
       let revisionResult;
@@ -454,10 +384,16 @@ export class PostgresGovernedValuationModelQualificationRepository {
             input.gateRecords[1].decision.decisionId,
             work.workId,
             input.expectedCurrentRevision,
-            qualification.content.evaluatedAt,
+            authorityEffectiveAt,
           ]
         );
       } catch (cause) {
+        if (
+          !(cause instanceof Error) ||
+          !cause.message.includes('Stale current model-pair revision')
+        ) {
+          throw cause;
+        }
         throw new GovernedValuationModelQualificationRepositoryError(
           'STALE_CURRENT_PAIR',
           'Current model pair changed before the qualification could advance.',

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
@@ -349,6 +349,11 @@ export class PostgresGovernedValuationModelQualificationRepository {
       try {
         await appendNewAflTradeGateDecisionsWithinTransaction(transaction, {
           expectedRevision: input.expectedGateLedgerRevision,
+          scopeKey: qualification.content.scopeKey,
+          qualificationId: qualification.qualificationId,
+          qualificationArtifactId: input.qualificationArtifact.artifactId,
+          playerRunId: qualification.content.player.runId,
+          pickRunId: qualification.content.pick.runId,
           records: input.gateRecords,
           updatedAt: authorityEffectiveAt,
         });

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
@@ -1,0 +1,485 @@
+import {
+  doesAflTradeArtifactRefMatchBytes,
+  doesAflTradeArtifactRefMatchCanonicalJson,
+  type AflTradeArtifactRef,
+} from '../../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
+import {
+  appendAflTradeGateDecision,
+  validateAflTradeGateDecisionLedger,
+  type AflTradeGateDecisionLedger,
+} from '../../governance/gateDecisionLedger';
+import {
+  aflTradeGateDecisionProposalSchema,
+  aflTradeGateDecisionRecordSchema,
+} from '../../governance/gateDecisionTypes';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../../outcomes/postgresOutcomeReleaseRepository';
+import {
+  governedValuationModelQualificationSchema,
+  type GovernedValuationModelQualification,
+  type GovernedValuationModelQualificationGateRecord,
+} from './governedValuationModelQualification';
+import {
+  createGovernedValuationModelQualificationWork,
+  governedValuationModelQualificationWorkSchema,
+  type GovernedValuationModelQualificationWork,
+} from './governedValuationModelQualificationWork';
+
+interface GateHeadRow extends Record<string, unknown> {
+  revision: number;
+}
+
+interface JsonRow extends Record<string, unknown> {
+  value: unknown;
+}
+
+interface QualificationRow extends Record<string, unknown> {
+  qualification_json: unknown;
+  artifact_id: string;
+}
+
+export interface GovernedCurrentValuationModelPair {
+  readonly scopeKey: string;
+  readonly revision: number;
+  readonly qualificationId: string;
+  readonly playerRunId: string;
+  readonly pickRunId: string;
+  readonly playerGate3DecisionId: string;
+  readonly pickGate3DecisionId: string;
+  readonly workId: string;
+  readonly advancedAt: string;
+}
+
+interface CurrentPairRow extends Record<string, unknown> {
+  scope_key: string;
+  revision: number;
+  qualification_id: string;
+  player_run_id: string;
+  pick_run_id: string;
+  player_gate3_decision_id: string;
+  pick_gate3_decision_id: string;
+  work_id: string;
+  advanced_at: Date | string;
+}
+
+export class GovernedValuationModelQualificationRepositoryError extends Error {
+  constructor(
+    readonly code:
+      | 'INTEGRITY_MISMATCH'
+      | 'CONFLICTING_REPLAY'
+      | 'STALE_GATE_LEDGER'
+      | 'STALE_CURRENT_PAIR',
+    message: string,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+    this.name = 'GovernedValuationModelQualificationRepositoryError';
+  }
+}
+
+function currentPair(row: CurrentPairRow): GovernedCurrentValuationModelPair {
+  return {
+    scopeKey: row.scope_key,
+    revision: Number(row.revision),
+    qualificationId: row.qualification_id,
+    playerRunId: row.player_run_id,
+    pickRunId: row.pick_run_id,
+    playerGate3DecisionId: row.player_gate3_decision_id,
+    pickGate3DecisionId: row.pick_gate3_decision_id,
+    workId: row.work_id,
+    advancedAt: (row.advanced_at instanceof Date
+      ? row.advanced_at
+      : new Date(row.advanced_at)
+    ).toISOString(),
+  };
+}
+
+async function loadCurrentFrom(
+  client: AflOutcomeSqlTransaction,
+  scopeKey: string
+): Promise<GovernedCurrentValuationModelPair | null> {
+  const result = await client.query<CurrentPairRow>(
+    `SELECT scope_key,revision,qualification_id,player_run_id,pick_run_id,
+       player_gate3_decision_id,pick_gate3_decision_id,work_id,advanced_at
+       FROM outcome_current_governed_valuation_model_pair WHERE scope_key=$1`,
+    [scopeKey]
+  );
+  if (result.rows.length > 1) {
+    throw new GovernedValuationModelQualificationRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'Current governed model-pair identity is ambiguous.'
+    );
+  }
+  return result.rows[0] ? currentPair(result.rows[0]) : null;
+}
+
+async function loadGateLedger(
+  transaction: AflOutcomeSqlTransaction
+): Promise<{ revision: number; ledger: AflTradeGateDecisionLedger }> {
+  const head = await transaction.query<GateHeadRow>(
+    `SELECT revision FROM outcome_gate_ledger_head WHERE singleton_id=1 FOR UPDATE`
+  );
+  const proposals = await transaction.query<JsonRow>(
+    `SELECT proposal_json AS value FROM outcome_gate_proposal
+     ORDER BY proposed_at,gate,decision_key,version,proposal_id`
+  );
+  const decisions = await transaction.query<JsonRow>(
+    `SELECT decision_json AS value FROM outcome_gate_decision
+     ORDER BY version,gate,decision_key,decision_id`
+  );
+  const ledger = {
+    proposals: proposals.rows.map(({ value }) => aflTradeGateDecisionProposalSchema.parse(value)),
+    decisions: decisions.rows.map(({ value }) => aflTradeGateDecisionRecordSchema.parse(value)),
+  };
+  if (
+    head.rows.length !== 1 ||
+    !validateAflTradeGateDecisionLedger(ledger).valid ||
+    head.rows[0]!.revision !== ledger.decisions.length
+  ) {
+    throw new GovernedValuationModelQualificationRepositoryError(
+      'INTEGRITY_MISMATCH',
+      'Stored Gate ledger failed exact authentication.'
+    );
+  }
+  return { revision: head.rows[0].revision, ledger };
+}
+
+async function insertGateRecord(
+  transaction: AflOutcomeSqlTransaction,
+  record: GovernedValuationModelQualificationGateRecord
+): Promise<void> {
+  const proposal = record.proposal;
+  const decision = record.decision;
+  await transaction.query(
+    `INSERT INTO outcome_gate_proposal
+      (proposal_id,gate,decision_key,version,environment,scope_key,proposed_at,proposal_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb)`,
+    [
+      proposal.proposalId,
+      proposal.content.gate,
+      proposal.content.decisionKey,
+      proposal.content.version,
+      proposal.content.environment,
+      proposal.content.scope.scopeKey,
+      proposal.content.proposedAt,
+      canonicalizeAflTradeJson(proposal),
+    ]
+  );
+  await transaction.query(
+    `INSERT INTO outcome_gate_decision
+      (decision_id,proposal_id,gate,decision_key,version,environment,state,decided_at,
+       effective_at,revalidate_at,supersedes_decision_id,decision_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
+    [
+      decision.decisionId,
+      decision.content.proposalId,
+      decision.content.gate,
+      decision.content.decisionKey,
+      decision.content.version,
+      decision.content.environment,
+      decision.content.state,
+      decision.content.decidedAt,
+      decision.content.effectiveAt,
+      decision.content.revalidateAt,
+      decision.content.supersedesDecisionId,
+      canonicalizeAflTradeJson(decision),
+    ]
+  );
+}
+
+async function retainQualification(
+  transaction: AflOutcomeSqlTransaction,
+  qualification: GovernedValuationModelQualification,
+  artifact: AflTradeArtifactRef
+): Promise<'inserted' | 'replayed'> {
+  const existing = await transaction.query<QualificationRow>(
+    `SELECT qualification_json,artifact_id
+       FROM outcome_governed_valuation_model_qualification WHERE qualification_id=$1`,
+    [qualification.qualificationId]
+  );
+  if (existing.rows[0]) {
+    if (
+      existing.rows.length !== 1 ||
+      existing.rows[0].artifact_id !== artifact.artifactId ||
+      canonicalizeAflTradeJson(existing.rows[0].qualification_json) !==
+        canonicalizeAflTradeJson(qualification)
+    ) {
+      throw new GovernedValuationModelQualificationRepositoryError(
+        'CONFLICTING_REPLAY',
+        'Qualification identity already names different retained evidence.'
+      );
+    }
+    return 'replayed';
+  }
+  const content = qualification.content;
+  await transaction.query(
+    `INSERT INTO outcome_governed_valuation_model_qualification
+      (qualification_id,scope_key,outcome,artifact_id,player_run_id,pick_run_id,
+       policy_artifact_id,player_criteria_artifact_id,pick_criteria_artifact_id,
+       player_evidence_artifact_id,pick_evidence_artifact_id,evaluated_at,content_sha256,
+       content_canonical_json,qualification_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15::jsonb)`,
+    [
+      qualification.qualificationId,
+      content.scopeKey,
+      content.outcome,
+      artifact.artifactId,
+      content.player.runId,
+      content.pick.runId,
+      content.policyArtifact.artifactId,
+      content.player.criteriaArtifact.artifactId,
+      content.pick.criteriaArtifact.artifactId,
+      content.player.validationEvidenceArtifact.artifactId,
+      content.pick.validationEvidenceArtifact.artifactId,
+      content.evaluatedAt,
+      qualification.qualificationId.slice('model-qualification:'.length),
+      canonicalizeAflTradeJson(content),
+      canonicalizeAflTradeJson(qualification),
+    ]
+  );
+  return 'inserted';
+}
+
+async function retainWork(
+  transaction: AflOutcomeSqlTransaction,
+  work: GovernedValuationModelQualificationWork
+): Promise<void> {
+  await transaction.query(
+    `INSERT INTO outcome_governed_model_qualification_work
+      (work_id,scope_key,qualification_id,player_gate3_decision_id,
+       pick_gate3_decision_id,available_at,status,work_json)
+     VALUES ($1,$2,$3,$4,$5,$6,'pending',$7::jsonb)`,
+    [
+      work.workId,
+      work.content.scopeKey,
+      work.content.qualificationId,
+      work.content.playerGate3DecisionId,
+      work.content.pickGate3DecisionId,
+      work.content.availableAt,
+      canonicalizeAflTradeJson(work),
+    ]
+  );
+}
+
+async function authenticateArtifacts(input: {
+  repository: AflTradeImmutableArtifactRepository;
+  maximumBytes: number;
+  qualification: GovernedValuationModelQualification;
+  qualificationArtifact: AflTradeArtifactRef;
+}): Promise<void> {
+  const content = input.qualification.content;
+  const references = [
+    input.qualificationArtifact,
+    content.policyArtifact,
+    content.player.runArtifact,
+    content.player.protocolArtifact,
+    content.player.criteriaArtifact,
+    content.player.validationEvidenceArtifact,
+    content.pick.runArtifact,
+    content.pick.protocolArtifact,
+    content.pick.criteriaArtifact,
+    content.pick.validationEvidenceArtifact,
+  ];
+  for (const reference of references) {
+    const loaded = await input.repository.loadExact(reference, input.maximumBytes);
+    if (
+      loaded === null ||
+      canonicalizeAflTradeJson(loaded.reference) !== canonicalizeAflTradeJson(reference) ||
+      !doesAflTradeArtifactRefMatchBytes(reference, loaded.bytes)
+    ) {
+      throw new GovernedValuationModelQualificationRepositoryError(
+        'INTEGRITY_MISMATCH',
+        `Qualification artifact custody failed for ${reference.artifactId}.`
+      );
+    }
+  }
+}
+
+export type GovernedValuationModelQualificationRegistrationResult =
+  | Readonly<{
+      status: 'failed_retained';
+      qualification: GovernedValuationModelQualification;
+      current: GovernedCurrentValuationModelPair | null;
+      idempotentReplay: boolean;
+    }>
+  | Readonly<{
+      status: 'advanced';
+      qualification: GovernedValuationModelQualification;
+      current: GovernedCurrentValuationModelPair;
+      work: GovernedValuationModelQualificationWork;
+      idempotentReplay: boolean;
+    }>;
+
+export class PostgresGovernedValuationModelQualificationRepository {
+  constructor(
+    private readonly dependencies: {
+      readonly client: AflOutcomeSqlClient;
+      readonly artifactRepository: AflTradeImmutableArtifactRepository;
+      readonly maximumArtifactBytes: number;
+    }
+  ) {
+    if (
+      dependencies.artifactRepository.artifactClass !== 'derived_private' ||
+      !Number.isSafeInteger(dependencies.maximumArtifactBytes) ||
+      dependencies.maximumArtifactBytes <= 0
+    ) {
+      throw new TypeError('Model qualification requires bounded private artifact custody.');
+    }
+  }
+
+  async register(input: {
+    readonly qualification: GovernedValuationModelQualification;
+    readonly qualificationArtifact: AflTradeArtifactRef;
+    readonly expectedGateLedgerRevision: number;
+    readonly expectedCurrentRevision: number;
+    readonly gateRecords?: readonly [
+      GovernedValuationModelQualificationGateRecord,
+      GovernedValuationModelQualificationGateRecord,
+    ];
+  }): Promise<GovernedValuationModelQualificationRegistrationResult> {
+    const qualification = governedValuationModelQualificationSchema.parse(input.qualification);
+    if (
+      !doesAflTradeArtifactRefMatchCanonicalJson(input.qualificationArtifact, qualification) ||
+      input.qualificationArtifact.createdAt !== qualification.content.evaluatedAt
+    ) {
+      throw new GovernedValuationModelQualificationRepositoryError(
+        'INTEGRITY_MISMATCH',
+        'Qualification artifact does not authenticate the exact evaluated record.'
+      );
+    }
+    await authenticateArtifacts({
+      repository: this.dependencies.artifactRepository,
+      maximumBytes: this.dependencies.maximumArtifactBytes,
+      qualification,
+      qualificationArtifact: input.qualificationArtifact,
+    });
+    return this.dependencies.client.transaction(async (transaction) => {
+      const replay =
+        (await retainQualification(transaction, qualification, input.qualificationArtifact)) ===
+        'replayed';
+      const existingCurrent = await loadCurrentFrom(transaction, qualification.content.scopeKey);
+      if (qualification.content.outcome === 'failed') {
+        return {
+          status: 'failed_retained',
+          qualification,
+          current: existingCurrent,
+          idempotentReplay: replay,
+        };
+      }
+      if (!input.gateRecords) {
+        throw new GovernedValuationModelQualificationRepositoryError(
+          'INTEGRITY_MISMATCH',
+          'A passing qualification requires both linked Gate 3 records.'
+        );
+      }
+      if (replay) {
+        if (existingCurrent?.qualificationId !== qualification.qualificationId) {
+          throw new GovernedValuationModelQualificationRepositoryError(
+            'STALE_CURRENT_PAIR',
+            'A retained qualification replay cannot replace a newer current pair.'
+          );
+        }
+        const workResult = await transaction.query<JsonRow>(
+          `SELECT work_json AS value FROM outcome_governed_model_qualification_work
+           WHERE work_id=$1`,
+          [existingCurrent.workId]
+        );
+        const work = governedValuationModelQualificationWorkSchema.parse(workResult.rows[0]?.value);
+        return { status: 'advanced', qualification, current: existingCurrent, work, idempotentReplay: true };
+      }
+      const gate = await loadGateLedger(transaction);
+      if (gate.revision !== input.expectedGateLedgerRevision) {
+        throw new GovernedValuationModelQualificationRepositoryError(
+          'STALE_GATE_LEDGER',
+          'Gate ledger changed before the qualified pair could commit.'
+        );
+      }
+      let candidate = gate.ledger;
+      const expectedRunIds = [
+        qualification.content.player.runId,
+        qualification.content.pick.runId,
+      ] as const;
+      for (const [index, record] of input.gateRecords.entries()) {
+        const decision = record.decision.content;
+        if (
+          decision.authorityKind !== 'automated_validation_record' ||
+          !decision.affectedArtifacts.some(
+            ({ kind, artifactId }) =>
+              kind === 'model_run' && artifactId === expectedRunIds[index]
+          ) ||
+          !decision.affectedArtifacts.some(
+            ({ kind, artifactId }) =>
+              kind === 'model_qualification' && artifactId === qualification.qualificationId
+          )
+        ) {
+          throw new GovernedValuationModelQualificationRepositoryError(
+            'INTEGRITY_MISMATCH',
+            'Gate 3 records do not cite the exact role-specific run and shared qualification.'
+          );
+        }
+        candidate = appendAflTradeGateDecision(candidate, record.proposal, record.decision);
+        await insertGateRecord(transaction, record);
+      }
+      const updatedHead = await transaction.query(
+        `UPDATE outcome_gate_ledger_head SET revision=$1,updated_at=$2
+         WHERE singleton_id=1 AND revision=$3`,
+        [gate.revision + 2, qualification.content.evaluatedAt, gate.revision]
+      );
+      if (updatedHead.rowCount !== 1) {
+        throw new GovernedValuationModelQualificationRepositoryError(
+          'STALE_GATE_LEDGER',
+          'Gate ledger head changed before the qualified pair could commit.'
+        );
+      }
+      const work = createGovernedValuationModelQualificationWork({
+        qualification,
+        playerGate3DecisionId: input.gateRecords[0].decision.decisionId,
+        pickGate3DecisionId: input.gateRecords[1].decision.decisionId,
+        availableAt: qualification.content.evaluatedAt,
+      });
+      await retainWork(transaction, work);
+      let revisionResult;
+      try {
+        revisionResult = await transaction.query<{ revision: number }>(
+          `SELECT advance_outcome_current_governed_valuation_model_pair(
+             $1,$2,$3,$4,$5,$6,$7) AS revision`,
+          [
+            qualification.content.scopeKey,
+            qualification.qualificationId,
+            input.gateRecords[0].decision.decisionId,
+            input.gateRecords[1].decision.decisionId,
+            work.workId,
+            input.expectedCurrentRevision,
+            qualification.content.evaluatedAt,
+          ]
+        );
+      } catch (cause) {
+        throw new GovernedValuationModelQualificationRepositoryError(
+          'STALE_CURRENT_PAIR',
+          'Current model pair changed before the qualification could advance.',
+          { cause }
+        );
+      }
+      const current = await loadCurrentFrom(transaction, qualification.content.scopeKey);
+      if (
+        !current ||
+        current.revision !== Number(revisionResult.rows[0]?.revision) ||
+        current.qualificationId !== qualification.qualificationId
+      ) {
+        throw new GovernedValuationModelQualificationRepositoryError(
+          'INTEGRITY_MISMATCH',
+          'Advanced current model pair failed exact readback.'
+        );
+      }
+      return { status: 'advanced', qualification, current, work, idempotentReplay: false };
+    });
+  }
+
+  loadCurrent(scopeKey: string): Promise<GovernedCurrentValuationModelPair | null> {
+    return loadCurrentFrom(this.dependencies.client, scopeKey);
+  }
+}

--- a/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
+++ b/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
@@ -1,0 +1,299 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { createAflTradeFixtureArtifactRepository } from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import {
+  createGovernedValuationModelQualification,
+  createGovernedValuationModelQualificationGateRecords,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification';
+import { createGovernedValuationComponentRunManifest } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest';
+import { PostgresGovernedValuationComponentRunRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationComponentRunRepository';
+import {
+  GovernedValuationModelQualificationRepositoryError,
+  PostgresGovernedValuationModelQualificationRepository,
+} from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository';
+
+import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('A disposable AFL_OUTCOMES_TEST_DATABASE_URL is required.');
+  })();
+const schemaName = `afl_governed_model_qualification_${process.pid}_${Date.now()}`;
+const adminPool = new Pool({ connectionString: databaseUrl });
+const pool = new Pool({
+  connectionString: databaseUrl,
+  options: `-c search_path=${schemaName}`,
+});
+const artifacts = createAflTradeFixtureArtifactRepository({ artifactClass: 'derived_private' });
+const retainedAt = '2026-08-21T08:00:00.000Z';
+const evaluatedAt = '2026-08-21T09:00:00.000Z';
+
+function scopedDatabaseUrl(targetSchema: string) {
+  const scoped = new URL(databaseUrl);
+  scoped.searchParams.set('schema', targetSchema);
+  return scoped.toString();
+}
+
+async function retain(document: unknown, createdAt = retainedAt) {
+  const reference = createAflTradeCanonicalJsonArtifactRef(document, createdAt);
+  const bytes = new TextEncoder().encode(canonicalizeAflTradeJson(document));
+  await artifacts.putIfAbsent(reference, bytes);
+  await pool.query(
+    `INSERT INTO outcome_artifact_custody
+      (artifact_id,content_sha256,storage_uri,media_type,byte_length,artifact_class,
+       environment,custody_profile_id,created_at,verified_at,custody_json)
+     VALUES ($1,$2,$3,$4,$5,'derived_private','non_production',NULL,$6,$6,$7::jsonb)
+     ON CONFLICT (artifact_id) DO NOTHING`,
+    [
+      reference.artifactId,
+      reference.contentSha256,
+      reference.storageUri,
+      reference.mediaType,
+      reference.byteLength,
+      reference.createdAt,
+      canonicalizeAflTradeJson({ assurance: 'disposable_model_qualification_test' }),
+    ]
+  );
+  return reference;
+}
+
+beforeAll(async () => {
+  await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
+  runOutcomesPrismaTestCommand(['migrate', 'deploy'], {
+    databaseUrl: scopedDatabaseUrl(schemaName),
+  });
+});
+
+afterAll(async () => {
+  await pool.end();
+  await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  await adminPool.end();
+});
+
+async function componentRuns() {
+  const repository = new PostgresGovernedValuationComponentRunRepository({
+    client: createPgAflOutcomeSqlClient(pool),
+    artifactRepository: artifacts,
+    maximumArtifactBytes: 1024 * 1024,
+  });
+  const common = async (label: string) => ({
+    environment: 'non_production' as const,
+    protocolId: `model-protocol:${label.repeat(64)}`,
+    protocolArtifact: await retain({ kind: 'protocol', label }),
+    datasetId: `dataset:${label.repeat(64)}`,
+    datasetArtifact: await retain({ kind: 'dataset', label }),
+    datasetAdmissionId: `dataset-admission:${label.repeat(64)}`,
+    datasetAdmissionArtifact: await retain({ kind: 'admission', label }),
+    datasetAdmissionGateLedgerRevision: 1,
+    registeredAt: retainedAt,
+  });
+  const player = createGovernedValuationComponentRunManifest({
+    ...(await common('a')),
+    role: 'player_contribution_and_availability',
+    nativeExecution: {
+      kind: 'admitted_player_model_run',
+      executionId: `model-run:${'c'.repeat(64)}`,
+      artifact: await retain({ kind: 'native-player-run' }),
+    },
+  });
+  const pick = createGovernedValuationComponentRunManifest({
+    ...(await common('b')),
+    role: 'draft_pick_and_future_pick_distribution',
+    nativeExecution: {
+      kind: 'governed_pick_pav_model_execution',
+      executionId: `pick-pav-model-execution:${'d'.repeat(64)}`,
+      artifact: await retain({ kind: 'native-pick-run' }),
+    },
+  });
+  const playerArtifact = await retain(player);
+  const pickArtifact = await retain(pick);
+  await repository.register({ manifest: player, artifact: playerArtifact });
+  await repository.register({ manifest: pick, artifact: pickArtifact });
+  return { player, playerArtifact, pick, pickArtifact };
+}
+
+async function qualificationFixture(
+  runs: Awaited<ReturnType<typeof componentRuns>>,
+  suffix: string,
+  passing: boolean
+) {
+  const policy = {
+    schemaVersion: 'governed-valuation-model-qualification-policy/v1' as const,
+    policyVersion: `afl-men-private-model-pair-${suffix}`,
+    player: {
+      schemaVersion: 'governed-player-model-qualification-criteria/v1' as const,
+      minimumComparableObservations: 100,
+      minimumRelativeMaeImprovement: 0.05,
+      minimumRelativeRmseImprovement: 0.05,
+      requiredAcceptanceOutcome: 'meets_declared_predictive_thresholds' as const,
+    },
+    pick: {
+      schemaVersion: 'governed-pick-model-qualification-criteria/v1' as const,
+      evaluatedScope: 'final_test' as const,
+      minimumObservations: 30,
+      maximumMulticlassBrierScore: 0.7,
+      maximumMulticlassLogLoss: 2,
+      maximumRankedProbabilityScore: 0.35,
+      maximumContributionCrps: 25,
+      maximumMeanAbsoluteContributionError: 30,
+      maximumRootMeanSquaredContributionError: 40,
+      maximumMeanAbsoluteGamesError: 35,
+      maximumRootMeanSquaredGamesError: 45,
+      minimumEmpiricalP10P90Coverage: 0.7,
+      maximumEmpiricalP10P90Coverage: 0.9,
+      maximumMeanEmpiricalIntervalWidth: 80,
+      maximumZeroProbabilityObservationCount: 0,
+    },
+  };
+  const playerEvidence = {
+    schemaVersion: 'governed-player-model-qualification-evidence/v1' as const,
+    validationReportId: `player-validation-report:${'e'.repeat(64)}`,
+    comparableObservationCount: 120,
+    acceptanceOutcome: 'meets_declared_predictive_thresholds' as const,
+    relativeMaeImprovement: passing ? 0.08 : 0.01,
+    relativeRmseImprovement: 0.07,
+  };
+  const pickEvidence = {
+    schemaVersion: 'governed-pick-model-qualification-evidence/v1' as const,
+    validationReportId: `pick-pav-validation-report:${'f'.repeat(64)}`,
+    evaluationStatus: 'scored_not_approved' as const,
+    scope: 'final_test' as const,
+    observationCount: 40,
+    metrics: {
+      multiclassBrierScore: 0.4,
+      multiclassLogLoss: 1.2,
+      rankedProbabilityScore: 0.2,
+      contributionCrps: 18,
+      meanAbsoluteContributionError: 22,
+      rootMeanSquaredContributionError: 31,
+      meanAbsoluteGamesError: 24,
+      rootMeanSquaredGamesError: 34,
+      empiricalP10P90Coverage: 0.8,
+      meanEmpiricalIntervalWidth: 60,
+      zeroProbabilityObservationCount: 0,
+    },
+  };
+  const qualification = createGovernedValuationModelQualification({
+    environment: 'non_production',
+    scopeKey: 'afl-men:2026-trades',
+    evaluatedAt,
+    policy,
+    policyArtifact: await retain(policy, evaluatedAt),
+    components: {
+      player: {
+        role: runs.player.content.role,
+        runId: runs.player.runId,
+        runArtifact: runs.playerArtifact,
+        protocolId: runs.player.content.protocolId,
+        protocolArtifact: runs.player.content.protocolArtifact,
+        criteriaArtifact: await retain(policy.player, evaluatedAt),
+        validationEvidence: playerEvidence,
+        validationEvidenceArtifact: await retain(playerEvidence, evaluatedAt),
+      },
+      pick: {
+        role: runs.pick.content.role,
+        runId: runs.pick.runId,
+        runArtifact: runs.pickArtifact,
+        protocolId: runs.pick.content.protocolId,
+        protocolArtifact: runs.pick.content.protocolArtifact,
+        criteriaArtifact: await retain(policy.pick, evaluatedAt),
+        validationEvidence: pickEvidence,
+        validationEvidenceArtifact: await retain(pickEvidence, evaluatedAt),
+      },
+    },
+  });
+  const qualificationArtifact = await retain(qualification, evaluatedAt);
+  return { qualification, qualificationArtifact };
+}
+
+describe('governed model qualification PostgreSQL registry', () => {
+  it('advances one passing pair atomically, replays it, and isolates failed or stale candidates', async () => {
+    const runs = await componentRuns();
+    const repository = new PostgresGovernedValuationModelQualificationRepository({
+      client: createPgAflOutcomeSqlClient(pool),
+      artifactRepository: artifacts,
+      maximumArtifactBytes: 1024 * 1024,
+    });
+    const passing = await qualificationFixture(runs, 'v1', true);
+    const gates = createGovernedValuationModelQualificationGateRecords({
+      ...passing,
+      decidedAt: evaluatedAt,
+      automationPrincipal: 'statly-model-qualification-agent',
+      accountableOwner: 'statly-model-owner',
+      versions: { player: 1, pick: 1 },
+      supersedes: { player: null, pick: null },
+    });
+
+    const advanced = await repository.register({
+      ...passing,
+      expectedGateLedgerRevision: 0,
+      expectedCurrentRevision: 0,
+      gateRecords: gates,
+    });
+    expect(advanced).toMatchObject({
+      status: 'advanced',
+      idempotentReplay: false,
+      current: { revision: 1, qualificationId: passing.qualification.qualificationId },
+      work: { content: { status: 'pending', cause: 'current_qualified_model_pair_advanced' } },
+    });
+    await expect(
+      repository.register({
+        ...passing,
+        expectedGateLedgerRevision: 0,
+        expectedCurrentRevision: 0,
+        gateRecords: gates,
+      })
+    ).resolves.toMatchObject({ status: 'advanced', idempotentReplay: true });
+
+    const failed = await qualificationFixture(runs, 'failed', false);
+    await expect(
+      repository.register({
+        ...failed,
+        expectedGateLedgerRevision: 2,
+        expectedCurrentRevision: 1,
+      })
+    ).resolves.toMatchObject({
+      status: 'failed_retained',
+      current: { qualificationId: passing.qualification.qualificationId, revision: 1 },
+    });
+
+    const stale = await qualificationFixture(runs, 'v2', true);
+    const staleGates = createGovernedValuationModelQualificationGateRecords({
+      ...stale,
+      decidedAt: evaluatedAt,
+      automationPrincipal: 'statly-model-qualification-agent',
+      accountableOwner: 'statly-model-owner',
+      versions: { player: 2, pick: 2 },
+      supersedes: {
+        player: gates[0].decision.decisionId,
+        pick: gates[1].decision.decisionId,
+      },
+    });
+    await expect(
+      repository.register({
+        ...stale,
+        expectedGateLedgerRevision: 2,
+        expectedCurrentRevision: 0,
+        gateRecords: staleGates,
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<GovernedValuationModelQualificationRepositoryError>>({
+        code: 'STALE_CURRENT_PAIR',
+      })
+    );
+    expect(await repository.loadCurrent('afl-men:2026-trades')).toMatchObject({
+      revision: 1,
+      qualificationId: passing.qualification.qualificationId,
+    });
+    const rolledBack = await pool.query(
+      `SELECT 1 FROM outcome_governed_valuation_model_qualification WHERE qualification_id=$1`,
+      [stale.qualification.qualificationId]
+    );
+    expect(rolledBack.rowCount).toBe(0);
+  }, 120_000);
+});

--- a/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
+++ b/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
@@ -281,6 +281,51 @@ describe('governed model qualification PostgreSQL registry', () => {
     await expect(
       insertQualificationDirectly(forgedQualification, forgedArtifact.artifactId)
     ).rejects.toThrow(/ancestry|mismatch/i);
+    const {
+      multiclassBrierScore: _omittedBrierScore,
+      ...incompletePickMetrics
+    } = passing.qualification.content.pick.validationEvidence.metrics!;
+    const incompletePickEvidence = {
+      ...passing.qualification.content.pick.validationEvidence,
+      metrics: incompletePickMetrics,
+    };
+    const incompletePickContent = {
+      ...passing.qualification.content,
+      pick: {
+        ...passing.qualification.content.pick,
+        validationEvidence: incompletePickEvidence,
+        validationEvidenceArtifact: await retain(incompletePickEvidence, evaluatedAt),
+      },
+    };
+    const incompletePickQualification = {
+      qualificationId: createAflTradeContentAddress(
+        'model-qualification',
+        incompletePickContent
+      ),
+      content: incompletePickContent,
+    } as unknown as typeof passing.qualification;
+    const incompletePickArtifact = await retain(incompletePickQualification, evaluatedAt);
+    await expect(
+      insertQualificationDirectly(
+        incompletePickQualification,
+        incompletePickArtifact.artifactId
+      )
+    ).rejects.toThrow(/ancestry|mismatch/i);
+    const wrongRoleContent = {
+      ...passing.qualification.content,
+      pick: {
+        ...passing.qualification.content.pick,
+        role: 'player_contribution_and_availability',
+      },
+    };
+    const wrongRoleQualification = {
+      qualificationId: createAflTradeContentAddress('model-qualification', wrongRoleContent),
+      content: wrongRoleContent,
+    } as unknown as typeof passing.qualification;
+    const wrongRoleArtifact = await retain(wrongRoleQualification, evaluatedAt);
+    await expect(
+      insertQualificationDirectly(wrongRoleQualification, wrongRoleArtifact.artifactId)
+    ).rejects.toThrow(/contract|mismatch/i);
     const conflictingPolicy = {
       ...passing.qualification.content.policy,
       player: {
@@ -322,6 +367,50 @@ describe('governed model qualification PostgreSQL registry', () => {
       versions: { player: 1, pick: 1 },
       supersedes: { player: null, pick: null },
     });
+    const bypassClient = await pool.connect();
+    try {
+      await bypassClient.query('BEGIN');
+      await bypassClient.query(
+        `INSERT INTO outcome_gate_proposal
+          (proposal_id,gate,decision_key,version,environment,scope_key,proposed_at,proposal_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb)`,
+        [
+          gates[0].proposal.proposalId,
+          gates[0].proposal.content.gate,
+          gates[0].proposal.content.decisionKey,
+          gates[0].proposal.content.version,
+          gates[0].proposal.content.environment,
+          gates[0].proposal.content.scope.scopeKey,
+          gates[0].proposal.content.proposedAt,
+          canonicalizeAflTradeJson(gates[0].proposal),
+        ]
+      );
+      await expect(
+        bypassClient.query(
+          `INSERT INTO outcome_gate_decision
+            (decision_id,proposal_id,gate,decision_key,version,environment,state,decided_at,
+             effective_at,revalidate_at,supersedes_decision_id,decision_json)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
+          [
+            gates[0].decision.decisionId,
+            gates[0].decision.content.proposalId,
+            gates[0].decision.content.gate,
+            gates[0].decision.content.decisionKey,
+            gates[0].decision.content.version,
+            gates[0].decision.content.environment,
+            gates[0].decision.content.state,
+            gates[0].decision.content.decidedAt,
+            gates[0].decision.content.effectiveAt,
+            gates[0].decision.content.revalidateAt,
+            gates[0].decision.content.supersedesDecisionId,
+            canonicalizeAflTradeJson(gates[0].decision),
+          ]
+        )
+      ).rejects.toThrow(/qualification|no rows/i);
+    } finally {
+      await bypassClient.query('ROLLBACK');
+      bypassClient.release();
+    }
 
     const advanced = await repository.register({
       ...passing,

--- a/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
+++ b/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
@@ -1,7 +1,8 @@
-import { Pool } from 'pg';
+import { Pool, type PoolClient } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { aflTradeModelRunManifestV3Schema } from '@/server/aflTradeIntelligence/artifacts/modelRunManifest';
 import {
   canonicalizeAflTradeJson,
   createAflTradeContentAddress,
@@ -12,8 +13,12 @@ import {
   createGovernedValuationModelQualification,
   createGovernedValuationModelQualificationGateRecords,
   createGovernedValuationModelQualificationPolicy,
+  deriveGovernedPickModelQualificationEvidence,
+  deriveGovernedPlayerModelQualificationEvidence,
 } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification';
+import { aflTradePlayerValidationReportSchema } from '@/server/aflTradeIntelligence/modeling/playerContributionValidation';
 import { createGovernedValuationComponentRunManifest } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest';
+import { loadGovernedNativeComponentValidationReport } from '@/server/aflTradeIntelligence/valuation/internal/governedNativeComponentExecution';
 import { PostgresGovernedValuationComponentRunRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationComponentRunRepository';
 import {
   GovernedValuationModelQualificationRepositoryError,
@@ -21,6 +26,7 @@ import {
 } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository';
 
 import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+import { createGovernedPickPavModelExecutionFixture } from '../testUtils/governedPickPavModelExecutionFixture';
 
 const databaseUrl =
   process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
@@ -113,40 +119,233 @@ async function componentRuns() {
     artifactRepository: artifacts,
     maximumArtifactBytes: 1024 * 1024,
   });
-  const common = async (label: string) => ({
-    environment: 'non_production' as const,
-    protocolId: `model-protocol:${label.repeat(64)}`,
-    protocolArtifact: await retain({ kind: 'protocol', label }),
-    datasetId: `dataset:${label.repeat(64)}`,
-    datasetArtifact: await retain({ kind: 'dataset', label }),
-    datasetAdmissionId: `dataset-admission:${label.repeat(64)}`,
-    datasetAdmissionArtifact: await retain({ kind: 'admission', label }),
-    datasetAdmissionGateLedgerRevision: 1,
-    registeredAt: retainedAt,
+  const playerDatasetId = createAflTradeContentAddress('dataset', 'player-dataset');
+  const playerDatasetAdmissionId = createAflTradeContentAddress(
+    'dataset-admission',
+    'player-dataset-admission'
+  );
+  const playerProtocolId = createAflTradeContentAddress('model-protocol', 'player-protocol');
+  const playerValidationContent = {
+    schemaVersion: 'afl-trade-player-validation-report/v1' as const,
+    publicIdentityBoundary: 'source_native_no_fantasy_ownership' as const,
+    observationSetId: createAflTradeContentAddress('player-observation-set', 'player-observations'),
+    baselineFitId: createAflTradeContentAddress('player-baseline-fit', 'player-baseline'),
+    predictionSetId: createAflTradeContentAddress('player-prediction-set', 'player-predictions'),
+    valueUnitId: 'player-contribution-above-replacement',
+    evaluatedPartition: 'final_test' as const,
+    candidateModelId: 'player-contribution-v1',
+    config: {
+      schemaVersion: 'afl-trade-player-validation-config/v1' as const,
+      minimumComparableObservations: 100,
+      acceptanceRule: 'candidate_improves_both_mae_and_rmse' as const,
+      minimumRelativeMaeImprovement: 0.05,
+      minimumRelativeRmseImprovement: 0.05,
+      incompletePredictionCoverage: 'fail_closed' as const,
+      governanceEffect: 'evidence_only_no_gate_or_source_approval' as const,
+    },
+    comparableObservationIds: Array.from(
+      { length: 120 },
+      (_, index) => `player-observation-${index + 1}`
+    ),
+    excludedObservations: [],
+    metrics: {
+      candidate: { meanAbsoluteError: 9.2, rootMeanSquaredError: 9.3, meanError: 0 },
+      gamesOnly: { meanAbsoluteError: 10, rootMeanSquaredError: 10, meanError: 0 },
+      candidateMinusGamesOnly: { meanAbsoluteError: -0.8, rootMeanSquaredError: -0.7 },
+      relativeImprovement: { meanAbsoluteError: 0.08, rootMeanSquaredError: 0.07 },
+    },
+    acceptanceOutcome: 'meets_declared_predictive_thresholds' as const,
+    evidenceLimitation:
+      'report_is_reproducible_evidence_not_source_approval_gate_approval_or_production_readiness' as const,
+  };
+  const playerValidationReport = aflTradePlayerValidationReportSchema.parse({
+    validationReportId: createAflTradeContentAddress(
+      'player-validation-report',
+      playerValidationContent
+    ),
+    content: playerValidationContent,
   });
+  const playerValidationReportArtifact = await retain(
+    playerValidationReport,
+    '2026-08-21T07:45:00.000Z'
+  );
+  const playerRunContent = {
+    schemaVersion: 'afl-trade-model-run/v3' as const,
+    environment: 'non_production' as const,
+    modelId: 'player-contribution-v1',
+    modelVersion: '1.0.0',
+    datasetId: playerDatasetId,
+    datasetAdmissionId: playerDatasetAdmissionId,
+    modelProtocolId: playerProtocolId,
+    runIntentId: createAflTradeContentAddress('model-run-intent', 'player-intent'),
+    runAuthorizationId: createAflTradeContentAddress(
+      'model-run-authorization',
+      'player-authorization'
+    ),
+    observationSetId: playerValidationContent.observationSetId,
+    modelTrainingEvaluationReceiptIds: [
+      createAflTradeContentAddress('gate0a-evaluation', 'player-evaluation'),
+    ],
+    codeCommitSha: 'a'.repeat(40),
+    cleanWorktree: true as const,
+    seed: 1,
+    job: {
+      jobId: 'player-model-job',
+      attempt: 1,
+      initiatedBy: 'statly-model-qualification-agent',
+      workerIdentity: 'statly-model-worker',
+    },
+    startedAt: '2026-08-21T07:00:00.000Z',
+    candidateLockedAt: '2026-08-21T07:30:00.000Z',
+    finalTestEvaluatedAt: '2026-08-21T07:40:00.000Z',
+    finishedAt: '2026-08-21T07:50:00.000Z',
+    windows: {
+      train: { from: '2010-01-01T00:00:00.000Z', to: '2014-01-01T00:00:00.000Z' },
+      calibration: { from: '2014-01-01T00:00:00.000Z', to: '2018-01-01T00:00:00.000Z' },
+      validation: { from: '2018-01-01T00:00:00.000Z', to: '2022-01-01T00:00:00.000Z' },
+      finalTest: { from: '2022-01-01T00:00:00.000Z', to: '2026-01-01T00:00:00.000Z' },
+      embargoDays: 0,
+    },
+    sourceCodeArtifact: await retain({ kind: 'player-source-code' }),
+    dependencyLockArtifact: await retain({ kind: 'player-dependency-lock' }),
+    runtimeArtifact: await retain({ kind: 'player-runtime' }),
+    containerArtifact: await retain({ kind: 'player-container' }),
+    configurationArtifact: await retain({ kind: 'player-configuration' }),
+    environmentArtifact: await retain({ kind: 'player-environment' }),
+    featureDefinitionArtifacts: [await retain({ kind: 'player-features' })],
+    outcome: {
+      status: 'succeeded' as const,
+      modelArtifact: await retain({ kind: 'player-model' }),
+      validationReportArtifact: playerValidationReportArtifact,
+      baselineComparisonArtifact: await retain({ kind: 'player-baseline-comparison' }),
+      calibrationReportArtifact: await retain({ kind: 'player-calibration-report' }),
+      intervalCoverageArtifact: await retain({ kind: 'player-interval-coverage' }),
+      subgroupReportArtifact: await retain({ kind: 'player-subgroup-report' }),
+      sensitivityReportArtifact: await retain({ kind: 'player-sensitivity-report' }),
+      leakageAuditArtifact: await retain({ kind: 'player-leakage-audit' }),
+      modelCardArtifact: await retain({ kind: 'player-model-card' }),
+      diagnosticsArtifact: await retain({ kind: 'player-diagnostics' }),
+    },
+  };
+  const playerNativeExecution = aflTradeModelRunManifestV3Schema.parse({
+    runId: createAflTradeContentAddress('model-run', playerRunContent),
+    content: playerRunContent,
+  });
+  const playerNativeExecutionArtifact = await retain(playerNativeExecution);
+  const pickFixture = createGovernedPickPavModelExecutionFixture();
+  const pickExecution = pickFixture.execution;
+  const pickNativeExecutionArtifact = await retain(pickExecution);
+  const pickAuthorityArtifacts = [
+    pickExecution.content.datasetArtifact,
+    pickExecution.content.datasetAdmissionArtifact,
+    pickExecution.content.protocolArtifact,
+  ] as const;
+  for (const [index, document] of pickFixture.authorityDocuments.entries()) {
+    const reference = pickAuthorityArtifacts[index];
+    if (reference === undefined) throw new Error('Pick fixture authority is incomplete.');
+    await retain(document, reference.createdAt);
+  }
+  const seed = await pool.connect();
+  await seed.query('BEGIN');
+  try {
+    await seed.query(`SET LOCAL session_replication_role='replica'`);
+    await seed.query(
+      `INSERT INTO outcome_valuation_model_run
+        (run_id,intent_id,authorization_id,status,started_at,finished_at,
+         run_canonical_json,run_json)
+       VALUES ($1,$2,$3,'succeeded',$4,$5,$6,$7::jsonb)`,
+      [
+        playerNativeExecution.runId,
+        playerRunContent.runIntentId,
+        playerRunContent.runAuthorizationId,
+        playerRunContent.startedAt,
+        playerRunContent.finishedAt,
+        canonicalizeAflTradeJson(playerRunContent),
+        canonicalizeAflTradeJson(playerNativeExecution),
+      ]
+    );
+    const pickContent = pickExecution.content;
+    await seed.query(
+      `INSERT INTO outcome_governed_pick_pav_model_execution
+        (execution_id,observation_set_id,dataset_id,dataset_artifact_id,
+         dataset_admission_id,dataset_admission_artifact_id,
+         dataset_admission_gate_ledger_revision,protocol_id,protocol_artifact_id,
+         execution_artifact_id,final_test_evaluation_started_at,completed_at,
+         content_sha256,content_canonical_json,execution_json)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15::jsonb)`,
+      [
+        pickExecution.executionId,
+        pickContent.observationSetId,
+        pickContent.datasetId,
+        pickContent.datasetArtifact.artifactId,
+        pickContent.datasetAdmissionId,
+        pickContent.datasetAdmissionArtifact.artifactId,
+        pickContent.datasetAdmissionGateLedgerRevision,
+        pickContent.protocolId,
+        pickContent.protocolArtifact.artifactId,
+        pickNativeExecutionArtifact.artifactId,
+        pickContent.finalTestEvaluationStartedAt,
+        pickContent.completedAt,
+        pickExecution.executionId.slice('pick-pav-model-execution:'.length),
+        canonicalizeAflTradeJson(pickContent),
+        canonicalizeAflTradeJson(pickExecution),
+      ]
+    );
+    await seed.query('COMMIT');
+  } catch (error) {
+    await seed.query('ROLLBACK');
+    throw error;
+  } finally {
+    seed.release();
+  }
   const player = createGovernedValuationComponentRunManifest({
-    ...(await common('a')),
+    environment: 'non_production',
     role: 'player_contribution_and_availability',
     nativeExecution: {
       kind: 'admitted_player_model_run',
-      executionId: `model-run:${'c'.repeat(64)}`,
-      artifact: await retain({ kind: 'native-player-run' }),
+      executionId: playerNativeExecution.runId,
+      artifact: playerNativeExecutionArtifact,
     },
+    protocolId: playerProtocolId,
+    protocolArtifact: await retain({ kind: 'player-protocol' }),
+    datasetId: playerDatasetId,
+    datasetArtifact: await retain({ kind: 'player-dataset' }),
+    datasetAdmissionId: playerDatasetAdmissionId,
+    datasetAdmissionArtifact: await retain({ kind: 'player-dataset-admission' }),
+    datasetAdmissionGateLedgerRevision: 1,
+    registeredAt: retainedAt,
   });
   const pick = createGovernedValuationComponentRunManifest({
-    ...(await common('b')),
+    environment: 'non_production',
     role: 'draft_pick_and_future_pick_distribution',
     nativeExecution: {
       kind: 'governed_pick_pav_model_execution',
-      executionId: `pick-pav-model-execution:${'d'.repeat(64)}`,
-      artifact: await retain({ kind: 'native-pick-run' }),
+      executionId: pickExecution.executionId,
+      artifact: pickNativeExecutionArtifact,
     },
+    protocolId: pickExecution.content.protocolId,
+    protocolArtifact: pickExecution.content.protocolArtifact,
+    datasetId: pickExecution.content.datasetId,
+    datasetArtifact: pickExecution.content.datasetArtifact,
+    datasetAdmissionId: pickExecution.content.datasetAdmissionId,
+    datasetAdmissionArtifact: pickExecution.content.datasetAdmissionArtifact,
+    datasetAdmissionGateLedgerRevision: pickExecution.content.datasetAdmissionGateLedgerRevision,
+    registeredAt: retainedAt,
   });
   const playerArtifact = await retain(player);
   const pickArtifact = await retain(pick);
   await repository.register({ manifest: player, artifact: playerArtifact });
   await repository.register({ manifest: pick, artifact: pickArtifact });
-  return { player, playerArtifact, pick, pickArtifact };
+  return {
+    player,
+    playerArtifact,
+    playerNativeExecution,
+    playerValidationReport,
+    pick,
+    pickArtifact,
+    pickNativeExecution: pickExecution,
+    pickValidationReport: pickExecution.content.validationReport,
+  };
 }
 
 async function qualificationFixture(
@@ -157,15 +356,15 @@ async function qualificationFixture(
   const policy = createGovernedValuationModelQualificationPolicy({
     player: {
       schemaVersion: 'governed-player-model-qualification-criteria/v1' as const,
-      minimumComparableObservations: 100,
-      minimumRelativeMaeImprovement: 0.05,
+      minimumComparableObservations: suffix === 'premature' ? 99 : 100,
+      minimumRelativeMaeImprovement: suffix === 'v2' ? 0.04 : passing ? 0.05 : 0.1,
       minimumRelativeRmseImprovement: 0.05,
       requiredAcceptanceOutcome: 'meets_declared_predictive_thresholds' as const,
     },
     pick: {
       schemaVersion: 'governed-pick-model-qualification-criteria/v1' as const,
       evaluatedScope: 'final_test' as const,
-      minimumObservations: 30,
+      minimumObservations: 1,
       maximumMulticlassBrierScore: 0.7,
       maximumMulticlassLogLoss: 2,
       maximumRankedProbabilityScore: 0.35,
@@ -175,45 +374,15 @@ async function qualificationFixture(
       maximumMeanAbsoluteGamesError: 35,
       maximumRootMeanSquaredGamesError: 45,
       minimumEmpiricalP10P90Coverage: 0.7,
-      maximumEmpiricalP10P90Coverage: 0.9,
+      maximumEmpiricalP10P90Coverage: 1,
       maximumMeanEmpiricalIntervalWidth: 80,
       maximumZeroProbabilityObservationCount: 0,
     },
   });
-  const playerEvidence = {
-    schemaVersion: 'governed-player-model-qualification-evidence/v1' as const,
-    validationReportId: createAflTradeContentAddress(
-      'player-validation-report',
-      `player-${suffix}`
-    ),
-    comparableObservationCount: 120,
-    acceptanceOutcome: 'meets_declared_predictive_thresholds' as const,
-    relativeMaeImprovement: passing ? 0.08 : 0.01,
-    relativeRmseImprovement: 0.07,
-  };
-  const pickEvidence = {
-    schemaVersion: 'governed-pick-model-qualification-evidence/v1' as const,
-    validationReportId: createAflTradeContentAddress(
-      'pick-pav-validation-report',
-      `pick-${suffix}`
-    ),
-    evaluationStatus: 'scored_not_approved' as const,
-    scope: 'final_test' as const,
-    observationCount: 40,
-    metrics: {
-      multiclassBrierScore: 0.4,
-      multiclassLogLoss: 1.2,
-      rankedProbabilityScore: 0.2,
-      contributionCrps: 18,
-      meanAbsoluteContributionError: 22,
-      rootMeanSquaredContributionError: 31,
-      meanAbsoluteGamesError: 24,
-      rootMeanSquaredGamesError: 34,
-      empiricalP10P90Coverage: 0.8,
-      meanEmpiricalIntervalWidth: 60,
-      zeroProbabilityObservationCount: 0,
-    },
-  };
+  const playerEvidence = deriveGovernedPlayerModelQualificationEvidence(
+    runs.playerValidationReport
+  );
+  const pickEvidence = deriveGovernedPickModelQualificationEvidence(runs.pickValidationReport);
   const qualification = createGovernedValuationModelQualification({
     environment: 'non_production',
     scopeKey: 'afl-men:2026-trades',
@@ -249,10 +418,11 @@ async function qualificationFixture(
 
 async function insertQualificationDirectly(
   qualification: Awaited<ReturnType<typeof qualificationFixture>>['qualification'],
-  artifactId: string
+  artifactId: string,
+  client: Pool | PoolClient = pool
 ) {
   const content = qualification.content;
-  return pool.query(
+  return client.query(
     `INSERT INTO outcome_governed_valuation_model_qualification
       (qualification_id,scope_key,outcome,artifact_id,player_run_id,pick_run_id,
        policy_artifact_id,player_criteria_artifact_id,pick_criteria_artifact_id,
@@ -279,6 +449,86 @@ async function insertQualificationDirectly(
   );
 }
 
+async function insertComponentDirectly(
+  manifest: ReturnType<typeof createGovernedValuationComponentRunManifest>,
+  artifactId: string
+) {
+  const content = manifest.content;
+  await pool.query(
+    `INSERT INTO outcome_governed_valuation_component_run
+      (run_id,role,native_execution_kind,native_execution_id,artifact_id,
+       native_execution_artifact_id,protocol_id,protocol_artifact_id,dataset_id,
+       dataset_artifact_id,dataset_admission_id,dataset_admission_artifact_id,
+       dataset_admission_gate_ledger_revision,registered_at,content_sha256,
+       content_canonical_json,manifest_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17::jsonb)`,
+    [
+      manifest.runId,
+      content.role,
+      content.nativeExecution.kind,
+      content.nativeExecution.executionId,
+      artifactId,
+      content.nativeExecution.artifact.artifactId,
+      content.protocolId,
+      content.protocolArtifact.artifactId,
+      content.datasetId,
+      content.datasetArtifact.artifactId,
+      content.datasetAdmissionId,
+      content.datasetAdmissionArtifact.artifactId,
+      content.datasetAdmissionGateLedgerRevision,
+      content.registeredAt,
+      manifest.runId.slice('model-run:'.length),
+      canonicalizeAflTradeJson(content),
+      canonicalizeAflTradeJson(manifest),
+    ]
+  );
+}
+
+async function insertPlayerNativeEvidenceDirectly(input: {
+  runId: string;
+  nativeExecutionArtifactId: string;
+  execution: unknown;
+  validationReport: Awaited<ReturnType<typeof componentRuns>>['playerValidationReport'];
+  validationReportArtifactId: string;
+}) {
+  return pool.query(
+    `INSERT INTO outcome_governed_component_validation_evidence
+      (run_id,role,native_execution_artifact_id,validation_report_id,
+       validation_report_artifact_id,native_execution_json,validation_report_json,recorded_at)
+     VALUES ($1,'player_contribution_and_availability',$2,$3,$4,$5::jsonb,$6::jsonb,$7)`,
+    [
+      input.runId,
+      input.nativeExecutionArtifactId,
+      input.validationReport.validationReportId,
+      input.validationReportArtifactId,
+      canonicalizeAflTradeJson(input.execution),
+      canonicalizeAflTradeJson(input.validationReport),
+      evaluatedAt,
+    ]
+  );
+}
+
+async function insertPickNativeEvidenceDirectly(input: {
+  runId: string;
+  nativeExecutionArtifactId: string;
+  execution: Awaited<ReturnType<typeof componentRuns>>['pickNativeExecution'];
+}) {
+  return pool.query(
+    `INSERT INTO outcome_governed_component_validation_evidence
+      (run_id,role,native_execution_artifact_id,validation_report_id,
+       validation_report_artifact_id,native_execution_json,validation_report_json,recorded_at)
+     VALUES ($1,'draft_pick_and_future_pick_distribution',$2,$3,NULL,$4::jsonb,$5::jsonb,$6)`,
+    [
+      input.runId,
+      input.nativeExecutionArtifactId,
+      input.execution.content.validationReport.validationReportId,
+      canonicalizeAflTradeJson(input.execution),
+      canonicalizeAflTradeJson(input.execution.content.validationReport),
+      evaluatedAt,
+    ]
+  );
+}
+
 describe('governed model qualification PostgreSQL registry', () => {
   it('advances one passing pair atomically, replays it, and isolates failed or stale candidates', async () => {
     const runs = await componentRuns();
@@ -287,7 +537,382 @@ describe('governed model qualification PostgreSQL registry', () => {
       artifactRepository: artifacts,
       maximumArtifactBytes: 1024 * 1024,
     });
+    const invalidPlayerComponent = async (input: {
+      candidateModelId: string;
+      reportCreatedAt: string;
+    }) => {
+      const validationContent = {
+        ...runs.playerValidationReport.content,
+        candidateModelId: input.candidateModelId,
+        valueUnitId: `player-contribution-${input.reportCreatedAt}`,
+      };
+      const validationReport = aflTradePlayerValidationReportSchema.parse({
+        validationReportId: createAflTradeContentAddress(
+          'player-validation-report',
+          validationContent
+        ),
+        content: validationContent,
+      });
+      const validationReportArtifact = await retain(validationReport, input.reportCreatedAt);
+      const executionContent = {
+        ...runs.playerNativeExecution.content,
+        outcome: {
+          ...runs.playerNativeExecution.content.outcome,
+          validationReportArtifact,
+        },
+      };
+      const execution = aflTradeModelRunManifestV3Schema.parse({
+        runId: createAflTradeContentAddress('model-run', executionContent),
+        content: executionContent,
+      });
+      const content = runs.player.content;
+      return createGovernedValuationComponentRunManifest({
+        environment: content.environment,
+        role: content.role,
+        nativeExecution: {
+          kind: 'admitted_player_model_run',
+          executionId: execution.runId,
+          artifact: await retain(execution),
+        },
+        protocolId: content.protocolId,
+        protocolArtifact: content.protocolArtifact,
+        datasetId: content.datasetId,
+        datasetArtifact: content.datasetArtifact,
+        datasetAdmissionId: content.datasetAdmissionId,
+        datasetAdmissionArtifact: content.datasetAdmissionArtifact,
+        datasetAdmissionGateLedgerRevision: content.datasetAdmissionGateLedgerRevision,
+        registeredAt: content.registeredAt,
+      });
+    };
+    for (const component of [
+      await invalidPlayerComponent({
+        candidateModelId: 'another-player-model',
+        reportCreatedAt: '2026-08-21T07:45:00.000Z',
+      }),
+      await invalidPlayerComponent({
+        candidateModelId: runs.playerNativeExecution.content.modelId,
+        reportCreatedAt: '2026-08-21T07:55:00.000Z',
+      }),
+    ]) {
+      await expect(
+        loadGovernedNativeComponentValidationReport({
+          manifest: component,
+          artifactRepository: artifacts,
+          maximumArtifactBytes: 1024 * 1024,
+        })
+      ).rejects.toThrow(/ancestry|chronology/i);
+    }
+    const directPlayerEvidenceFixture = async (suffix: string) => {
+      const content = {
+        ...runs.playerNativeExecution.content,
+        modelVersion: `1.0.${suffix}`,
+        runIntentId: createAflTradeContentAddress('model-run-intent', `player-intent-${suffix}`),
+        runAuthorizationId: createAflTradeContentAddress(
+          'model-run-authorization',
+          `player-authorization-${suffix}`
+        ),
+        job: {
+          ...runs.playerNativeExecution.content.job,
+          jobId: `player-model-job-${suffix}`,
+        },
+      };
+      const execution = aflTradeModelRunManifestV3Schema.parse({
+        runId: createAflTradeContentAddress('model-run', content),
+        content,
+      });
+      const seed = await pool.connect();
+      await seed.query('BEGIN');
+      try {
+        await seed.query(`SET LOCAL session_replication_role='replica'`);
+        await seed.query(
+          `INSERT INTO outcome_valuation_model_run
+            (run_id,intent_id,authorization_id,status,started_at,finished_at,
+             run_canonical_json,run_json)
+           VALUES ($1,$2,$3,'succeeded',$4,$5,$6,$7::jsonb)`,
+          [
+            execution.runId,
+            content.runIntentId,
+            content.runAuthorizationId,
+            content.startedAt,
+            content.finishedAt,
+            canonicalizeAflTradeJson(content),
+            canonicalizeAflTradeJson(execution),
+          ]
+        );
+        await seed.query('COMMIT');
+      } catch (error) {
+        await seed.query('ROLLBACK');
+        throw error;
+      } finally {
+        seed.release();
+      }
+      return execution;
+    };
+    const playerComponentAuthority = {
+      environment: runs.player.content.environment,
+      role: runs.player.content.role,
+      protocolId: runs.player.content.protocolId,
+      protocolArtifact: runs.player.content.protocolArtifact,
+      datasetArtifact: runs.player.content.datasetArtifact,
+      datasetAdmissionId: runs.player.content.datasetAdmissionId,
+      datasetAdmissionArtifact: runs.player.content.datasetAdmissionArtifact,
+      datasetAdmissionGateLedgerRevision: runs.player.content.datasetAdmissionGateLedgerRevision,
+      registeredAt: runs.player.content.registeredAt,
+    } as const;
+    const sourceBoundExecution = await directPlayerEvidenceFixture('1');
+    const forgedNativeExecution = {
+      ...sourceBoundExecution,
+      content: {
+        ...sourceBoundExecution.content,
+        datasetId: createAflTradeContentAddress('dataset', 'forged-native-player-dataset'),
+      },
+    };
+    const forgedNativeArtifact = await retain(forgedNativeExecution);
+    const forgedComponent = createGovernedValuationComponentRunManifest({
+      ...playerComponentAuthority,
+      nativeExecution: {
+        kind: 'admitted_player_model_run',
+        executionId: sourceBoundExecution.runId,
+        artifact: forgedNativeArtifact,
+      },
+      datasetId: forgedNativeExecution.content.datasetId,
+    });
+    const forgedComponentArtifact = await retain(forgedComponent);
+    await insertComponentDirectly(forgedComponent, forgedComponentArtifact.artifactId);
+    await expect(
+      insertPlayerNativeEvidenceDirectly({
+        runId: forgedComponent.runId,
+        nativeExecutionArtifactId: forgedNativeArtifact.artifactId,
+        execution: forgedNativeExecution,
+        validationReport: runs.playerValidationReport,
+        validationReportArtifactId:
+          runs.playerNativeExecution.content.outcome.validationReportArtifact.artifactId,
+      })
+    ).rejects.toThrow(/validation evidence/i);
+
+    const custodyBoundExecution = await directPlayerEvidenceFixture('2');
+    const custodyNativeArtifact = await retain(custodyBoundExecution);
+    const custodyComponentBase = createGovernedValuationComponentRunManifest({
+      ...playerComponentAuthority,
+      nativeExecution: {
+        kind: 'admitted_player_model_run',
+        executionId: custodyBoundExecution.runId,
+        artifact: custodyNativeArtifact,
+      },
+      datasetId: custodyBoundExecution.content.datasetId,
+    });
+    const custodyComponentContent = {
+      ...custodyComponentBase.content,
+      nativeExecution: {
+        ...custodyComponentBase.content.nativeExecution,
+        artifact: {
+          ...custodyNativeArtifact,
+          storageUri: `artifact://sha256/${'f'.repeat(64)}`,
+        },
+      },
+    };
+    const custodyComponent = {
+      runId: createAflTradeContentAddress('model-run', custodyComponentContent),
+      content: custodyComponentContent,
+    } as typeof custodyComponentBase;
+    const custodyComponentArtifact = await retain(custodyComponent);
+    await expect(
+      insertComponentDirectly(custodyComponent, custodyComponentArtifact.artifactId)
+    ).rejects.toThrow(/component-run columns/i);
+
+    const backdatedExecution = await directPlayerEvidenceFixture('4');
+    const backdatedNativeArtifact = await retain(backdatedExecution);
+    const backdatedComponentBase = createGovernedValuationComponentRunManifest({
+      ...playerComponentAuthority,
+      nativeExecution: {
+        kind: 'admitted_player_model_run',
+        executionId: backdatedExecution.runId,
+        artifact: backdatedNativeArtifact,
+      },
+      datasetId: backdatedExecution.content.datasetId,
+    });
+    const backdatedComponentContent = {
+      ...backdatedComponentBase.content,
+      registeredAt: '2026-08-21T07:59:00.000Z',
+    };
+    const backdatedComponent = {
+      runId: createAflTradeContentAddress('model-run', backdatedComponentContent),
+      content: backdatedComponentContent,
+    } as typeof backdatedComponentBase;
+    const backdatedComponentArtifact = await retain(
+      backdatedComponent,
+      backdatedComponent.content.registeredAt
+    );
+    await expect(
+      insertComponentDirectly(backdatedComponent, backdatedComponentArtifact.artifactId)
+    ).rejects.toThrow(/component-run columns/i);
+
+    const directPickEvidenceFixture = async (
+      suffix: string,
+      mutate: (
+        content: typeof runs.pickValidationReport.content
+      ) => typeof runs.pickValidationReport.content
+    ) => {
+      const reportContent = mutate(runs.pickValidationReport.content);
+      const validationReport = {
+        validationReportId: createAflTradeContentAddress(
+          'pick-pav-validation-report',
+          reportContent
+        ),
+        content: reportContent,
+      } as typeof runs.pickValidationReport;
+      const executionContent = {
+        ...runs.pickNativeExecution.content,
+        completedAt: `2026-08-21T08:0${suffix}:00.000Z`,
+        validationConfig: reportContent.config,
+        validationReport,
+      };
+      const execution = {
+        executionId: createAflTradeContentAddress('pick-pav-model-execution', executionContent),
+        content: executionContent,
+      } as typeof runs.pickNativeExecution;
+      const executionArtifact = await retain(execution, executionContent.completedAt);
+      const seed = await pool.connect();
+      await seed.query('BEGIN');
+      try {
+        await seed.query(`SET LOCAL session_replication_role='replica'`);
+        await seed.query(
+          `INSERT INTO outcome_governed_pick_pav_model_execution
+            (execution_id,observation_set_id,dataset_id,dataset_artifact_id,
+             dataset_admission_id,dataset_admission_artifact_id,
+             dataset_admission_gate_ledger_revision,protocol_id,protocol_artifact_id,
+             execution_artifact_id,final_test_evaluation_started_at,completed_at,
+             content_sha256,content_canonical_json,execution_json)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15::jsonb)`,
+          [
+            execution.executionId,
+            executionContent.observationSetId,
+            executionContent.datasetId,
+            executionContent.datasetArtifact.artifactId,
+            executionContent.datasetAdmissionId,
+            executionContent.datasetAdmissionArtifact.artifactId,
+            executionContent.datasetAdmissionGateLedgerRevision,
+            executionContent.protocolId,
+            executionContent.protocolArtifact.artifactId,
+            executionArtifact.artifactId,
+            executionContent.finalTestEvaluationStartedAt,
+            executionContent.completedAt,
+            execution.executionId.slice('pick-pav-model-execution:'.length),
+            canonicalizeAflTradeJson(executionContent),
+            canonicalizeAflTradeJson(execution),
+          ]
+        );
+        await seed.query('COMMIT');
+      } catch (error) {
+        await seed.query('ROLLBACK');
+        throw error;
+      } finally {
+        seed.release();
+      }
+      const component = createGovernedValuationComponentRunManifest({
+        environment: 'non_production',
+        role: 'draft_pick_and_future_pick_distribution',
+        nativeExecution: {
+          kind: 'governed_pick_pav_model_execution',
+          executionId: execution.executionId,
+          artifact: executionArtifact,
+        },
+        protocolId: executionContent.protocolId,
+        protocolArtifact: executionContent.protocolArtifact,
+        datasetId: executionContent.datasetId,
+        datasetArtifact: executionContent.datasetArtifact,
+        datasetAdmissionId: executionContent.datasetAdmissionId,
+        datasetAdmissionArtifact: executionContent.datasetAdmissionArtifact,
+        datasetAdmissionGateLedgerRevision: executionContent.datasetAdmissionGateLedgerRevision,
+        registeredAt: executionContent.completedAt,
+      });
+      const componentArtifact = await retain(component, component.content.registeredAt);
+      await insertComponentDirectly(component, componentArtifact.artifactId);
+      return { component, execution, executionArtifact };
+    };
+    const insufficientStatusPick = await directPickEvidenceFixture('1', (content) => ({
+      ...content,
+      config: {
+        ...content.config,
+        minimumEligibleObservations: content.inputObservationCount + 1,
+      },
+    }));
+    await expect(
+      insertPickNativeEvidenceDirectly({
+        runId: insufficientStatusPick.component.runId,
+        nativeExecutionArtifactId: insufficientStatusPick.executionArtifact.artifactId,
+        execution: insufficientStatusPick.execution,
+      })
+    ).rejects.toThrow(/pick validation evidence/i);
+    const mismatchedAncestryPick = await directPickEvidenceFixture('2', (content) => ({
+      ...content,
+      observationSetId: createAflTradeContentAddress(
+        'pick-pav-observation-set',
+        'mismatched-report-observation-set'
+      ),
+    }));
+    await expect(
+      insertPickNativeEvidenceDirectly({
+        runId: mismatchedAncestryPick.component.runId,
+        nativeExecutionArtifactId: mismatchedAncestryPick.executionArtifact.artifactId,
+        execution: mismatchedAncestryPick.execution,
+      })
+    ).rejects.toThrow(/pick validation evidence/i);
+    const publicationClaimPick = await directPickEvidenceFixture(
+      '3',
+      (content) =>
+        ({
+          ...content,
+          publicationEligible: true,
+        }) as unknown as typeof content
+    );
+    await expect(
+      insertPickNativeEvidenceDirectly({
+        runId: publicationClaimPick.component.runId,
+        nativeExecutionArtifactId: publicationClaimPick.executionArtifact.artifactId,
+        execution: publicationClaimPick.execution,
+      })
+    ).rejects.toThrow(/pick validation evidence/i);
+
     const passing = await qualificationFixture(runs, 'v1', true);
+    const fabricatedPassingEvidence = {
+      ...passing.qualification.content.player.validationEvidence,
+      relativeMaeImprovement: 0.06,
+    };
+    const fabricatedPassingContent = {
+      ...passing.qualification.content,
+      player: {
+        ...passing.qualification.content.player,
+        validationEvidence: fabricatedPassingEvidence,
+        validationEvidenceArtifact: await retain(fabricatedPassingEvidence, evaluatedAt),
+      },
+    };
+    const fabricatedPassingQualification = {
+      qualificationId: createAflTradeContentAddress(
+        'model-qualification',
+        fabricatedPassingContent
+      ),
+      content: fabricatedPassingContent,
+    };
+    const fabricatedPassingArtifact = await retain(fabricatedPassingQualification, evaluatedAt);
+    const fabricatedPassingGates = createGovernedValuationModelQualificationGateRecords({
+      qualification: fabricatedPassingQualification,
+      qualificationArtifact: fabricatedPassingArtifact,
+      decidedAt: authorityAt,
+      automationPrincipal: 'statly-model-qualification-agent',
+      accountableOwner: 'statly-model-owner',
+      versions: { player: 1, pick: 1 },
+      supersedes: { player: null, pick: null },
+    });
+    await expect(
+      repository.register({
+        qualification: fabricatedPassingQualification,
+        qualificationArtifact: fabricatedPassingArtifact,
+        expectedGateLedgerRevision: 0,
+        expectedCurrentRevision: 0,
+        gateRecords: fabricatedPassingGates,
+      })
+    ).rejects.toThrow(/native validation reports/i);
     const forgedEvidence = {
       ...passing.qualification.content.player.validationEvidence,
       relativeMaeImprovement: 0,
@@ -308,10 +933,8 @@ describe('governed model qualification PostgreSQL registry', () => {
     await expect(
       insertQualificationDirectly(forgedQualification, forgedArtifact.artifactId)
     ).rejects.toThrow(/ancestry|mismatch/i);
-    const {
-      multiclassBrierScore: _omittedBrierScore,
-      ...incompletePickMetrics
-    } = passing.qualification.content.pick.validationEvidence.metrics!;
+    const { multiclassBrierScore: _omittedBrierScore, ...incompletePickMetrics } =
+      passing.qualification.content.pick.validationEvidence.metrics!;
     const incompletePickEvidence = {
       ...passing.qualification.content.pick.validationEvidence,
       metrics: incompletePickMetrics,
@@ -325,18 +948,12 @@ describe('governed model qualification PostgreSQL registry', () => {
       },
     };
     const incompletePickQualification = {
-      qualificationId: createAflTradeContentAddress(
-        'model-qualification',
-        incompletePickContent
-      ),
+      qualificationId: createAflTradeContentAddress('model-qualification', incompletePickContent),
       content: incompletePickContent,
     } as unknown as typeof passing.qualification;
     const incompletePickArtifact = await retain(incompletePickQualification, evaluatedAt);
     await expect(
-      insertQualificationDirectly(
-        incompletePickQualification,
-        incompletePickArtifact.artifactId
-      )
+      insertQualificationDirectly(incompletePickQualification, incompletePickArtifact.artifactId)
     ).rejects.toThrow(/ancestry|mismatch/i);
     const wrongRoleContent = {
       ...passing.qualification.content,
@@ -359,28 +976,19 @@ describe('governed model qualification PostgreSQL registry', () => {
       player: { ...passing.qualification.content.player, passed: 'true' },
     };
     const stringBooleanQualification = {
-      qualificationId: createAflTradeContentAddress(
-        'model-qualification',
-        stringBooleanContent
-      ),
+      qualificationId: createAflTradeContentAddress('model-qualification', stringBooleanContent),
       content: stringBooleanContent,
     } as unknown as typeof passing.qualification;
     const stringBooleanArtifact = await retain(stringBooleanQualification, evaluatedAt);
     await expect(
-      insertQualificationDirectly(
-        stringBooleanQualification,
-        stringBooleanArtifact.artifactId
-      )
+      insertQualificationDirectly(stringBooleanQualification, stringBooleanArtifact.artifactId)
     ).rejects.toThrow(/contract|mismatch/i);
     const invalidScopeContent = {
       ...passing.qualification.content,
       scopeKey: 'invalid scope',
     };
     const invalidScopeQualification = {
-      qualificationId: createAflTradeContentAddress(
-        'model-qualification',
-        invalidScopeContent
-      ),
+      qualificationId: createAflTradeContentAddress('model-qualification', invalidScopeContent),
       content: invalidScopeContent,
     } as unknown as typeof passing.qualification;
     const invalidScopeArtifact = await retain(invalidScopeQualification, evaluatedAt);
@@ -400,18 +1008,12 @@ describe('governed model qualification PostgreSQL registry', () => {
       },
     };
     const invalidReportQualification = {
-      qualificationId: createAflTradeContentAddress(
-        'model-qualification',
-        invalidReportContent
-      ),
+      qualificationId: createAflTradeContentAddress('model-qualification', invalidReportContent),
       content: invalidReportContent,
     } as unknown as typeof passing.qualification;
     const invalidReportArtifact = await retain(invalidReportQualification, evaluatedAt);
     await expect(
-      insertQualificationDirectly(
-        invalidReportQualification,
-        invalidReportArtifact.artifactId
-      )
+      insertQualificationDirectly(invalidReportQualification, invalidReportArtifact.artifactId)
     ).rejects.toThrow(/contract|mismatch/i);
     const custodyMismatchContent = {
       ...passing.qualification.content,
@@ -424,18 +1026,12 @@ describe('governed model qualification PostgreSQL registry', () => {
       },
     };
     const custodyMismatchQualification = {
-      qualificationId: createAflTradeContentAddress(
-        'model-qualification',
-        custodyMismatchContent
-      ),
+      qualificationId: createAflTradeContentAddress('model-qualification', custodyMismatchContent),
       content: custodyMismatchContent,
     } as unknown as typeof passing.qualification;
     const custodyMismatchArtifact = await retain(custodyMismatchQualification, evaluatedAt);
     await expect(
-      insertQualificationDirectly(
-        custodyMismatchQualification,
-        custodyMismatchArtifact.artifactId
-      )
+      insertQualificationDirectly(custodyMismatchQualification, custodyMismatchArtifact.artifactId)
     ).rejects.toThrow(/custody|mismatch/i);
     const wrongMediaEvidence = {
       ...passing.qualification.content.player.validationEvidence,
@@ -453,10 +1049,7 @@ describe('governed model qualification PostgreSQL registry', () => {
       },
     };
     const wrongMediaQualification = {
-      qualificationId: createAflTradeContentAddress(
-        'model-qualification',
-        wrongMediaContent
-      ),
+      qualificationId: createAflTradeContentAddress('model-qualification', wrongMediaContent),
       content: wrongMediaContent,
     } as unknown as typeof passing.qualification;
     const wrongMediaArtifact = await retain(wrongMediaQualification, evaluatedAt);
@@ -468,10 +1061,7 @@ describe('governed model qualification PostgreSQL registry', () => {
       scopeKey: 'afl-men:2026-outer-custody',
     };
     const outerCustodyQualification = {
-      qualificationId: createAflTradeContentAddress(
-        'model-qualification',
-        outerCustodyContent
-      ),
+      qualificationId: createAflTradeContentAddress('model-qualification', outerCustodyContent),
       content: outerCustodyContent,
     } as unknown as typeof passing.qualification;
     const outerCustodyArtifact = await retainWithMetadata(outerCustodyQualification, {
@@ -479,10 +1069,7 @@ describe('governed model qualification PostgreSQL registry', () => {
       createdAt: evaluatedAt,
     });
     await expect(
-      insertQualificationDirectly(
-        outerCustodyQualification,
-        outerCustodyArtifact.artifactId
-      )
+      insertQualificationDirectly(outerCustodyQualification, outerCustodyArtifact.artifactId)
     ).rejects.toThrow(/ancestry|mismatch/i);
     const conflictingPolicy = {
       ...passing.qualification.content.policy,
@@ -507,10 +1094,7 @@ describe('governed model qualification PostgreSQL registry', () => {
       ),
       content: conflictingPolicyContent,
     };
-    const conflictingPolicyArtifact = await retain(
-      conflictingPolicyQualification,
-      evaluatedAt
-    );
+    const conflictingPolicyArtifact = await retain(conflictingPolicyQualification, evaluatedAt);
     await expect(
       insertQualificationDirectly(
         conflictingPolicyQualification,
@@ -525,6 +1109,42 @@ describe('governed model qualification PostgreSQL registry', () => {
       versions: { player: 1, pick: 1 },
       supersedes: { player: null, pick: null },
     });
+    const prematureProposalContent = {
+      ...gates[0].proposal.content,
+      proposedAt: '2026-08-21T08:59:00.000Z',
+    };
+    const prematureProposal = {
+      proposalId: createAflTradeContentAddress('gate-proposal', prematureProposalContent),
+      content: prematureProposalContent,
+    };
+    const prematureDecisionContent = {
+      ...gates[0].decision.content,
+      proposalId: prematureProposal.proposalId,
+      decidedAt: '2026-08-21T08:59:00.000Z',
+      effectiveAt: '2026-08-21T08:59:00.000Z',
+    };
+    const prematureGates = [
+      {
+        proposal: prematureProposal,
+        decision: {
+          decisionId: createAflTradeContentAddress('gate-decision', prematureDecisionContent),
+          content: prematureDecisionContent,
+        },
+      },
+      gates[1],
+    ] as const;
+    await expect(
+      repository.register({
+        ...passing,
+        expectedGateLedgerRevision: 0,
+        expectedCurrentRevision: 0,
+        gateRecords: prematureGates,
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<GovernedValuationModelQualificationRepositoryError>>({
+        code: 'INTEGRITY_MISMATCH',
+      })
+    );
     const bypassClient = await pool.connect();
     try {
       await bypassClient.query('BEGIN');
@@ -588,6 +1208,101 @@ describe('governed model qualification PostgreSQL registry', () => {
         },
       },
     });
+    await expect(
+      insertQualificationDirectly(
+        fabricatedPassingQualification,
+        fabricatedPassingArtifact.artifactId
+      )
+    ).rejects.toThrow(/native|validation|evidence/i);
+
+    const prematureBase = await qualificationFixture(runs, 'premature', true);
+    const directPrematureContent = {
+      ...prematureBase.qualification.content,
+      scopeKey: 'afl-men:2026-premature-trades',
+    };
+    const directPrematureQualification = {
+      qualificationId: createAflTradeContentAddress('model-qualification', directPrematureContent),
+      content: directPrematureContent,
+    };
+    const directPrematureArtifact = await retain(directPrematureQualification, evaluatedAt);
+    const directGates = createGovernedValuationModelQualificationGateRecords({
+      qualification: directPrematureQualification,
+      qualificationArtifact: directPrematureArtifact,
+      decidedAt: authorityAt,
+      automationPrincipal: 'statly-model-qualification-agent',
+      accountableOwner: 'statly-model-owner',
+      versions: { player: 1, pick: 1 },
+      supersedes: { player: null, pick: null },
+    });
+    const directPrematureProposalContent = {
+      ...directGates[0].proposal.content,
+      proposedAt: '2026-08-21T08:59:00.000Z',
+    };
+    const directPrematureProposal = {
+      proposalId: createAflTradeContentAddress('gate-proposal', directPrematureProposalContent),
+      content: directPrematureProposalContent,
+    };
+    const directPrematureDecisionContent = {
+      ...directGates[0].decision.content,
+      proposalId: directPrematureProposal.proposalId,
+      decidedAt: '2026-08-21T08:59:00.000Z',
+      effectiveAt: '2026-08-21T08:59:00.000Z',
+    };
+    const directPrematureClient = await pool.connect();
+    try {
+      await directPrematureClient.query('BEGIN');
+      await insertQualificationDirectly(
+        directPrematureQualification,
+        directPrematureArtifact.artifactId,
+        directPrematureClient
+      );
+      await directPrematureClient.query(
+        `INSERT INTO outcome_gate_proposal
+          (proposal_id,gate,decision_key,version,environment,scope_key,proposed_at,proposal_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb)`,
+        [
+          directPrematureProposal.proposalId,
+          directPrematureProposal.content.gate,
+          directPrematureProposal.content.decisionKey,
+          directPrematureProposal.content.version,
+          directPrematureProposal.content.environment,
+          directPrematureProposal.content.scope.scopeKey,
+          directPrematureProposal.content.proposedAt,
+          canonicalizeAflTradeJson(directPrematureProposal),
+        ]
+      );
+      await expect(
+        directPrematureClient.query(
+          `INSERT INTO outcome_gate_decision
+            (decision_id,proposal_id,gate,decision_key,version,environment,state,decided_at,
+             effective_at,revalidate_at,supersedes_decision_id,decision_json)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
+          [
+            createAflTradeContentAddress('gate-decision', directPrematureDecisionContent),
+            directPrematureDecisionContent.proposalId,
+            directPrematureDecisionContent.gate,
+            directPrematureDecisionContent.decisionKey,
+            directPrematureDecisionContent.version,
+            directPrematureDecisionContent.environment,
+            directPrematureDecisionContent.state,
+            directPrematureDecisionContent.decidedAt,
+            directPrematureDecisionContent.effectiveAt,
+            directPrematureDecisionContent.revalidateAt,
+            directPrematureDecisionContent.supersedesDecisionId,
+            canonicalizeAflTradeJson({
+              decisionId: createAflTradeContentAddress(
+                'gate-decision',
+                directPrematureDecisionContent
+              ),
+              content: directPrematureDecisionContent,
+            }),
+          ]
+        )
+      ).rejects.toThrow(/qualification|automated|chronolog/i);
+    } finally {
+      await directPrematureClient.query('ROLLBACK');
+      directPrematureClient.release();
+    }
     const unpairedGates = createGovernedValuationModelQualificationGateRecords({
       ...passing,
       decidedAt: '2026-08-21T09:06:00.000Z',

--- a/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
+++ b/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
@@ -67,6 +67,33 @@ async function retain(document: unknown, createdAt = retainedAt) {
   return reference;
 }
 
+async function retainWithMetadata(
+  document: unknown,
+  overrides: Partial<Pick<Awaited<ReturnType<typeof retain>>, 'mediaType' | 'createdAt'>>
+) {
+  const canonicalReference = createAflTradeCanonicalJsonArtifactRef(
+    document,
+    overrides.createdAt ?? retainedAt
+  );
+  const reference = { ...canonicalReference, ...overrides };
+  await pool.query(
+    `INSERT INTO outcome_artifact_custody
+      (artifact_id,content_sha256,storage_uri,media_type,byte_length,artifact_class,
+       environment,custody_profile_id,created_at,verified_at,custody_json)
+     VALUES ($1,$2,$3,$4,$5,'derived_private','non_production',NULL,$6,$6,$7::jsonb)`,
+    [
+      reference.artifactId,
+      reference.contentSha256,
+      reference.storageUri,
+      reference.mediaType,
+      reference.byteLength,
+      reference.createdAt,
+      canonicalizeAflTradeJson({ assurance: 'disposable_metadata_mismatch_test' }),
+    ]
+  );
+  return reference;
+}
+
 beforeAll(async () => {
   await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
   runOutcomesPrismaTestCommand(['migrate', 'deploy'], {
@@ -410,6 +437,53 @@ describe('governed model qualification PostgreSQL registry', () => {
         custodyMismatchArtifact.artifactId
       )
     ).rejects.toThrow(/custody|mismatch/i);
+    const wrongMediaEvidence = {
+      ...passing.qualification.content.player.validationEvidence,
+      comparableObservationCount: 121,
+    };
+    const wrongMediaContent = {
+      ...passing.qualification.content,
+      player: {
+        ...passing.qualification.content.player,
+        validationEvidence: wrongMediaEvidence,
+        validationEvidenceArtifact: await retainWithMetadata(wrongMediaEvidence, {
+          mediaType: 'text/plain',
+          createdAt: evaluatedAt,
+        }),
+      },
+    };
+    const wrongMediaQualification = {
+      qualificationId: createAflTradeContentAddress(
+        'model-qualification',
+        wrongMediaContent
+      ),
+      content: wrongMediaContent,
+    } as unknown as typeof passing.qualification;
+    const wrongMediaArtifact = await retain(wrongMediaQualification, evaluatedAt);
+    await expect(
+      insertQualificationDirectly(wrongMediaQualification, wrongMediaArtifact.artifactId)
+    ).rejects.toThrow(/lineage|mismatch/i);
+    const outerCustodyContent = {
+      ...passing.qualification.content,
+      scopeKey: 'afl-men:2026-outer-custody',
+    };
+    const outerCustodyQualification = {
+      qualificationId: createAflTradeContentAddress(
+        'model-qualification',
+        outerCustodyContent
+      ),
+      content: outerCustodyContent,
+    } as unknown as typeof passing.qualification;
+    const outerCustodyArtifact = await retainWithMetadata(outerCustodyQualification, {
+      mediaType: 'text/plain',
+      createdAt: evaluatedAt,
+    });
+    await expect(
+      insertQualificationDirectly(
+        outerCustodyQualification,
+        outerCustodyArtifact.artifactId
+      )
+    ).rejects.toThrow(/ancestry|mismatch/i);
     const conflictingPolicy = {
       ...passing.qualification.content.policy,
       player: {
@@ -543,27 +617,31 @@ describe('governed model qualification PostgreSQL registry', () => {
           canonicalizeAflTradeJson(unpairedGates[0].proposal),
         ]
       );
-      await unpairedClient.query(
-        `INSERT INTO outcome_gate_decision
-          (decision_id,proposal_id,gate,decision_key,version,environment,state,decided_at,
-           effective_at,revalidate_at,supersedes_decision_id,decision_json)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
-        [
-          unpairedGates[0].decision.decisionId,
-          unpairedGates[0].decision.content.proposalId,
-          unpairedGates[0].decision.content.gate,
-          unpairedGates[0].decision.content.decisionKey,
-          unpairedGates[0].decision.content.version,
-          unpairedGates[0].decision.content.environment,
-          unpairedGates[0].decision.content.state,
-          unpairedGates[0].decision.content.decidedAt,
-          unpairedGates[0].decision.content.effectiveAt,
-          unpairedGates[0].decision.content.revalidateAt,
-          unpairedGates[0].decision.content.supersedesDecisionId,
-          canonicalizeAflTradeJson(unpairedGates[0].decision),
-        ]
-      );
-      await expect(unpairedClient.query('COMMIT')).rejects.toThrow(/atomic|pair/i);
+      await expect(
+        (async () => {
+          await unpairedClient.query(
+            `INSERT INTO outcome_gate_decision
+              (decision_id,proposal_id,gate,decision_key,version,environment,state,decided_at,
+               effective_at,revalidate_at,supersedes_decision_id,decision_json)
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
+            [
+              unpairedGates[0].decision.decisionId,
+              unpairedGates[0].decision.content.proposalId,
+              unpairedGates[0].decision.content.gate,
+              unpairedGates[0].decision.content.decisionKey,
+              unpairedGates[0].decision.content.version,
+              unpairedGates[0].decision.content.environment,
+              unpairedGates[0].decision.content.state,
+              unpairedGates[0].decision.content.decidedAt,
+              unpairedGates[0].decision.content.effectiveAt,
+              unpairedGates[0].decision.content.revalidateAt,
+              unpairedGates[0].decision.content.supersedesDecisionId,
+              canonicalizeAflTradeJson(unpairedGates[0].decision),
+            ]
+          );
+          await unpairedClient.query('COMMIT');
+        })()
+      ).rejects.toThrow(/atomic|pair|unique|duplicate/i);
     } finally {
       await unpairedClient.query('ROLLBACK');
       unpairedClient.release();
@@ -576,6 +654,14 @@ describe('governed model qualification PostgreSQL registry', () => {
         gateRecords: gates,
       })
     ).resolves.toMatchObject({ status: 'advanced', idempotentReplay: true });
+    await expect(
+      pool.query(
+        `UPDATE outcome_governed_model_qualification_work
+            SET work_json=jsonb_set(work_json,'{content,cause}','"forged"'::jsonb)
+          WHERE work_id=$1`,
+        [advanced.work!.workId]
+      )
+    ).rejects.toThrow(/immutable/i);
 
     const failed = await qualificationFixture(runs, 'failed', false);
     await expect(

--- a/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
+++ b/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
@@ -2,12 +2,16 @@ import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
-import { canonicalizeAflTradeJson } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import {
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import { createAflTradeFixtureArtifactRepository } from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
 import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
 import {
   createGovernedValuationModelQualification,
   createGovernedValuationModelQualificationGateRecords,
+  createGovernedValuationModelQualificationPolicy,
 } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification';
 import { createGovernedValuationComponentRunManifest } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest';
 import { PostgresGovernedValuationComponentRunRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationComponentRunRepository';
@@ -32,6 +36,7 @@ const pool = new Pool({
 const artifacts = createAflTradeFixtureArtifactRepository({ artifactClass: 'derived_private' });
 const retainedAt = '2026-08-21T08:00:00.000Z';
 const evaluatedAt = '2026-08-21T09:00:00.000Z';
+const authorityAt = '2026-08-21T09:05:00.000Z';
 
 function scopedDatabaseUrl(targetSchema: string) {
   const scoped = new URL(databaseUrl);
@@ -122,9 +127,7 @@ async function qualificationFixture(
   suffix: string,
   passing: boolean
 ) {
-  const policy = {
-    schemaVersion: 'governed-valuation-model-qualification-policy/v1' as const,
-    policyVersion: `afl-men-private-model-pair-${suffix}`,
+  const policy = createGovernedValuationModelQualificationPolicy({
     player: {
       schemaVersion: 'governed-player-model-qualification-criteria/v1' as const,
       minimumComparableObservations: 100,
@@ -149,10 +152,13 @@ async function qualificationFixture(
       maximumMeanEmpiricalIntervalWidth: 80,
       maximumZeroProbabilityObservationCount: 0,
     },
-  };
+  });
   const playerEvidence = {
     schemaVersion: 'governed-player-model-qualification-evidence/v1' as const,
-    validationReportId: `player-validation-report:${'e'.repeat(64)}`,
+    validationReportId: createAflTradeContentAddress(
+      'player-validation-report',
+      `player-${suffix}`
+    ),
     comparableObservationCount: 120,
     acceptanceOutcome: 'meets_declared_predictive_thresholds' as const,
     relativeMaeImprovement: passing ? 0.08 : 0.01,
@@ -160,7 +166,10 @@ async function qualificationFixture(
   };
   const pickEvidence = {
     schemaVersion: 'governed-pick-model-qualification-evidence/v1' as const,
-    validationReportId: `pick-pav-validation-report:${'f'.repeat(64)}`,
+    validationReportId: createAflTradeContentAddress(
+      'pick-pav-validation-report',
+      `pick-${suffix}`
+    ),
     evaluationStatus: 'scored_not_approved' as const,
     scope: 'final_test' as const,
     observationCount: 40,
@@ -211,6 +220,38 @@ async function qualificationFixture(
   return { qualification, qualificationArtifact };
 }
 
+async function insertQualificationDirectly(
+  qualification: Awaited<ReturnType<typeof qualificationFixture>>['qualification'],
+  artifactId: string
+) {
+  const content = qualification.content;
+  return pool.query(
+    `INSERT INTO outcome_governed_valuation_model_qualification
+      (qualification_id,scope_key,outcome,artifact_id,player_run_id,pick_run_id,
+       policy_artifact_id,player_criteria_artifact_id,pick_criteria_artifact_id,
+       player_evidence_artifact_id,pick_evidence_artifact_id,evaluated_at,content_sha256,
+       content_canonical_json,qualification_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15::jsonb)`,
+    [
+      qualification.qualificationId,
+      content.scopeKey,
+      content.outcome,
+      artifactId,
+      content.player.runId,
+      content.pick.runId,
+      content.policyArtifact.artifactId,
+      content.player.criteriaArtifact.artifactId,
+      content.pick.criteriaArtifact.artifactId,
+      content.player.validationEvidenceArtifact.artifactId,
+      content.pick.validationEvidenceArtifact.artifactId,
+      content.evaluatedAt,
+      qualification.qualificationId.slice('model-qualification:'.length),
+      canonicalizeAflTradeJson(content),
+      canonicalizeAflTradeJson(qualification),
+    ]
+  );
+}
+
 describe('governed model qualification PostgreSQL registry', () => {
   it('advances one passing pair atomically, replays it, and isolates failed or stale candidates', async () => {
     const runs = await componentRuns();
@@ -220,9 +261,62 @@ describe('governed model qualification PostgreSQL registry', () => {
       maximumArtifactBytes: 1024 * 1024,
     });
     const passing = await qualificationFixture(runs, 'v1', true);
+    const forgedEvidence = {
+      ...passing.qualification.content.player.validationEvidence,
+      relativeMaeImprovement: 0,
+    };
+    const forgedContent = {
+      ...passing.qualification.content,
+      player: {
+        ...passing.qualification.content.player,
+        validationEvidence: forgedEvidence,
+        validationEvidenceArtifact: await retain(forgedEvidence, evaluatedAt),
+      },
+    };
+    const forgedQualification = {
+      qualificationId: createAflTradeContentAddress('model-qualification', forgedContent),
+      content: forgedContent,
+    };
+    const forgedArtifact = await retain(forgedQualification, evaluatedAt);
+    await expect(
+      insertQualificationDirectly(forgedQualification, forgedArtifact.artifactId)
+    ).rejects.toThrow(/ancestry|mismatch/i);
+    const conflictingPolicy = {
+      ...passing.qualification.content.policy,
+      player: {
+        ...passing.qualification.content.policy.player,
+        minimumComparableObservations: 101,
+      },
+    };
+    const conflictingPolicyContent = {
+      ...passing.qualification.content,
+      policy: conflictingPolicy,
+      policyArtifact: await retain(conflictingPolicy, evaluatedAt),
+      player: {
+        ...passing.qualification.content.player,
+        criteriaArtifact: await retain(conflictingPolicy.player, evaluatedAt),
+      },
+    };
+    const conflictingPolicyQualification = {
+      qualificationId: createAflTradeContentAddress(
+        'model-qualification',
+        conflictingPolicyContent
+      ),
+      content: conflictingPolicyContent,
+    };
+    const conflictingPolicyArtifact = await retain(
+      conflictingPolicyQualification,
+      evaluatedAt
+    );
+    await expect(
+      insertQualificationDirectly(
+        conflictingPolicyQualification,
+        conflictingPolicyArtifact.artifactId
+      )
+    ).rejects.toThrow(/ancestry|mismatch/i);
     const gates = createGovernedValuationModelQualificationGateRecords({
       ...passing,
-      decidedAt: evaluatedAt,
+      decidedAt: authorityAt,
       automationPrincipal: 'statly-model-qualification-agent',
       accountableOwner: 'statly-model-owner',
       versions: { player: 1, pick: 1 },
@@ -239,7 +333,13 @@ describe('governed model qualification PostgreSQL registry', () => {
       status: 'advanced',
       idempotentReplay: false,
       current: { revision: 1, qualificationId: passing.qualification.qualificationId },
-      work: { content: { status: 'pending', cause: 'current_qualified_model_pair_advanced' } },
+      work: {
+        content: {
+          status: 'pending',
+          cause: 'current_qualified_model_pair_advanced',
+          availableAt: authorityAt,
+        },
+      },
     });
     await expect(
       repository.register({
@@ -265,7 +365,7 @@ describe('governed model qualification PostgreSQL registry', () => {
     const stale = await qualificationFixture(runs, 'v2', true);
     const staleGates = createGovernedValuationModelQualificationGateRecords({
       ...stale,
-      decidedAt: evaluatedAt,
+      decidedAt: '2026-08-21T09:10:00.000Z',
       automationPrincipal: 'statly-model-qualification-agent',
       accountableOwner: 'statly-model-owner',
       versions: { player: 2, pick: 2 },
@@ -274,6 +374,41 @@ describe('governed model qualification PostgreSQL registry', () => {
         pick: gates[1].decision.decisionId,
       },
     });
+    const crossScopeProposalContent = {
+      ...staleGates[0].proposal.content,
+      scope: { ...staleGates[0].proposal.content.scope, scopeKey: 'afl-men:2025-trades' },
+    };
+    const crossScopeProposal = {
+      proposalId: createAflTradeContentAddress('gate-proposal', crossScopeProposalContent),
+      content: crossScopeProposalContent,
+    };
+    const crossScopeDecisionContent = {
+      ...staleGates[0].decision.content,
+      proposalId: crossScopeProposal.proposalId,
+      scope: crossScopeProposalContent.scope,
+    };
+    const crossScopeGates = [
+      {
+        proposal: crossScopeProposal,
+        decision: {
+          decisionId: createAflTradeContentAddress('gate-decision', crossScopeDecisionContent),
+          content: crossScopeDecisionContent,
+        },
+      },
+      staleGates[1],
+    ] as const;
+    await expect(
+      repository.register({
+        ...stale,
+        expectedGateLedgerRevision: 2,
+        expectedCurrentRevision: 1,
+        gateRecords: crossScopeGates,
+      })
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<GovernedValuationModelQualificationRepositoryError>>({
+        code: 'INTEGRITY_MISMATCH',
+      })
+    );
     await expect(
       repository.register({
         ...stale,

--- a/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
+++ b/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
@@ -326,6 +326,90 @@ describe('governed model qualification PostgreSQL registry', () => {
     await expect(
       insertQualificationDirectly(wrongRoleQualification, wrongRoleArtifact.artifactId)
     ).rejects.toThrow(/contract|mismatch/i);
+    const stringBooleanContent = {
+      ...passing.qualification.content,
+      publicationEligible: 'false',
+      player: { ...passing.qualification.content.player, passed: 'true' },
+    };
+    const stringBooleanQualification = {
+      qualificationId: createAflTradeContentAddress(
+        'model-qualification',
+        stringBooleanContent
+      ),
+      content: stringBooleanContent,
+    } as unknown as typeof passing.qualification;
+    const stringBooleanArtifact = await retain(stringBooleanQualification, evaluatedAt);
+    await expect(
+      insertQualificationDirectly(
+        stringBooleanQualification,
+        stringBooleanArtifact.artifactId
+      )
+    ).rejects.toThrow(/contract|mismatch/i);
+    const invalidScopeContent = {
+      ...passing.qualification.content,
+      scopeKey: 'invalid scope',
+    };
+    const invalidScopeQualification = {
+      qualificationId: createAflTradeContentAddress(
+        'model-qualification',
+        invalidScopeContent
+      ),
+      content: invalidScopeContent,
+    } as unknown as typeof passing.qualification;
+    const invalidScopeArtifact = await retain(invalidScopeQualification, evaluatedAt);
+    await expect(
+      insertQualificationDirectly(invalidScopeQualification, invalidScopeArtifact.artifactId)
+    ).rejects.toThrow(/contract|mismatch/i);
+    const invalidReportEvidence = {
+      ...passing.qualification.content.player.validationEvidence,
+      validationReportId: 'not a report id',
+    };
+    const invalidReportContent = {
+      ...passing.qualification.content,
+      player: {
+        ...passing.qualification.content.player,
+        validationEvidence: invalidReportEvidence,
+        validationEvidenceArtifact: await retain(invalidReportEvidence, evaluatedAt),
+      },
+    };
+    const invalidReportQualification = {
+      qualificationId: createAflTradeContentAddress(
+        'model-qualification',
+        invalidReportContent
+      ),
+      content: invalidReportContent,
+    } as unknown as typeof passing.qualification;
+    const invalidReportArtifact = await retain(invalidReportQualification, evaluatedAt);
+    await expect(
+      insertQualificationDirectly(
+        invalidReportQualification,
+        invalidReportArtifact.artifactId
+      )
+    ).rejects.toThrow(/contract|mismatch/i);
+    const custodyMismatchContent = {
+      ...passing.qualification.content,
+      player: {
+        ...passing.qualification.content.player,
+        validationEvidenceArtifact: {
+          ...passing.qualification.content.player.validationEvidenceArtifact,
+          createdAt: '2026-08-20T00:00:00.000Z',
+        },
+      },
+    };
+    const custodyMismatchQualification = {
+      qualificationId: createAflTradeContentAddress(
+        'model-qualification',
+        custodyMismatchContent
+      ),
+      content: custodyMismatchContent,
+    } as unknown as typeof passing.qualification;
+    const custodyMismatchArtifact = await retain(custodyMismatchQualification, evaluatedAt);
+    await expect(
+      insertQualificationDirectly(
+        custodyMismatchQualification,
+        custodyMismatchArtifact.artifactId
+      )
+    ).rejects.toThrow(/custody|mismatch/i);
     const conflictingPolicy = {
       ...passing.qualification.content.policy,
       player: {
@@ -430,6 +514,60 @@ describe('governed model qualification PostgreSQL registry', () => {
         },
       },
     });
+    const unpairedGates = createGovernedValuationModelQualificationGateRecords({
+      ...passing,
+      decidedAt: '2026-08-21T09:06:00.000Z',
+      automationPrincipal: 'statly-model-qualification-agent',
+      accountableOwner: 'statly-model-owner',
+      versions: { player: 2, pick: 2 },
+      supersedes: {
+        player: gates[0].decision.decisionId,
+        pick: gates[1].decision.decisionId,
+      },
+    });
+    const unpairedClient = await pool.connect();
+    try {
+      await unpairedClient.query('BEGIN');
+      await unpairedClient.query(
+        `INSERT INTO outcome_gate_proposal
+          (proposal_id,gate,decision_key,version,environment,scope_key,proposed_at,proposal_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb)`,
+        [
+          unpairedGates[0].proposal.proposalId,
+          unpairedGates[0].proposal.content.gate,
+          unpairedGates[0].proposal.content.decisionKey,
+          unpairedGates[0].proposal.content.version,
+          unpairedGates[0].proposal.content.environment,
+          unpairedGates[0].proposal.content.scope.scopeKey,
+          unpairedGates[0].proposal.content.proposedAt,
+          canonicalizeAflTradeJson(unpairedGates[0].proposal),
+        ]
+      );
+      await unpairedClient.query(
+        `INSERT INTO outcome_gate_decision
+          (decision_id,proposal_id,gate,decision_key,version,environment,state,decided_at,
+           effective_at,revalidate_at,supersedes_decision_id,decision_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
+        [
+          unpairedGates[0].decision.decisionId,
+          unpairedGates[0].decision.content.proposalId,
+          unpairedGates[0].decision.content.gate,
+          unpairedGates[0].decision.content.decisionKey,
+          unpairedGates[0].decision.content.version,
+          unpairedGates[0].decision.content.environment,
+          unpairedGates[0].decision.content.state,
+          unpairedGates[0].decision.content.decidedAt,
+          unpairedGates[0].decision.content.effectiveAt,
+          unpairedGates[0].decision.content.revalidateAt,
+          unpairedGates[0].decision.content.supersedesDecisionId,
+          canonicalizeAflTradeJson(unpairedGates[0].decision),
+        ]
+      );
+      await expect(unpairedClient.query('COMMIT')).rejects.toThrow(/atomic|pair/i);
+    } finally {
+      await unpairedClient.query('ROLLBACK');
+      unpairedClient.release();
+    }
     await expect(
       repository.register({
         ...passing,

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1090,6 +1090,7 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0061_governed_valuation_component_runs',
       '0062_authenticated_prepared_v3_ancestry',
       '0063_governed_pick_pav_model_execution',
+      '0064_automated_model_pair_qualification',
     ]);
 
     const tables = await query<{ table_name: string }>(

--- a/tests/unit/afl-trade-intelligence-gate-decisions.test.ts
+++ b/tests/unit/afl-trade-intelligence-gate-decisions.test.ts
@@ -398,6 +398,8 @@ describe('AFL trade-intelligence gate decisions', () => {
     for (const invalidContent of [
       { ...decisionContent, environment: 'production' as const },
       { ...decisionContent, gate: 'gate_4_publication_api_readiness' as const },
+      { ...decisionContent, revalidateAt: '2027-08-21T09:00:00.000Z' },
+      { ...decisionContent, state: 'rejected' as const },
     ]) {
       expect(
         aflTradeGateDecisionRecordSchema.safeParse({

--- a/tests/unit/afl-trade-intelligence-gate-decisions.test.ts
+++ b/tests/unit/afl-trade-intelligence-gate-decisions.test.ts
@@ -199,6 +199,7 @@ describe('AFL trade-intelligence gate decisions', () => {
 
   it.each([
     ['valuation_bundle', 'valuation-bundle'],
+    ['model_qualification', 'model-qualification'],
     ['architecture_current_state', 'architecture-current-state'],
     ['architecture_decision_package', 'architecture-decision-package'],
     ['authority_transition', 'authority-transition'],
@@ -323,6 +324,88 @@ describe('AFL trade-intelligence gate decisions', () => {
         content,
       }).success
     ).toBe(false);
+  });
+
+  it('permits non-expiring automated authority only for non-production Gate 3 validity', () => {
+    const qualificationId = createAflTradeContentAddress('model-qualification', 'qualification');
+    const runId = createAflTradeContentAddress('model-run', 'qualified-run');
+    const proposalContent = {
+      ...proposal().content,
+      gate: 'gate_3_model_validity' as const,
+      decisionKey: 'automated-player-model-validity',
+      environment: 'non_production' as const,
+      scope: {
+        scopeKey: 'afl-men:2026-trades',
+        description: 'Exact automated model validity for one qualified component run.',
+        dimensions: [],
+        exclusions: [],
+      },
+      reviewRequirement: 'accountable_owner_only' as const,
+      requiredReviewerRoles: [],
+      conditions: [],
+      affectedArtifacts: [
+        { kind: 'model_run' as const, artifactId: runId },
+        { kind: 'model_qualification' as const, artifactId: qualificationId },
+      ],
+    };
+    const automatedProposal = aflTradeGateDecisionProposalSchema.parse({
+      proposalId: createAflTradeContentAddress('gate-proposal', proposalContent),
+      content: proposalContent,
+    });
+    const decisionContent = {
+      schemaVersion: 'afl-trade-gate-decision/v1' as const,
+      proposalId: automatedProposal.proposalId,
+      gate: automatedProposal.content.gate,
+      decisionKey: automatedProposal.content.decisionKey,
+      version: 1,
+      environment: automatedProposal.content.environment,
+      scope: automatedProposal.content.scope,
+      state: 'approved' as const,
+      authorityKind: 'automated_validation_record' as const,
+      accountableOwner: automatedProposal.content.accountableOwner,
+      decidedBy: 'statly-model-qualification-agent',
+      reviewers: [],
+      authorityEvidenceIds: [refs.authority],
+      conditionResults: [],
+      rationale: 'The exact retained model-pair qualification recomputed successfully.',
+      limitations: ['Private non-production model validity only.'],
+      decidedAt: '2026-08-21T09:00:00.000Z',
+      effectiveAt: '2026-08-21T09:00:00.000Z',
+      revalidateAt: null,
+      supersedesDecisionId: null,
+      affectedArtifacts: automatedProposal.content.affectedArtifacts,
+      withdrawalActions: [],
+    };
+    const automatedDecision = aflTradeGateDecisionRecordSchema.parse({
+      decisionId: createAflTradeContentAddress('gate-decision', decisionContent),
+      content: decisionContent,
+    });
+    const automatedLedger = ledger([automatedProposal], [automatedDecision]);
+
+    expect(validateAflTradeGateDecisionLedger(automatedLedger)).toEqual({
+      valid: true,
+      issues: [],
+    });
+    expect(
+      resolveAflTradeGateEligibility(automatedLedger, {
+        gate: 'gate_3_model_validity',
+        decisionKey: automatedProposal.content.decisionKey,
+        environment: 'non_production',
+        evaluatedAt: '2036-08-21T09:00:00.000Z',
+      }).status
+    ).toBe('mechanically_eligible');
+
+    for (const invalidContent of [
+      { ...decisionContent, environment: 'production' as const },
+      { ...decisionContent, gate: 'gate_4_publication_api_readiness' as const },
+    ]) {
+      expect(
+        aflTradeGateDecisionRecordSchema.safeParse({
+          decisionId: createAflTradeContentAddress('gate-decision', invalidContent),
+          content: invalidContent,
+        }).success
+      ).toBe(false);
+    }
   });
 
   it('preserves ordered decision-record issues when lifecycle rules fail together', () => {

--- a/tests/unit/afl-trade-intelligence-gate-decisions.test.ts
+++ b/tests/unit/afl-trade-intelligence-gate-decisions.test.ts
@@ -400,6 +400,14 @@ describe('AFL trade-intelligence gate decisions', () => {
       { ...decisionContent, gate: 'gate_4_publication_api_readiness' as const },
       { ...decisionContent, revalidateAt: '2027-08-21T09:00:00.000Z' },
       { ...decisionContent, state: 'rejected' as const },
+      {
+        ...decisionContent,
+        state: 'pending' as const,
+        decidedBy: null,
+        rationale: null,
+        decidedAt: null,
+        effectiveAt: null,
+      },
     ]) {
       expect(
         aflTradeGateDecisionRecordSchema.safeParse({

--- a/tests/unit/afl-trade-intelligence-governed-model-qualification-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-model-qualification-migration.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const migrationPath =
+  'prisma/afl-trade-outcomes/migrations/0064_automated_model_pair_qualification/migration.sql';
+
+describe('automated model-pair qualification migration', () => {
+  it('adds immutable qualification history and one atomic current pair with immediate work', () => {
+    expect(existsSync(join(process.cwd(), migrationPath))).toBe(true);
+    const sql = readFileSync(join(process.cwd(), migrationPath), 'utf8');
+
+    expect(sql).toContain('CREATE TABLE "outcome_governed_valuation_model_qualification"');
+    expect(sql).toContain('CREATE TABLE "outcome_current_governed_valuation_model_pair"');
+    expect(sql).toContain('CREATE TABLE "outcome_governed_model_qualification_work"');
+    expect(sql).toContain('Governed valuation model qualifications are append-only');
+    expect(sql).toContain('Current governed valuation model pairs require a passing qualification');
+    expect(sql).toContain('"player_gate3_decision_id"');
+    expect(sql).toContain('"pick_gate3_decision_id"');
+    expect(sql).toContain('"qualification_id"');
+    expect(sql).toContain('expected_revision INTEGER');
+  });
+
+  it('allows successor pending records and limits automated Gate authority to non-production Gate 3', () => {
+    const sql = readFileSync(join(process.cwd(), migrationPath), 'utf8');
+
+    expect(sql).toContain("'governed-valuation-component-run/v2'");
+    expect(sql).toContain("'afl-trade-pick-pav-model-execution/v3'");
+    expect(sql).toContain("'automated_qualification_pending'");
+    expect(sql).toContain("'automated_validation_record'");
+    expect(sql).toContain("'gate_3_model_validity'");
+    expect(sql).toContain("'non_production'");
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-model-qualification-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-model-qualification-migration.test.ts
@@ -33,5 +33,8 @@ describe('automated model-pair qualification migration', () => {
     expect(sql).toContain("'automated_validation_record'");
     expect(sql).toContain("'gate_3_model_validity'");
     expect(sql).toContain("'non_production'");
+    expect(sql).toContain('validate_outcome_prepared_valuation_input_v2_artifact');
+    expect(sql).toContain('outcome_automated_gate_pair_commit_guard');
+    expect(sql).toContain('DEFERRABLE INITIALLY DEFERRED');
   });
 });

--- a/tests/unit/afl-trade-intelligence-governed-model-qualification-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-model-qualification-migration.test.ts
@@ -36,5 +36,8 @@ describe('automated model-pair qualification migration', () => {
     expect(sql).toContain('validate_outcome_prepared_valuation_input_v2_artifact');
     expect(sql).toContain('outcome_automated_gate_pair_commit_guard');
     expect(sql).toContain('DEFERRABLE INITIALLY DEFERRED');
+    expect(sql).toContain('outcome_automated_gate_qualification_run_unique');
+    expect(sql).toContain('validate_outcome_governed_model_qualification_work');
+    expect(sql).toContain('Governed model qualification work evidence is immutable');
   });
 });

--- a/tests/unit/afl-trade-intelligence-governed-pick-pav-model-execution.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-pick-pav-model-execution.test.ts
@@ -1,12 +1,16 @@
 import { createHash } from 'node:crypto';
 
 import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import { createAflTradePickPavPolicy } from '@/server/aflTradeIntelligence/modeling/pickOutcomeContracts';
 import {
   computeAflTradePickPavModelExecutionOutputs,
 } from '@/server/aflTradeIntelligence/modeling/pickPavModelExecution';
 import { materializeAflTradePickPavObservationSet } from '@/server/aflTradeIntelligence/modeling/pickPavObservationService';
-import { createGovernedAflTradePickPavModelExecution } from '@/server/aflTradeIntelligence/modeling/governedPickPavModelExecution';
+import {
+  createGovernedAflTradePickPavModelExecution,
+  governedAflTradePickPavModelExecutionSchema,
+} from '@/server/aflTradeIntelligence/modeling/governedPickPavModelExecution';
 
 const sha = (value: string) => createHash('sha256').update(value).digest('hex');
 const addressed = (prefix: string, value: string) => `${prefix}:${sha(value)}`;
@@ -171,9 +175,9 @@ describe('governed pick-PAV model execution', () => {
     });
 
     expect(execution.content).toMatchObject({
-      schemaVersion: 'afl-trade-pick-pav-model-execution/v2',
+      schemaVersion: 'afl-trade-pick-pav-model-execution/v3',
       environment: 'non_production',
-      approvalStatus: 'gate_3_review_required',
+      qualificationStatus: 'automated_qualification_pending',
       publicationEligible: false,
       datasetId,
       datasetAdmissionId,
@@ -181,5 +185,28 @@ describe('governed pick-PAV model execution', () => {
       protocolId,
     });
     expect(execution.content).not.toHaveProperty('grade');
+
+    const {
+      qualificationStatus: _qualificationStatus,
+      ...successorWithoutQualificationStatus
+    } = execution.content;
+    const legacyContent = {
+      ...successorWithoutQualificationStatus,
+      schemaVersion: 'afl-trade-pick-pav-model-execution/v2' as const,
+      authorityBoundary:
+        'authenticated_non_production_pick_model_candidate_no_gate_3_approval_grade_publication_or_fantasy_ownership' as const,
+      approvalStatus: 'gate_3_review_required' as const,
+      limitation:
+        'This retained non-production execution is eligible for independent Gate 3 review only; it is not an approval, trade grade, or public numerical authority.' as const,
+    };
+    const legacy = governedAflTradePickPavModelExecutionSchema.parse({
+      executionId: createAflTradeContentAddress('pick-pav-model-execution', legacyContent),
+      content: legacyContent,
+    });
+    expect(legacy.content).toMatchObject({
+      schemaVersion: 'afl-trade-pick-pav-model-execution/v2',
+      approvalStatus: 'gate_3_review_required',
+    });
+    expect(legacy.content).not.toHaveProperty('qualificationStatus');
   });
 });

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-authority-snapshot.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-authority-snapshot.test.ts
@@ -47,6 +47,8 @@ function readyAuthorityInput() {
         datasetAdmissionGateLedgerRevision: 11,
         gate3DecisionId: `gate-decision:${'a'.repeat(64)}`,
         gate3DecisionVersion: 3,
+        qualificationId: `model-qualification:${'a'.repeat(64)}`,
+        qualificationPolicyVersion: `model-qualification-policy:${'b'.repeat(64)}`,
       },
       {
         role: 'draft_pick_and_future_pick_distribution' as const,
@@ -57,6 +59,8 @@ function readyAuthorityInput() {
         datasetAdmissionGateLedgerRevision: 12,
         gate3DecisionId: `gate-decision:${'f'.repeat(64)}`,
         gate3DecisionVersion: 2,
+        qualificationId: `model-qualification:${'a'.repeat(64)}`,
+        qualificationPolicyVersion: `model-qualification-policy:${'b'.repeat(64)}`,
       },
     ],
   };
@@ -278,5 +282,16 @@ describe('governed private evaluation authority snapshot', () => {
     expect(() => createReadyGovernedPrivateEvaluationAuthorityInspection(reordered)).toThrow(
       /component|role|canonical/i
     );
+
+    const unqualified = readyAuthorityInput();
+    delete (unqualified.components[0] as { qualificationId?: string }).qualificationId;
+    delete (unqualified.components[0] as { qualificationPolicyVersion?: string })
+      .qualificationPolicyVersion;
+    delete (unqualified.components[1] as { qualificationId?: string }).qualificationId;
+    delete (unqualified.components[1] as { qualificationPolicyVersion?: string })
+      .qualificationPolicyVersion;
+    expect(() =>
+      createReadyGovernedPrivateEvaluationAuthorityInspection(unqualified)
+    ).toThrow(/qualification custody/i);
   });
 });

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-authority-snapshot.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-authority-snapshot.test.ts
@@ -208,6 +208,11 @@ describe('governed private evaluation authority snapshot', () => {
 
   it('pins ready v3 authority to one current prepared head and its exact replay manifest', () => {
     const legacy = readyAuthorityInput();
+    const qualifiedComponents = legacy.components.map((component) => ({
+      ...component,
+      qualificationId: `model-qualification:${'a'.repeat(64)}`,
+      qualificationPolicyVersion: `model-qualification-policy:${'b'.repeat(64)}`,
+    }));
     const retained = createReadyGovernedPrivateEvaluationAuthorityInspectionV3({
       selector: legacy.selector,
       capturedAt: legacy.capturedAt,
@@ -226,7 +231,7 @@ describe('governed private evaluation authority snapshot', () => {
       valuationInputBundleId: legacy.valuationInputBundleId,
       valuationInputBundleArtifact: legacy.valuationInputBundleArtifact,
       gateLedgerRevision: legacy.gateLedgerRevision,
-      components: legacy.components,
+      components: qualifiedComponents,
     });
 
     expect(retained.snapshot.content).toMatchObject({
@@ -247,7 +252,7 @@ describe('governed private evaluation authority snapshot', () => {
         ),
         privateValuationDecisionRevision: 3,
         valuationInputBundleId: legacy.valuationInputBundleId,
-        components: legacy.components,
+        components: qualifiedComponents,
       },
     });
     expect(authenticateGovernedPrivateEvaluationAuthorityInspection(retained)).toEqual(retained);

--- a/tests/unit/afl-trade-intelligence-governed-ready-component-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-ready-component-authority.test.ts
@@ -4,7 +4,10 @@ import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelli
 import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import { aflTradeGateDecisionRecordSchema } from '@/server/aflTradeIntelligence/governance/gateDecisionTypes';
 import { authenticateGovernedReadyComponentAuthority } from '@/server/aflTradeIntelligence/valuation/internal/governedReadyComponentAuthority';
-import { createGovernedValuationModelQualification } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification';
+import {
+  createGovernedValuationModelQualification,
+  createGovernedValuationModelQualificationPolicy,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification';
 import { createGovernedValuationComponentRunManifest } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest';
 
 const capturedAt = '2026-08-20T10:00:00.000Z';
@@ -26,9 +29,7 @@ function qualificationFor(
   run: ReturnType<typeof createGovernedValuationComponentRunManifest>,
   options: Readonly<{ playerMinimumComparableObservations?: number }> = {}
 ) {
-  const policy = {
-    schemaVersion: 'governed-valuation-model-qualification-policy/v1' as const,
-    policyVersion: 'ready-authority-v1',
+  const policy = createGovernedValuationModelQualificationPolicy({
     player: {
       schemaVersion: 'governed-player-model-qualification-criteria/v1' as const,
       minimumComparableObservations: options.playerMinimumComparableObservations ?? 1,
@@ -53,7 +54,7 @@ function qualificationFor(
       maximumMeanEmpiricalIntervalWidth: 100,
       maximumZeroProbabilityObservationCount: 0,
     },
-  };
+  });
   const playerEvidence = {
     schemaVersion: 'governed-player-model-qualification-evidence/v1' as const,
     validationReportId: createAflTradeContentAddress('player-validation-report', 'ready-player'),
@@ -356,6 +357,21 @@ describe('governed ready component authority', () => {
         currentQualificationId: otherQualification.qualification.qualificationId,
       })
     ).toThrow(/exact component run/i);
+
+    const crossScope = replaceDecision(value, {
+      ...value.gate3Decision.content,
+      scope: { ...value.gate3Decision.content.scope, scopeKey: 'afl-men:2024-trades' },
+    });
+    expect(() =>
+      authenticateGovernedReadyComponentAuthority({
+        ...common,
+        ...crossScope,
+        gate3IsCurrent: true,
+        qualification: value.qualification,
+        qualificationArtifact: value.qualificationArtifact,
+        currentQualificationId: value.qualification.qualificationId,
+      })
+    ).toThrow(/exact run and qualification/i);
   });
 
   it('rejects a legacy pick fixture wrapper even when a Gate 3 record names it', () => {

--- a/tests/unit/afl-trade-intelligence-governed-ready-component-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-ready-component-authority.test.ts
@@ -4,6 +4,7 @@ import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelli
 import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import { aflTradeGateDecisionRecordSchema } from '@/server/aflTradeIntelligence/governance/gateDecisionTypes';
 import { authenticateGovernedReadyComponentAuthority } from '@/server/aflTradeIntelligence/valuation/internal/governedReadyComponentAuthority';
+import { createGovernedValuationModelQualification } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification';
 import { createGovernedValuationComponentRunManifest } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest';
 
 const capturedAt = '2026-08-20T10:00:00.000Z';
@@ -18,6 +19,110 @@ function artifact(label: string) {
     mediaType: 'application/json',
     byteLength: 128,
     createdAt,
+  };
+}
+
+function qualificationFor(
+  run: ReturnType<typeof createGovernedValuationComponentRunManifest>,
+  options: Readonly<{ playerMinimumComparableObservations?: number }> = {}
+) {
+  const policy = {
+    schemaVersion: 'governed-valuation-model-qualification-policy/v1' as const,
+    policyVersion: 'ready-authority-v1',
+    player: {
+      schemaVersion: 'governed-player-model-qualification-criteria/v1' as const,
+      minimumComparableObservations: options.playerMinimumComparableObservations ?? 1,
+      minimumRelativeMaeImprovement: 0.05,
+      minimumRelativeRmseImprovement: 0.05,
+      requiredAcceptanceOutcome: 'meets_declared_predictive_thresholds' as const,
+    },
+    pick: {
+      schemaVersion: 'governed-pick-model-qualification-criteria/v1' as const,
+      evaluatedScope: 'final_test' as const,
+      minimumObservations: 1,
+      maximumMulticlassBrierScore: 1,
+      maximumMulticlassLogLoss: 2,
+      maximumRankedProbabilityScore: 1,
+      maximumContributionCrps: 100,
+      maximumMeanAbsoluteContributionError: 100,
+      maximumRootMeanSquaredContributionError: 100,
+      maximumMeanAbsoluteGamesError: 100,
+      maximumRootMeanSquaredGamesError: 100,
+      minimumEmpiricalP10P90Coverage: 0.5,
+      maximumEmpiricalP10P90Coverage: 1,
+      maximumMeanEmpiricalIntervalWidth: 100,
+      maximumZeroProbabilityObservationCount: 0,
+    },
+  };
+  const playerEvidence = {
+    schemaVersion: 'governed-player-model-qualification-evidence/v1' as const,
+    validationReportId: createAflTradeContentAddress('player-validation-report', 'ready-player'),
+    comparableObservationCount: 10,
+    acceptanceOutcome: 'meets_declared_predictive_thresholds' as const,
+    relativeMaeImprovement: 0.1,
+    relativeRmseImprovement: 0.1,
+  };
+  const pickEvidence = {
+    schemaVersion: 'governed-pick-model-qualification-evidence/v1' as const,
+    validationReportId: createAflTradeContentAddress(
+      'pick-pav-validation-report',
+      'ready-pick'
+    ),
+    evaluationStatus: 'scored_not_approved' as const,
+    scope: 'final_test' as const,
+    observationCount: 10,
+    metrics: {
+      multiclassBrierScore: 0.5,
+      multiclassLogLoss: 1,
+      rankedProbabilityScore: 0.5,
+      contributionCrps: 50,
+      meanAbsoluteContributionError: 50,
+      rootMeanSquaredContributionError: 50,
+      meanAbsoluteGamesError: 50,
+      rootMeanSquaredGamesError: 50,
+      empiricalP10P90Coverage: 0.8,
+      meanEmpiricalIntervalWidth: 50,
+      zeroProbabilityObservationCount: 0,
+    },
+  };
+  const qualification = createGovernedValuationModelQualification({
+    environment: 'non_production',
+    scopeKey: 'afl-men:2025-trades',
+    evaluatedAt: capturedAt,
+    policy,
+    policyArtifact: createAflTradeCanonicalJsonArtifactRef(policy, capturedAt),
+    components: {
+      player: {
+        role: run.content.role as 'player_contribution_and_availability',
+        runId: run.runId,
+        runArtifact: createAflTradeCanonicalJsonArtifactRef(run, createdAt),
+        protocolId: run.content.protocolId,
+        protocolArtifact: run.content.protocolArtifact,
+        criteriaArtifact: createAflTradeCanonicalJsonArtifactRef(policy.player, capturedAt),
+        validationEvidence: playerEvidence,
+        validationEvidenceArtifact: createAflTradeCanonicalJsonArtifactRef(
+          playerEvidence,
+          capturedAt
+        ),
+      },
+      pick: {
+        role: 'draft_pick_and_future_pick_distribution',
+        runId: createAflTradeContentAddress('model-run', 'ready-pick-run'),
+        runArtifact: artifact('ready-pick-run'),
+        protocolId: createAflTradeContentAddress('model-protocol', 'ready-pick-protocol'),
+        protocolArtifact: artifact('ready-pick-protocol'),
+        criteriaArtifact: createAflTradeCanonicalJsonArtifactRef(policy.pick, capturedAt),
+        validationEvidence: pickEvidence,
+        validationEvidenceArtifact: createAflTradeCanonicalJsonArtifactRef(
+          pickEvidence,
+          capturedAt
+        ),
+      },
+    },
+  });
+  return {
+    qualification,
+    qualificationArtifact: createAflTradeCanonicalJsonArtifactRef(qualification, capturedAt),
   };
 }
 
@@ -45,6 +150,7 @@ function fixture() {
     registeredAt: createdAt,
   });
   const runArtifact = createAflTradeCanonicalJsonArtifactRef(run, createdAt);
+  const qualification = qualificationFor(run);
   const decisionContent = {
     schemaVersion: 'afl-trade-gate-decision/v1' as const,
     proposalId: createAflTradeContentAddress('gate-proposal', { fixture: 'player-gate3' }),
@@ -59,9 +165,9 @@ function fixture() {
       exclusions: [],
     },
     state: 'approved' as const,
-    authorityKind: 'external_human_record' as const,
+    authorityKind: 'automated_validation_record' as const,
     accountableOwner: 'statly-model-owner',
-    decidedBy: 'statly-independent-reviewer',
+    decidedBy: 'statly-model-qualification-agent',
     reviewers: [],
     authorityEvidenceIds: [artifact('review-evidence').artifactId],
     conditionResults: [],
@@ -69,9 +175,15 @@ function fixture() {
     limitations: ['Private non-production calculation only.'],
     decidedAt: '2026-08-20T09:10:00.000Z',
     effectiveAt: '2026-08-20T09:15:00.000Z',
-    revalidateAt: '2026-09-20T09:15:00.000Z',
+    revalidateAt: null,
     supersedesDecisionId: null,
-    affectedArtifacts: [{ kind: 'model_run' as const, artifactId: run.runId }],
+    affectedArtifacts: [
+      { kind: 'model_run' as const, artifactId: run.runId },
+      {
+        kind: 'model_qualification' as const,
+        artifactId: qualification.qualification.qualificationId,
+      },
+    ],
     withdrawalActions: [],
   };
   const gate3Decision = aflTradeGateDecisionRecordSchema.parse({
@@ -98,6 +210,7 @@ function fixture() {
       },
     },
     gate3Decision,
+    ...qualification,
   };
 }
 
@@ -126,7 +239,7 @@ function replaceDecision(
 }
 
 describe('governed ready component authority', () => {
-  it('returns only exact current externally reviewed Gate 3 authority', () => {
+  it('returns only exact current automated model-pair qualification authority', () => {
     const value = fixture();
     expect(
       authenticateGovernedReadyComponentAuthority({
@@ -135,6 +248,9 @@ describe('governed ready component authority', () => {
         gate3IsCurrent: true,
         gateLedgerRevision: 19,
         capturedAt,
+        qualification: value.qualification,
+        qualificationArtifact: value.qualificationArtifact,
+        currentQualificationId: value.qualification.qualificationId,
       })
     ).toEqual({
       role: value.traceComponent.role,
@@ -145,36 +261,42 @@ describe('governed ready component authority', () => {
       datasetAdmissionGateLedgerRevision: 11,
       gate3DecisionId: value.gate3Decision.decisionId,
       gate3DecisionVersion: 2,
+      qualificationId: value.qualification.qualificationId,
+      qualificationPolicyVersion: value.qualification.content.policy.policyVersion,
     });
   });
 
-  it('rejects superseded, expired, and fixture-only review authority', () => {
+  it('rejects superseded, not-yet-effective, and non-automated Gate authority', () => {
     const value = fixture();
     const common = {
       ...value,
       gate3DecisionArtifact: value.traceComponent.evidence.gate3Decision,
       gateLedgerRevision: 19,
       capturedAt,
+      qualification: value.qualification,
+      qualificationArtifact: value.qualificationArtifact,
+      currentQualificationId: value.qualification.qualificationId,
     };
     expect(() =>
       authenticateGovernedReadyComponentAuthority({ ...common, gate3IsCurrent: false })
     ).toThrow(/current/i);
 
-    const expired = replaceDecision(value, {
+    const notYetEffective = replaceDecision(value, {
       ...value.gate3Decision.content,
-      revalidateAt: capturedAt,
+      effectiveAt: '2026-08-20T10:00:01.000Z',
     });
     expect(() =>
       authenticateGovernedReadyComponentAuthority({
         ...common,
-        ...expired,
+        ...notYetEffective,
         gate3IsCurrent: true,
       })
-    ).toThrow(/current|revalidation/i);
+    ).toThrow(/effective/i);
 
     const fixtureOnly = replaceDecision(value, {
       ...value.gate3Decision.content,
       authorityKind: 'fixture',
+      revalidateAt: '2026-08-21T10:00:00.000Z',
     });
     expect(() =>
       authenticateGovernedReadyComponentAuthority({
@@ -182,7 +304,58 @@ describe('governed ready component authority', () => {
         ...fixtureOnly,
         gate3IsCurrent: true,
       })
-    ).toThrow(/external human/i);
+    ).toThrow(/automated/i);
+  });
+
+  it('rejects failed, stale, or mismatched model-pair qualification evidence', () => {
+    const value = fixture();
+    const common = {
+      ...value,
+      gate3DecisionArtifact: value.traceComponent.evidence.gate3Decision,
+      gate3IsCurrent: true,
+      gateLedgerRevision: 19,
+      capturedAt,
+    };
+    const failed = qualificationFor(value.run.manifest, {
+      playerMinimumComparableObservations: 100,
+    });
+
+    expect(() =>
+      authenticateGovernedReadyComponentAuthority({
+        ...common,
+        qualification: failed.qualification,
+        qualificationArtifact: failed.qualificationArtifact,
+        currentQualificationId: failed.qualification.qualificationId,
+      })
+    ).toThrow(/passing/i);
+
+    expect(() =>
+      authenticateGovernedReadyComponentAuthority({
+        ...common,
+        currentQualificationId: createAflTradeContentAddress(
+          'model-qualification',
+          'superseding-current-qualification'
+        ),
+      })
+    ).toThrow(/current/i);
+
+    const otherRun = createGovernedValuationComponentRunManifest({
+      ...value.run.manifest.content,
+      nativeExecution: {
+        kind: 'admitted_player_model_run',
+        executionId: createAflTradeContentAddress('model-run', 'other-player-run'),
+        artifact: artifact('other-player-run'),
+      },
+    });
+    const otherQualification = qualificationFor(otherRun);
+    expect(() =>
+      authenticateGovernedReadyComponentAuthority({
+        ...common,
+        qualification: otherQualification.qualification,
+        qualificationArtifact: otherQualification.qualificationArtifact,
+        currentQualificationId: otherQualification.qualification.qualificationId,
+      })
+    ).toThrow(/exact component run/i);
   });
 
   it('rejects a legacy pick fixture wrapper even when a Gate 3 record names it', () => {
@@ -201,7 +374,13 @@ describe('governed ready component authority', () => {
     const runArtifact = createAflTradeCanonicalJsonArtifactRef(legacyPickRun, createdAt);
     const replaced = replaceDecision(value, {
       ...value.gate3Decision.content,
-      affectedArtifacts: [{ kind: 'model_run', artifactId: legacyPickRun.runId }],
+      affectedArtifacts: [
+        { kind: 'model_run', artifactId: legacyPickRun.runId },
+        {
+          kind: 'model_qualification',
+          artifactId: value.qualification.qualificationId,
+        },
+      ],
     });
 
     expect(() =>
@@ -226,6 +405,9 @@ describe('governed ready component authority', () => {
         gate3IsCurrent: true,
         gateLedgerRevision: 19,
         capturedAt,
+        qualification: value.qualification,
+        qualificationArtifact: value.qualificationArtifact,
+        currentQualificationId: value.qualification.qualificationId,
       })
     ).toThrow(/governed|fixture|eligible/i);
   });

--- a/tests/unit/afl-trade-intelligence-governed-valuation-component-run.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-valuation-component-run.test.ts
@@ -1,4 +1,5 @@
 import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import {
   authenticateGovernedValuationComponentRunManifest,
   createGovernedValuationComponentRunManifest,
@@ -48,15 +49,36 @@ describe('governed valuation component run manifest', () => {
     for (const manifest of [player, pick]) {
       expect(manifest.runId).toMatch(/^model-run:[a-f0-9]{64}$/);
       expect(manifest.content).toMatchObject({
-        schemaVersion: 'governed-valuation-component-run/v1',
+        schemaVersion: 'governed-valuation-component-run/v2',
         environment: 'non_production',
-        approvalState: 'gate_3_review_required',
+        qualificationState: 'automated_qualification_pending',
         publicationEligible: false,
       });
       expect(authenticateGovernedValuationComponentRunManifest(manifest)).toEqual(manifest);
     }
     expect(player.content.nativeExecution.kind).toBe('admitted_player_model_run');
     expect(pick.content.nativeExecution.kind).toBe('governed_pick_pav_model_execution');
+
+    const {
+      qualificationState: _qualificationState,
+      ...successorWithoutQualificationState
+    } = player.content;
+    const legacyContent = {
+      ...successorWithoutQualificationState,
+      schemaVersion: 'governed-valuation-component-run/v1' as const,
+      approvalState: 'gate_3_review_required' as const,
+      limitation:
+        'Authenticated non-production component-run candidate only; Gate 3 approval, grades, production use, and publication remain prohibited.' as const,
+    };
+    const legacy = authenticateGovernedValuationComponentRunManifest({
+      runId: createAflTradeContentAddress('model-run', legacyContent),
+      content: legacyContent,
+    });
+    expect(legacy.content).toMatchObject({
+      schemaVersion: 'governed-valuation-component-run/v1',
+      approvalState: 'gate_3_review_required',
+    });
+    expect(legacy.content).not.toHaveProperty('qualificationState');
   });
 
   it('rejects role substitution and duplicate retained evidence', () => {

--- a/tests/unit/afl-trade-intelligence-governed-valuation-model-qualification.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-valuation-model-qualification.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import {
+  createGovernedValuationModelQualification,
+  createGovernedValuationModelQualificationGateRecords,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification';
+
+const evaluatedAt = '2026-08-21T09:00:00.000Z';
+
+function ref(prefix: string, label: string) {
+  const value = { prefix, label };
+  return createAflTradeCanonicalJsonArtifactRef(value, '2026-08-21T08:00:00.000Z');
+}
+
+function fixture() {
+  const policy = {
+    schemaVersion: 'governed-valuation-model-qualification-policy/v1' as const,
+    policyVersion: 'afl-men-private-model-pair-v1',
+    player: {
+      schemaVersion: 'governed-player-model-qualification-criteria/v1' as const,
+      minimumComparableObservations: 100,
+      minimumRelativeMaeImprovement: 0.05,
+      minimumRelativeRmseImprovement: 0.05,
+      requiredAcceptanceOutcome: 'meets_declared_predictive_thresholds' as const,
+    },
+    pick: {
+      schemaVersion: 'governed-pick-model-qualification-criteria/v1' as const,
+      evaluatedScope: 'final_test' as const,
+      minimumObservations: 30,
+      maximumMulticlassBrierScore: 0.7,
+      maximumMulticlassLogLoss: 2,
+      maximumRankedProbabilityScore: 0.35,
+      maximumContributionCrps: 25,
+      maximumMeanAbsoluteContributionError: 30,
+      maximumRootMeanSquaredContributionError: 40,
+      maximumMeanAbsoluteGamesError: 35,
+      maximumRootMeanSquaredGamesError: 45,
+      minimumEmpiricalP10P90Coverage: 0.7,
+      maximumEmpiricalP10P90Coverage: 0.9,
+      maximumMeanEmpiricalIntervalWidth: 80,
+      maximumZeroProbabilityObservationCount: 0,
+    },
+  };
+  const playerEvidence = {
+    schemaVersion: 'governed-player-model-qualification-evidence/v1' as const,
+    validationReportId: createAflTradeContentAddress('player-validation-report', 'player-report'),
+    comparableObservationCount: 120,
+    acceptanceOutcome: 'meets_declared_predictive_thresholds' as const,
+    relativeMaeImprovement: 0.08,
+    relativeRmseImprovement: 0.07,
+  };
+  const pickEvidence = {
+    schemaVersion: 'governed-pick-model-qualification-evidence/v1' as const,
+    validationReportId: createAflTradeContentAddress(
+      'pick-pav-validation-report',
+      'pick-report'
+    ),
+    evaluationStatus: 'scored_not_approved' as const,
+    scope: 'final_test' as const,
+    observationCount: 40,
+    metrics: {
+      multiclassBrierScore: 0.4,
+      multiclassLogLoss: 1.2,
+      rankedProbabilityScore: 0.2,
+      contributionCrps: 18,
+      meanAbsoluteContributionError: 22,
+      rootMeanSquaredContributionError: 31,
+      meanAbsoluteGamesError: 24,
+      rootMeanSquaredGamesError: 34,
+      empiricalP10P90Coverage: 0.8,
+      meanEmpiricalIntervalWidth: 60,
+      zeroProbabilityObservationCount: 0,
+    },
+  };
+  const playerRunId = createAflTradeContentAddress('model-run', 'qualified-player-run');
+  const pickRunId = createAflTradeContentAddress('model-run', 'qualified-pick-run');
+  return {
+    environment: 'non_production' as const,
+    scopeKey: 'afl-men:2026-trades',
+    evaluatedAt,
+    policy,
+    policyArtifact: createAflTradeCanonicalJsonArtifactRef(policy, evaluatedAt),
+    components: {
+      player: {
+        role: 'player_contribution_and_availability' as const,
+        runId: playerRunId,
+        runArtifact: ref('run', 'player'),
+        protocolId: createAflTradeContentAddress('model-protocol', 'player-protocol'),
+        protocolArtifact: ref('protocol', 'player'),
+        criteriaArtifact: createAflTradeCanonicalJsonArtifactRef(policy.player, evaluatedAt),
+        validationEvidence: playerEvidence,
+        validationEvidenceArtifact: createAflTradeCanonicalJsonArtifactRef(
+          playerEvidence,
+          evaluatedAt
+        ),
+      },
+      pick: {
+        role: 'draft_pick_and_future_pick_distribution' as const,
+        runId: pickRunId,
+        runArtifact: ref('run', 'pick'),
+        protocolId: createAflTradeContentAddress('model-protocol', 'pick-protocol'),
+        protocolArtifact: ref('protocol', 'pick'),
+        criteriaArtifact: createAflTradeCanonicalJsonArtifactRef(policy.pick, evaluatedAt),
+        validationEvidence: pickEvidence,
+        validationEvidenceArtifact: createAflTradeCanonicalJsonArtifactRef(
+          pickEvidence,
+          evaluatedAt
+        ),
+      },
+    },
+  };
+}
+
+describe('governed valuation model qualification', () => {
+  it('qualifies one exact player-and-pick release by recomputing authenticated criteria', () => {
+    const input = fixture();
+    const qualification = createGovernedValuationModelQualification(input);
+
+    expect(qualification.qualificationId).toMatch(/^model-qualification:[a-f0-9]{64}$/u);
+    expect(qualification.content).toMatchObject({
+      environment: 'non_production',
+      scopeKey: input.scopeKey,
+      outcome: 'qualified',
+      publicationEligible: false,
+      player: { runId: input.components.player.runId, passed: true },
+      pick: { runId: input.components.pick.runId, passed: true },
+      failureCodes: [],
+    });
+    expect(qualification.content.policyArtifact).toEqual(input.policyArtifact);
+  });
+
+  it('retains a failed exact pair without converting scored evidence into approval', () => {
+    const input = fixture();
+    const failedEvidence = {
+      ...input.components.pick.validationEvidence,
+      metrics: {
+        ...input.components.pick.validationEvidence.metrics,
+        multiclassLogLoss: 2.5,
+      },
+    };
+    const qualification = createGovernedValuationModelQualification({
+      ...input,
+      components: {
+        ...input.components,
+        pick: {
+          ...input.components.pick,
+          validationEvidence: failedEvidence,
+          validationEvidenceArtifact: createAflTradeCanonicalJsonArtifactRef(
+            failedEvidence,
+            evaluatedAt
+          ),
+        },
+      },
+    });
+
+    expect(qualification.content.outcome).toBe('failed');
+    expect(qualification.content.pick.passed).toBe(false);
+    expect(qualification.content.failureCodes).toContain('pick_log_loss_above_maximum');
+  });
+
+  it('rejects criteria or evidence that are not authenticated by their retained references', () => {
+    const input = fixture();
+    expect(() =>
+      createGovernedValuationModelQualification({
+        ...input,
+        components: {
+          ...input.components,
+          player: { ...input.components.player, criteriaArtifact: ref('criteria', 'wrong') },
+        },
+      })
+    ).toThrow(/criteria artifact/i);
+
+    expect(() =>
+      createGovernedValuationModelQualification({
+        ...input,
+        components: {
+          ...input.components,
+          pick: { ...input.components.pick, validationEvidenceArtifact: ref('evidence', 'wrong') },
+        },
+      })
+    ).toThrow(/validation evidence artifact/i);
+  });
+
+  it('creates two linked automated Gate 3 records only for a passing exact pair', () => {
+    const input = fixture();
+    const qualification = createGovernedValuationModelQualification(input);
+    const qualificationArtifact = createAflTradeCanonicalJsonArtifactRef(
+      qualification,
+      evaluatedAt
+    );
+    const records = createGovernedValuationModelQualificationGateRecords({
+      qualification,
+      qualificationArtifact,
+      decidedAt: evaluatedAt,
+      automationPrincipal: 'statly-model-qualification-agent',
+      accountableOwner: 'statly-model-owner',
+      versions: { player: 1, pick: 1 },
+      supersedes: { player: null, pick: null },
+    });
+
+    expect(records.map(({ decision }) => decision.content)).toEqual([
+      expect.objectContaining({
+        gate: 'gate_3_model_validity',
+        authorityKind: 'automated_validation_record',
+        revalidateAt: null,
+        affectedArtifacts: [
+          { kind: 'model_run', artifactId: input.components.player.runId },
+          { kind: 'model_qualification', artifactId: qualification.qualificationId },
+        ],
+      }),
+      expect.objectContaining({
+        gate: 'gate_3_model_validity',
+        authorityKind: 'automated_validation_record',
+        revalidateAt: null,
+        affectedArtifacts: [
+          { kind: 'model_run', artifactId: input.components.pick.runId },
+          { kind: 'model_qualification', artifactId: qualification.qualificationId },
+        ],
+      }),
+    ]);
+    expect(records[0]!.decision.content.authorityEvidenceIds).toEqual([
+      qualificationArtifact.artifactId,
+    ]);
+
+    const failedInput = fixture();
+    failedInput.components.player.validationEvidence.relativeMaeImprovement = 0;
+    failedInput.components.player.validationEvidenceArtifact =
+      createAflTradeCanonicalJsonArtifactRef(
+        failedInput.components.player.validationEvidence,
+        evaluatedAt
+      );
+    const failed = createGovernedValuationModelQualification(failedInput);
+    expect(() =>
+      createGovernedValuationModelQualificationGateRecords({
+        qualification: failed,
+        qualificationArtifact: createAflTradeCanonicalJsonArtifactRef(failed, evaluatedAt),
+        decidedAt: evaluatedAt,
+        automationPrincipal: 'statly-model-qualification-agent',
+        accountableOwner: 'statly-model-owner',
+        versions: { player: 1, pick: 1 },
+        supersedes: { player: null, pick: null },
+      })
+    ).toThrow(/passing|qualified/i);
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-valuation-model-qualification.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-valuation-model-qualification.test.ts
@@ -5,6 +5,7 @@ import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/arti
 import {
   createGovernedValuationModelQualification,
   createGovernedValuationModelQualificationGateRecords,
+  createGovernedValuationModelQualificationPolicy,
 } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification';
 
 const evaluatedAt = '2026-08-21T09:00:00.000Z';
@@ -15,9 +16,7 @@ function ref(prefix: string, label: string) {
 }
 
 function fixture() {
-  const policy = {
-    schemaVersion: 'governed-valuation-model-qualification-policy/v1' as const,
-    policyVersion: 'afl-men-private-model-pair-v1',
+  const policy = createGovernedValuationModelQualificationPolicy({
     player: {
       schemaVersion: 'governed-player-model-qualification-criteria/v1' as const,
       minimumComparableObservations: 100,
@@ -42,7 +41,7 @@ function fixture() {
       maximumMeanEmpiricalIntervalWidth: 80,
       maximumZeroProbabilityObservationCount: 0,
     },
-  };
+  });
   const playerEvidence = {
     schemaVersion: 'governed-player-model-qualification-evidence/v1' as const,
     validationReportId: createAflTradeContentAddress('player-validation-report', 'player-report'),
@@ -119,6 +118,9 @@ describe('governed valuation model qualification', () => {
     const qualification = createGovernedValuationModelQualification(input);
 
     expect(qualification.qualificationId).toMatch(/^model-qualification:[a-f0-9]{64}$/u);
+    expect(qualification.content.policy.policyVersion).toMatch(
+      /^model-qualification-policy:[a-f0-9]{64}$/u
+    );
     expect(qualification.content).toMatchObject({
       environment: 'non_production',
       scopeKey: input.scopeKey,
@@ -162,6 +164,18 @@ describe('governed valuation model qualification', () => {
 
   it('rejects criteria or evidence that are not authenticated by their retained references', () => {
     const input = fixture();
+    const conflictingPolicy = {
+      ...input.policy,
+      player: { ...input.policy.player, minimumComparableObservations: 101 },
+    };
+    expect(() =>
+      createGovernedValuationModelQualification({
+        ...input,
+        policy: conflictingPolicy,
+        policyArtifact: createAflTradeCanonicalJsonArtifactRef(conflictingPolicy, evaluatedAt),
+      })
+    ).toThrow(/policyVersion|content-address/i);
+
     expect(() =>
       createGovernedValuationModelQualification({
         ...input,

--- a/tests/unit/afl-trade-intelligence-postgres-gate-ledger.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-gate-ledger.test.ts
@@ -514,7 +514,51 @@ describe('PostgreSQL AFL trade Gate decision ledger', () => {
 
     await expect(
       repository.appendDecision({ expectedRevision: 0, proposal, decision })
-    ).rejects.toMatchObject({ code: 'INVALID_APPEND' });
+    ).rejects.toMatchObject({
+      code: 'INVALID_APPEND',
+      message: 'Automated model-validity records must use the governed qualification boundary.',
+    });
+
+    const rights = sourceRights();
+    const sourceBoundAffectedArtifacts = [
+      ...affectedArtifacts,
+      { kind: 'source_rights' as const, artifactId: rights.rightsArtifactId },
+    ];
+    const sourceBoundProposalContent = {
+      ...proposal.content,
+      affectedArtifacts: sourceBoundAffectedArtifacts,
+    };
+    const sourceBoundProposal = aflTradeGateDecisionProposalSchema.parse({
+      proposalId: createAflTradeContentAddress('gate-proposal', sourceBoundProposalContent),
+      content: sourceBoundProposalContent,
+    });
+    const sourceBoundDecisionContent = {
+      ...decision.content,
+      proposalId: sourceBoundProposal.proposalId,
+      affectedArtifacts: sourceBoundAffectedArtifacts,
+    };
+    const sourceBoundDecision = aflTradeGateDecisionRecordSchema.parse({
+      decisionId: createAflTradeContentAddress('gate-decision', sourceBoundDecisionContent),
+      content: sourceBoundDecisionContent,
+    });
+    const sourceBoundRecord = {
+      sourceRights: rights,
+      proposal: sourceBoundProposal,
+      decision: sourceBoundDecision,
+    };
+
+    await expect(
+      repository.append({ expectedRevision: 0, ...sourceBoundRecord })
+    ).rejects.toMatchObject({
+      code: 'INVALID_APPEND',
+      message: 'The source-rights append boundary accepts only Gate 0A decisions.',
+    });
+    await expect(
+      repository.appendBatch({ expectedRevision: 0, records: [sourceBoundRecord] })
+    ).rejects.toMatchObject({
+      code: 'INVALID_APPEND',
+      message: 'The source-rights append boundary accepts only Gate 0A decisions.',
+    });
   });
 
   it('applies expected-revision CAS to a new generic gate append', async () => {

--- a/tests/unit/afl-trade-intelligence-postgres-gate-ledger.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-gate-ledger.test.ts
@@ -466,6 +466,57 @@ describe('PostgreSQL AFL trade Gate decision ledger', () => {
     ).rejects.toMatchObject({ code: 'INVALID_APPEND' });
   });
 
+  it('reserves automated model-validity records for the governed qualification boundary', async () => {
+    const repository = createPostgresAflTradeGateDecisionLedgerRepository(
+      new MemoryGateSqlClient()
+    );
+    const base = gate2Approval();
+    const qualificationId = `model-qualification:${'6'.repeat(64)}`;
+    const qualificationArtifactId = evidence('7');
+    const affectedArtifacts = [
+      { kind: 'model_run' as const, artifactId: `model-run:${'8'.repeat(64)}` },
+      { kind: 'model_qualification' as const, artifactId: qualificationId },
+    ];
+    const scope = {
+      ...base.proposal.content.scope,
+      scopeKey: 'afl-men:2026-trades',
+      dimensions: [{ name: 'qualification', values: [qualificationId] }],
+    };
+    const proposalContent = {
+      ...base.proposal.content,
+      gate: 'gate_3_model_validity' as const,
+      decisionKey: 'afl-men:2026-trades:player-model-validity',
+      environment: 'non_production' as const,
+      scope,
+      evidenceIds: [qualificationArtifactId],
+      affectedArtifacts,
+    };
+    const proposal = aflTradeGateDecisionProposalSchema.parse({
+      proposalId: createAflTradeContentAddress('gate-proposal', proposalContent),
+      content: proposalContent,
+    });
+    const decisionContent = {
+      ...base.decision.content,
+      proposalId: proposal.proposalId,
+      gate: proposal.content.gate,
+      decisionKey: proposal.content.decisionKey,
+      environment: proposal.content.environment,
+      scope,
+      authorityKind: 'automated_validation_record' as const,
+      authorityEvidenceIds: [qualificationArtifactId],
+      revalidateAt: null,
+      affectedArtifacts,
+    };
+    const decision = aflTradeGateDecisionRecordSchema.parse({
+      decisionId: createAflTradeContentAddress('gate-decision', decisionContent),
+      content: decisionContent,
+    });
+
+    await expect(
+      repository.appendDecision({ expectedRevision: 0, proposal, decision })
+    ).rejects.toMatchObject({ code: 'INVALID_APPEND' });
+  });
+
   it('applies expected-revision CAS to a new generic gate append', async () => {
     const client = new MemoryGateSqlClient();
     const repository = createPostgresAflTradeGateDecisionLedgerRepository(client);

--- a/tests/unit/afl-trade-intelligence-postgres-governed-current-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-current-authority.test.ts
@@ -129,7 +129,7 @@ describe('PostgreSQL governed current calculation authority', () => {
         {
           code: 'model_not_approved',
           message:
-            'Current external Gate 3 approval is unavailable for both governed model components.',
+            'The exact current automated qualification is unavailable for both governed model components.',
         },
       ],
     });

--- a/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-inspection.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-inspection.test.ts
@@ -141,6 +141,11 @@ describe('PostgreSQL governed private evaluation inspection repository', () => {
       { kind: 'valuation-input-bundle' },
       '2026-08-19T09:00:00.000Z'
     );
+    const qualificationId = addressed('model-qualification', 'qualification');
+    const qualificationPolicyVersion = addressed(
+      'model-qualification-policy',
+      'qualification-policy'
+    );
     const components = [
       'player_contribution_and_availability',
       'draft_pick_and_future_pick_distribution',
@@ -155,6 +160,8 @@ describe('PostgreSQL governed private evaluation inspection repository', () => {
       datasetAdmissionGateLedgerRevision: 10 + index,
       gate3DecisionId: addressed('gate-decision', `gate-${index}`),
       gate3DecisionVersion: 2,
+      qualificationId,
+      qualificationPolicyVersion,
     }));
     let captureTransaction: AflOutcomeSqlTransaction | null = null;
     const repository = createPostgresGovernedPrivateEvaluationInspectionRepository({


### PR DESCRIPTION
Closes #534.

## What changed

- adds immutable, content-addressed qualification for one exact player/pick model pair against authenticated versioned thresholds
- authenticates the selected native player report and pick execution, including exact run ancestry, custody, chronology, and qualification-relevant metric recomputation
- creates two linked non-production automated Gate 3 decisions while preserving role-specific lineage
- advances the qualified pair atomically and records authenticated immediate work
- updates ready calculation authority to require the exact shared current qualification
- adds forward migration 0064 with direct-SQL recomputation, canonical custody, pair uniqueness, immutable evidence/work guards, and component chronology enforcement
- preserves legacy approval-pending records while new executions use neutral automated-qualification-pending successors
- waits for API readiness in the isolated Draft worker browser topology, preventing tests from starting against a partial route manifest
- decomposes the qualification registration transaction into focused validation, Gate append, work retention, and current-pair advancement helpers

## Authority boundary

This remains private, local/non-production model-validity authority only. It grants no publication authority, no production approval, and no trade-grade authority. Failed, stale, mismatched, superseded, withdrawn, or policy-inconsistent candidates cannot replace the current qualified pair.

## Verification

- npm run test:unit — 581 files / 3,691 tests passed locally
- focused qualification/Gate unit tests — 27 tests passed locally
- npm run test:outcomes:int — 20 files / 70 tests passed locally on the authority-hardening diff
- focused disposable PostgreSQL qualification test — passed after the final complexity refactor
- npm run outcomes:prisma:validate — passed locally
- npm run typecheck — passed locally with a 4 GB Node heap
- npm run lint:ci — passed locally after the final refactor
- npm run docs:check — passed locally
- independent final Spec and Standards reviews — passed after the final refactor
- exact-head CI gate — passed for 7d3a8743; CodeFactor and GitGuardian also passed

## Advisory notes

- The PostgreSQL suite emits the existing pg@9 concurrent-query deprecation advisory; all tests pass.
- Local npm run test:int requires DATABASE_URL_TEST, which is not configured in this isolated worktree; repository CI covers it.
- Local npm run build requires Firebase worker configuration, which is not configured in this isolated worktree; repository CI covers it.
- CodeFactor flagged one complex registration method on the prior head; the method was decomposed and the replacement exact-head analysis passed.
- CodeRabbit previously skipped automatic review because of its OSS repository policy; independent local reviews passed.
- Sourcery previously skipped code review because the diff exceeds its 150,000-character limit.

## Summary by Sourcery

Automate private non-production qualification and current-authority advancement for exact player-and-pick model pairs.

New Features:
- Add immutable, content-addressed qualification for exact player-and-pick model pairs against authenticated thresholds.
- Create linked automated non-production Gate 3 validity decisions and advance the qualified pair with durable immediate work.
- Require ready calculations to reference the exact shared current model-pair qualification.

Bug Fixes:
- Prevent unauthenticated, stale, mismatched, backdated, superseded, or policy-inconsistent model evidence from becoming current authority.
- Prevent isolated Draft worker browser tests from starting before the API route manifest is ready.

Enhancements:
- Authenticate native executions, validation reports, ancestry, custody, chronology, and recomputed qualification metrics.
- Preserve legacy approval-pending records while introducing neutral automated-qualification-pending successors.
- Enforce immutable evidence, pair uniqueness, linear Gate decision lineage, and atomic current-pair updates at the database boundary.

Tests:
- Add unit and PostgreSQL integration coverage for qualification, evidence authentication, Gate 3 pairing, atomic advancement, replay, stale candidates, and migration constraints.
