### PR TITLE
Automatically prepare the current valuation cohort

### DIFF
--- a/prisma/afl-trade-outcomes/migrations/0065_automated_private_evaluation_authority/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0065_automated_private_evaluation_authority/migration.sql
@@ -1106,36 +1106,47 @@ RETURNS TRIGGER LANGUAGE plpgsql AS $$
 DECLARE
   receipt RECORD;
   prior RECORD;
+  prior_exists BOOLEAN;
 BEGIN
   SELECT * INTO receipt FROM "outcome_private_evaluation_transition_receipt"
    WHERE "transition_id"=NEW."last_transition_id" FOR KEY SHARE;
-  IF TG_OP='INSERT' THEN
-    SELECT * INTO prior FROM "outcome_local_private_trade_evaluation_head"
-     WHERE "valuation_scope_key"=NEW."valuation_scope_key"
-       AND "trade_id"=NEW."trade_id" FOR KEY SHARE;
-  END IF;
   IF receipt."transition_id" IS NULL
     OR receipt."valuation_scope_key" IS DISTINCT FROM NEW."valuation_scope_key"
     OR receipt."trade_id" IS DISTINCT FROM NEW."trade_id"
     OR receipt."to_revision" IS DISTINCT FROM NEW."revision"
     OR receipt."to_status" IS DISTINCT FROM NEW."status"
     OR receipt."to_generation_id" IS DISTINCT FROM NEW."generation_id"
-    OR (TG_OP='INSERT' AND prior."revision" IS NULL AND (
-      receipt."from_revision"<>0 OR receipt."from_status"<>'absent'
+  THEN
+    RAISE EXCEPTION 'Private evaluation head must advance through its exact retained receipt';
+  END IF;
+
+  IF TG_OP='INSERT' THEN
+    SELECT * INTO prior FROM "outcome_local_private_trade_evaluation_head"
+     WHERE "valuation_scope_key"=NEW."valuation_scope_key"
+       AND "trade_id"=NEW."trade_id" FOR KEY SHARE;
+    prior_exists := FOUND;
+    IF NOT prior_exists AND (
+      receipt."from_revision" IS DISTINCT FROM 0
+      OR receipt."from_status" IS DISTINCT FROM 'absent'
       OR receipt."from_generation_id" IS NOT NULL
-      OR receipt."receipt_json"->'content'->>'previousTransitionId' IS NOT NULL))
-    OR (TG_OP='INSERT' AND prior."revision" IS NOT NULL AND (
+      OR receipt."receipt_json"->'content'->>'previousTransitionId' IS NOT NULL)
+    THEN
+      RAISE EXCEPTION 'Private evaluation head must advance through its exact retained receipt';
+    ELSIF prior_exists AND (
       receipt."from_revision" IS DISTINCT FROM prior."revision"
       OR receipt."from_status" IS DISTINCT FROM prior."status"
       OR receipt."from_generation_id" IS DISTINCT FROM prior."generation_id"
       OR receipt."receipt_json"->'content'->>'previousTransitionId'
-         IS DISTINCT FROM prior."last_transition_id"))
-    OR (TG_OP='UPDATE' AND (
+         IS DISTINCT FROM prior."last_transition_id")
+    THEN
+      RAISE EXCEPTION 'Private evaluation head must advance through its exact retained receipt';
+    END IF;
+  ELSIF TG_OP='UPDATE' AND (
       receipt."from_revision" IS DISTINCT FROM OLD."revision"
       OR receipt."from_status" IS DISTINCT FROM OLD."status"
       OR receipt."from_generation_id" IS DISTINCT FROM OLD."generation_id"
       OR receipt."receipt_json"->'content'->>'previousTransitionId'
-         IS DISTINCT FROM OLD."last_transition_id"))
+         IS DISTINCT FROM OLD."last_transition_id")
   THEN
     RAISE EXCEPTION 'Private evaluation head must advance through its exact retained receipt';
   END IF;

--- a/prisma/afl-trade-outcomes/migrations/0065_automated_private_evaluation_authority/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0065_automated_private_evaluation_authority/migration.sql
@@ -1,0 +1,1147 @@
+-- Authenticate automated private-evaluation transitions at the PostgreSQL boundary and retain
+-- restart-safe cohort-operation authority. This remains non-production and publication-prohibited.
+
+CREATE TABLE "outcome_current_valuation_cohort_operation" (
+  "operation_id" TEXT NOT NULL,
+  "scope_key" TEXT NOT NULL,
+  "factual_release_id" TEXT NOT NULL,
+  "factual_release_revision" INTEGER NOT NULL,
+  "model_qualification_id" TEXT NOT NULL,
+  "model_qualification_work_id" TEXT NOT NULL,
+  "model_qualification_revision" INTEGER NOT NULL,
+  "expected_prepared_input_revision" INTEGER NOT NULL,
+  "captured_at" TIMESTAMPTZ(3) NOT NULL,
+  "context_sha256" CHAR(64) NOT NULL,
+  "context_canonical_json" TEXT NOT NULL,
+  "context_json" JSONB NOT NULL,
+
+  CONSTRAINT "outcome_current_valuation_cohort_operation_pkey" PRIMARY KEY ("operation_id"),
+  CONSTRAINT "outcome_current_valuation_cohort_operation_id_check" CHECK (
+    "operation_id" ~ '^valuation-cohort-preparation-operation:[a-f0-9]{64}$'
+  ),
+  CONSTRAINT "outcome_current_valuation_cohort_operation_revision_check" CHECK (
+    "factual_release_revision">0 AND "model_qualification_revision">0
+    AND "expected_prepared_input_revision">=0
+  ),
+  CONSTRAINT "outcome_current_valuation_cohort_operation_sha_check" CHECK (
+    "context_sha256" ~ '^[a-f0-9]{64}$'
+  ),
+  CONSTRAINT "outcome_current_valuation_cohort_operation_release_fkey"
+    FOREIGN KEY ("factual_release_id") REFERENCES "outcome_release_manifest"("release_id")
+    ON DELETE RESTRICT,
+  CONSTRAINT "outcome_current_valuation_cohort_operation_qualification_fkey"
+    FOREIGN KEY ("model_qualification_id")
+    REFERENCES "outcome_governed_valuation_model_qualification"("qualification_id")
+    ON DELETE RESTRICT,
+  CONSTRAINT "outcome_current_valuation_cohort_operation_work_fkey"
+    FOREIGN KEY ("model_qualification_work_id")
+    REFERENCES "outcome_governed_model_qualification_work"("work_id")
+    ON DELETE RESTRICT
+);
+
+CREATE TABLE "outcome_current_valuation_cohort_operation_result" (
+  "operation_id" TEXT NOT NULL,
+  "prepared_input_set_id" TEXT NOT NULL,
+  "head_revision" INTEGER NOT NULL,
+  "completed_at" TIMESTAMPTZ(3) NOT NULL,
+
+  CONSTRAINT "outcome_current_valuation_cohort_operation_result_pkey"
+    PRIMARY KEY ("operation_id"),
+  CONSTRAINT "outcome_current_valuation_cohort_operation_result_prepared_key"
+    UNIQUE ("prepared_input_set_id"),
+  CONSTRAINT "outcome_current_valuation_cohort_operation_result_revision_check"
+    CHECK ("head_revision">0),
+  CONSTRAINT "outcome_current_cohort_result_operation_fkey"
+    FOREIGN KEY ("operation_id")
+    REFERENCES "outcome_current_valuation_cohort_operation"("operation_id") ON DELETE RESTRICT,
+  CONSTRAINT "outcome_current_cohort_result_prepared_fkey"
+    FOREIGN KEY ("prepared_input_set_id")
+    REFERENCES "outcome_prepared_valuation_input_set"("prepared_input_set_id") ON DELETE RESTRICT
+);
+
+CREATE OR REPLACE FUNCTION "validate_outcome_current_valuation_input_bundle"(
+  bundle JSONB,
+  bundle_artifact JSONB,
+  requested_scope_key TEXT,
+  requested_player_run_id TEXT,
+  requested_pick_run_id TEXT,
+  requested_player_gate_id TEXT,
+  requested_pick_gate_id TEXT
+) RETURNS BOOLEAN LANGUAGE plpgsql AS $$
+DECLARE
+  content JSONB := bundle->'content';
+  player_component JSONB := content->'components'->0;
+  pick_component JSONB := content->'components'->1;
+  player_run RECORD;
+  pick_run RECORD;
+  parent_ref JSONB;
+  created_at TIMESTAMPTZ;
+BEGIN
+  SELECT * INTO player_run FROM "outcome_governed_valuation_component_run"
+   WHERE "run_id"=requested_player_run_id FOR KEY SHARE;
+  SELECT * INTO pick_run FROM "outcome_governed_valuation_component_run"
+   WHERE "run_id"=requested_pick_run_id FOR KEY SHARE;
+  created_at:=(content->>'createdAt')::TIMESTAMPTZ;
+  IF jsonb_typeof(bundle)<>'object'
+    OR (SELECT count(*) FROM jsonb_object_keys(bundle))<>2
+    OR jsonb_typeof(content)<>'object'
+    OR (SELECT count(*) FROM jsonb_object_keys(content))<>13
+    OR content->>'schemaVersion' IS DISTINCT FROM 'afl-trade-valuation-input-bundle/v1'
+    OR content->>'publicAssetBoundary' IS DISTINCT FROM
+       'source_native_afl_assets_no_user_or_fantasy_ownership'
+    OR content->>'environment' IS DISTINCT FROM 'non_production'
+    OR content->>'scopeKey' IS DISTINCT FROM requested_scope_key
+    OR content->>'valueUnitId' !~ '^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,199}$'
+    OR content->'publicationEligible' IS DISTINCT FROM 'false'::JSONB
+    OR content->>'limitation' IS DISTINCT FROM
+       'Approved calculation inputs only; not execution evidence, numerical validity, publication approval, or activation authority.'
+    OR jsonb_typeof(content->'components')<>'array'
+    OR jsonb_array_length(content->'components')<>2
+    OR (SELECT count(*) FROM jsonb_object_keys(player_component))<>6
+    OR (SELECT count(*) FROM jsonb_object_keys(pick_component))<>6
+    OR player_component->>'role' IS DISTINCT FROM 'player_contribution_and_availability'
+    OR player_component->>'modelKind' IS DISTINCT FROM
+       'player_contribution_and_availability'
+    OR player_component->>'runId' IS DISTINCT FROM requested_player_run_id
+    OR player_component->>'protocolId' IS DISTINCT FROM player_run."protocol_id"
+    OR player_component->>'datasetId' IS DISTINCT FROM player_run."dataset_id"
+    OR player_component->>'gate3DecisionId' IS DISTINCT FROM requested_player_gate_id
+    OR pick_component->>'role' IS DISTINCT FROM
+       'draft_pick_and_future_pick_distribution'
+    OR pick_component->>'modelKind' IS DISTINCT FROM
+       'draft_pick_and_future_pick_distribution'
+    OR pick_component->>'runId' IS DISTINCT FROM requested_pick_run_id
+    OR pick_component->>'protocolId' IS DISTINCT FROM pick_run."protocol_id"
+    OR pick_component->>'datasetId' IS DISTINCT FROM pick_run."dataset_id"
+    OR pick_component->>'gate3DecisionId' IS DISTINCT FROM requested_pick_gate_id
+    OR player_component->>'protocolId'=pick_component->>'protocolId'
+    OR player_component->>'datasetId'=pick_component->>'datasetId'
+    OR player_component->>'gate3DecisionId'=pick_component->>'gate3DecisionId'
+    OR (SELECT count(*) FROM jsonb_object_keys(content->'viewPolicy'))<>3
+    OR (SELECT count(*) FROM jsonb_object_keys(content->'viewPolicy'->'atTrade'))<>2
+    OR content->'viewPolicy'->'atTrade'->>'modelVintage' IS DISTINCT FROM
+       'historical_restatement'
+    OR content->'viewPolicy'->'atTrade'->>'knowledgeCutoff' IS DISTINCT FROM
+       'transaction_effective_at_exclusive'
+    OR (SELECT count(*) FROM jsonb_object_keys(content->'viewPolicy'->'current'))<>4
+    OR content->'viewPolicy'->'current'->>'modelVintage' IS DISTINCT FROM 'current'
+    OR (content->'viewPolicy'->'current'->>'effectiveAt')::TIMESTAMPTZ>
+       (content->'viewPolicy'->'current'->>'valuationAsOf')::TIMESTAMPTZ
+    OR (content->'viewPolicy'->'current'->>'knowledgeCutoffAt')::TIMESTAMPTZ>
+       (content->'viewPolicy'->'current'->>'valuationAsOf')::TIMESTAMPTZ
+    OR content->'viewPolicy'->'currentViewsShareOneTemporalContext'
+       IS DISTINCT FROM 'true'::JSONB
+    OR (SELECT count(*) FROM jsonb_object_keys(content->'packagePolicy'))<>8
+    OR content->'packagePolicy'->>'calculationUnit' IS DISTINCT FROM
+       'complete_multi_party_trade'
+    OR content->'packagePolicy'->>'attribution' IS DISTINCT FROM
+       'lineage_frontier_exactly_once'
+    OR content->'packagePolicy'->>'aggregation' IS DISTINCT FROM
+       'joint_simulation_not_independent_point_sum'
+    OR content->'packagePolicy'->>'currentOutcomeIdentity' IS DISTINCT FROM
+       'realized_club_value_plus_remaining_asset_value'
+    OR content->'packagePolicy'->>'unresolvedAssetTreatment' IS DISTINCT FROM
+       'exclude_with_explicit_reason_no_fallback_value'
+    OR (SELECT count(*) FROM jsonb_object_keys(content->'simulation'))<>10
+    OR content->'simulation'->>'mode' IS DISTINCT FROM 'deterministic_counter_sample'
+    OR (content->'simulation'->>'draws')::INTEGER NOT BETWEEN 1 AND 100000
+    OR content->'simulation'->>'seed' !~ '^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,199}$'
+    OR content->'simulation'->>'samplingAlgorithmVersion' IS DISTINCT FROM
+       'counter_sha256_rejection_v1'
+    OR (content->'simulation'->>'centralIntervalLevel')::NUMERIC<>0.8
+    OR (content->'simulation'->>'downsideQuantile')::NUMERIC<>0.1
+    OR (content->'simulation'->>'upsideQuantile')::NUMERIC<>0.9
+    OR bundle->>'valuationInputBundleId' IS DISTINCT FROM 'valuation-input-bundle:' ||
+       encode(sha256(convert_to(outcome_afl_trade_canonical_json(content),'UTF8')),'hex')
+    OR bundle_artifact->>'contentSha256' IS DISTINCT FROM
+       encode(sha256(convert_to(outcome_afl_trade_canonical_json(bundle),'UTF8')),'hex')
+    OR (bundle_artifact->>'byteLength')::BIGINT IS DISTINCT FROM
+       octet_length(convert_to(outcome_afl_trade_canonical_json(bundle),'UTF8'))
+    OR (bundle_artifact->>'createdAt')::TIMESTAMPTZ IS DISTINCT FROM created_at
+    OR validate_outcome_prepared_valuation_input_v2_artifact(
+         bundle_artifact,'non_production'::"OutcomeEnvironment"
+       ) IS DISTINCT FROM TRUE
+  THEN RETURN FALSE;
+  END IF;
+  FOR parent_ref IN SELECT value FROM jsonb_array_elements(jsonb_build_array(
+    content->'packagePolicy'->'listSpotPolicyArtifact',
+    content->'packagePolicy'->'scarcityPolicyArtifact',
+    content->'packagePolicy'->'roleCongestionPolicyArtifact',
+    content->'simulation'->'lowReturnDefinitionArtifact',
+    content->'simulation'->'eliteOutcomeDefinitionArtifact',
+    content->'simulation'->'practicalEquivalenceDefinitionArtifact',
+    content->'explanationPolicyArtifact'
+  )) LOOP
+    IF validate_outcome_prepared_valuation_input_v2_artifact(
+         parent_ref,'non_production'::"OutcomeEnvironment"
+       ) IS DISTINCT FROM TRUE
+      OR (parent_ref->>'createdAt')::TIMESTAMPTZ>created_at
+    THEN RETURN FALSE;
+    END IF;
+  END LOOP;
+  RETURN TRUE;
+EXCEPTION WHEN OTHERS THEN
+  RETURN FALSE;
+END $$;
+
+CREATE OR REPLACE FUNCTION "validate_outcome_current_valuation_cohort_operation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  identity_json JSONB;
+  release_row RECORD;
+  active_release_row RECORD;
+  model_pair_row RECORD;
+  qualification_row RECORD;
+  qualification_work_row RECORD;
+  source_qualification_row RECORD;
+  prepared_head_revision INTEGER;
+  release_canonical_text TEXT;
+  membership_canonical_text TEXT;
+  source_qualification_canonical_text TEXT;
+  bundle_canonical_text TEXT;
+  expected_trade_ids JSONB;
+  expected_release_artifact JSONB;
+  expected_membership_artifact JSONB;
+  expected_source_qualification_artifact JSONB;
+  bundle JSONB;
+BEGIN
+  identity_json:=jsonb_build_object(
+    'scopeKey',NEW."scope_key",
+    'factualReleaseId',NEW."factual_release_id",
+    'factualReleaseRevision',NEW."factual_release_revision",
+    'modelQualificationId',NEW."model_qualification_id",
+    'modelQualificationWorkId',NEW."model_qualification_work_id",
+    'modelQualificationRevision',NEW."model_qualification_revision",
+    'expectedPreparedInputRevision',NEW."expected_prepared_input_revision"
+  );
+  SELECT * INTO release_row FROM "outcome_release_manifest"
+   WHERE "release_id"=NEW."factual_release_id" FOR KEY SHARE;
+  SELECT * INTO active_release_row FROM "outcome_active_release"
+   WHERE "scope_key"=NEW."context_json"->>'factualReleaseScopeKey' FOR KEY SHARE;
+  SELECT * INTO model_pair_row FROM "outcome_current_governed_valuation_model_pair"
+   WHERE "scope_key"=NEW."scope_key" FOR KEY SHARE;
+  SELECT * INTO qualification_row FROM "outcome_governed_valuation_model_qualification"
+   WHERE "qualification_id"=NEW."model_qualification_id" FOR KEY SHARE;
+  SELECT * INTO qualification_work_row FROM "outcome_governed_model_qualification_work"
+   WHERE "work_id"=NEW."model_qualification_work_id" FOR KEY SHARE;
+  SELECT * INTO source_qualification_row FROM "outcome_valuation_source_qualification_report"
+   WHERE "qualification_report_id"=NEW."context_json"->>'sourceQualificationReportId'
+   FOR KEY SHARE;
+  SELECT COALESCE("revision",0) INTO prepared_head_revision
+    FROM "outcome_current_prepared_valuation_input_set"
+   WHERE "scope_key"=NEW."scope_key" FOR KEY SHARE;
+  prepared_head_revision:=COALESCE(prepared_head_revision,0);
+
+  release_canonical_text:=outcome_afl_trade_canonical_json(release_row."manifest_json");
+  membership_canonical_text:=outcome_afl_trade_canonical_json(
+    release_row."manifest_json"->'content'->'canonicalMembers'
+  );
+  source_qualification_canonical_text:=outcome_afl_trade_canonical_json(
+    source_qualification_row."report_json"
+  );
+  SELECT jsonb_agg(to_jsonb(member->>'canonicalRecordId') ORDER BY member->>'canonicalRecordId')
+    INTO expected_trade_ids
+    FROM jsonb_array_elements(
+      release_row."manifest_json"->'content'->'canonicalMembers'
+    ) members(member)
+   WHERE member->>'recordKind'='transaction';
+  expected_release_artifact:=jsonb_build_object(
+    'artifactId','artifact:'||encode(sha256(convert_to(release_canonical_text,'UTF8')),'hex'),
+    'contentSha256',encode(sha256(convert_to(release_canonical_text,'UTF8')),'hex'),
+    'storageUri','artifact://sha256/'||encode(sha256(convert_to(release_canonical_text,'UTF8')),'hex'),
+    'mediaType','application/json',
+    'byteLength',octet_length(convert_to(release_canonical_text,'UTF8')),
+    'createdAt',to_char(release_row."created_at" AT TIME ZONE 'UTC',
+      'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+  );
+  expected_membership_artifact:=jsonb_build_object(
+    'artifactId','artifact:'||encode(sha256(convert_to(membership_canonical_text,'UTF8')),'hex'),
+    'contentSha256',encode(sha256(convert_to(membership_canonical_text,'UTF8')),'hex'),
+    'storageUri','artifact://sha256/'||encode(sha256(convert_to(membership_canonical_text,'UTF8')),'hex'),
+    'mediaType','application/json',
+    'byteLength',octet_length(convert_to(membership_canonical_text,'UTF8')),
+    'createdAt',to_char(release_row."created_at" AT TIME ZONE 'UTC',
+      'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+  );
+  expected_source_qualification_artifact:=jsonb_build_object(
+    'artifactId','artifact:'||encode(sha256(convert_to(source_qualification_canonical_text,'UTF8')),'hex'),
+    'contentSha256',encode(sha256(convert_to(source_qualification_canonical_text,'UTF8')),'hex'),
+    'storageUri','artifact://sha256/'||encode(sha256(convert_to(source_qualification_canonical_text,'UTF8')),'hex'),
+    'mediaType','application/json',
+    'byteLength',octet_length(convert_to(source_qualification_canonical_text,'UTF8')),
+    'createdAt',to_char(source_qualification_row."finalized_at" AT TIME ZONE 'UTC',
+      'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+  );
+  bundle:=NEW."context_json"->'valuationInputBundle';
+  bundle_canonical_text:=outcome_afl_trade_canonical_json(bundle);
+  IF release_row."release_id" IS NULL
+    OR release_row."scope_key" IS DISTINCT FROM NEW."context_json"->>'factualReleaseScopeKey'
+    OR active_release_row."release_id" IS DISTINCT FROM NEW."factual_release_id"
+    OR active_release_row."revision" IS DISTINCT FROM NEW."factual_release_revision"
+    OR NEW."context_json"->'factualReleaseArtifact' IS DISTINCT FROM expected_release_artifact
+    OR NEW."context_json"->'releaseMembershipArtifact' IS DISTINCT FROM expected_membership_artifact
+    OR NEW."context_json"->'releaseTradeIds' IS DISTINCT FROM expected_trade_ids
+  THEN RAISE EXCEPTION 'Current valuation cohort factual release authority mismatch'; END IF;
+  IF source_qualification_row."qualification_report_id" IS NULL
+    OR source_qualification_row."valuation_scope_key" IS DISTINCT FROM NEW."scope_key"
+    OR source_qualification_row."factual_release_id" IS DISTINCT FROM NEW."factual_release_id"
+    OR NEW."context_json"->'sourceQualificationReportArtifact'
+       IS DISTINCT FROM expected_source_qualification_artifact
+    OR NEW."context_json"->'sourceQualificationEvidenceRefs'
+       IS DISTINCT FROM source_qualification_row."report_json"->'content'->'sourceRightsEvidenceRefs'
+  THEN RAISE EXCEPTION 'Current valuation cohort source qualification authority mismatch'; END IF;
+  IF model_pair_row."revision" IS DISTINCT FROM NEW."model_qualification_revision"
+    OR model_pair_row."qualification_id" IS DISTINCT FROM NEW."model_qualification_id"
+    OR model_pair_row."work_id" IS DISTINCT FROM NEW."model_qualification_work_id"
+    OR qualification_row."outcome" IS DISTINCT FROM 'qualified'
+    OR qualification_work_row."qualification_id" IS DISTINCT FROM NEW."model_qualification_id"
+    OR prepared_head_revision IS DISTINCT FROM NEW."expected_prepared_input_revision"
+  THEN RAISE EXCEPTION 'Current valuation cohort model or head authority mismatch'; END IF;
+  IF bundle->>'valuationInputBundleId' IS DISTINCT FROM
+       NEW."context_json"->>'valuationInputBundleId'
+    OR bundle->>'valuationInputBundleId' IS DISTINCT FROM 'valuation-input-bundle:' ||
+       encode(sha256(convert_to(outcome_afl_trade_canonical_json(bundle->'content'),'UTF8')),'hex')
+    OR bundle->'content'->>'scopeKey' IS DISTINCT FROM NEW."scope_key"
+    OR bundle->'content'->'components'->0->>'runId' IS DISTINCT FROM model_pair_row."player_run_id"
+    OR bundle->'content'->'components'->1->>'runId' IS DISTINCT FROM model_pair_row."pick_run_id"
+    OR NEW."context_json"->'valuationInputBundleArtifact'->>'contentSha256'
+       IS DISTINCT FROM encode(sha256(convert_to(bundle_canonical_text,'UTF8')),'hex')
+    OR (NEW."context_json"->'valuationInputBundleArtifact'->>'byteLength')::INTEGER
+       IS DISTINCT FROM octet_length(convert_to(bundle_canonical_text,'UTF8'))
+  THEN RAISE EXCEPTION 'Current valuation cohort valuation bundle authority mismatch'; END IF;
+  IF NEW."context_canonical_json" IS DISTINCT FROM
+       outcome_afl_trade_canonical_json(NEW."context_json")
+    OR NEW."context_sha256" IS DISTINCT FROM encode(sha256(convert_to(
+       NEW."context_canonical_json",'UTF8')),'hex')
+    OR NEW."operation_id" IS DISTINCT FROM 'valuation-cohort-preparation-operation:' ||
+       encode(sha256(convert_to(outcome_afl_trade_canonical_json(identity_json),'UTF8')),'hex')
+    OR NEW."context_json"->>'operationId' IS DISTINCT FROM NEW."operation_id"
+    OR NEW."context_json"->>'scopeKey' IS DISTINCT FROM NEW."scope_key"
+    OR NEW."context_json"->>'factualReleaseId' IS DISTINCT FROM NEW."factual_release_id"
+    OR (NEW."context_json"->>'factualReleaseRevision')::INTEGER
+       IS DISTINCT FROM NEW."factual_release_revision"
+    OR NEW."context_json"->>'modelQualificationId'
+       IS DISTINCT FROM NEW."model_qualification_id"
+    OR NEW."context_json"->>'modelQualificationWorkId'
+       IS DISTINCT FROM NEW."model_qualification_work_id"
+    OR (NEW."context_json"->>'modelQualificationRevision')::INTEGER
+       IS DISTINCT FROM NEW."model_qualification_revision"
+    OR (NEW."context_json"->>'expectedPreparedInputRevision')::INTEGER
+       IS DISTINCT FROM NEW."expected_prepared_input_revision"
+    OR (NEW."context_json"->>'capturedAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."captured_at"
+    OR (SELECT count(*) FROM jsonb_object_keys(NEW."context_json"))<>21
+    OR release_row."release_id" IS NULL
+    OR release_row."scope_key" IS DISTINCT FROM NEW."context_json"->>'factualReleaseScopeKey'
+    OR release_row."environment" IS DISTINCT FROM 'non_production'
+    OR active_release_row."release_id" IS DISTINCT FROM NEW."factual_release_id"
+    OR active_release_row."revision" IS DISTINCT FROM NEW."factual_release_revision"
+    OR NEW."context_json"->'factualReleaseArtifact' IS DISTINCT FROM expected_release_artifact
+    OR NEW."context_json"->'releaseMembershipArtifact' IS DISTINCT FROM expected_membership_artifact
+    OR NEW."context_json"->'releaseTradeIds' IS DISTINCT FROM expected_trade_ids
+    OR validate_outcome_prepared_valuation_input_v2_artifact(
+         NEW."context_json"->'factualReleaseArtifact','non_production'::"OutcomeEnvironment"
+       ) IS DISTINCT FROM TRUE
+    OR validate_outcome_prepared_valuation_input_v2_artifact(
+         NEW."context_json"->'releaseMembershipArtifact','non_production'::"OutcomeEnvironment"
+       ) IS DISTINCT FROM TRUE
+    OR source_qualification_row."qualification_report_id" IS NULL
+    OR source_qualification_row."valuation_scope_key" IS DISTINCT FROM NEW."scope_key"
+    OR source_qualification_row."factual_release_scope_key" IS DISTINCT FROM release_row."scope_key"
+    OR source_qualification_row."factual_release_id" IS DISTINCT FROM NEW."factual_release_id"
+    OR source_qualification_row."decision_state" IS DISTINCT FROM 'eligible_for_dataset_admission'
+    OR source_qualification_row."report_json"->'content'->'releaseTradeIds'
+       IS DISTINCT FROM expected_trade_ids
+    OR NEW."context_json"->'sourceQualificationReportArtifact'
+       IS DISTINCT FROM expected_source_qualification_artifact
+    OR NEW."context_json"->'sourceQualificationEvidenceRefs'
+       IS DISTINCT FROM source_qualification_row."report_json"->'content'->'sourceRightsEvidenceRefs'
+    OR EXISTS (
+      SELECT 1
+        FROM jsonb_array_elements(
+          NEW."context_json"->'sourceQualificationEvidenceRefs'
+        ) evidence(reference)
+       WHERE validate_outcome_prepared_valuation_input_v2_artifact(
+         evidence.reference,'non_production'::"OutcomeEnvironment"
+       ) IS DISTINCT FROM TRUE
+    )
+    OR validate_outcome_prepared_valuation_input_v2_artifact(
+         NEW."context_json"->'sourceQualificationReportArtifact',
+         'non_production'::"OutcomeEnvironment"
+       ) IS DISTINCT FROM TRUE
+    OR model_pair_row."revision" IS DISTINCT FROM NEW."model_qualification_revision"
+    OR model_pair_row."qualification_id" IS DISTINCT FROM NEW."model_qualification_id"
+    OR model_pair_row."work_id" IS DISTINCT FROM NEW."model_qualification_work_id"
+    OR model_pair_row."player_run_id" IS DISTINCT FROM NEW."context_json"->>'playerRunId'
+    OR model_pair_row."pick_run_id" IS DISTINCT FROM NEW."context_json"->>'pickRunId'
+    OR qualification_row."scope_key" IS DISTINCT FROM NEW."scope_key"
+    OR qualification_row."outcome" IS DISTINCT FROM 'qualified'
+    OR qualification_row."player_run_id" IS DISTINCT FROM model_pair_row."player_run_id"
+    OR qualification_row."pick_run_id" IS DISTINCT FROM model_pair_row."pick_run_id"
+    OR qualification_work_row."scope_key" IS DISTINCT FROM NEW."scope_key"
+    OR qualification_work_row."qualification_id" IS DISTINCT FROM NEW."model_qualification_id"
+    OR prepared_head_revision IS DISTINCT FROM NEW."expected_prepared_input_revision"
+    OR bundle->>'valuationInputBundleId' IS DISTINCT FROM
+       NEW."context_json"->>'valuationInputBundleId'
+    OR bundle->>'valuationInputBundleId' IS DISTINCT FROM 'valuation-input-bundle:' ||
+       encode(sha256(convert_to(outcome_afl_trade_canonical_json(bundle->'content'),'UTF8')),'hex')
+    OR bundle->'content'->>'schemaVersion' IS DISTINCT FROM
+       'afl-trade-valuation-input-bundle/v1'
+    OR bundle->'content'->>'environment' IS DISTINCT FROM 'non_production'
+    OR bundle->'content'->>'scopeKey' IS DISTINCT FROM NEW."scope_key"
+    OR bundle->'content'->'publicationEligible' IS DISTINCT FROM 'false'::JSONB
+    OR bundle->'content'->'components'->0->>'role' IS DISTINCT FROM
+       'player_contribution_and_availability'
+    OR bundle->'content'->'components'->0->>'runId' IS DISTINCT FROM
+       model_pair_row."player_run_id"
+    OR bundle->'content'->'components'->1->>'role' IS DISTINCT FROM
+       'draft_pick_and_future_pick_distribution'
+    OR bundle->'content'->'components'->1->>'runId' IS DISTINCT FROM
+       model_pair_row."pick_run_id"
+    OR NEW."context_json"->'valuationInputBundleArtifact'->>'contentSha256'
+       IS DISTINCT FROM encode(sha256(convert_to(bundle_canonical_text,'UTF8')),'hex')
+    OR (NEW."context_json"->'valuationInputBundleArtifact'->>'byteLength')::INTEGER
+       IS DISTINCT FROM octet_length(convert_to(bundle_canonical_text,'UTF8'))
+    OR validate_outcome_prepared_valuation_input_v2_artifact(
+         NEW."context_json"->'valuationInputBundleArtifact',
+         'non_production'::"OutcomeEnvironment"
+       ) IS DISTINCT FROM TRUE
+    OR (NEW."context_json"->'valuationInputBundleArtifact'->>'createdAt')::TIMESTAMPTZ
+       IS DISTINCT FROM (bundle->'content'->>'createdAt')::TIMESTAMPTZ
+    OR (NEW."context_json"->'valuationInputBundleArtifact'->>'createdAt')::TIMESTAMPTZ
+       > NEW."captured_at"
+    OR validate_outcome_current_valuation_input_bundle(
+         bundle,
+         NEW."context_json"->'valuationInputBundleArtifact',
+         NEW."scope_key",
+         model_pair_row."player_run_id",
+         model_pair_row."pick_run_id",
+         model_pair_row."player_gate3_decision_id",
+         model_pair_row."pick_gate3_decision_id"
+       ) IS DISTINCT FROM TRUE
+  THEN
+    RAISE EXCEPTION 'Current valuation cohort operation identity disagrees with its context';
+  END IF;
+  RETURN NEW;
+EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+  RAISE EXCEPTION 'Current valuation cohort operation contains invalid typed context';
+END $$;
+
+CREATE TRIGGER "outcome_current_valuation_cohort_operation_validate"
+BEFORE INSERT ON "outcome_current_valuation_cohort_operation"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_current_valuation_cohort_operation"();
+
+CREATE OR REPLACE FUNCTION "reject_outcome_current_valuation_cohort_operation_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Current valuation cohort operation records are append-only';
+END $$;
+
+CREATE TRIGGER "outcome_current_valuation_cohort_operation_append_only"
+BEFORE UPDATE OR DELETE ON "outcome_current_valuation_cohort_operation"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_current_valuation_cohort_operation_mutation"();
+CREATE TRIGGER "outcome_current_valuation_cohort_result_append_only"
+BEFORE UPDATE OR DELETE ON "outcome_current_valuation_cohort_operation_result"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_current_valuation_cohort_operation_mutation"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_current_valuation_cohort_result"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  operation RECORD;
+  head RECORD;
+BEGIN
+  SELECT * INTO operation FROM "outcome_current_valuation_cohort_operation"
+   WHERE "operation_id"=NEW."operation_id" FOR KEY SHARE;
+  SELECT * INTO head FROM "outcome_current_prepared_valuation_input_set"
+   WHERE "scope_key"=operation."scope_key" FOR KEY SHARE;
+  IF operation."operation_id" IS NULL
+    OR NEW."head_revision" IS DISTINCT FROM
+       operation."expected_prepared_input_revision"+1
+    OR head."prepared_input_set_id" IS DISTINCT FROM NEW."prepared_input_set_id"
+    OR head."revision" IS DISTINCT FROM NEW."head_revision"
+    OR head."activated_at" IS DISTINCT FROM NEW."completed_at"
+  THEN
+    RAISE EXCEPTION 'Current valuation cohort result does not match its exact activated head';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_current_valuation_cohort_result_validate"
+BEFORE INSERT ON "outcome_current_valuation_cohort_operation_result"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_current_valuation_cohort_result"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_automated_ready_calculation_authority"(
+  authority JSONB, requested_scope_key TEXT, requested_trade_id TEXT
+) RETURNS BOOLEAN LANGUAGE plpgsql AS $$
+DECLARE
+  prepared_head RECORD;
+  prepared_set RECORD;
+  prepared_entry RECORD;
+  manifest RECORD;
+  model_pair RECORD;
+  qualification RECORD;
+  player_component RECORD;
+  pick_component RECORD;
+  player_gate RECORD;
+  pick_gate RECORD;
+BEGIN
+  SELECT * INTO prepared_head FROM "outcome_current_prepared_valuation_input_set"
+   WHERE "scope_key"=requested_scope_key FOR KEY SHARE;
+  SELECT * INTO prepared_set FROM "outcome_prepared_valuation_input_set"
+   WHERE "prepared_input_set_id"=authority->>'preparedInputSetId' FOR KEY SHARE;
+  SELECT * INTO prepared_entry FROM "outcome_prepared_valuation_input_entry"
+   WHERE "prepared_input_set_id"=authority->>'preparedInputSetId'
+     AND "trade_id"=requested_trade_id FOR KEY SHARE;
+  SELECT * INTO manifest FROM "outcome_private_evaluation_materialization_manifest"
+   WHERE "materialization_manifest_id"=authority->>'materializationManifestId'
+   FOR KEY SHARE;
+  SELECT * INTO model_pair FROM "outcome_current_governed_valuation_model_pair"
+   WHERE "scope_key"=requested_scope_key FOR KEY SHARE;
+  SELECT * INTO qualification FROM "outcome_governed_valuation_model_qualification"
+   WHERE "qualification_id"=model_pair."qualification_id" FOR KEY SHARE;
+  SELECT * INTO player_component FROM "outcome_governed_valuation_component_run"
+   WHERE "run_id"=model_pair."player_run_id" FOR KEY SHARE;
+  SELECT * INTO pick_component FROM "outcome_governed_valuation_component_run"
+   WHERE "run_id"=model_pair."pick_run_id" FOR KEY SHARE;
+  SELECT * INTO player_gate FROM "outcome_gate_decision"
+   WHERE "decision_id"=model_pair."player_gate3_decision_id" FOR KEY SHARE;
+  SELECT * INTO pick_gate FROM "outcome_gate_decision"
+   WHERE "decision_id"=model_pair."pick_gate3_decision_id" FOR KEY SHARE;
+  RETURN COALESCE(
+    jsonb_typeof(authority)='object'
+    AND (SELECT count(*) FROM jsonb_object_keys(authority))=14
+    AND jsonb_typeof(authority->'components')='array'
+    AND jsonb_array_length(authority->'components')=2
+    AND jsonb_typeof(authority->'components'->0)='object'
+    AND jsonb_typeof(authority->'components'->1)='object'
+    AND (SELECT count(*) FROM jsonb_object_keys(authority->'components'->0))=10
+    AND (SELECT count(*) FROM jsonb_object_keys(authority->'components'->1))=10
+    AND authority->>'state'='ready'
+    AND prepared_head."prepared_input_set_id"=authority->>'preparedInputSetId'
+    AND prepared_head."revision"=(authority->>'preparedInputHeadRevision')::INTEGER
+    AND prepared_set."schema_version"='afl-trade-prepared-valuation-input-set/v3'
+    AND prepared_set."finalized_at" IS NOT NULL
+    AND prepared_entry."state"='ready'
+    AND prepared_entry."entry_json"->>'materializationManifestId'=
+        authority->>'materializationManifestId'
+    AND manifest."valuation_scope_key"=requested_scope_key
+    AND manifest."trade_id"=requested_trade_id
+    AND manifest."artifact_id"=authority->'materializationManifestArtifact'->>'artifactId'
+    AND manifest."manifest_json"->'content'->>'valuationInputBundleId'=
+        authority->>'valuationInputBundleId'
+    AND manifest."manifest_json"->'content'->'valuationInputBundleArtifact'=
+        authority->'valuationInputBundleArtifact'
+    AND model_pair."qualification_id"=authority->'components'->0->>'qualificationId'
+    AND model_pair."qualification_id"=authority->'components'->1->>'qualificationId'
+    AND qualification."outcome"='qualified'
+    AND authority->'components'->0->>'qualificationPolicyVersion'=
+        qualification."qualification_json"->'content'->'policy'->>'policyVersion'
+    AND authority->'components'->1->>'qualificationPolicyVersion'=
+        qualification."qualification_json"->'content'->'policy'->>'policyVersion'
+    AND model_pair."player_run_id"=authority->'components'->0->>'runId'
+    AND model_pair."pick_run_id"=authority->'components'->1->>'runId'
+    AND authority->'components'->0->>'role'='player_contribution_and_availability'
+    AND authority->'components'->1->>'role'='draft_pick_and_future_pick_distribution'
+    AND authority->'components'->0->>'protocolId'=player_component."protocol_id"
+    AND authority->'components'->1->>'protocolId'=pick_component."protocol_id"
+    AND authority->'components'->0->>'datasetId'=player_component."dataset_id"
+    AND authority->'components'->1->>'datasetId'=pick_component."dataset_id"
+    AND authority->'components'->0->>'datasetAdmissionId'=
+        player_component."dataset_admission_id"
+    AND authority->'components'->1->>'datasetAdmissionId'=
+        pick_component."dataset_admission_id"
+    AND (authority->'components'->0->>'datasetAdmissionGateLedgerRevision')::INTEGER=
+        player_component."dataset_admission_gate_ledger_revision"
+    AND (authority->'components'->1->>'datasetAdmissionGateLedgerRevision')::INTEGER=
+        pick_component."dataset_admission_gate_ledger_revision"
+    AND authority->'components'->0->>'gate3DecisionId'=player_gate."decision_id"
+    AND authority->'components'->1->>'gate3DecisionId'=pick_gate."decision_id"
+    AND (authority->'components'->0->>'gate3DecisionVersion')::INTEGER=
+        player_gate."version"
+    AND (authority->'components'->1->>'gate3DecisionVersion')::INTEGER=
+        pick_gate."version"
+    AND player_gate."gate"='gate_3_model_approval'
+    AND pick_gate."gate"='gate_3_model_approval'
+    AND player_gate."environment"='non_production'::"OutcomeEnvironment"
+    AND pick_gate."environment"='non_production'::"OutcomeEnvironment"
+    AND player_gate."state"='approved'
+    AND pick_gate."state"='approved'
+    AND NOT EXISTS (SELECT 1 FROM "outcome_gate_decision" successor
+      WHERE successor."supersedes_decision_id"=player_gate."decision_id")
+    AND NOT EXISTS (SELECT 1 FROM "outcome_gate_decision" successor
+      WHERE successor."supersedes_decision_id"=pick_gate."decision_id")
+    AND validate_outcome_prepared_valuation_input_v2_artifact(
+      authority->'materializationManifestArtifact','non_production'::"OutcomeEnvironment"
+    )
+    AND validate_outcome_prepared_valuation_input_v2_artifact(
+      authority->'valuationInputBundleArtifact','non_production'::"OutcomeEnvironment"
+    ),FALSE);
+EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+  RETURN FALSE;
+END $$;
+
+CREATE OR REPLACE FUNCTION "validate_outcome_automated_private_intent"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  content JSONB := NEW."intent_json"->'content';
+  custody RECORD;
+  snapshot RECORD;
+  inspection RECORD;
+  snapshot_custody RECORD;
+  inspection_custody RECORD;
+  prior_transition_id TEXT;
+  operator_authority_id TEXT;
+BEGIN
+  IF content->>'schemaVersion' NOT IN (
+    'private-evaluation-transition-intent/v1','private-evaluation-transition-intent/v2'
+  ) THEN
+    RAISE EXCEPTION 'Unsupported private evaluation intent schema version';
+  END IF;
+  SELECT * INTO custody FROM "outcome_artifact_custody"
+   WHERE "artifact_id"=NEW."artifact_id" FOR KEY SHARE;
+  SELECT * INTO snapshot FROM "outcome_private_evaluation_authority_snapshot"
+   WHERE "snapshot_id"=NEW."authority_snapshot_id" FOR KEY SHARE;
+  SELECT * INTO inspection FROM "outcome_private_evaluation_inspection_receipt"
+   WHERE "inspection_id"=NEW."inspection_id" FOR KEY SHARE;
+  SELECT * INTO snapshot_custody FROM "outcome_artifact_custody"
+   WHERE "artifact_id"=snapshot."artifact_id" FOR KEY SHARE;
+  SELECT * INTO inspection_custody FROM "outcome_artifact_custody"
+   WHERE "artifact_id"=inspection."artifact_id" FOR KEY SHARE;
+  SELECT "last_transition_id" INTO prior_transition_id
+    FROM "outcome_local_private_trade_evaluation_head"
+   WHERE "valuation_scope_key"=NEW."valuation_scope_key" AND "trade_id"=NEW."trade_id"
+   FOR KEY SHARE;
+  IF content->>'schemaVersion'='private-evaluation-transition-intent/v1' THEN
+    SELECT authority."authority_evidence_id" INTO operator_authority_id
+      FROM "outcome_operational_principal_authority" authority
+      JOIN "outcome_governed_evidence_reference" evidence
+        ON evidence."reference_id"=authority."authority_evidence_id"
+      JOIN "outcome_review_decision" approval
+        ON approval."decision_id"=evidence."approval_decision_id"
+     WHERE authority."principal_ref"=content->'review'->>'principalId'
+       AND authority."role"='afl_trade_private_evaluation_operator'
+       AND authority."scope_key"=NEW."valuation_scope_key"
+       AND authority."provider"='statly_modeling'
+       AND authority."capability_id"='manage_private_trade_evaluation'
+       AND authority."competition"='AFLM'
+       AND authority."valid_from"<=NEW."requested_at"
+       AND (authority."valid_through" IS NULL OR
+            authority."valid_through">NEW."requested_at")
+       AND evidence."environment"='test_fixture'::"OutcomeEnvironment"
+       AND evidence."status"='approved'::"OutcomeRecordStatus"
+       AND approval."decision"='approved'
+       AND NOT EXISTS (
+         SELECT 1 FROM "outcome_review_decision" successor
+          WHERE successor."supersedes_decision_id"=approval."decision_id"
+       )
+     LIMIT 1;
+    IF custody."artifact_id" IS NULL
+      OR operator_authority_id IS NULL
+      OR inspection."inspection_id" IS NULL
+      OR content->>'environment' IS DISTINCT FROM 'test_fixture'
+      OR content->'publicationProhibited' IS DISTINCT FROM 'true'::JSONB
+      OR (SELECT count(*) FROM jsonb_object_keys(NEW."intent_json"))<>2
+      OR (SELECT count(*) FROM jsonb_object_keys(content))<>13
+      OR content->>'limitation' IS DISTINCT FROM
+         'Private test-fixture lifecycle evidence only; it grants no factual, model, production, or publication authority.'
+      OR content->'selector'->>'valuationScopeKey' IS DISTINCT FROM NEW."valuation_scope_key"
+      OR content->'selector'->>'tradeId' IS DISTINCT FROM NEW."trade_id"
+      OR content->>'inspectionId' IS DISTINCT FROM NEW."inspection_id"
+      OR content->>'authoritySnapshotId' IS DISTINCT FROM NEW."authority_snapshot_id"
+      OR content->>'operationId' IS DISTINCT FROM NEW."operation_id"
+      OR content->'action'->>'kind' IS DISTINCT FROM NEW."action"
+      OR content->'expectedHead'->>'status' IS DISTINCT FROM NEW."expected_head_status"
+      OR (content->'expectedHead'->>'revision')::INTEGER
+         IS DISTINCT FROM NEW."expected_head_revision"
+      OR content->'expectedHead'->>'generationId'
+         IS DISTINCT FROM NEW."expected_head_generation_id"
+      OR content->'action'->>'targetGenerationId' IS DISTINCT FROM NEW."target_generation_id"
+      OR (content->>'requestedAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."requested_at"
+      OR (content->>'expiresAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."expires_at"
+      OR content->'review' IS NULL
+      OR (SELECT count(*) FROM jsonb_object_keys(content->'review'))<>2
+      OR NEW."content_canonical_json" IS DISTINCT FROM outcome_afl_trade_canonical_json(content)
+      OR NEW."content_sha256" IS DISTINCT FROM encode(sha256(convert_to(
+         NEW."content_canonical_json",'UTF8')),'hex')
+      OR NEW."transition_intent_id" IS DISTINCT FROM
+         'private-evaluation-transition-intent:'||NEW."content_sha256"
+      OR NEW."intent_json"->>'transitionIntentId' IS DISTINCT FROM NEW."transition_intent_id"
+      OR custody."content_sha256" IS DISTINCT FROM substring(NEW."artifact_id" FROM 10)
+      OR custody."storage_uri" IS DISTINCT FROM 'artifact://sha256/'||custody."content_sha256"
+      OR custody."media_type" IS DISTINCT FROM 'application/json'
+      OR custody."byte_length" IS DISTINCT FROM octet_length(convert_to(
+         outcome_afl_trade_canonical_json(NEW."intent_json"),'UTF8'))
+      OR custody."environment" IS DISTINCT FROM 'test_fixture'::"OutcomeEnvironment"
+      OR custody."created_at" IS DISTINCT FROM NEW."requested_at"
+      OR inspection."valuation_scope_key" IS DISTINCT FROM NEW."valuation_scope_key"
+      OR inspection."trade_id" IS DISTINCT FROM NEW."trade_id"
+      OR inspection."content_canonical_json" IS DISTINCT FROM
+         outcome_afl_trade_canonical_json(inspection."receipt_json"->'content')
+      OR inspection."content_sha256" IS DISTINCT FROM encode(sha256(convert_to(
+         inspection."content_canonical_json",'UTF8')),'hex')
+      OR inspection_custody."content_sha256" IS DISTINCT FROM
+         substring(inspection."artifact_id" FROM 10)
+    THEN
+      RAISE EXCEPTION 'Legacy private intent failed exact test-fixture authentication';
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF custody."artifact_id" IS NULL
+    OR snapshot."snapshot_id" IS NULL
+    OR inspection."inspection_id" IS NULL
+    OR content->>'environment' IS DISTINCT FROM 'non_production'
+    OR content->'publicationProhibited' IS DISTINCT FROM 'true'::JSONB
+    OR (SELECT count(*) FROM jsonb_object_keys(NEW."intent_json"))<>2
+    OR (SELECT count(*) FROM jsonb_object_keys(content))<>13
+    OR content->>'limitation' IS DISTINCT FROM
+       'Automated private calculation only; it grants no source approval, production, publication, withdrawal, rollback, or recovery authority.'
+    OR content->'action'->>'kind' IS DISTINCT FROM 'construct_and_activate'
+    OR content->'constructionAuthority'->>'kind'
+       IS DISTINCT FROM 'automated_private_calculation_agent'
+    OR content->'constructionAuthority'->>'principalId'
+       IS DISTINCT FROM 'system:weekly-valuation-coordinator'
+    OR content->'selector'->>'valuationScopeKey' IS DISTINCT FROM NEW."valuation_scope_key"
+    OR content->'selector'->>'tradeId' IS DISTINCT FROM NEW."trade_id"
+    OR content->>'inspectionId' IS DISTINCT FROM NEW."inspection_id"
+    OR content->>'authoritySnapshotId' IS DISTINCT FROM NEW."authority_snapshot_id"
+    OR content->>'operationId' IS DISTINCT FROM NEW."operation_id"
+    OR content->'expectedHead'->>'status' IS DISTINCT FROM NEW."expected_head_status"
+    OR (content->'expectedHead'->>'revision')::INTEGER
+       IS DISTINCT FROM NEW."expected_head_revision"
+    OR content->'expectedHead'->>'generationId'
+       IS DISTINCT FROM NEW."expected_head_generation_id"
+    OR (content->>'requestedAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."requested_at"
+    OR (content->>'expiresAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."expires_at"
+    OR NEW."target_generation_id" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Automated private intent has invalid shape or column binding';
+  END IF;
+  IF NEW."content_canonical_json" IS DISTINCT FROM outcome_afl_trade_canonical_json(content)
+    OR NEW."content_sha256" IS DISTINCT FROM encode(sha256(convert_to(
+       NEW."content_canonical_json",'UTF8')),'hex')
+    OR NEW."transition_intent_id" IS DISTINCT FROM 'private-evaluation-transition-intent:' ||
+       NEW."content_sha256"
+    OR NEW."intent_json"->>'transitionIntentId' IS DISTINCT FROM NEW."transition_intent_id"
+  THEN
+    RAISE EXCEPTION 'Automated private intent has invalid content address';
+  END IF;
+  IF custody."content_sha256" IS DISTINCT FROM substring(NEW."artifact_id" FROM 10)
+    OR custody."storage_uri" IS DISTINCT FROM 'artifact://sha256/' || custody."content_sha256"
+    OR custody."media_type" IS DISTINCT FROM 'application/json'
+    OR custody."byte_length" IS DISTINCT FROM octet_length(convert_to(
+       outcome_afl_trade_canonical_json(NEW."intent_json"),'UTF8'))
+    OR custody."environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR custody."created_at" IS DISTINCT FROM NEW."requested_at"
+  THEN
+    RAISE EXCEPTION 'Automated private intent has invalid artifact custody';
+  END IF;
+  IF snapshot."valuation_scope_key" IS DISTINCT FROM NEW."valuation_scope_key"
+    OR snapshot."trade_id" IS DISTINCT FROM NEW."trade_id"
+    OR snapshot."content_canonical_json" IS DISTINCT FROM
+       outcome_afl_trade_canonical_json(snapshot."snapshot_json"->'content')
+    OR snapshot."snapshot_json"->'content'->>'schemaVersion'
+       IS DISTINCT FROM 'private-evaluation-authority-snapshot/v3'
+    OR snapshot."snapshot_json"->'content'->>'environment' IS DISTINCT FROM 'non_production'
+    OR snapshot."snapshot_json"->'content'->'publicationProhibited'
+       IS DISTINCT FROM 'true'::JSONB
+    OR (SELECT count(*) FROM jsonb_object_keys(snapshot."snapshot_json"))<>2
+    OR (SELECT count(*) FROM jsonb_object_keys(snapshot."snapshot_json"->'content'))<>11
+    OR snapshot."snapshot_json"->'content'->>'limitation' IS DISTINCT FROM
+       'Authenticated private non-production calculation authority only; publication and production use remain prohibited.'
+    OR snapshot."snapshot_json"->'content'->'selector' IS DISTINCT FROM content->'selector'
+    OR snapshot."snapshot_json"->'content'->'head' IS DISTINCT FROM content->'expectedHead'
+    OR snapshot."snapshot_json"->'content'->>'lastTransitionId' IS DISTINCT FROM
+       prior_transition_id
+    OR snapshot."snapshot_json"->'content'->'calculationAuthority'->>'state'
+       IS DISTINCT FROM 'ready'
+    OR snapshot."content_sha256" IS DISTINCT FROM encode(sha256(convert_to(
+       snapshot."content_canonical_json",'UTF8')),'hex')
+    OR snapshot."snapshot_id" IS DISTINCT FROM 'private-evaluation-authority-snapshot:' ||
+       snapshot."content_sha256"
+    OR snapshot."snapshot_json"->>'snapshotId' IS DISTINCT FROM snapshot."snapshot_id"
+    OR snapshot_custody."content_sha256" IS DISTINCT FROM
+       substring(snapshot."artifact_id" FROM 10)
+    OR snapshot_custody."storage_uri" IS DISTINCT FROM
+       'artifact://sha256/' || snapshot_custody."content_sha256"
+    OR snapshot_custody."media_type" IS DISTINCT FROM 'application/json'
+    OR snapshot_custody."byte_length" IS DISTINCT FROM octet_length(convert_to(
+       outcome_afl_trade_canonical_json(snapshot."snapshot_json"),'UTF8'))
+    OR snapshot_custody."environment" IS DISTINCT FROM
+       'non_production'::"OutcomeEnvironment"
+    OR snapshot_custody."created_at" IS DISTINCT FROM snapshot."captured_at"
+    OR snapshot."expected_head_status" IS DISTINCT FROM NEW."expected_head_status"
+    OR snapshot."expected_head_revision" IS DISTINCT FROM NEW."expected_head_revision"
+    OR snapshot."expected_head_generation_id" IS DISTINCT FROM NEW."expected_head_generation_id"
+  THEN
+    RAISE EXCEPTION 'Automated private intent has invalid snapshot authority';
+  END IF;
+  IF inspection."snapshot_id" IS DISTINCT FROM NEW."authority_snapshot_id"
+    OR inspection."valuation_scope_key" IS DISTINCT FROM NEW."valuation_scope_key"
+    OR inspection."trade_id" IS DISTINCT FROM NEW."trade_id"
+    OR inspection."state" IS DISTINCT FROM 'ready'
+    OR inspection."content_canonical_json" IS DISTINCT FROM
+       outcome_afl_trade_canonical_json(inspection."receipt_json"->'content')
+    OR inspection."receipt_json"->'content'->>'schemaVersion'
+       IS DISTINCT FROM 'private-evaluation-inspection/v3'
+    OR inspection."receipt_json"->'content'->>'environment' IS DISTINCT FROM 'non_production'
+    OR inspection."receipt_json"->'content'->'publicationProhibited'
+       IS DISTINCT FROM 'true'::JSONB
+    OR (SELECT count(*) FROM jsonb_object_keys(inspection."receipt_json"))<>2
+    OR (SELECT count(*) FROM jsonb_object_keys(inspection."receipt_json"->'content'))<>13
+    OR inspection."receipt_json"->'content'->>'limitation' IS DISTINCT FROM
+       'Authenticated private non-production calculation authority only; publication and production use remain prohibited.'
+    OR inspection."receipt_json"->'content'->>'snapshotId' IS DISTINCT FROM snapshot."snapshot_id"
+    OR inspection."receipt_json"->'content'->'selector' IS DISTINCT FROM content->'selector'
+    OR inspection."receipt_json"->'content'->'head' IS DISTINCT FROM content->'expectedHead'
+    OR inspection."receipt_json"->'content'->'calculationAuthority' IS DISTINCT FROM
+       snapshot."snapshot_json"->'content'->'calculationAuthority'
+    OR inspection."receipt_json"->'content'->'blockers' IS DISTINCT FROM '[]'::JSONB
+    OR inspection."content_sha256" IS DISTINCT FROM encode(sha256(convert_to(
+       inspection."content_canonical_json",'UTF8')),'hex')
+    OR inspection."inspection_id" IS DISTINCT FROM 'private-evaluation-inspection:' ||
+       inspection."content_sha256"
+    OR inspection."receipt_json"->>'inspectionId' IS DISTINCT FROM inspection."inspection_id"
+    OR inspection_custody."content_sha256" IS DISTINCT FROM
+       substring(inspection."artifact_id" FROM 10)
+    OR inspection_custody."storage_uri" IS DISTINCT FROM
+       'artifact://sha256/' || inspection_custody."content_sha256"
+    OR inspection_custody."media_type" IS DISTINCT FROM 'application/json'
+    OR inspection_custody."byte_length" IS DISTINCT FROM octet_length(convert_to(
+       outcome_afl_trade_canonical_json(inspection."receipt_json"),'UTF8'))
+    OR inspection_custody."environment" IS DISTINCT FROM
+       'non_production'::"OutcomeEnvironment"
+    OR inspection_custody."created_at" IS DISTINCT FROM inspection."inspected_at"
+    OR inspection."expected_head_status" IS DISTINCT FROM NEW."expected_head_status"
+    OR inspection."expected_head_revision" IS DISTINCT FROM NEW."expected_head_revision"
+    OR inspection."expected_head_generation_id" IS DISTINCT FROM NEW."expected_head_generation_id"
+    OR validate_outcome_automated_ready_calculation_authority(
+      snapshot."snapshot_json"->'content'->'calculationAuthority',
+      NEW."valuation_scope_key",NEW."trade_id"
+    ) IS DISTINCT FROM TRUE
+    OR (content->>'requestedAt')::TIMESTAMPTZ < snapshot."captured_at"
+    OR (content->>'requestedAt')::TIMESTAMPTZ > snapshot."valid_through"
+  THEN
+    RAISE EXCEPTION 'Automated private intent has invalid inspection authority';
+  END IF;
+  RETURN NEW;
+EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+  RAISE EXCEPTION 'Automated private intent contains invalid typed evidence';
+END $$;
+
+CREATE TRIGGER "outcome_automated_private_intent_validate"
+BEFORE INSERT ON "outcome_private_evaluation_transition_intent"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_automated_private_intent"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_automated_private_generation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  content JSONB := NEW."generation_json"->'content';
+  intent RECORD;
+  custody RECORD;
+BEGIN
+  IF content->>'schemaVersion' NOT IN (
+    'local-private-trade-evaluation-generation/v1',
+    'local-private-trade-evaluation-generation/v2'
+  ) THEN
+    RAISE EXCEPTION 'Unsupported private evaluation generation schema version';
+  END IF;
+  SELECT * INTO intent FROM "outcome_private_evaluation_transition_intent"
+   WHERE "transition_intent_id"=NEW."transition_intent_id" FOR KEY SHARE;
+  SELECT * INTO custody FROM "outcome_artifact_custody"
+   WHERE "artifact_id"=NEW."generation_artifact_id" FOR KEY SHARE;
+  IF content->>'schemaVersion'='local-private-trade-evaluation-generation/v1' THEN
+    IF intent."transition_intent_id" IS NULL
+      OR custody."artifact_id" IS NULL
+      OR content->>'environment' IS DISTINCT FROM 'test_fixture'
+      OR content->'publicationProhibited' IS DISTINCT FROM 'true'::JSONB
+      OR (SELECT count(*) FROM jsonb_object_keys(NEW."generation_json"))<>2
+      OR (SELECT count(*) FROM jsonb_object_keys(content))<>11
+      OR content->'selector'->>'valuationScopeKey' IS DISTINCT FROM NEW."valuation_scope_key"
+      OR content->'selector'->>'tradeId' IS DISTINCT FROM NEW."trade_id"
+      OR content->>'transitionIntentId' IS DISTINCT FROM NEW."transition_intent_id"
+      OR content->'narrativeArtifact'->>'artifactId' IS DISTINCT FROM NEW."narrative_artifact_id"
+      OR content->'projectionManifestArtifact'->>'artifactId'
+         IS DISTINCT FROM NEW."projection_manifest_artifact_id"
+      OR (content->>'generatedAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."generated_at"
+      OR NEW."content_canonical_json" IS DISTINCT FROM outcome_afl_trade_canonical_json(content)
+      OR NEW."content_sha256" IS DISTINCT FROM encode(sha256(convert_to(
+         NEW."content_canonical_json",'UTF8')),'hex')
+      OR NEW."generation_id" IS DISTINCT FROM
+         'local-private-trade-evaluation-generation:'||NEW."content_sha256"
+      OR NEW."generation_json"->>'generationId' IS DISTINCT FROM NEW."generation_id"
+      OR custody."content_sha256" IS DISTINCT FROM substring(NEW."generation_artifact_id" FROM 10)
+      OR custody."storage_uri" IS DISTINCT FROM 'artifact://sha256/'||custody."content_sha256"
+      OR custody."media_type" IS DISTINCT FROM 'application/json'
+      OR custody."byte_length" IS DISTINCT FROM octet_length(convert_to(
+         outcome_afl_trade_canonical_json(NEW."generation_json"),'UTF8'))
+      OR custody."environment" IS DISTINCT FROM 'test_fixture'::"OutcomeEnvironment"
+      OR custody."created_at" IS DISTINCT FROM NEW."generated_at"
+      OR validate_outcome_prepared_valuation_input_v2_artifact(
+         content->'narrativeArtifact','test_fixture'::"OutcomeEnvironment"
+      ) IS DISTINCT FROM TRUE
+      OR validate_outcome_prepared_valuation_input_v2_artifact(
+         content->'projectionManifestArtifact','test_fixture'::"OutcomeEnvironment"
+      ) IS DISTINCT FROM TRUE
+    THEN
+      RAISE EXCEPTION 'Legacy private generation failed exact test-fixture authentication';
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF intent."transition_intent_id" IS NULL
+    OR custody."artifact_id" IS NULL
+    OR content->>'environment' IS DISTINCT FROM 'non_production'
+    OR content->'publicationProhibited' IS DISTINCT FROM 'true'::JSONB
+    OR (SELECT count(*) FROM jsonb_object_keys(NEW."generation_json"))<>2
+    OR (SELECT count(*) FROM jsonb_object_keys(content))<>12
+    OR content->>'activationReceipt' IS DISTINCT FROM 'separate_append_only_transition'
+    OR content->'constructionAuthority'->>'kind'
+       IS DISTINCT FROM 'automated_private_calculation_agent'
+    OR content->'constructionAuthority'->>'principalId'
+       IS DISTINCT FROM 'system:weekly-valuation-coordinator'
+    OR content->'constructionAuthority' IS DISTINCT FROM
+       intent."intent_json"->'content'->'constructionAuthority'
+    OR content->'selector'->>'valuationScopeKey' IS DISTINCT FROM NEW."valuation_scope_key"
+    OR content->'selector'->>'tradeId' IS DISTINCT FROM NEW."trade_id"
+    OR content->>'transitionIntentId' IS DISTINCT FROM NEW."transition_intent_id"
+    OR content->'narrativeArtifact'->>'artifactId' IS DISTINCT FROM NEW."narrative_artifact_id"
+    OR content->'projectionManifestArtifact'->>'artifactId'
+       IS DISTINCT FROM NEW."projection_manifest_artifact_id"
+    OR (content->>'generatedAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."generated_at"
+    OR NEW."content_canonical_json" IS DISTINCT FROM outcome_afl_trade_canonical_json(content)
+    OR NEW."content_sha256" IS DISTINCT FROM encode(sha256(convert_to(
+       NEW."content_canonical_json",'UTF8')),'hex')
+    OR NEW."generation_id" IS DISTINCT FROM 'local-private-trade-evaluation-generation:' ||
+       NEW."content_sha256"
+    OR NEW."generation_json"->>'generationId' IS DISTINCT FROM NEW."generation_id"
+    OR custody."content_sha256" IS DISTINCT FROM substring(NEW."generation_artifact_id" FROM 10)
+    OR custody."storage_uri" IS DISTINCT FROM 'artifact://sha256/' || custody."content_sha256"
+    OR custody."media_type" IS DISTINCT FROM 'application/json'
+    OR custody."byte_length" IS DISTINCT FROM octet_length(convert_to(
+       outcome_afl_trade_canonical_json(NEW."generation_json"),'UTF8'))
+    OR custody."environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR custody."created_at" IS DISTINCT FROM NEW."generated_at"
+    OR validate_outcome_prepared_valuation_input_v2_artifact(
+       content->'narrativeArtifact','non_production'::"OutcomeEnvironment") IS DISTINCT FROM TRUE
+    OR validate_outcome_prepared_valuation_input_v2_artifact(
+       content->'projectionManifestArtifact','non_production'::"OutcomeEnvironment")
+       IS DISTINCT FROM TRUE
+  THEN
+    RAISE EXCEPTION 'Automated private generation failed PostgreSQL authority authentication';
+  END IF;
+  RETURN NEW;
+EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+  RAISE EXCEPTION 'Automated private generation contains invalid typed evidence';
+END $$;
+
+CREATE TRIGGER "outcome_automated_private_generation_validate"
+BEFORE INSERT ON "outcome_local_private_trade_evaluation_generation"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_automated_private_generation"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_automated_private_receipt"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  content JSONB := NEW."receipt_json"->'content';
+  intent RECORD;
+  generation RECORD;
+  custody RECORD;
+  prior RECORD;
+  operator_authority_id TEXT;
+BEGIN
+  IF content->>'schemaVersion' NOT IN (
+    'private-evaluation-transition-receipt/v1','private-evaluation-transition-receipt/v2'
+  ) THEN
+    RAISE EXCEPTION 'Unsupported private evaluation receipt schema version';
+  END IF;
+  SELECT * INTO intent FROM "outcome_private_evaluation_transition_intent"
+   WHERE "transition_intent_id"=NEW."transition_intent_id" FOR KEY SHARE;
+  SELECT * INTO generation FROM "outcome_local_private_trade_evaluation_generation"
+   WHERE "generation_id"=NEW."to_generation_id" FOR KEY SHARE;
+  SELECT * INTO custody FROM "outcome_artifact_custody"
+   WHERE "artifact_id"=NEW."artifact_id" FOR KEY SHARE;
+  SELECT * INTO prior FROM "outcome_local_private_trade_evaluation_head"
+   WHERE "valuation_scope_key"=NEW."valuation_scope_key" AND "trade_id"=NEW."trade_id"
+   FOR KEY SHARE;
+  IF content->>'schemaVersion'='private-evaluation-transition-receipt/v1' THEN
+    SELECT authority."authority_evidence_id" INTO operator_authority_id
+      FROM "outcome_operational_principal_authority" authority
+      JOIN "outcome_governed_evidence_reference" evidence
+        ON evidence."reference_id"=authority."authority_evidence_id"
+      JOIN "outcome_review_decision" approval
+        ON approval."decision_id"=evidence."approval_decision_id"
+     WHERE authority."principal_ref"=content->'intent'->'content'->'review'->>'principalId'
+       AND authority."role"='afl_trade_private_evaluation_operator'
+       AND authority."scope_key"=NEW."valuation_scope_key"
+       AND authority."provider"='statly_modeling'
+       AND authority."capability_id"='manage_private_trade_evaluation'
+       AND authority."competition"='AFLM'
+       AND authority."valid_from"<=NEW."transitioned_at"
+       AND (authority."valid_through" IS NULL OR
+            authority."valid_through">NEW."transitioned_at")
+       AND authority."valid_from"<=transaction_timestamp()
+       AND (authority."valid_through" IS NULL OR
+            authority."valid_through">transaction_timestamp())
+       AND evidence."environment"='test_fixture'::"OutcomeEnvironment"
+       AND evidence."status"='approved'::"OutcomeRecordStatus"
+       AND approval."decision"='approved'
+       AND NOT EXISTS (
+         SELECT 1 FROM "outcome_review_decision" successor
+          WHERE successor."supersedes_decision_id"=approval."decision_id"
+       )
+     LIMIT 1;
+    IF intent."transition_intent_id" IS NULL
+      OR operator_authority_id IS NULL
+      OR custody."artifact_id" IS NULL
+      OR content->>'environment' IS DISTINCT FROM 'test_fixture'
+      OR content->'publicationProhibited' IS DISTINCT FROM 'true'::JSONB
+      OR (SELECT count(*) FROM jsonb_object_keys(NEW."receipt_json"))<>2
+      OR (SELECT count(*) FROM jsonb_object_keys(content))<>11
+      OR content->>'limitation' IS DISTINCT FROM
+         'Private test-fixture lifecycle evidence only; it grants no factual, model, production, or publication authority.'
+      OR content->'intent' IS DISTINCT FROM intent."intent_json"
+      OR content->'selector'->>'valuationScopeKey' IS DISTINCT FROM NEW."valuation_scope_key"
+      OR content->'selector'->>'tradeId' IS DISTINCT FROM NEW."trade_id"
+      OR content->'action'->>'kind' IS DISTINCT FROM NEW."action"
+      OR content->'fromHead'->>'status' IS DISTINCT FROM NEW."from_status"
+      OR (content->'fromHead'->>'revision')::INTEGER IS DISTINCT FROM NEW."from_revision"
+      OR content->'fromHead'->>'generationId' IS DISTINCT FROM NEW."from_generation_id"
+      OR content->'toHead'->>'status' IS DISTINCT FROM NEW."to_status"
+      OR (content->'toHead'->>'revision')::INTEGER IS DISTINCT FROM NEW."to_revision"
+      OR content->'toHead'->>'generationId' IS DISTINCT FROM NEW."to_generation_id"
+      OR content->>'previousTransitionId' IS DISTINCT FROM prior."last_transition_id"
+      OR (prior."revision" IS NULL AND content->>'previousTransitionId' IS NOT NULL)
+      OR (content->>'transitionedAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."transitioned_at"
+      OR NEW."operation_id" IS DISTINCT FROM intent."operation_id"
+      OR NEW."to_revision" IS DISTINCT FROM NEW."from_revision"+1
+      OR (NEW."action"='withdraw' AND (
+        NEW."to_status" IS DISTINCT FROM 'withdrawn' OR NEW."to_generation_id" IS NOT NULL))
+      OR (NEW."action"<>'withdraw' AND NEW."to_status" IS DISTINCT FROM 'active')
+      OR (NEW."action"='rollback' AND NEW."to_generation_id" IS DISTINCT FROM
+          content->'action'->>'targetGenerationId')
+      OR (NEW."action"='construct_and_activate' AND (
+        generation."generation_id" IS NULL
+        OR generation."transition_intent_id" IS DISTINCT FROM NEW."transition_intent_id"
+        OR generation."valuation_scope_key" IS DISTINCT FROM NEW."valuation_scope_key"
+        OR generation."trade_id" IS DISTINCT FROM NEW."trade_id"
+      ))
+      OR NEW."content_canonical_json" IS DISTINCT FROM outcome_afl_trade_canonical_json(content)
+      OR NEW."content_sha256" IS DISTINCT FROM encode(sha256(convert_to(
+         NEW."content_canonical_json",'UTF8')),'hex')
+      OR NEW."transition_id" IS DISTINCT FROM 'private-evaluation-transition:'||NEW."content_sha256"
+      OR NEW."receipt_json"->>'transitionId' IS DISTINCT FROM NEW."transition_id"
+      OR custody."content_sha256" IS DISTINCT FROM substring(NEW."artifact_id" FROM 10)
+      OR custody."storage_uri" IS DISTINCT FROM 'artifact://sha256/'||custody."content_sha256"
+      OR custody."media_type" IS DISTINCT FROM 'application/json'
+      OR custody."byte_length" IS DISTINCT FROM octet_length(convert_to(
+         outcome_afl_trade_canonical_json(NEW."receipt_json"),'UTF8'))
+      OR custody."environment" IS DISTINCT FROM 'test_fixture'::"OutcomeEnvironment"
+      OR custody."created_at" IS DISTINCT FROM NEW."transitioned_at"
+      OR (content->>'transitionedAt')::TIMESTAMPTZ < intent."requested_at"
+      OR (content->>'transitionedAt')::TIMESTAMPTZ > intent."expires_at"
+      OR transaction_timestamp()<NEW."transitioned_at"
+      OR transaction_timestamp()>intent."expires_at"
+    THEN
+      RAISE EXCEPTION 'Legacy private receipt failed exact test-fixture authentication';
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF intent."transition_intent_id" IS NULL
+    OR generation."generation_id" IS NULL
+    OR custody."artifact_id" IS NULL
+    OR content->>'environment' IS DISTINCT FROM 'non_production'
+    OR content->'publicationProhibited' IS DISTINCT FROM 'true'::JSONB
+    OR (SELECT count(*) FROM jsonb_object_keys(NEW."receipt_json"))<>2
+    OR (SELECT count(*) FROM jsonb_object_keys(content))<>11
+    OR content->>'limitation' IS DISTINCT FROM
+       'Automated private calculation only; it grants no source approval, production, publication, withdrawal, rollback, or recovery authority.'
+    OR content->'intent' IS DISTINCT FROM intent."intent_json"
+    OR content->'intent'->'content'->'constructionAuthority'->>'principalId'
+       IS DISTINCT FROM 'system:weekly-valuation-coordinator'
+    OR content->'action'->>'kind' IS DISTINCT FROM 'construct_and_activate'
+    OR content->'selector'->>'valuationScopeKey' IS DISTINCT FROM NEW."valuation_scope_key"
+    OR content->'selector'->>'tradeId' IS DISTINCT FROM NEW."trade_id"
+    OR content->'fromHead'->>'status' IS DISTINCT FROM NEW."from_status"
+    OR (content->'fromHead'->>'revision')::INTEGER IS DISTINCT FROM NEW."from_revision"
+    OR content->'fromHead'->>'generationId' IS DISTINCT FROM NEW."from_generation_id"
+    OR content->'toHead'->>'status' IS DISTINCT FROM NEW."to_status"
+    OR (content->'toHead'->>'revision')::INTEGER IS DISTINCT FROM NEW."to_revision"
+    OR content->'toHead'->>'generationId' IS DISTINCT FROM NEW."to_generation_id"
+    OR content->>'previousTransitionId' IS DISTINCT FROM prior."last_transition_id"
+    OR (prior."revision" IS NULL AND content->>'previousTransitionId' IS NOT NULL)
+    OR (content->>'transitionedAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."transitioned_at"
+    OR NEW."operation_id" IS DISTINCT FROM intent."operation_id"
+    OR NEW."action" IS DISTINCT FROM 'construct_and_activate'
+    OR NEW."to_status" IS DISTINCT FROM 'active'
+    OR generation."transition_intent_id" IS DISTINCT FROM NEW."transition_intent_id"
+    OR generation."valuation_scope_key" IS DISTINCT FROM NEW."valuation_scope_key"
+    OR generation."trade_id" IS DISTINCT FROM NEW."trade_id"
+    OR NEW."content_canonical_json" IS DISTINCT FROM outcome_afl_trade_canonical_json(content)
+    OR NEW."content_sha256" IS DISTINCT FROM encode(sha256(convert_to(
+       NEW."content_canonical_json",'UTF8')),'hex')
+    OR NEW."transition_id" IS DISTINCT FROM 'private-evaluation-transition:' || NEW."content_sha256"
+    OR NEW."receipt_json"->>'transitionId' IS DISTINCT FROM NEW."transition_id"
+    OR custody."content_sha256" IS DISTINCT FROM substring(NEW."artifact_id" FROM 10)
+    OR custody."storage_uri" IS DISTINCT FROM 'artifact://sha256/' || custody."content_sha256"
+    OR custody."media_type" IS DISTINCT FROM 'application/json'
+    OR custody."byte_length" IS DISTINCT FROM octet_length(convert_to(
+       outcome_afl_trade_canonical_json(NEW."receipt_json"),'UTF8'))
+    OR custody."environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR custody."created_at" IS DISTINCT FROM NEW."transitioned_at"
+    OR (content->>'transitionedAt')::TIMESTAMPTZ < intent."requested_at"
+    OR (content->>'transitionedAt')::TIMESTAMPTZ > intent."expires_at"
+    OR transaction_timestamp()<NEW."transitioned_at"
+    OR transaction_timestamp()>intent."expires_at"
+  THEN
+    RAISE EXCEPTION 'Automated private receipt failed PostgreSQL authority authentication';
+  END IF;
+  RETURN NEW;
+EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+  RAISE EXCEPTION 'Automated private receipt contains invalid typed evidence';
+END $$;
+
+CREATE TRIGGER "outcome_automated_private_receipt_validate"
+BEFORE INSERT ON "outcome_private_evaluation_transition_receipt"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_automated_private_receipt"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_evaluation_head_transition"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  receipt RECORD;
+  prior RECORD;
+BEGIN
+  SELECT * INTO receipt FROM "outcome_private_evaluation_transition_receipt"
+   WHERE "transition_id"=NEW."last_transition_id" FOR KEY SHARE;
+  IF TG_OP='INSERT' THEN
+    SELECT * INTO prior FROM "outcome_local_private_trade_evaluation_head"
+     WHERE "valuation_scope_key"=NEW."valuation_scope_key"
+       AND "trade_id"=NEW."trade_id" FOR KEY SHARE;
+  END IF;
+  IF receipt."transition_id" IS NULL
+    OR receipt."valuation_scope_key" IS DISTINCT FROM NEW."valuation_scope_key"
+    OR receipt."trade_id" IS DISTINCT FROM NEW."trade_id"
+    OR receipt."to_revision" IS DISTINCT FROM NEW."revision"
+    OR receipt."to_status" IS DISTINCT FROM NEW."status"
+    OR receipt."to_generation_id" IS DISTINCT FROM NEW."generation_id"
+    OR (TG_OP='INSERT' AND prior."revision" IS NULL AND (
+      receipt."from_revision"<>0 OR receipt."from_status"<>'absent'
+      OR receipt."from_generation_id" IS NOT NULL
+      OR receipt."receipt_json"->'content'->>'previousTransitionId' IS NOT NULL))
+    OR (TG_OP='INSERT' AND prior."revision" IS NOT NULL AND (
+      receipt."from_revision" IS DISTINCT FROM prior."revision"
+      OR receipt."from_status" IS DISTINCT FROM prior."status"
+      OR receipt."from_generation_id" IS DISTINCT FROM prior."generation_id"
+      OR receipt."receipt_json"->'content'->>'previousTransitionId'
+         IS DISTINCT FROM prior."last_transition_id"))
+    OR (TG_OP='UPDATE' AND (
+      receipt."from_revision" IS DISTINCT FROM OLD."revision"
+      OR receipt."from_status" IS DISTINCT FROM OLD."status"
+      OR receipt."from_generation_id" IS DISTINCT FROM OLD."generation_id"
+      OR receipt."receipt_json"->'content'->>'previousTransitionId'
+         IS DISTINCT FROM OLD."last_transition_id"))
+  THEN
+    RAISE EXCEPTION 'Private evaluation head must advance through its exact retained receipt';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_private_evaluation_head_transition_validate"
+BEFORE INSERT OR UPDATE ON "outcome_local_private_trade_evaluation_head"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_evaluation_head_transition"();

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -150,6 +150,7 @@ model OutcomeReleaseManifest {
   preparedValuationInputSets          OutcomePreparedValuationInputSet[]
   privateValuationEvaluationDecisions OutcomePrivateValuationEvaluationDecision[]
   privateValuationEvaluationHeads     OutcomePrivateValuationEvaluationHead[]
+  currentValuationCohortOperations    OutcomeCurrentValuationCohortOperation[]
 
   @@index([scopeKey, createdAt])
   @@map("outcome_release_manifest")
@@ -4377,28 +4378,29 @@ model OutcomeValuationSourceQualificationReport {
 }
 
 model OutcomePreparedValuationInputSet {
-  preparedInputSetId       String                                    @id @map("prepared_input_set_id")
-  contentSha256            String                                    @map("content_sha256") @outcomes.Char(64)
-  schemaVersion            String                                    @map("schema_version")
-  environment              OutcomeEnvironment
-  scopeKey                 String                                    @map("scope_key")
-  factualReleaseScopeKey   String                                    @map("factual_release_scope_key")
-  factualReleaseId         String                                    @map("factual_release_id")
-  qualificationReportId    String                                    @map("qualification_report_id")
-  tradeCount               Int                                       @map("trade_count")
-  readyCount               Int                                       @map("ready_count")
-  blockedCount             Int                                       @map("blocked_count")
-  preparedAt               DateTime                                  @map("prepared_at") @outcomes.Timestamptz(3)
-  contentCanonicalJson     String                                    @map("content_canonical_json") @outcomes.Text
-  preparedSetCanonicalJson String                                    @map("prepared_set_canonical_json") @outcomes.Text
-  preparedSetJson          Json                                      @map("prepared_set_json")
-  finalizedAt              DateTime?                                 @map("finalized_at") @outcomes.Timestamptz(3)
-  registeredAt             DateTime                                  @default(dbgenerated("transaction_timestamp()")) @map("registered_at") @outcomes.Timestamptz(3)
-  registeredBy             String                                    @default(dbgenerated("CURRENT_USER")) @map("registered_by")
-  factualRelease           OutcomeReleaseManifest                    @relation(fields: [factualReleaseId], references: [releaseId], onDelete: Restrict)
-  qualificationReport      OutcomeValuationSourceQualificationReport @relation(fields: [qualificationReportId], references: [qualificationReportId], onDelete: Restrict)
-  entries                  OutcomePreparedValuationInputEntry[]
-  currentHeads             OutcomeCurrentPreparedValuationInputSet[]
+  preparedInputSetId           String                                        @id @map("prepared_input_set_id")
+  contentSha256                String                                        @map("content_sha256") @outcomes.Char(64)
+  schemaVersion                String                                        @map("schema_version")
+  environment                  OutcomeEnvironment
+  scopeKey                     String                                        @map("scope_key")
+  factualReleaseScopeKey       String                                        @map("factual_release_scope_key")
+  factualReleaseId             String                                        @map("factual_release_id")
+  qualificationReportId        String                                        @map("qualification_report_id")
+  tradeCount                   Int                                           @map("trade_count")
+  readyCount                   Int                                           @map("ready_count")
+  blockedCount                 Int                                           @map("blocked_count")
+  preparedAt                   DateTime                                      @map("prepared_at") @outcomes.Timestamptz(3)
+  contentCanonicalJson         String                                        @map("content_canonical_json") @outcomes.Text
+  preparedSetCanonicalJson     String                                        @map("prepared_set_canonical_json") @outcomes.Text
+  preparedSetJson              Json                                          @map("prepared_set_json")
+  finalizedAt                  DateTime?                                     @map("finalized_at") @outcomes.Timestamptz(3)
+  registeredAt                 DateTime                                      @default(dbgenerated("transaction_timestamp()")) @map("registered_at") @outcomes.Timestamptz(3)
+  registeredBy                 String                                        @default(dbgenerated("CURRENT_USER")) @map("registered_by")
+  factualRelease               OutcomeReleaseManifest                        @relation(fields: [factualReleaseId], references: [releaseId], onDelete: Restrict)
+  qualificationReport          OutcomeValuationSourceQualificationReport     @relation(fields: [qualificationReportId], references: [qualificationReportId], onDelete: Restrict)
+  entries                      OutcomePreparedValuationInputEntry[]
+  currentHeads                 OutcomeCurrentPreparedValuationInputSet[]
+  currentValuationCohortResult OutcomeCurrentValuationCohortOperationResult?
 
   @@index([environment, scopeKey, preparedAt], map: "outcome_prepared_valuation_input_set_scope_idx")
   @@index([factualReleaseId, preparedAt], map: "outcome_prepared_valuation_input_set_release_idx")
@@ -4968,37 +4970,39 @@ model OutcomeGovernedComponentValidationEvidence {
 }
 
 model OutcomeGovernedValuationModelQualification {
-  qualificationId          String   @id @map("qualification_id") @outcomes.Text
-  scopeKey                 String   @map("scope_key") @outcomes.Text
-  outcome                  String   @outcomes.Text
-  artifactId               String   @unique @map("artifact_id") @outcomes.Text
-  playerRunId              String   @map("player_run_id") @outcomes.Text
-  pickRunId                String   @map("pick_run_id") @outcomes.Text
-  policyArtifactId         String   @map("policy_artifact_id") @outcomes.Text
-  playerCriteriaArtifactId String   @map("player_criteria_artifact_id") @outcomes.Text
-  pickCriteriaArtifactId   String   @map("pick_criteria_artifact_id") @outcomes.Text
-  playerEvidenceArtifactId String   @map("player_evidence_artifact_id") @outcomes.Text
-  pickEvidenceArtifactId   String   @map("pick_evidence_artifact_id") @outcomes.Text
-  evaluatedAt              DateTime @map("evaluated_at") @outcomes.Timestamptz(3)
-  contentSha256            String   @map("content_sha256") @outcomes.Char(64)
-  contentCanonicalJson     String   @map("content_canonical_json") @outcomes.Text
-  qualificationJson        Json     @map("qualification_json")
-  recordedAt               DateTime @default(dbgenerated("clock_timestamp()")) @map("recorded_at") @outcomes.Timestamptz(3)
+  qualificationId                  String                                   @id @map("qualification_id") @outcomes.Text
+  scopeKey                         String                                   @map("scope_key") @outcomes.Text
+  outcome                          String                                   @outcomes.Text
+  artifactId                       String                                   @unique @map("artifact_id") @outcomes.Text
+  playerRunId                      String                                   @map("player_run_id") @outcomes.Text
+  pickRunId                        String                                   @map("pick_run_id") @outcomes.Text
+  policyArtifactId                 String                                   @map("policy_artifact_id") @outcomes.Text
+  playerCriteriaArtifactId         String                                   @map("player_criteria_artifact_id") @outcomes.Text
+  pickCriteriaArtifactId           String                                   @map("pick_criteria_artifact_id") @outcomes.Text
+  playerEvidenceArtifactId         String                                   @map("player_evidence_artifact_id") @outcomes.Text
+  pickEvidenceArtifactId           String                                   @map("pick_evidence_artifact_id") @outcomes.Text
+  evaluatedAt                      DateTime                                 @map("evaluated_at") @outcomes.Timestamptz(3)
+  contentSha256                    String                                   @map("content_sha256") @outcomes.Char(64)
+  contentCanonicalJson             String                                   @map("content_canonical_json") @outcomes.Text
+  qualificationJson                Json                                     @map("qualification_json")
+  recordedAt                       DateTime                                 @default(dbgenerated("clock_timestamp()")) @map("recorded_at") @outcomes.Timestamptz(3)
+  currentValuationCohortOperations OutcomeCurrentValuationCohortOperation[]
 
   @@index([scopeKey, evaluatedAt, qualificationId], map: "outcome_governed_model_qualification_scope_idx")
   @@map("outcome_governed_valuation_model_qualification")
 }
 
 model OutcomeGovernedModelQualificationWork {
-  workId                String   @id @map("work_id") @outcomes.Text
-  scopeKey              String   @map("scope_key") @outcomes.Text
-  qualificationId       String   @unique @map("qualification_id") @outcomes.Text
-  playerGate3DecisionId String   @map("player_gate3_decision_id") @outcomes.Text
-  pickGate3DecisionId   String   @map("pick_gate3_decision_id") @outcomes.Text
-  availableAt           DateTime @map("available_at") @outcomes.Timestamptz(3)
-  status                String   @default("pending") @outcomes.Text
-  workJson              Json     @map("work_json")
-  recordedAt            DateTime @default(dbgenerated("clock_timestamp()")) @map("recorded_at") @outcomes.Timestamptz(3)
+  workId                           String                                   @id @map("work_id") @outcomes.Text
+  scopeKey                         String                                   @map("scope_key") @outcomes.Text
+  qualificationId                  String                                   @unique @map("qualification_id") @outcomes.Text
+  playerGate3DecisionId            String                                   @map("player_gate3_decision_id") @outcomes.Text
+  pickGate3DecisionId              String                                   @map("pick_gate3_decision_id") @outcomes.Text
+  availableAt                      DateTime                                 @map("available_at") @outcomes.Timestamptz(3)
+  status                           String                                   @default("pending") @outcomes.Text
+  workJson                         Json                                     @map("work_json")
+  recordedAt                       DateTime                                 @default(dbgenerated("clock_timestamp()")) @map("recorded_at") @outcomes.Timestamptz(3)
+  currentValuationCohortOperations OutcomeCurrentValuationCohortOperation[]
 
   @@index([status, availableAt, scopeKey], map: "outcome_governed_model_qualification_work_pending_idx")
   @@map("outcome_governed_model_qualification_work")
@@ -5016,6 +5020,38 @@ model OutcomeCurrentGovernedValuationModelPair {
   advancedAt            DateTime @map("advanced_at") @outcomes.Timestamptz(3)
 
   @@map("outcome_current_governed_valuation_model_pair")
+}
+
+model OutcomeCurrentValuationCohortOperation {
+  operationId                   String                                        @id @map("operation_id") @outcomes.Text
+  scopeKey                      String                                        @map("scope_key") @outcomes.Text
+  factualReleaseId              String                                        @map("factual_release_id") @outcomes.Text
+  factualReleaseRevision        Int                                           @map("factual_release_revision")
+  modelQualificationId          String                                        @map("model_qualification_id") @outcomes.Text
+  modelQualificationWorkId      String                                        @map("model_qualification_work_id") @outcomes.Text
+  modelQualificationRevision    Int                                           @map("model_qualification_revision")
+  expectedPreparedInputRevision Int                                           @map("expected_prepared_input_revision")
+  capturedAt                    DateTime                                      @map("captured_at") @outcomes.Timestamptz(3)
+  contextSha256                 String                                        @map("context_sha256") @outcomes.Char(64)
+  contextCanonicalJson          String                                        @map("context_canonical_json") @outcomes.Text
+  contextJson                   Json                                          @map("context_json")
+  factualRelease                OutcomeReleaseManifest                        @relation(fields: [factualReleaseId], references: [releaseId], onDelete: Restrict, map: "outcome_current_valuation_cohort_operation_release_fkey")
+  modelQualification            OutcomeGovernedValuationModelQualification    @relation(fields: [modelQualificationId], references: [qualificationId], onDelete: Restrict, map: "outcome_current_valuation_cohort_operation_qualification_fkey")
+  modelQualificationWork        OutcomeGovernedModelQualificationWork         @relation(fields: [modelQualificationWorkId], references: [workId], onDelete: Restrict, map: "outcome_current_valuation_cohort_operation_work_fkey")
+  result                        OutcomeCurrentValuationCohortOperationResult?
+
+  @@map("outcome_current_valuation_cohort_operation")
+}
+
+model OutcomeCurrentValuationCohortOperationResult {
+  operationId        String                                 @id @map("operation_id") @outcomes.Text
+  preparedInputSetId String                                 @unique @map("prepared_input_set_id") @outcomes.Text
+  headRevision       Int                                    @map("head_revision")
+  completedAt        DateTime                               @map("completed_at") @outcomes.Timestamptz(3)
+  operation          OutcomeCurrentValuationCohortOperation @relation(fields: [operationId], references: [operationId], onDelete: Restrict, map: "outcome_current_cohort_result_operation_fkey")
+  preparedInputSet   OutcomePreparedValuationInputSet       @relation(fields: [preparedInputSetId], references: [preparedInputSetId], onDelete: Restrict, map: "outcome_current_cohort_result_prepared_fkey")
+
+  @@map("outcome_current_valuation_cohort_operation_result")
 }
 
 model OutcomePrivateEvaluationAuthoritySnapshot {

--- a/src/server/aflTradeIntelligence/valuation/automatedPrivateEvaluationPolicy.ts
+++ b/src/server/aflTradeIntelligence/valuation/automatedPrivateEvaluationPolicy.ts
@@ -1,0 +1,2 @@
+export const AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID =
+  'system:weekly-valuation-coordinator' as const;

--- a/src/server/aflTradeIntelligence/valuation/currentValuationCohortPreparation.ts
+++ b/src/server/aflTradeIntelligence/valuation/currentValuationCohortPreparation.ts
@@ -1,0 +1,278 @@
+import { z } from 'zod';
+
+import { aflTradeArtifactRefSchema } from '../artifacts/artifactReference';
+import {
+  aflTradeContentAddressedIdSchema,
+  createAflTradeContentAddress,
+} from '../artifacts/contentAddress';
+import { aflTradeValuationInputBundleSchema } from '../artifacts/valuationInputBundle';
+import {
+  AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V3_SCHEMA_VERSION,
+  aflTradePreparedValuationInputEntrySchema,
+  createAflTradePreparedValuationInputSet,
+  type AflTradePreparedValuationInputSet,
+  type AflTradePreparedValuationInputSetContent,
+} from './preparedValuationInputSet';
+import type { AflTradeCurrentPreparedValuationInputHead } from './postgresPreparedValuationInputSetStore';
+
+const publicIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(400)
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9._:/-]*$/u);
+
+export const aflTradeCurrentValuationCohortPreparationRequestSchema = z
+  .object({
+    operationId: aflTradeContentAddressedIdSchema(
+      'valuation-cohort-preparation-operation'
+    ),
+    scopeKey: publicIdSchema,
+  })
+  .strict();
+
+export const aflTradeCurrentValuationCohortConstructionContextSchema = z
+  .object({
+    operationId: aflTradeContentAddressedIdSchema(
+      'valuation-cohort-preparation-operation'
+    ),
+    scopeKey: publicIdSchema,
+    factualReleaseScopeKey: publicIdSchema,
+    factualReleaseId: aflTradeContentAddressedIdSchema('outcome-release'),
+    factualReleaseRevision: z.number().int().positive(),
+    factualReleaseArtifact: aflTradeArtifactRefSchema,
+    releaseMembershipArtifact: aflTradeArtifactRefSchema,
+    releaseTradeIds: z.array(publicIdSchema).min(1).max(10_000),
+    sourceQualificationReportId: aflTradeContentAddressedIdSchema(
+      'valuation-source-qualification'
+    ),
+    sourceQualificationReportArtifact: aflTradeArtifactRefSchema,
+    sourceQualificationEvidenceRefs: z.array(aflTradeArtifactRefSchema).min(1).max(1_000),
+    modelQualificationId: aflTradeContentAddressedIdSchema('model-qualification'),
+    modelQualificationWorkId: aflTradeContentAddressedIdSchema('model-qualification-work'),
+    modelQualificationRevision: z.number().int().positive(),
+    playerRunId: aflTradeContentAddressedIdSchema('model-run'),
+    pickRunId: aflTradeContentAddressedIdSchema('model-run'),
+    expectedPreparedInputRevision: z.number().int().nonnegative(),
+    valuationInputBundleId: aflTradeContentAddressedIdSchema('valuation-input-bundle'),
+    valuationInputBundleArtifact: aflTradeArtifactRefSchema,
+    capturedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict()
+  .superRefine((context, refinement) => {
+    const tradeIds = context.releaseTradeIds;
+    if (
+      new Set(tradeIds).size !== tradeIds.length ||
+      tradeIds.some((tradeId, index) => index > 0 && tradeIds[index - 1]! > tradeId)
+    ) {
+      refinement.addIssue({
+        code: 'custom',
+        path: ['releaseTradeIds'],
+        message: 'Current cohort release trades must be unique and canonically ordered.',
+      });
+    }
+    const capturedAt = Date.parse(context.capturedAt);
+    const parents = [
+      context.factualReleaseArtifact,
+      context.releaseMembershipArtifact,
+      context.sourceQualificationReportArtifact,
+      ...context.sourceQualificationEvidenceRefs,
+      context.valuationInputBundleArtifact,
+    ];
+    if (parents.some(({ createdAt }) => Date.parse(createdAt) > capturedAt)) {
+      refinement.addIssue({
+        code: 'custom',
+        path: ['capturedAt'],
+        message: 'Current cohort authority cannot predate retained construction evidence.',
+      });
+    }
+  });
+
+export const aflTradePersistedCurrentValuationCohortConstructionContextSchema =
+  aflTradeCurrentValuationCohortConstructionContextSchema
+    .safeExtend({ valuationInputBundle: aflTradeValuationInputBundleSchema })
+    .superRefine((context, refinement) => {
+      if (
+        context.valuationInputBundle.valuationInputBundleId !==
+          context.valuationInputBundleId ||
+        context.valuationInputBundle.content.scopeKey !== context.scopeKey ||
+        context.valuationInputBundle.content.components[0]?.runId !== context.playerRunId ||
+        context.valuationInputBundle.content.components[1]?.runId !== context.pickRunId
+      ) {
+        refinement.addIssue({
+          code: 'custom',
+          path: ['valuationInputBundle'],
+          message: 'Retained cohort valuation bundle must bind the exact scope and model runs.',
+        });
+      }
+    });
+
+export type AflTradeCurrentValuationCohortPreparationRequest = z.infer<
+  typeof aflTradeCurrentValuationCohortPreparationRequestSchema
+>;
+
+export function createAflTradeCurrentValuationCohortPreparationOperationId(input: {
+  readonly scopeKey: string;
+  readonly factualReleaseId: string;
+  readonly factualReleaseRevision: number;
+  readonly modelQualificationId: string;
+  readonly modelQualificationWorkId: string;
+  readonly modelQualificationRevision: number;
+  readonly expectedPreparedInputRevision: number;
+}): string {
+  return createAflTradeContentAddress('valuation-cohort-preparation-operation', input);
+}
+export type AflTradeCurrentValuationCohortConstructionContext = z.infer<
+  typeof aflTradeCurrentValuationCohortConstructionContextSchema
+>;
+type AflTradePreparedValuationInputEntryV3 = Extract<
+  AflTradePreparedValuationInputSetContent,
+  { readonly schemaVersion: typeof AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V3_SCHEMA_VERSION }
+>['entries'][number];
+
+export type AflTradeCurrentValuationCohortPreparationResult =
+  | Readonly<{
+      state: 'advanced' | 'already_current';
+      preparedInputSet: AflTradePreparedValuationInputSet;
+      head: AflTradeCurrentPreparedValuationInputHead;
+    }>
+  | Readonly<{
+      state: 'stale_authority';
+      reason: string;
+    }>;
+
+interface AflTradeCurrentValuationCohortPreparationDependencies {
+  readonly maximumConcurrency?: number;
+  readonly captureCurrent: (
+    request: AflTradeCurrentValuationCohortPreparationRequest
+  ) => Promise<AflTradeCurrentValuationCohortConstructionContext>;
+  readonly prepareTrade: (input: {
+    readonly context: AflTradeCurrentValuationCohortConstructionContext;
+    readonly tradeId: string;
+  }) => Promise<AflTradePreparedValuationInputEntryV3>;
+  readonly commitIfCurrent: (input: {
+    readonly context: AflTradeCurrentValuationCohortConstructionContext;
+    readonly preparedInputSet: AflTradePreparedValuationInputSet;
+  }) => Promise<AflTradeCurrentValuationCohortPreparationResult>;
+}
+
+export interface AflTradeCurrentValuationCohortCoordinator {
+  prepare(
+    request: AflTradeCurrentValuationCohortPreparationRequest
+  ): Promise<AflTradeCurrentValuationCohortPreparationResult>;
+}
+
+export class AflTradeCurrentValuationTradeUnavailableError extends Error {}
+
+export function createAflTradeCurrentValuationCohortCoordinator(
+  dependencies: AflTradeCurrentValuationCohortPreparationDependencies
+): AflTradeCurrentValuationCohortCoordinator {
+  const maximumConcurrency = dependencies.maximumConcurrency ?? 8;
+  if (
+    !Number.isSafeInteger(maximumConcurrency) ||
+    maximumConcurrency < 1 ||
+    maximumConcurrency > 32
+  ) {
+    throw new TypeError('Current cohort preparation concurrency must be between 1 and 32.');
+  }
+  return {
+    async prepare(unparsedRequest) {
+      const request = aflTradeCurrentValuationCohortPreparationRequestSchema.parse(
+        unparsedRequest
+      );
+      const context = aflTradeCurrentValuationCohortConstructionContextSchema.parse(
+        await dependencies.captureCurrent(request)
+      );
+      if (context.operationId !== request.operationId || context.scopeKey !== request.scopeKey) {
+        throw new TypeError('Current cohort capture escaped its requested operation or scope.');
+      }
+      const entries = new Array<AflTradePreparedValuationInputEntryV3>(
+        context.releaseTradeIds.length
+      );
+      let nextIndex = 0;
+      await Promise.all(
+        Array.from(
+          { length: Math.min(maximumConcurrency, context.releaseTradeIds.length) },
+          async () => {
+            while (nextIndex < context.releaseTradeIds.length) {
+              const index = nextIndex;
+              nextIndex += 1;
+              const tradeId = context.releaseTradeIds[index]!;
+              let entry: AflTradePreparedValuationInputEntryV3;
+              try {
+                entry = aflTradePreparedValuationInputEntrySchema.parse(
+                  await dependencies.prepareTrade({ context, tradeId })
+                ) as AflTradePreparedValuationInputEntryV3;
+              } catch (error) {
+                if (!(error instanceof AflTradeCurrentValuationTradeUnavailableError)) {
+                  throw error;
+                }
+                entry = aflTradePreparedValuationInputEntrySchema.parse({
+                  tradeId,
+                  state: 'blocked',
+                  blockers: [
+                    {
+                      code: 'component_output_unavailable',
+                      subject: { kind: 'trade', id: tradeId },
+                      evidenceRefs: [context.valuationInputBundleArtifact],
+                    },
+                  ],
+                }) as AflTradePreparedValuationInputEntryV3;
+              }
+              if (entry.tradeId !== tradeId) {
+                throw new TypeError(
+                  'Current cohort trade preparation escaped its factual member.'
+                );
+              }
+              entries[index] = entry;
+            }
+          }
+        )
+      );
+      const readyCount = entries.filter(({ state }) => state === 'ready').length;
+      const entryEvidence = entries.flatMap((entry) =>
+        entry.state === 'ready'
+          ? [entry.materializationManifestArtifact]
+          : entry.blockers.flatMap(({ evidenceRefs }) => evidenceRefs)
+      );
+      const preparedAt = [
+        context.factualReleaseArtifact,
+        context.releaseMembershipArtifact,
+        context.sourceQualificationReportArtifact,
+        ...context.sourceQualificationEvidenceRefs,
+        context.valuationInputBundleArtifact,
+        ...entryEvidence,
+      ].reduce(
+        (latest, { createdAt }) =>
+          Date.parse(createdAt) > Date.parse(latest) ? createdAt : latest,
+        context.factualReleaseArtifact.createdAt
+      );
+      const preparedInputSet = createAflTradePreparedValuationInputSet({
+        schemaVersion: AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V3_SCHEMA_VERSION,
+        environment: 'non_production',
+        scopeKey: context.scopeKey,
+        factualReleaseScopeKey: context.factualReleaseScopeKey,
+        factualReleaseId: context.factualReleaseId,
+        factualReleaseArtifact: context.factualReleaseArtifact,
+        releaseMembershipArtifact: context.releaseMembershipArtifact,
+        preparationAuthority: 'authenticated_calculation_evidence_snapshot',
+        qualificationOperation: 'valuation_model_training_and_derived_feature_creation',
+        qualificationReportId: context.sourceQualificationReportId,
+        qualificationReportArtifact: context.sourceQualificationReportArtifact,
+        sourceQualificationEvidenceRefs: context.sourceQualificationEvidenceRefs,
+        valuationInputBundleId: context.valuationInputBundleId,
+        valuationInputBundleArtifact: context.valuationInputBundleArtifact,
+        releaseTradeIds: context.releaseTradeIds,
+        entries,
+        tradeCount: entries.length,
+        readyCount,
+        blockedCount: entries.length - readyCount,
+        preparedAt,
+        publicationEligible: false,
+        limitation:
+          'Private preparation evidence only; not a valuation result, publication approval, or activation authority.',
+      });
+      return dependencies.commitIfCurrent({ context, preparedInputSet });
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/currentValuationTradePreparation.ts
+++ b/src/server/aflTradeIntelligence/valuation/currentValuationTradePreparation.ts
@@ -1,0 +1,272 @@
+import { z } from 'zod';
+
+import {
+  aflTradeArtifactRefSchema,
+  doesAflTradeArtifactRefMatchBytes,
+  doesAflTradeArtifactRefMatchCanonicalJson,
+  type AflTradeArtifactRef,
+} from '../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../artifacts/contentAddress';
+import type { AflTradeLineageGraph } from '../domain/lineageTypes';
+import { aflTradePickPavDistributionBenchmarkSchema } from '../modeling/pickPavDistributionBenchmark';
+import { aflTradePlayerPavObservationSchema } from '../modeling/playerPavObservationContracts';
+import { aflTradeValuationCalculationInputPackageSchema } from './valuationCalculationInputPackage';
+import {
+  governedPrivateEvaluationMaterializationManifestSchema,
+  type GovernedPrivateEvaluationMaterializationManifest,
+} from './internal/governedPrivateEvaluationMaterializationManifest';
+import { governedPrivateEvaluationExplanationPolicySchema } from './internal/governedPrivateEvaluationExplanationPolicy';
+import { governedPrivateEvaluationInputTraceSchema } from './internal/governedPrivateEvaluationInputTrace';
+import { replayGovernedPrivateEvaluationMaterialization } from './internal/governedPrivateEvaluationMaterializer';
+import {
+  aflTradeCurrentValuationCohortConstructionContextSchema,
+  type AflTradeCurrentValuationCohortConstructionContext,
+} from './currentValuationCohortPreparation';
+import type { AflTradeValuationInputBlocker } from './preparedValuationInputSet';
+
+const publicIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(400)
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9._:/-]*$/u);
+
+const preparationInputSchema = z
+  .object({
+    context: aflTradeCurrentValuationCohortConstructionContextSchema,
+    tradeId: publicIdSchema,
+  })
+  .strict()
+  .superRefine((input, refinement) => {
+    if (!input.context.releaseTradeIds.includes(input.tradeId)) {
+      refinement.addIssue({
+        code: 'custom',
+        path: ['tradeId'],
+        message: 'Current trade preparation requires one factual-release member.',
+      });
+    }
+  });
+
+export type AflTradeCurrentValuationTradePreparationInput = Readonly<{
+  context: AflTradeCurrentValuationCohortConstructionContext;
+  tradeId: string;
+}>;
+type PreparationInput = z.input<typeof preparationInputSchema>;
+type RetainedArtifact = Readonly<{
+  reference: AflTradeArtifactRef;
+  bytes: Uint8Array;
+}>;
+export type AflTradeConstructedCurrentValuationTrade =
+  | Readonly<{
+      state: 'blocked';
+      blockers: readonly AflTradeValuationInputBlocker[];
+    }>
+  | Readonly<{
+      state: 'ready';
+      manifest: GovernedPrivateEvaluationMaterializationManifest;
+      manifestArtifact: AflTradeArtifactRef;
+      retainedParents: readonly RetainedArtifact[];
+    }>;
+
+export interface AflTradeCurrentValuationTradePreparationDependencies {
+  readonly construct: (
+    input: AflTradeCurrentValuationTradePreparationInput
+  ) => Promise<AflTradeConstructedCurrentValuationTrade>;
+  readonly retainArtifact: (input: RetainedArtifact) => Promise<AflTradeArtifactRef>;
+  readonly registerManifest: (input: {
+    readonly manifest: GovernedPrivateEvaluationMaterializationManifest;
+    readonly artifact: AflTradeArtifactRef;
+  }) => Promise<{
+    readonly manifest: GovernedPrivateEvaluationMaterializationManifest;
+    readonly artifact: AflTradeArtifactRef;
+  }>;
+}
+
+function exactJson(left: unknown, right: unknown): boolean {
+  return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+}
+
+function expectedParentArtifacts(
+  manifest: GovernedPrivateEvaluationMaterializationManifest
+): readonly AflTradeArtifactRef[] {
+  return [
+    manifest.content.calculationInputArtifact,
+    manifest.content.inputTraceArtifact,
+    manifest.content.explanationPolicyArtifact,
+    manifest.content.lineageGraphArtifact,
+    ...manifest.content.pickBenchmarks.map(({ artifact }) => artifact),
+    ...manifest.content.playerObservations.map(({ artifact }) => artifact),
+  ].sort((left, right) => left.artifactId.localeCompare(right.artifactId));
+}
+
+function parseJson(bytes: Uint8Array): unknown {
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    throw new TypeError('Current trade construction parent is not valid JSON.');
+  }
+}
+
+function parentValue(
+  parents: readonly RetainedArtifact[],
+  reference: AflTradeArtifactRef
+): unknown {
+  const parent = parents.find(
+    ({ reference: candidate }) => candidate.artifactId === reference.artifactId
+  );
+  if (parent === undefined) {
+    throw new TypeError('Current trade construction omitted a required retained parent.');
+  }
+  return parseJson(parent.bytes);
+}
+
+function authenticateConstructionAncestry(input: {
+  readonly context: AflTradeCurrentValuationCohortConstructionContext;
+  readonly tradeId: string;
+  readonly manifest: GovernedPrivateEvaluationMaterializationManifest;
+  readonly parents: readonly RetainedArtifact[];
+}) {
+  const content = input.manifest.content;
+  const trace = governedPrivateEvaluationInputTraceSchema.parse(
+    parentValue(input.parents, content.inputTraceArtifact)
+  );
+  const calculationInputPackage = aflTradeValuationCalculationInputPackageSchema.parse(
+    parentValue(input.parents, content.calculationInputArtifact)
+  );
+  const explanationPolicy = governedPrivateEvaluationExplanationPolicySchema.parse(
+    parentValue(input.parents, content.explanationPolicyArtifact)
+  );
+  const lineageGraph = parentValue(
+    input.parents,
+    content.lineageGraphArtifact
+  ) as AflTradeLineageGraph;
+  const pickBenchmarks = content.pickBenchmarks.map(({ artifact }) =>
+    aflTradePickPavDistributionBenchmarkSchema.parse(
+      parentValue(input.parents, artifact)
+    )
+  );
+  const playerObservations = content.playerObservations.map(({ artifact }) =>
+    aflTradePlayerPavObservationSchema.parse(parentValue(input.parents, artifact))
+  );
+  const player = trace.content.components.find(
+    ({ role }) => role === 'player_contribution_and_availability'
+  );
+  const pick = trace.content.components.find(
+    ({ role }) => role === 'draft_pick_and_future_pick_distribution'
+  );
+  if (
+    trace.content.selector.valuationScopeKey !== input.context.scopeKey ||
+    trace.content.selector.tradeId !== input.tradeId ||
+    trace.content.factualReleaseId !== input.context.factualReleaseId ||
+    trace.content.valuationInputBundleId !== input.context.valuationInputBundleId ||
+    calculationInputPackage.content.tradeId !== input.tradeId ||
+    calculationInputPackage.content.valuationInputBundleId !==
+      input.context.valuationInputBundleId ||
+    player?.runId !== input.context.playerRunId ||
+    pick?.runId !== input.context.pickRunId
+  ) {
+    throw new TypeError(
+      'Current trade construction does not match the captured release, model, or bundle authority.'
+    );
+  }
+  const replay = replayGovernedPrivateEvaluationMaterialization({
+    materializationManifest: input.manifest,
+    trace,
+    calculationInputPackage,
+    explanationPolicy,
+    lineageGraph,
+    pickBenchmarks,
+    playerObservations,
+  });
+  if (replay.state !== 'ready') {
+    throw new TypeError(
+      'Current trade construction did not replay to one complete private evaluation.'
+    );
+  }
+}
+
+export function createAflTradeCurrentValuationTradePreparer(
+  dependencies: AflTradeCurrentValuationTradePreparationDependencies
+) {
+  return {
+    async prepare(unparsedInput: PreparationInput) {
+      const input = preparationInputSchema.parse(unparsedInput);
+      const constructed = await dependencies.construct(input);
+      if (constructed.state === 'blocked') {
+        return {
+          tradeId: input.tradeId,
+          state: 'blocked' as const,
+          blockers: constructed.blockers.map(({ code, subject, evidenceRefs }) => ({
+            code,
+            subject: { ...subject },
+            evidenceRefs: [...evidenceRefs],
+          })),
+        };
+      }
+      const manifest = governedPrivateEvaluationMaterializationManifestSchema.parse(
+        constructed.manifest
+      );
+      const manifestArtifact = aflTradeArtifactRefSchema.parse(
+        constructed.manifestArtifact
+      );
+      const parents = constructed.retainedParents
+        .map(({ reference, bytes }) => ({
+          reference: aflTradeArtifactRefSchema.parse(reference),
+          bytes,
+        }))
+        .sort((left, right) =>
+          left.reference.artifactId.localeCompare(right.reference.artifactId)
+        );
+      if (
+        manifest.content.selector.valuationScopeKey !== input.context.scopeKey ||
+        manifest.content.selector.tradeId !== input.tradeId ||
+        Date.parse(manifest.content.createdAt) > Date.parse(input.context.capturedAt) ||
+        !doesAflTradeArtifactRefMatchCanonicalJson(manifestArtifact, manifest) ||
+        !exactJson(
+          parents.map(({ reference }) => reference),
+          expectedParentArtifacts(manifest)
+        ) ||
+        parents.some(
+          ({ reference, bytes }) =>
+            !doesAflTradeArtifactRefMatchBytes(reference, bytes, 'application/json')
+        )
+      ) {
+        throw new TypeError(
+          'Current trade construction must retain one exact, complete materialization ancestry.'
+        );
+      }
+      authenticateConstructionAncestry({
+        context: input.context,
+        tradeId: input.tradeId,
+        manifest,
+        parents,
+      });
+      for (const parent of parents) {
+        const retained = await dependencies.retainArtifact(parent);
+        if (!exactJson(retained, parent.reference)) {
+          throw new TypeError('Current trade construction parent retention changed its identity.');
+        }
+      }
+      const retainedManifestArtifact = await dependencies.retainArtifact({
+        reference: manifestArtifact,
+        bytes: new TextEncoder().encode(canonicalizeAflTradeJson(manifest)),
+      });
+      if (!exactJson(retainedManifestArtifact, manifestArtifact)) {
+        throw new TypeError('Current trade construction manifest retention changed its identity.');
+      }
+      const registered = await dependencies.registerManifest({
+        manifest,
+        artifact: manifestArtifact,
+      });
+      if (!exactJson(registered, { manifest, artifact: manifestArtifact })) {
+        throw new TypeError('Current trade construction manifest registration conflicted.');
+      }
+      return {
+        tradeId: input.tradeId,
+        state: 'ready' as const,
+        materializationManifestId: manifest.manifestId,
+        materializationManifestArtifact: manifestArtifact,
+      };
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration.ts
+++ b/src/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration.ts
@@ -11,6 +11,7 @@ import {
   canonicalizeAflTradeJson,
   createAflTradeContentAddress,
 } from '../artifacts/contentAddress';
+import { AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID } from './automatedPrivateEvaluationPolicy';
 import type { createAflTradeCalculationNarrative } from './tradeCalculationNarrative';
 
 type CalculationNarrative = ReturnType<typeof createAflTradeCalculationNarrative>;
@@ -97,7 +98,7 @@ interface EvaluationGenerationV2 {
     readonly generatedAt: string;
     readonly constructionAuthority: {
       readonly kind: 'automated_private_calculation_agent';
-      readonly principalId: string;
+      readonly principalId: typeof AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID;
     };
     readonly activationReceipt: 'separate_append_only_transition';
     readonly publicationProhibited: true;
@@ -158,7 +159,7 @@ const retainedGenerationV1Schema = z
 const automatedConstructionAuthoritySchema = z
   .object({
     kind: z.literal('automated_private_calculation_agent'),
-    principalId: z.string().regex(/^system:[a-z0-9][a-z0-9._:-]{0,199}$/u),
+    principalId: z.literal(AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID),
   })
   .strict();
 const retainedGenerationV2Schema = z

--- a/src/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration.ts
+++ b/src/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration.ts
@@ -32,7 +32,7 @@ export interface GovernedPrivateEvaluationRetainedArtifact {
   readonly bytes: Uint8Array;
 }
 
-interface ProjectionManifest {
+interface ProjectionManifestV1 {
   readonly projectionManifestId: string;
   readonly content: {
     readonly schemaVersion: 'governed-private-evaluation-projection-manifest/v1';
@@ -47,7 +47,26 @@ interface ProjectionManifest {
   };
 }
 
-interface EvaluationGeneration {
+interface ProjectionManifestV2 {
+  readonly projectionManifestId: string;
+  readonly content: {
+    readonly schemaVersion: 'governed-private-evaluation-projection-manifest/v2';
+    readonly environment: 'non_production';
+    readonly selector: GovernedPrivateEvaluationSelector;
+    readonly narrativeId: string;
+    readonly generatedAt: string;
+    readonly documents: readonly Readonly<{
+      kind: ReaderDocumentKind;
+      artifact: AflTradeArtifactRef;
+    }>[];
+    readonly runtimeHtmlRetention: 'prohibited';
+    readonly publicationProhibited: true;
+  };
+}
+
+type ProjectionManifest = ProjectionManifestV1 | ProjectionManifestV2;
+
+interface EvaluationGenerationV1 {
   readonly generationId: string;
   readonly content: {
     readonly schemaVersion: 'local-private-trade-evaluation-generation/v1';
@@ -63,6 +82,29 @@ interface EvaluationGeneration {
     readonly publicationProhibited: true;
   };
 }
+
+interface EvaluationGenerationV2 {
+  readonly generationId: string;
+  readonly content: {
+    readonly schemaVersion: 'local-private-trade-evaluation-generation/v2';
+    readonly environment: 'non_production';
+    readonly selector: GovernedPrivateEvaluationSelector;
+    readonly transitionIntentId: string;
+    readonly narrativeId: string;
+    readonly narrativeArtifact: AflTradeArtifactRef;
+    readonly projectionManifestId: string;
+    readonly projectionManifestArtifact: AflTradeArtifactRef;
+    readonly generatedAt: string;
+    readonly constructionAuthority: {
+      readonly kind: 'automated_private_calculation_agent';
+      readonly principalId: string;
+    };
+    readonly activationReceipt: 'separate_append_only_transition';
+    readonly publicationProhibited: true;
+  };
+}
+
+type EvaluationGeneration = EvaluationGenerationV1 | EvaluationGenerationV2;
 
 export interface GovernedPrivateEvaluationDetailDocument {
   readonly schemaVersion: 'governed-private-evaluation-detail/v1';
@@ -113,6 +155,37 @@ const retainedGenerationV1Schema = z
       .strict(),
   })
   .strict();
+const automatedConstructionAuthoritySchema = z
+  .object({
+    kind: z.literal('automated_private_calculation_agent'),
+    principalId: z.string().regex(/^system:[a-z0-9][a-z0-9._:-]{0,199}$/u),
+  })
+  .strict();
+const retainedGenerationV2Schema = z
+  .object({
+    generationId: aflTradeContentAddressedIdSchema('local-private-trade-evaluation-generation'),
+    content: z
+      .object({
+        schemaVersion: z.literal('local-private-trade-evaluation-generation/v2'),
+        environment: z.literal('non_production'),
+        selector: retainedSelectorSchema,
+        transitionIntentId: aflTradeContentAddressedIdSchema(
+          'private-evaluation-transition-intent'
+        ),
+        narrativeId: aflTradeContentAddressedIdSchema('trade-calculation-narrative'),
+        narrativeArtifact: aflTradeArtifactRefSchema,
+        projectionManifestId: aflTradeContentAddressedIdSchema(
+          'private-evaluation-projection-manifest'
+        ),
+        projectionManifestArtifact: aflTradeArtifactRefSchema,
+        generatedAt: z.iso.datetime({ offset: true }),
+        constructionAuthority: automatedConstructionAuthoritySchema,
+        activationReceipt: z.literal('separate_append_only_transition'),
+        publicationProhibited: z.literal(true),
+      })
+      .strict(),
+  })
+  .strict();
 const retainedProjectionManifestV1Schema = z
   .object({
     projectionManifestId: aflTradeContentAddressedIdSchema(
@@ -139,6 +212,34 @@ const retainedProjectionManifestV1Schema = z
       .strict(),
   })
   .strict();
+const retainedProjectionManifestV2Schema = z
+  .object({
+    projectionManifestId: aflTradeContentAddressedIdSchema(
+      'private-evaluation-projection-manifest'
+    ),
+    content: z
+      .object({
+        schemaVersion: z.literal('governed-private-evaluation-projection-manifest/v2'),
+        environment: z.literal('non_production'),
+        selector: retainedSelectorSchema,
+        narrativeId: aflTradeContentAddressedIdSchema('trade-calculation-narrative'),
+        generatedAt: z.iso.datetime({ offset: true }),
+        documents: z
+          .array(
+            z
+              .object({
+                kind: readerDocumentKindSchema,
+                artifact: aflTradeArtifactRefSchema,
+              })
+              .strict()
+          )
+          .length(4),
+        runtimeHtmlRetention: z.literal('prohibited'),
+        publicationProhibited: z.literal(true),
+      })
+      .strict(),
+  })
+  .strict();
 
 export class UnsupportedGovernedPrivateEvaluationProjectionVersionError extends Error {}
 
@@ -154,30 +255,36 @@ export function parseGovernedPrivateEvaluationGeneration(
   value: unknown
 ): EvaluationGeneration {
   const version = retainedSchemaVersion(value);
-  if (
-    version !== null &&
-    version !== 'local-private-trade-evaluation-generation/v1'
-  ) {
+  if (version === 'local-private-trade-evaluation-generation/v1') {
+    return retainedGenerationV1Schema.parse(value) as EvaluationGenerationV1;
+  }
+  if (version === 'local-private-trade-evaluation-generation/v2') {
+    return retainedGenerationV2Schema.parse(value) as EvaluationGenerationV2;
+  }
+  if (version !== null) {
     throw new UnsupportedGovernedPrivateEvaluationProjectionVersionError(
       `Unsupported private evaluation generation version: ${version}`
     );
   }
-  return retainedGenerationV1Schema.parse(value) as EvaluationGeneration;
+  return retainedGenerationV1Schema.parse(value) as EvaluationGenerationV1;
 }
 
 export function parseGovernedPrivateEvaluationProjectionManifest(
   value: unknown
 ): ProjectionManifest {
   const version = retainedSchemaVersion(value);
-  if (
-    version !== null &&
-    version !== 'governed-private-evaluation-projection-manifest/v1'
-  ) {
+  if (version === 'governed-private-evaluation-projection-manifest/v1') {
+    return retainedProjectionManifestV1Schema.parse(value) as ProjectionManifestV1;
+  }
+  if (version === 'governed-private-evaluation-projection-manifest/v2') {
+    return retainedProjectionManifestV2Schema.parse(value) as ProjectionManifestV2;
+  }
+  if (version !== null) {
     throw new UnsupportedGovernedPrivateEvaluationProjectionVersionError(
       `Unsupported private evaluation projection manifest version: ${version}`
     );
   }
-  return retainedProjectionManifestV1Schema.parse(value) as ProjectionManifest;
+  return retainedProjectionManifestV1Schema.parse(value) as ProjectionManifestV1;
 }
 
 const encoder = new TextEncoder();
@@ -367,6 +474,72 @@ export function createGovernedPrivateEvaluationGeneration(input: {
     content: generationContent,
   };
   artifacts.push(retained('generation', canonicalBytes(generation), input.generatedAt));
+  return { projectionManifest, generation, artifacts };
+}
+
+export function createAutomatedGovernedPrivateEvaluationGeneration(input: {
+  readonly selector: GovernedPrivateEvaluationSelector;
+  readonly transitionIntentId: string;
+  readonly generatedAt: string;
+  readonly constructionAuthority: z.infer<typeof automatedConstructionAuthoritySchema>;
+  readonly narrative: CalculationNarrative;
+}): GovernedPrivateEvaluationGenerationMaterialization {
+  const constructionAuthority = automatedConstructionAuthoritySchema.parse(
+    input.constructionAuthority
+  );
+  const legacyMaterialization = createGovernedPrivateEvaluationGeneration(input);
+  const documentArtifacts = legacyMaterialization.artifacts.slice(0, 5);
+  const projectionManifestContent: ProjectionManifestV2['content'] = {
+    schemaVersion: 'governed-private-evaluation-projection-manifest/v2',
+    environment: 'non_production',
+    selector: { ...input.selector },
+    narrativeId: input.narrative.narrativeId,
+    generatedAt: input.generatedAt,
+    documents: documentArtifacts.slice(1).map(({ kind, reference }) => ({
+      kind: kind as ReaderDocumentKind,
+      artifact: reference,
+    })),
+    runtimeHtmlRetention: 'prohibited',
+    publicationProhibited: true,
+  };
+  const projectionManifest: ProjectionManifestV2 = {
+    projectionManifestId: createAflTradeContentAddress(
+      'private-evaluation-projection-manifest',
+      projectionManifestContent
+    ),
+    content: projectionManifestContent,
+  };
+  const manifestArtifact = retained(
+    'projection_manifest',
+    canonicalBytes(projectionManifest),
+    input.generatedAt
+  );
+  const generationContent: EvaluationGenerationV2['content'] = {
+    schemaVersion: 'local-private-trade-evaluation-generation/v2',
+    environment: 'non_production',
+    selector: { ...input.selector },
+    transitionIntentId: input.transitionIntentId,
+    narrativeId: input.narrative.narrativeId,
+    narrativeArtifact: documentArtifacts[0]!.reference,
+    projectionManifestId: projectionManifest.projectionManifestId,
+    projectionManifestArtifact: manifestArtifact.reference,
+    generatedAt: input.generatedAt,
+    constructionAuthority,
+    activationReceipt: 'separate_append_only_transition',
+    publicationProhibited: true,
+  };
+  const generation: EvaluationGenerationV2 = {
+    generationId: createAflTradeContentAddress(
+      'local-private-trade-evaluation-generation',
+      generationContent
+    ),
+    content: generationContent,
+  };
+  const artifacts = [
+    ...documentArtifacts,
+    manifestArtifact,
+    retained('generation', canonicalBytes(generation), input.generatedAt),
+  ];
   return { projectionManifest, generation, artifacts };
 }
 

--- a/src/server/aflTradeIntelligence/valuation/governedPrivateEvaluationWorkspace.ts
+++ b/src/server/aflTradeIntelligence/valuation/governedPrivateEvaluationWorkspace.ts
@@ -1,4 +1,6 @@
 import type {
+  GovernedPrivateEvaluationAutomatedStageRequest,
+  GovernedPrivateEvaluationAutomatedStageResult,
   GovernedPrivateEvaluationExecuteRequest,
   GovernedPrivateEvaluationExecuteResult,
   GovernedPrivateEvaluationInspectRequest,
@@ -8,6 +10,8 @@ import type {
 } from './internal/governedPrivateEvaluationWorkspaceContracts';
 
 export type {
+  GovernedPrivateEvaluationAutomatedStageRequest,
+  GovernedPrivateEvaluationAutomatedStageResult,
   GovernedPrivateEvaluationExecuteRequest,
   GovernedPrivateEvaluationExecuteResult,
   GovernedPrivateEvaluationInspectRequest,
@@ -17,6 +21,9 @@ export type {
 };
 
 export interface GovernedPrivateEvaluationWorkspace {
+  stageAutomated(
+    request: GovernedPrivateEvaluationAutomatedStageRequest
+  ): Promise<GovernedPrivateEvaluationAutomatedStageResult>;
   inspect(
     request: GovernedPrivateEvaluationInspectRequest
   ): Promise<GovernedPrivateEvaluationInspectResult>;

--- a/src/server/aflTradeIntelligence/valuation/internal/automatedGovernedPrivateEvaluationStagingService.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/automatedGovernedPrivateEvaluationStagingService.ts
@@ -1,0 +1,231 @@
+import { z } from 'zod';
+
+import { createAflTradeCanonicalJsonArtifactRef, type AflTradeArtifactRef } from '../../artifacts/artifactReference';
+import { aflTradeContentAddressedIdSchema, canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
+import {
+  createAutomatedGovernedPrivateEvaluationGeneration,
+  type GovernedPrivateEvaluationGenerationMaterialization,
+} from '../governedPrivateEvaluationGeneration';
+import {
+  createAutomatedGovernedPrivateEvaluationTransitionIntent,
+  createAutomatedGovernedPrivateEvaluationTransitionReceipt,
+  type AutomatedGovernedPrivateEvaluationTransitionIntent,
+  type AutomatedGovernedPrivateEvaluationTransitionReceipt,
+} from './governedPrivateEvaluationLifecycle';
+import type { GovernedPrivateEvaluationMaterializationResult } from './governedPrivateEvaluationMaterializer';
+import { governedPrivateEvaluationSelectorSchema } from './governedPrivateEvaluationWorkspaceContracts';
+
+const requestSchema = z
+  .object({
+    selector: governedPrivateEvaluationSelectorSchema,
+    operationId: aflTradeContentAddressedIdSchema('private-evaluation-operation'),
+  })
+  .strict();
+
+type Selector = z.infer<typeof governedPrivateEvaluationSelectorSchema>;
+type Head = Readonly<{
+  status: 'absent' | 'active' | 'withdrawn';
+  revision: number;
+  generationId: string | null;
+}>;
+type CapturedAuthority =
+  | Readonly<{
+      state: 'unavailable';
+      selector: Selector;
+      blockers: readonly Readonly<{ code: string; message: string }>[];
+    }>
+  | Readonly<{
+      state: 'ready';
+      selector: Selector;
+      inspectionId: string;
+      authoritySnapshotId: string;
+      validThrough: string;
+      head: Head;
+      previousTransitionId: string | null;
+      materializationManifestId: string;
+    }>;
+
+interface StagedOperation {
+  readonly selector: Selector;
+  readonly principalId: string;
+  readonly generationId: string;
+  readonly intent: AutomatedGovernedPrivateEvaluationTransitionIntent;
+  readonly previousTransitionId: string | null;
+}
+
+interface Dependencies {
+  readonly principalId: string;
+  readonly trustedNow: () => Promise<string>;
+  readonly loadStaged: (operationId: string) => Promise<StagedOperation | null>;
+  readonly captureAuthority: (input: { readonly selector: Selector }) => Promise<CapturedAuthority>;
+  readonly replayMaterialization: (input: {
+    readonly materializationManifestId: string;
+  }) => Promise<GovernedPrivateEvaluationMaterializationResult>;
+  readonly stage: (input: {
+    readonly intent: AutomatedGovernedPrivateEvaluationTransitionIntent;
+    readonly intentArtifact: AflTradeArtifactRef;
+    readonly materialization: GovernedPrivateEvaluationGenerationMaterialization;
+  }) => Promise<{
+    readonly transitionIntentId: string;
+    readonly generationId: string | null;
+  }>;
+  readonly retainArtifact: (input: {
+    readonly reference: AflTradeArtifactRef;
+    readonly bytes: Uint8Array;
+  }) => Promise<AflTradeArtifactRef>;
+  readonly commit: (input: {
+    readonly receipt: AutomatedGovernedPrivateEvaluationTransitionReceipt;
+    readonly receiptArtifact: AflTradeArtifactRef;
+  }) => Promise<
+    | Readonly<{
+        state: 'committed' | 'replayed';
+        head: Head;
+        transitionId: string;
+      }>
+    | Readonly<{ state: 'conflict'; expectedHead: Head; actualHead: Head }>
+  >;
+}
+
+function same(left: unknown, right: unknown): boolean {
+  return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+}
+
+export function createAutomatedGovernedPrivateEvaluationStagingService(
+  dependencies: Dependencies
+) {
+  if (!/^system:[a-z0-9][a-z0-9._:-]{0,199}$/u.test(dependencies.principalId)) {
+    throw new TypeError('Automated private staging requires one narrow system principal.');
+  }
+  const activate = async (input: {
+    readonly request: z.infer<typeof requestSchema>;
+    readonly intent: AutomatedGovernedPrivateEvaluationTransitionIntent;
+    readonly generationId: string;
+    readonly previousTransitionId: string | null;
+  }) => {
+    const receipt = createAutomatedGovernedPrivateEvaluationTransitionReceipt({
+      intent: input.intent,
+      previousTransitionId: input.previousTransitionId,
+      toGenerationId: input.generationId,
+      transitionedAt: input.intent.content.requestedAt,
+    });
+    const receiptArtifact = createAflTradeCanonicalJsonArtifactRef(
+      receipt,
+      receipt.content.transitionedAt
+    );
+    const retained = await dependencies.retainArtifact({
+      reference: receiptArtifact,
+      bytes: new TextEncoder().encode(canonicalizeAflTradeJson(receipt)),
+    });
+    if (!same(retained, receiptArtifact)) {
+      throw new TypeError('Automated private activation changed its receipt identity.');
+    }
+    const committed = await dependencies.commit({ receipt, receiptArtifact });
+    if (committed.state === 'conflict') {
+      return {
+        state: 'stale_authority' as const,
+        selector: input.request.selector,
+        operationId: input.request.operationId,
+      };
+    }
+    return {
+      state: 'activated' as const,
+      selector: input.request.selector,
+      operationId: input.request.operationId,
+      generationId: input.generationId,
+      head: committed.head,
+    };
+  };
+  return {
+    async stage(unparsedRequest: z.input<typeof requestSchema>) {
+      const request = requestSchema.parse(unparsedRequest);
+      const existing = await dependencies.loadStaged(request.operationId);
+      if (existing !== null) {
+        if (
+          existing.principalId !== dependencies.principalId ||
+          !same(existing.selector, request.selector)
+        ) {
+          throw new TypeError('Automated private staging replay conflicts with its operation.');
+        }
+        return activate({
+          request,
+          intent: existing.intent,
+          generationId: existing.generationId,
+          previousTransitionId: existing.previousTransitionId,
+        });
+      }
+      const authority = await dependencies.captureAuthority({ selector: request.selector });
+      if (!same(authority.selector, request.selector)) {
+        throw new TypeError('Automated private staging escaped its requested selector.');
+      }
+      if (authority.state === 'unavailable') {
+        return {
+          state: 'unavailable' as const,
+          selector: request.selector,
+          operationId: request.operationId,
+          blockers: authority.blockers,
+        };
+      }
+      const requestedAt = await dependencies.trustedNow();
+      if (
+        !Number.isFinite(Date.parse(requestedAt)) ||
+        Date.parse(requestedAt) > Date.parse(authority.validThrough)
+      ) {
+        return {
+          state: 'stale_authority' as const,
+          selector: request.selector,
+          operationId: request.operationId,
+        };
+      }
+      const replay = await dependencies.replayMaterialization({
+        materializationManifestId: authority.materializationManifestId,
+      });
+      if (replay.state === 'unavailable') {
+        return {
+          state: 'unavailable' as const,
+          selector: request.selector,
+          operationId: request.operationId,
+          blockers: replay.blockers.map(({ code, message }) => ({
+            code: 'insufficient_data' as const,
+            message: `${code}: ${message}`,
+          })),
+        };
+      }
+      const constructionAuthority = {
+        kind: 'automated_private_calculation_agent' as const,
+        principalId: dependencies.principalId,
+      };
+      const intent = createAutomatedGovernedPrivateEvaluationTransitionIntent({
+        selector: request.selector,
+        inspectionId: authority.inspectionId,
+        authoritySnapshotId: authority.authoritySnapshotId,
+        operationId: request.operationId,
+        action: { kind: 'construct_and_activate' },
+        expectedHead: authority.head,
+        constructionAuthority,
+        requestedAt,
+        expiresAt: authority.validThrough,
+      });
+      const intentArtifact = createAflTradeCanonicalJsonArtifactRef(intent, requestedAt);
+      const materialization = createAutomatedGovernedPrivateEvaluationGeneration({
+        selector: request.selector,
+        transitionIntentId: intent.transitionIntentId,
+        generatedAt: requestedAt,
+        constructionAuthority,
+        narrative: replay.narrative,
+      });
+      const staged = await dependencies.stage({ intent, intentArtifact, materialization });
+      if (
+        staged.transitionIntentId !== intent.transitionIntentId ||
+        staged.generationId !== materialization.generation.generationId
+      ) {
+        throw new TypeError('Automated private staging did not retain its exact generation.');
+      }
+      return activate({
+        request,
+        intent,
+        generationId: materialization.generation.generationId,
+        previousTransitionId: authority.previousTransitionId,
+      });
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/automatedGovernedPrivateEvaluationStagingService.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/automatedGovernedPrivateEvaluationStagingService.ts
@@ -6,6 +6,7 @@ import {
   createAutomatedGovernedPrivateEvaluationGeneration,
   type GovernedPrivateEvaluationGenerationMaterialization,
 } from '../governedPrivateEvaluationGeneration';
+import { AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID } from '../automatedPrivateEvaluationPolicy';
 import {
   createAutomatedGovernedPrivateEvaluationTransitionIntent,
   createAutomatedGovernedPrivateEvaluationTransitionReceipt,
@@ -54,7 +55,6 @@ interface StagedOperation {
 }
 
 interface Dependencies {
-  readonly principalId: string;
   readonly trustedNow: () => Promise<string>;
   readonly loadStaged: (operationId: string) => Promise<StagedOperation | null>;
   readonly captureAuthority: (input: { readonly selector: Selector }) => Promise<CapturedAuthority>;
@@ -93,8 +93,10 @@ function same(left: unknown, right: unknown): boolean {
 export function createAutomatedGovernedPrivateEvaluationStagingService(
   dependencies: Dependencies
 ) {
-  if (!/^system:[a-z0-9][a-z0-9._:-]{0,199}$/u.test(dependencies.principalId)) {
-    throw new TypeError('Automated private staging requires one narrow system principal.');
+  if ('principalId' in dependencies) {
+    throw new TypeError(
+      'Automated private staging does not accept a caller-supplied principal.'
+    );
   }
   const activate = async (input: {
     readonly request: z.infer<typeof requestSchema>;
@@ -141,7 +143,7 @@ export function createAutomatedGovernedPrivateEvaluationStagingService(
       const existing = await dependencies.loadStaged(request.operationId);
       if (existing !== null) {
         if (
-          existing.principalId !== dependencies.principalId ||
+          existing.principalId !== AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID ||
           !same(existing.selector, request.selector)
         ) {
           throw new TypeError('Automated private staging replay conflicts with its operation.');
@@ -192,7 +194,7 @@ export function createAutomatedGovernedPrivateEvaluationStagingService(
       }
       const constructionAuthority = {
         kind: 'automated_private_calculation_agent' as const,
-        principalId: dependencies.principalId,
+        principalId: AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID,
       };
       const intent = createAutomatedGovernedPrivateEvaluationTransitionIntent({
         selector: request.selector,

--- a/src/server/aflTradeIntelligence/valuation/internal/createGovernedPrivateEvaluationWorkspace.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/createGovernedPrivateEvaluationWorkspace.ts
@@ -2,18 +2,24 @@ import { doesAflTradeArtifactRefMatchBytes } from '../../artifacts/artifactRefer
 import { canonicalizeAflTradeJson } from '../../artifacts/contentAddress';
 import type { GovernedPrivateEvaluationWorkspace } from '../governedPrivateEvaluationWorkspace';
 import {
+  governedPrivateEvaluationAutomatedStageRequestSchema,
+  governedPrivateEvaluationAutomatedStageResultSchema,
   governedPrivateEvaluationExecuteRequestSchema,
   governedPrivateEvaluationExecuteResultSchema,
   governedPrivateEvaluationInspectRequestSchema,
   governedPrivateEvaluationInspectResultSchema,
   governedPrivateEvaluationReadRequestSchema,
   governedPrivateEvaluationReadResultSchema,
+  type GovernedPrivateEvaluationAutomatedStageRequest,
   type GovernedPrivateEvaluationExecuteRequest,
   type GovernedPrivateEvaluationInspectRequest,
   type GovernedPrivateEvaluationReadRequest,
 } from './governedPrivateEvaluationWorkspaceContracts';
 
 interface GovernedPrivateEvaluationInternalComposition {
+  readonly stageAutomated?: (
+    request: GovernedPrivateEvaluationAutomatedStageRequest
+  ) => Promise<unknown>;
   readonly inspect: (request: GovernedPrivateEvaluationInspectRequest) => Promise<unknown>;
   readonly execute: (request: GovernedPrivateEvaluationExecuteRequest) => Promise<unknown>;
   readonly read: (request: GovernedPrivateEvaluationReadRequest) => Promise<unknown>;
@@ -27,6 +33,25 @@ export function createGovernedPrivateEvaluationWorkspaceForInternalComposition(
   composition: GovernedPrivateEvaluationInternalComposition
 ): GovernedPrivateEvaluationWorkspace {
   return {
+    async stageAutomated(unparsedRequest) {
+      if (composition.stageAutomated === undefined) {
+        throw new TypeError('Automated private staging is not configured for this workspace.');
+      }
+      const request = governedPrivateEvaluationAutomatedStageRequestSchema.parse(
+        unparsedRequest
+      );
+      const result = governedPrivateEvaluationAutomatedStageResultSchema.parse(
+        await composition.stageAutomated(request)
+      );
+      if (
+        result.operationId !== request.operationId ||
+        !sameCanonicalJson(result.selector, request.selector)
+      ) {
+        throw new RangeError('Automated private staging escaped its request authority.');
+      }
+      return result;
+    },
+
     async inspect(unparsedRequest) {
       const request = governedPrivateEvaluationInspectRequestSchema.parse(unparsedRequest);
       const result = governedPrivateEvaluationInspectResultSchema.parse(

--- a/src/server/aflTradeIntelligence/valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace.ts
@@ -1,6 +1,9 @@
 import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
 import type { AflOutcomeSqlClient } from '../../outcomes/postgresOutcomeReleaseRepository';
 import { createGovernedPrivateEvaluationWorkspaceForInternalComposition } from './createGovernedPrivateEvaluationWorkspace';
+import { createAutomatedGovernedPrivateEvaluationStagingService } from './automatedGovernedPrivateEvaluationStagingService';
+import { authenticateGovernedPrivateEvaluationAuthorityInspection } from './governedPrivateEvaluationAuthoritySnapshot';
+import { automatedGovernedPrivateEvaluationTransitionIntentSchema } from './governedPrivateEvaluationLifecycle';
 import { createPostgresGovernedPrivateEvaluationExecutionService } from './postgresGovernedPrivateEvaluationExecutionService';
 import { createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture } from './postgresGovernedPrivateEvaluationCalculationAuthority';
 import { createPostgresGovernedPrivateEvaluationInspectionRepository } from './postgresGovernedPrivateEvaluationInspectionRepository';
@@ -8,6 +11,7 @@ import { createPostgresGovernedPrivateEvaluationLifecycleRepository } from './po
 import { createPostgresGovernedPrivateEvaluationReadRepository } from './postgresGovernedPrivateEvaluationReadRepository';
 import { createPostgresGovernedPrivateEvaluationReconstructionRepository } from './postgresGovernedPrivateEvaluationReconstructionRepository';
 import { createPostgresGovernedPrivateEvaluationStagingRepository } from './postgresGovernedPrivateEvaluationStagingRepository';
+import { createPostgresGovernedPrivateEvaluationMaterializationReplay } from './postgresGovernedPrivateEvaluationMaterializationReplay';
 import type { GovernedPrivateEvaluationReadRequest } from './governedPrivateEvaluationWorkspaceContracts';
 
 export function createPostgresGovernedPrivateEvaluationWorkspace(dependencies: {
@@ -15,6 +19,7 @@ export function createPostgresGovernedPrivateEvaluationWorkspace(dependencies: {
   readonly artifactRepository: AflTradeImmutableArtifactRepository;
   readonly maximumArtifactBytes: number;
   readonly principalId: string;
+  readonly automatedPrincipalId?: string;
   readonly authorizeReader: (input: {
     readonly principalId: string;
     readonly selector: GovernedPrivateEvaluationReadRequest['selector'];
@@ -24,11 +29,17 @@ export function createPostgresGovernedPrivateEvaluationWorkspace(dependencies: {
     client: dependencies.client,
     artifactRepository: dependencies.artifactRepository,
     maximumArtifactBytes: dependencies.maximumArtifactBytes,
+    ...(dependencies.automatedPrincipalId === undefined
+      ? {}
+      : { automatedPrincipalId: dependencies.automatedPrincipalId }),
   });
   const lifecycle = createPostgresGovernedPrivateEvaluationLifecycleRepository({
     client: dependencies.client,
     artifactRepository: dependencies.artifactRepository,
     maximumArtifactBytes: dependencies.maximumArtifactBytes,
+    ...(dependencies.automatedPrincipalId === undefined
+      ? {}
+      : { automatedPrincipalId: dependencies.automatedPrincipalId }),
   });
   const captureCalculationAuthority =
     createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture({
@@ -61,8 +72,115 @@ export function createPostgresGovernedPrivateEvaluationWorkspace(dependencies: {
     lifecycle,
     reconstruction,
   });
+  const replayMaterialization = createPostgresGovernedPrivateEvaluationMaterializationReplay({
+    client: dependencies.client,
+    artifactRepository: dependencies.artifactRepository,
+    maximumArtifactBytes: dependencies.maximumArtifactBytes,
+  });
+  const automatedStaging =
+    dependencies.automatedPrincipalId === undefined
+      ? undefined
+      : createAutomatedGovernedPrivateEvaluationStagingService({
+          principalId: dependencies.automatedPrincipalId,
+          trustedNow: async () => {
+            const result = await dependencies.client.query<{ readonly trusted_at: Date | string }>(
+              `SELECT date_trunc('milliseconds',transaction_timestamp()) AS trusted_at`
+            );
+            const value = result.rows[0]?.trusted_at;
+            const parsed = value instanceof Date ? value : new Date(value ?? Number.NaN);
+            if (result.rows.length !== 1 || !Number.isFinite(parsed.getTime())) {
+              throw new TypeError('Automated private staging requires trusted PostgreSQL time.');
+            }
+            return parsed.toISOString();
+          },
+          loadStaged: async (operationId) => {
+            const result = await dependencies.client.query<{
+              readonly intent_json: unknown;
+              readonly generation_id: string;
+              readonly receipt_json: unknown;
+            }>(
+              `SELECT intent.intent_json,generation.generation_id,inspection.receipt_json
+                 FROM outcome_private_evaluation_transition_intent intent
+                 JOIN outcome_local_private_trade_evaluation_generation generation
+                   ON generation.transition_intent_id=intent.transition_intent_id
+                 JOIN outcome_private_evaluation_inspection_receipt inspection
+                   ON inspection.inspection_id=intent.inspection_id
+                WHERE intent.operation_id=$1`,
+              [operationId]
+            );
+            if (result.rows.length > 1) {
+              throw new TypeError('Automated private staging operation is not unique.');
+            }
+            if (result.rows[0] === undefined) return null;
+            const intent = automatedGovernedPrivateEvaluationTransitionIntentSchema.parse(
+              result.rows[0].intent_json
+            );
+            const inspection = result.rows[0].receipt_json as {
+              readonly content?: { readonly lastTransitionId?: unknown };
+            };
+            const previousTransitionId = inspection.content?.lastTransitionId;
+            if (previousTransitionId !== null && typeof previousTransitionId !== 'string') {
+              throw new TypeError('Automated private staging lost its exact predecessor.');
+            }
+            return {
+              selector: intent.content.selector,
+              principalId: intent.content.constructionAuthority.principalId,
+              generationId: result.rows[0].generation_id,
+              intent,
+              previousTransitionId,
+            };
+          },
+          captureAuthority: async ({ selector }) => {
+            const result = await inspection.inspect(selector);
+            if (result.state === 'unavailable') return result;
+            const retainedResult = await dependencies.client.query<{
+              readonly snapshot_json: unknown;
+              readonly receipt_json: unknown;
+            }>(
+              `SELECT snapshot.snapshot_json,inspection.receipt_json
+                 FROM outcome_private_evaluation_inspection_receipt inspection
+                 JOIN outcome_private_evaluation_authority_snapshot snapshot
+                   ON snapshot.snapshot_id=inspection.snapshot_id
+                WHERE inspection.inspection_id=$1`,
+              [result.inspectionId]
+            );
+            if (retainedResult.rows.length !== 1) {
+              throw new TypeError('Automated private staging lost its retained inspection.');
+            }
+            const retained = authenticateGovernedPrivateEvaluationAuthorityInspection({
+              snapshot: retainedResult.rows[0]!.snapshot_json,
+              inspection: retainedResult.rows[0]!.receipt_json,
+            });
+            const calculationAuthority = retained.inspection.content.calculationAuthority;
+            if (
+              retained.result.state !== 'ready' ||
+              calculationAuthority.state !== 'ready' ||
+              !('materializationManifestId' in calculationAuthority)
+            ) {
+              throw new TypeError('Automated private staging requires v3 calculation authority.');
+            }
+            return {
+              state: 'ready' as const,
+              selector: retained.result.selector,
+              inspectionId: retained.inspection.inspectionId,
+              authoritySnapshotId: retained.snapshot.snapshotId,
+              validThrough: retained.result.validThrough,
+              head: retained.result.head,
+              previousTransitionId: retained.inspection.content.lastTransitionId,
+              materializationManifestId: calculationAuthority.materializationManifestId,
+            };
+          },
+          replayMaterialization,
+          stage: (input) => staging.stage(input),
+          retainArtifact: (input) => staging.retainArtifact(input),
+          commit: (input) => lifecycle.commitAutomated(input),
+        });
 
   return createGovernedPrivateEvaluationWorkspaceForInternalComposition({
+    stageAutomated:
+      automatedStaging === undefined
+        ? undefined
+        : (request) => automatedStaging.stage(request),
     inspect: (request) => inspection.inspect(request),
     execute: (request) => execution.execute(request),
     read: (request) => read.read(request),

--- a/src/server/aflTradeIntelligence/valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace.ts
@@ -19,27 +19,34 @@ export function createPostgresGovernedPrivateEvaluationWorkspace(dependencies: {
   readonly artifactRepository: AflTradeImmutableArtifactRepository;
   readonly maximumArtifactBytes: number;
   readonly principalId: string;
-  readonly automatedPrincipalId?: string;
+  readonly enableAutomatedPrivateCalculation?: true;
   readonly authorizeReader: (input: {
     readonly principalId: string;
     readonly selector: GovernedPrivateEvaluationReadRequest['selector'];
   }) => Promise<boolean>;
 }) {
+  if ('automatedPrincipalId' in dependencies) {
+    throw new TypeError(
+      'The PostgreSQL private evaluation workspace does not accept a caller-supplied automated principal.'
+    );
+  }
+  const automatedCalculationEnabled =
+    dependencies.enableAutomatedPrivateCalculation === true;
   const staging = createPostgresGovernedPrivateEvaluationStagingRepository({
     client: dependencies.client,
     artifactRepository: dependencies.artifactRepository,
     maximumArtifactBytes: dependencies.maximumArtifactBytes,
-    ...(dependencies.automatedPrincipalId === undefined
+    ...(!automatedCalculationEnabled
       ? {}
-      : { automatedPrincipalId: dependencies.automatedPrincipalId }),
+      : { enableAutomatedPrivateCalculation: true as const }),
   });
   const lifecycle = createPostgresGovernedPrivateEvaluationLifecycleRepository({
     client: dependencies.client,
     artifactRepository: dependencies.artifactRepository,
     maximumArtifactBytes: dependencies.maximumArtifactBytes,
-    ...(dependencies.automatedPrincipalId === undefined
+    ...(!automatedCalculationEnabled
       ? {}
-      : { automatedPrincipalId: dependencies.automatedPrincipalId }),
+      : { enableAutomatedPrivateCalculation: true as const }),
   });
   const captureCalculationAuthority =
     createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture({
@@ -78,10 +85,9 @@ export function createPostgresGovernedPrivateEvaluationWorkspace(dependencies: {
     maximumArtifactBytes: dependencies.maximumArtifactBytes,
   });
   const automatedStaging =
-    dependencies.automatedPrincipalId === undefined
+    !automatedCalculationEnabled
       ? undefined
       : createAutomatedGovernedPrivateEvaluationStagingService({
-          principalId: dependencies.automatedPrincipalId,
           trustedNow: async () => {
             const result = await dependencies.client.query<{ readonly trusted_at: Date | string }>(
               `SELECT date_trunc('milliseconds',transaction_timestamp()) AS trusted_at`

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle.ts
@@ -276,3 +276,203 @@ export function createGovernedPrivateEvaluationTransitionReceipt(input: {
     content,
   });
 }
+
+const AUTOMATED_LIMITATION =
+  'Automated private calculation only; it grants no source approval, production, publication, withdrawal, rollback, or recovery authority.' as const;
+const automatedConstructionAuthoritySchema = z
+  .object({
+    kind: z.literal('automated_private_calculation_agent'),
+    principalId: z.string().regex(/^system:[a-z0-9][a-z0-9._:-]{0,199}$/u),
+  })
+  .strict();
+const automatedTransitionActionSchema = z
+  .object({ kind: z.literal('construct_and_activate') })
+  .strict();
+const automatedTransitionIntentContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-transition-intent/v2'),
+    environment: z.literal('non_production'),
+    publicationProhibited: z.literal(true),
+    selector: governedPrivateEvaluationSelectorSchema,
+    inspectionId: aflTradeContentAddressedIdSchema('private-evaluation-inspection'),
+    authoritySnapshotId: aflTradeContentAddressedIdSchema(
+      'private-evaluation-authority-snapshot'
+    ),
+    operationId: aflTradeContentAddressedIdSchema('private-evaluation-operation'),
+    action: automatedTransitionActionSchema,
+    expectedHead: lifecycleHeadSchema,
+    constructionAuthority: automatedConstructionAuthoritySchema,
+    requestedAt: instantSchema,
+    expiresAt: instantSchema,
+    limitation: z.literal(AUTOMATED_LIMITATION),
+  })
+  .strict()
+  .superRefine((intent, context) => {
+    if (Date.parse(intent.expiresAt) <= Date.parse(intent.requestedAt)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['expiresAt'],
+        message: 'An automated transition intent requires a positive validity window.',
+      });
+    }
+  });
+
+export const automatedGovernedPrivateEvaluationTransitionIntentSchema = z
+  .object({
+    transitionIntentId: aflTradeContentAddressedIdSchema(
+      'private-evaluation-transition-intent'
+    ),
+    content: automatedTransitionIntentContentSchema,
+  })
+  .strict()
+  .superRefine((intent, context) => {
+    addAflTradeContentAddressIssue(
+      'private-evaluation-transition-intent',
+      intent.transitionIntentId,
+      intent.content,
+      context,
+      ['transitionIntentId']
+    );
+  });
+
+export type AutomatedGovernedPrivateEvaluationTransitionIntent = z.infer<
+  typeof automatedGovernedPrivateEvaluationTransitionIntentSchema
+>;
+
+export function createAutomatedGovernedPrivateEvaluationTransitionIntent(
+  input: Omit<
+    z.input<typeof automatedTransitionIntentContentSchema>,
+    'schemaVersion' | 'environment' | 'publicationProhibited' | 'limitation'
+  >
+): AutomatedGovernedPrivateEvaluationTransitionIntent {
+  const content = automatedTransitionIntentContentSchema.parse({
+    schemaVersion: 'private-evaluation-transition-intent/v2',
+    environment: 'non_production',
+    publicationProhibited: true,
+    ...input,
+    limitation: AUTOMATED_LIMITATION,
+  });
+  return automatedGovernedPrivateEvaluationTransitionIntentSchema.parse({
+    transitionIntentId: createAflTradeContentAddress(
+      'private-evaluation-transition-intent',
+      content
+    ),
+    content,
+  });
+}
+
+const automatedTransitionReceiptContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-transition-receipt/v2'),
+    environment: z.literal('non_production'),
+    publicationProhibited: z.literal(true),
+    intent: automatedGovernedPrivateEvaluationTransitionIntentSchema,
+    selector: governedPrivateEvaluationSelectorSchema,
+    action: automatedTransitionActionSchema,
+    previousTransitionId: transitionIdSchema.nullable(),
+    fromHead: lifecycleHeadSchema,
+    toHead: lifecycleHeadSchema,
+    transitionedAt: instantSchema,
+    limitation: z.literal(AUTOMATED_LIMITATION),
+  })
+  .strict()
+  .superRefine((receipt, context) => {
+    const intent = receipt.intent.content;
+    const inWindow =
+      Date.parse(receipt.transitionedAt) >= Date.parse(intent.requestedAt) &&
+      Date.parse(receipt.transitionedAt) <= Date.parse(intent.expiresAt);
+    if (
+      receipt.selector.valuationScopeKey !== intent.selector.valuationScopeKey ||
+      receipt.selector.tradeId !== intent.selector.tradeId ||
+      receipt.fromHead.status !== intent.expectedHead.status ||
+      receipt.fromHead.revision !== intent.expectedHead.revision ||
+      receipt.fromHead.generationId !== intent.expectedHead.generationId ||
+      receipt.toHead.status !== 'active' ||
+      receipt.toHead.revision !== receipt.fromHead.revision + 1 ||
+      receipt.toHead.generationId === null ||
+      (receipt.fromHead.status === 'absent') !== (receipt.previousTransitionId === null) ||
+      !inWindow
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['toHead'],
+        message: 'An automated receipt must bind one exact construct-and-activate transition.',
+      });
+    }
+  });
+
+export const automatedGovernedPrivateEvaluationTransitionReceiptSchema = z
+  .object({
+    transitionId: transitionIdSchema,
+    content: automatedTransitionReceiptContentSchema,
+  })
+  .strict()
+  .superRefine((receipt, context) => {
+    addAflTradeContentAddressIssue(
+      'private-evaluation-transition',
+      receipt.transitionId,
+      receipt.content,
+      context,
+      ['transitionId']
+    );
+  });
+
+export type AutomatedGovernedPrivateEvaluationTransitionReceipt = z.infer<
+  typeof automatedGovernedPrivateEvaluationTransitionReceiptSchema
+>;
+export type AnyGovernedPrivateEvaluationTransitionIntent =
+  | GovernedPrivateEvaluationTransitionIntent
+  | AutomatedGovernedPrivateEvaluationTransitionIntent;
+export type AnyGovernedPrivateEvaluationTransitionReceipt =
+  | GovernedPrivateEvaluationTransitionReceipt
+  | AutomatedGovernedPrivateEvaluationTransitionReceipt;
+
+export function parseAnyGovernedPrivateEvaluationTransitionIntent(
+  value: unknown
+): AnyGovernedPrivateEvaluationTransitionIntent {
+  const version = (value as { readonly content?: { readonly schemaVersion?: unknown } } | null)
+    ?.content?.schemaVersion;
+  return version === 'private-evaluation-transition-intent/v2'
+    ? automatedGovernedPrivateEvaluationTransitionIntentSchema.parse(value)
+    : governedPrivateEvaluationTransitionIntentSchema.parse(value);
+}
+
+export function parseAnyGovernedPrivateEvaluationTransitionReceipt(
+  value: unknown
+): AnyGovernedPrivateEvaluationTransitionReceipt {
+  const version = (value as { readonly content?: { readonly schemaVersion?: unknown } } | null)
+    ?.content?.schemaVersion;
+  return version === 'private-evaluation-transition-receipt/v2'
+    ? automatedGovernedPrivateEvaluationTransitionReceiptSchema.parse(value)
+    : governedPrivateEvaluationTransitionReceiptSchema.parse(value);
+}
+
+export function createAutomatedGovernedPrivateEvaluationTransitionReceipt(input: {
+  readonly intent: AutomatedGovernedPrivateEvaluationTransitionIntent;
+  readonly previousTransitionId: string | null;
+  readonly toGenerationId: string;
+  readonly transitionedAt: string;
+}): AutomatedGovernedPrivateEvaluationTransitionReceipt {
+  const intent = automatedGovernedPrivateEvaluationTransitionIntentSchema.parse(input.intent);
+  const content = automatedTransitionReceiptContentSchema.parse({
+    schemaVersion: 'private-evaluation-transition-receipt/v2',
+    environment: 'non_production',
+    publicationProhibited: true,
+    intent,
+    selector: intent.content.selector,
+    action: intent.content.action,
+    previousTransitionId: input.previousTransitionId,
+    fromHead: intent.content.expectedHead,
+    toHead: {
+      status: 'active',
+      revision: intent.content.expectedHead.revision + 1,
+      generationId: input.toGenerationId,
+    },
+    transitionedAt: input.transitionedAt,
+    limitation: AUTOMATED_LIMITATION,
+  });
+  return automatedGovernedPrivateEvaluationTransitionReceiptSchema.parse({
+    transitionId: createAflTradeContentAddress('private-evaluation-transition', content),
+    content,
+  });
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle.ts
@@ -5,6 +5,7 @@ import {
   aflTradeContentAddressedIdSchema,
   createAflTradeContentAddress,
 } from '../../artifacts/contentAddress';
+import { AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID } from '../automatedPrivateEvaluationPolicy';
 import { governedPrivateEvaluationSelectorSchema } from './governedPrivateEvaluationWorkspaceContracts';
 
 const LIMITATION =
@@ -282,7 +283,7 @@ const AUTOMATED_LIMITATION =
 const automatedConstructionAuthoritySchema = z
   .object({
     kind: z.literal('automated_private_calculation_agent'),
-    principalId: z.string().regex(/^system:[a-z0-9][a-z0-9._:-]{0,199}$/u),
+    principalId: z.literal(AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID),
   })
   .strict();
 const automatedTransitionActionSchema = z

--- a/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationWorkspaceContracts.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationWorkspaceContracts.ts
@@ -137,6 +137,43 @@ export const governedPrivateEvaluationExecuteRequestSchema = z
   })
   .strict();
 
+export const governedPrivateEvaluationAutomatedStageRequestSchema = z
+  .object({
+    selector: governedPrivateEvaluationSelectorSchema,
+    operationId: operationIdSchema,
+  })
+  .strict();
+
+export const governedPrivateEvaluationAutomatedStageResultSchema = z.discriminatedUnion(
+  'state',
+  [
+    z
+      .object({
+        state: z.literal('activated'),
+        selector: governedPrivateEvaluationSelectorSchema,
+        operationId: operationIdSchema,
+        generationId: generationIdSchema,
+        head: lifecycleHeadSchema,
+      })
+      .strict(),
+    z
+      .object({
+        state: z.literal('unavailable'),
+        selector: governedPrivateEvaluationSelectorSchema,
+        operationId: operationIdSchema,
+        blockers: z.array(blockerSchema).min(1).max(10_000),
+      })
+      .strict(),
+    z
+      .object({
+        state: z.literal('stale_authority'),
+        selector: governedPrivateEvaluationSelectorSchema,
+        operationId: operationIdSchema,
+      })
+      .strict(),
+  ]
+);
+
 const executionResultBase = {
   selector: governedPrivateEvaluationSelectorSchema,
   inspectionId: inspectionIdSchema,
@@ -296,6 +333,12 @@ export type GovernedPrivateEvaluationExecuteRequest = z.infer<
 >;
 export type GovernedPrivateEvaluationExecuteResult = z.infer<
   typeof governedPrivateEvaluationExecuteResultSchema
+>;
+export type GovernedPrivateEvaluationAutomatedStageRequest = z.infer<
+  typeof governedPrivateEvaluationAutomatedStageRequestSchema
+>;
+export type GovernedPrivateEvaluationAutomatedStageResult = z.infer<
+  typeof governedPrivateEvaluationAutomatedStageResultSchema
 >;
 export type GovernedPrivateEvaluationReadRequest = z.infer<
   typeof governedPrivateEvaluationReadRequestSchema

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationLifecycleRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationLifecycleRepository.ts
@@ -11,6 +11,7 @@ import type {
   AflOutcomeSqlClient,
   AflOutcomeSqlTransaction,
 } from '../../outcomes/postgresOutcomeReleaseRepository';
+import { AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID } from '../automatedPrivateEvaluationPolicy';
 import { parseGovernedPrivateEvaluationGeneration } from '../governedPrivateEvaluationGeneration';
 import {
   automatedGovernedPrivateEvaluationTransitionReceiptSchema,
@@ -527,8 +528,13 @@ export function createPostgresGovernedPrivateEvaluationLifecycleRepository(depen
   readonly client: AflOutcomeSqlClient;
   readonly artifactRepository: AflTradeImmutableArtifactRepository;
   readonly maximumArtifactBytes: number;
-  readonly automatedPrincipalId?: string;
+  readonly enableAutomatedPrivateCalculation?: true;
 }) {
+  if ('automatedPrincipalId' in dependencies) {
+    throw new TypeError(
+      'Lifecycle commits do not accept a caller-supplied automated principal.'
+    );
+  }
   if (
     dependencies.artifactRepository.artifactClass !== 'derived_private' ||
     !Number.isSafeInteger(dependencies.maximumArtifactBytes) ||
@@ -536,12 +542,8 @@ export function createPostgresGovernedPrivateEvaluationLifecycleRepository(depen
   ) {
     throw new TypeError('Lifecycle commits require bounded private artifact custody.');
   }
-  if (
-    dependencies.automatedPrincipalId !== undefined &&
-    !/^system:[a-z0-9][a-z0-9._:-]{0,199}$/u.test(dependencies.automatedPrincipalId)
-  ) {
-    throw new TypeError('Lifecycle commits received an invalid automated principal.');
-  }
+  const automatedCalculationEnabled =
+    dependencies.enableAutomatedPrivateCalculation === true;
   async function commitReceipt(input: {
     readonly receipt: AnyGovernedPrivateEvaluationTransitionReceipt;
     readonly receiptArtifact: AflTradeArtifactRef;
@@ -645,9 +647,9 @@ export function createPostgresGovernedPrivateEvaluationLifecycleRepository(depen
         input.receipt
       );
       if (
-        dependencies.automatedPrincipalId === undefined ||
+        !automatedCalculationEnabled ||
         receipt.content.intent.content.constructionAuthority.principalId !==
-          dependencies.automatedPrincipalId
+          AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID
       ) {
         throw new TypeError(
           'Automated lifecycle activation requires the exact configured system principal.'

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationLifecycleRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationLifecycleRepository.ts
@@ -11,8 +11,12 @@ import type {
   AflOutcomeSqlClient,
   AflOutcomeSqlTransaction,
 } from '../../outcomes/postgresOutcomeReleaseRepository';
+import { parseGovernedPrivateEvaluationGeneration } from '../governedPrivateEvaluationGeneration';
 import {
+  automatedGovernedPrivateEvaluationTransitionReceiptSchema,
   governedPrivateEvaluationTransitionReceiptSchema,
+  type AnyGovernedPrivateEvaluationTransitionReceipt,
+  type AutomatedGovernedPrivateEvaluationTransitionReceipt,
   type GovernedPrivateEvaluationTransitionReceipt,
 } from './governedPrivateEvaluationLifecycle';
 import { authenticateGovernedPrivateEvaluationAuthorityInspection } from './governedPrivateEvaluationAuthoritySnapshot';
@@ -67,7 +71,7 @@ interface StoredAuthorityRow {
   readonly inspection_artifact_created_at: Date | string;
 }
 
-type LifecycleHead = GovernedPrivateEvaluationTransitionReceipt['content']['toHead'];
+type LifecycleHead = AnyGovernedPrivateEvaluationTransitionReceipt['content']['toHead'];
 
 export type GovernedPrivateEvaluationLifecycleCommitResult =
   | {
@@ -144,7 +148,7 @@ async function loadHeadForUpdate(
 
 async function proveResultGeneration(
   transaction: AflOutcomeSqlTransaction,
-  receipt: GovernedPrivateEvaluationTransitionReceipt
+  receipt: AnyGovernedPrivateEvaluationTransitionReceipt
 ): Promise<void> {
   const { action, selector, toHead, fromHead, previousTransitionId, intent } = receipt.content;
   if (action.kind === 'withdraw') return;
@@ -178,8 +182,11 @@ async function proveResultGeneration(
       throw new TypeError('Rollback requires a generation previously activated for this selector.');
     }
   }
-  const generation = await transaction.query<{ generation_id: string }>(
-    `SELECT generation_id
+  const generation = await transaction.query<{
+    generation_id: string;
+    generation_json: unknown;
+  }>(
+    `SELECT generation_id,generation_json
        FROM outcome_local_private_trade_evaluation_generation
       WHERE valuation_scope_key=$1 AND trade_id=$2 AND generation_id=$3
         AND ($4<>'construct_and_activate' OR transition_intent_id=$5)
@@ -194,6 +201,23 @@ async function proveResultGeneration(
   );
   if (generation.rows.length !== 1) {
     throw new TypeError('The lifecycle result generation is absent or escaped its transition intent.');
+  }
+  if (receipt.content.schemaVersion === 'private-evaluation-transition-receipt/v2') {
+    const retainedGeneration = parseGovernedPrivateEvaluationGeneration(
+      generation.rows[0]!.generation_json
+    );
+    if (
+      retainedGeneration.content.schemaVersion !==
+        'local-private-trade-evaluation-generation/v2' ||
+      !same(
+        retainedGeneration.content.constructionAuthority,
+        receipt.content.intent.content.constructionAuthority
+      )
+    ) {
+      throw new TypeError(
+        'Automated lifecycle activation requires the exact v2 system construction authority.'
+      );
+    }
   }
 }
 
@@ -275,7 +299,7 @@ async function authenticateStoredAuthorityArtifacts(input: {
 
 async function proveStoredAuthority(
   transaction: AflOutcomeSqlTransaction,
-  receipt: GovernedPrivateEvaluationTransitionReceipt,
+  receipt: AnyGovernedPrivateEvaluationTransitionReceipt,
   artifactRepository: AflTradeImmutableArtifactRepository,
   maximumArtifactBytes: number
 ): Promise<void> {
@@ -366,6 +390,16 @@ async function proveStoredAuthority(
     maximumArtifactBytes,
   });
   if (
+    content.schemaVersion === 'private-evaluation-transition-receipt/v2' &&
+    (retained.snapshot.content.schemaVersion !==
+      'private-evaluation-authority-snapshot/v3' ||
+      retained.inspection.content.schemaVersion !== 'private-evaluation-inspection/v3')
+  ) {
+    throw new TypeError(
+      'Automated lifecycle activation requires exact non-production v3 calculation authority.'
+    );
+  }
+  if (
     !same(retained.result.selector, content.selector) ||
     retained.inspection.content.lastTransitionId !== content.previousTransitionId ||
     retained.result.state !== row.inspection_state ||
@@ -429,7 +463,7 @@ async function proveCurrentOperatorAuthority(
 
 async function insertReceiptAndCasHead(
   transaction: AflOutcomeSqlTransaction,
-  receipt: GovernedPrivateEvaluationTransitionReceipt,
+  receipt: AnyGovernedPrivateEvaluationTransitionReceipt,
   artifact: AflTradeArtifactRef
 ): Promise<void> {
   const content = receipt.content;
@@ -493,6 +527,7 @@ export function createPostgresGovernedPrivateEvaluationLifecycleRepository(depen
   readonly client: AflOutcomeSqlClient;
   readonly artifactRepository: AflTradeImmutableArtifactRepository;
   readonly maximumArtifactBytes: number;
+  readonly automatedPrincipalId?: string;
 }) {
   if (
     dependencies.artifactRepository.artifactClass !== 'derived_private' ||
@@ -501,67 +536,127 @@ export function createPostgresGovernedPrivateEvaluationLifecycleRepository(depen
   ) {
     throw new TypeError('Lifecycle commits require bounded private artifact custody.');
   }
+  if (
+    dependencies.automatedPrincipalId !== undefined &&
+    !/^system:[a-z0-9][a-z0-9._:-]{0,199}$/u.test(dependencies.automatedPrincipalId)
+  ) {
+    throw new TypeError('Lifecycle commits received an invalid automated principal.');
+  }
+  async function commitReceipt(input: {
+    readonly receipt: AnyGovernedPrivateEvaluationTransitionReceipt;
+    readonly receiptArtifact: AflTradeArtifactRef;
+    readonly requireOperatorAuthority: boolean;
+  }): Promise<GovernedPrivateEvaluationLifecycleCommitResult> {
+    const receipt = input.receipt;
+    const artifact = aflTradeArtifactRefSchema.parse(input.receiptArtifact);
+    if (!doesAflTradeArtifactRefMatchCanonicalJson(artifact, receipt)) {
+      throw new TypeError('The lifecycle receipt artifact does not authenticate its exact JSON.');
+    }
+    return dependencies.client.transaction(async (transaction) => {
+      await transaction.query(`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`);
+      const existing = await transaction.query<ExistingReceiptRow>(
+        `SELECT receipt_json,artifact_id
+           FROM outcome_private_evaluation_transition_receipt
+          WHERE operation_id=$1 FOR KEY SHARE`,
+        [receipt.content.intent.content.operationId]
+      );
+      if (existing.rows.length > 0) {
+        if (
+          existing.rows.length !== 1 ||
+          !same(existing.rows[0]?.receipt_json, receipt) ||
+          existing.rows[0]?.artifact_id !== artifact.artifactId
+        ) {
+          throw new TypeError('The lifecycle operation replay conflicts with retained evidence.');
+        }
+        const current = await loadHeadForUpdate(transaction, receipt.content.selector);
+        if (
+          sameHead(current.head, receipt.content.toHead) &&
+          current.lastTransitionId === receipt.transitionId
+        ) {
+          return {
+            state: 'replayed',
+            head: current.head,
+            transitionId: receipt.transitionId,
+          };
+        }
+        return {
+          state: 'conflict',
+          expectedHead: receipt.content.toHead,
+          actualHead: current.head,
+        };
+      }
+      const trusted = await transaction.query<TrustedTimeRow>(
+        `SELECT date_trunc('milliseconds',transaction_timestamp()) AS trusted_at`
+      );
+      if (
+        trusted.rows.length !== 1 ||
+        trusted.rows[0] === undefined ||
+        parseTime(trusted.rows[0].trusted_at) < parseTime(receipt.content.transitionedAt) ||
+        parseTime(trusted.rows[0].trusted_at) >
+          parseTime(receipt.content.intent.content.expiresAt)
+      ) {
+        throw new TypeError('The lifecycle transition is future-dated or its authority expired.');
+      }
+      const current = await loadHeadForUpdate(transaction, receipt.content.selector);
+      if (
+        !sameHead(current.head, receipt.content.fromHead) ||
+        current.lastTransitionId !== receipt.content.previousTransitionId
+      ) {
+        return {
+          state: 'conflict',
+          expectedHead: receipt.content.fromHead,
+          actualHead: current.head,
+        };
+      }
+      await proveStoredAuthority(
+        transaction,
+        receipt,
+        dependencies.artifactRepository,
+        dependencies.maximumArtifactBytes
+      );
+      if (input.requireOperatorAuthority) {
+        await proveCurrentOperatorAuthority(
+          transaction,
+          receipt as GovernedPrivateEvaluationTransitionReceipt
+        );
+      }
+      await proveResultGeneration(transaction, receipt);
+      await insertReceiptAndCasHead(transaction, receipt, artifact);
+      return { state: 'committed', head: receipt.content.toHead, transitionId: receipt.transitionId };
+    });
+  }
   return {
     async commit(input: {
       readonly receipt: GovernedPrivateEvaluationTransitionReceipt;
       readonly receiptArtifact: AflTradeArtifactRef;
     }): Promise<GovernedPrivateEvaluationLifecycleCommitResult> {
       const receipt = governedPrivateEvaluationTransitionReceiptSchema.parse(input.receipt);
-      const artifact = aflTradeArtifactRefSchema.parse(input.receiptArtifact);
-      if (!doesAflTradeArtifactRefMatchCanonicalJson(artifact, receipt)) {
-        throw new TypeError('The lifecycle receipt artifact does not authenticate its exact JSON.');
+      return commitReceipt({
+        receipt,
+        receiptArtifact: input.receiptArtifact,
+        requireOperatorAuthority: true,
+      });
+    },
+    async commitAutomated(input: {
+      readonly receipt: AutomatedGovernedPrivateEvaluationTransitionReceipt;
+      readonly receiptArtifact: AflTradeArtifactRef;
+    }): Promise<GovernedPrivateEvaluationLifecycleCommitResult> {
+      const receipt = automatedGovernedPrivateEvaluationTransitionReceiptSchema.parse(
+        input.receipt
+      );
+      if (
+        dependencies.automatedPrincipalId === undefined ||
+        receipt.content.intent.content.constructionAuthority.principalId !==
+          dependencies.automatedPrincipalId
+      ) {
+        throw new TypeError(
+          'Automated lifecycle activation requires the exact configured system principal.'
+        );
       }
-      return dependencies.client.transaction(async (transaction) => {
-        await transaction.query(`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`);
-        const existing = await transaction.query<ExistingReceiptRow>(
-          `SELECT receipt_json,artifact_id
-             FROM outcome_private_evaluation_transition_receipt
-            WHERE operation_id=$1 FOR KEY SHARE`,
-          [receipt.content.intent.content.operationId]
-        );
-        if (existing.rows.length > 0) {
-          if (
-            existing.rows.length !== 1 ||
-            !same(existing.rows[0]?.receipt_json, receipt) ||
-            existing.rows[0]?.artifact_id !== artifact.artifactId
-          ) {
-            throw new TypeError('The lifecycle operation replay conflicts with retained evidence.');
-          }
-          return { state: 'replayed', head: receipt.content.toHead, transitionId: receipt.transitionId };
-        }
-        const trusted = await transaction.query<TrustedTimeRow>(
-          `SELECT date_trunc('milliseconds',transaction_timestamp()) AS trusted_at`
-        );
-        if (
-          trusted.rows.length !== 1 ||
-          trusted.rows[0] === undefined ||
-          parseTime(trusted.rows[0].trusted_at) < parseTime(receipt.content.transitionedAt) ||
-          parseTime(trusted.rows[0].trusted_at) >
-            parseTime(receipt.content.intent.content.expiresAt)
-        ) {
-          throw new TypeError('The lifecycle transition is future-dated or its authority expired.');
-        }
-        const current = await loadHeadForUpdate(transaction, receipt.content.selector);
-        if (
-          !sameHead(current.head, receipt.content.fromHead) ||
-          current.lastTransitionId !== receipt.content.previousTransitionId
-        ) {
-          return {
-            state: 'conflict',
-            expectedHead: receipt.content.fromHead,
-            actualHead: current.head,
-          };
-        }
-        await proveStoredAuthority(
-          transaction,
-          receipt,
-          dependencies.artifactRepository,
-          dependencies.maximumArtifactBytes
-        );
-        await proveCurrentOperatorAuthority(transaction, receipt);
-        await proveResultGeneration(transaction, receipt);
-        await insertReceiptAndCasHead(transaction, receipt, artifact);
-        return { state: 'committed', head: receipt.content.toHead, transitionId: receipt.transitionId };
+      return commitReceipt({
+        receipt,
+        receiptArtifact: input.receiptArtifact,
+        requireOperatorAuthority: false,
       });
     },
   };

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationMaterializationReplay.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationMaterializationReplay.ts
@@ -1,0 +1,86 @@
+import {
+  doAflTradeArtifactRefsExactlyMatch,
+  doesAflTradeArtifactRefMatchBytes,
+  type AflTradeArtifactRef,
+} from '../../artifacts/artifactReference';
+import type { AflTradeImmutableArtifactRepository } from '../../artifacts/immutableArtifactRepository';
+import type { AflTradeLineageGraph } from '../../domain/lineageTypes';
+import { aflTradePickPavDistributionBenchmarkSchema } from '../../modeling/pickPavDistributionBenchmark';
+import { aflTradePlayerPavObservationSchema } from '../../modeling/playerPavObservationContracts';
+import { aflTradeValuationCalculationInputPackageSchema } from '../valuationCalculationInputPackage';
+import { governedPrivateEvaluationExplanationPolicySchema } from './governedPrivateEvaluationExplanationPolicy';
+import { governedPrivateEvaluationInputTraceSchema } from './governedPrivateEvaluationInputTrace';
+import { replayGovernedPrivateEvaluationMaterialization } from './governedPrivateEvaluationMaterializer';
+import { PostgresGovernedPrivateEvaluationMaterializationManifestRepository } from './postgresGovernedPrivateEvaluationMaterializationManifestRepository';
+import type { AflOutcomeSqlClient } from '../../outcomes/postgresOutcomeReleaseRepository';
+
+async function loadJson(input: {
+  readonly repository: AflTradeImmutableArtifactRepository;
+  readonly reference: AflTradeArtifactRef;
+  readonly maximumBytes: number;
+}): Promise<unknown> {
+  const retained = await input.repository.loadExact(input.reference, input.maximumBytes);
+  if (
+    retained === null ||
+    !doAflTradeArtifactRefsExactlyMatch(retained.reference, input.reference) ||
+    !doesAflTradeArtifactRefMatchBytes(retained.reference, retained.bytes, 'application/json')
+  ) {
+    throw new TypeError('Materialization replay parent failed exact retained-byte authentication.');
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(retained.bytes));
+  } catch {
+    throw new TypeError('Materialization replay parent is not valid JSON.');
+  }
+}
+
+export function createPostgresGovernedPrivateEvaluationMaterializationReplay(
+  dependencies: {
+    readonly client: AflOutcomeSqlClient;
+    readonly artifactRepository: AflTradeImmutableArtifactRepository;
+    readonly maximumArtifactBytes: number;
+  }
+) {
+  const manifests = new PostgresGovernedPrivateEvaluationMaterializationManifestRepository(
+    dependencies.client
+  );
+  const load = (reference: AflTradeArtifactRef) =>
+    loadJson({
+      repository: dependencies.artifactRepository,
+      reference,
+      maximumBytes: dependencies.maximumArtifactBytes,
+    });
+  return async function replay(input: { readonly materializationManifestId: string }) {
+    const retained = await manifests.loadExact(input.materializationManifestId);
+    const manifest = retained.manifest;
+    const content = manifest.content;
+    const [trace, calculationInputPackage, explanationPolicy, lineageGraph] =
+      await Promise.all([
+        load(content.inputTraceArtifact),
+        load(content.calculationInputArtifact),
+        load(content.explanationPolicyArtifact),
+        load(content.lineageGraphArtifact),
+      ]);
+    const pickBenchmarks = await Promise.all(
+      content.pickBenchmarks.map(async ({ artifact }) =>
+        aflTradePickPavDistributionBenchmarkSchema.parse(await load(artifact))
+      )
+    );
+    const playerObservations = await Promise.all(
+      content.playerObservations.map(async ({ artifact }) =>
+        aflTradePlayerPavObservationSchema.parse(await load(artifact))
+      )
+    );
+    return replayGovernedPrivateEvaluationMaterialization({
+      materializationManifest: manifest,
+      trace: governedPrivateEvaluationInputTraceSchema.parse(trace),
+      calculationInputPackage:
+        aflTradeValuationCalculationInputPackageSchema.parse(calculationInputPackage),
+      explanationPolicy:
+        governedPrivateEvaluationExplanationPolicySchema.parse(explanationPolicy),
+      lineageGraph: lineageGraph as AflTradeLineageGraph,
+      pickBenchmarks,
+      playerObservations,
+    });
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationStagingRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationStagingRepository.ts
@@ -17,8 +17,8 @@ import {
   type GovernedPrivateEvaluationRetainedArtifact,
 } from '../governedPrivateEvaluationGeneration';
 import {
-  governedPrivateEvaluationTransitionIntentSchema,
-  type GovernedPrivateEvaluationTransitionIntent,
+  parseAnyGovernedPrivateEvaluationTransitionIntent,
+  type AnyGovernedPrivateEvaluationTransitionIntent,
 } from './governedPrivateEvaluationLifecycle';
 
 interface CustodyRow {
@@ -139,10 +139,26 @@ async function registerCustody(
 
 async function insertIntent(
   transaction: AflOutcomeSqlTransaction,
-  intent: GovernedPrivateEvaluationTransitionIntent,
+  intent: AnyGovernedPrivateEvaluationTransitionIntent,
   artifact: AflTradeArtifactRef
 ): Promise<void> {
   const content = intent.content;
+  const existing = await transaction.query<IntentRow>(
+    `SELECT intent_json,artifact_id
+       FROM outcome_private_evaluation_transition_intent
+      WHERE transition_intent_id=$1 FOR KEY SHARE`,
+    [intent.transitionIntentId]
+  );
+  if (existing.rows[0] !== undefined) {
+    if (
+      existing.rows.length !== 1 ||
+      !same(existing.rows[0].intent_json, intent) ||
+      existing.rows[0].artifact_id !== artifact.artifactId
+    ) {
+      throw new TypeError('Private evaluation transition intent replay conflicts.');
+    }
+    return;
+  }
   await transaction.query(
     `INSERT INTO outcome_private_evaluation_transition_intent
       (transition_intent_id,inspection_id,authority_snapshot_id,operation_id,valuation_scope_key,trade_id,
@@ -150,7 +166,7 @@ async function insertIntent(
        expected_head_generation_id,target_generation_id,requested_at,expires_at,
        content_sha256,content_canonical_json,intent_json)
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17::jsonb)
-     ON CONFLICT (transition_intent_id) DO NOTHING`,
+    `,
     [
       intent.transitionIntentId,
       content.inspectionId,
@@ -195,13 +211,29 @@ async function insertGeneration(
   const generationArtifact = byKind.get('generation')!;
   const narrativeArtifact = byKind.get('calculation_narrative')!;
   const manifestArtifact = byKind.get('projection_manifest')!;
+  const existing = await transaction.query<GenerationRow>(
+    `SELECT generation_json,generation_artifact_id
+       FROM outcome_local_private_trade_evaluation_generation
+      WHERE generation_id=$1 FOR KEY SHARE`,
+    [generation.generationId]
+  );
+  if (existing.rows[0] !== undefined) {
+    if (
+      existing.rows.length !== 1 ||
+      !same(existing.rows[0].generation_json, generation) ||
+      existing.rows[0].generation_artifact_id !== generationArtifact.reference.artifactId
+    ) {
+      throw new TypeError('Private evaluation dormant generation replay conflicts.');
+    }
+    return;
+  }
   await transaction.query(
     `INSERT INTO outcome_local_private_trade_evaluation_generation
       (generation_id,valuation_scope_key,trade_id,transition_intent_id,
        generation_artifact_id,narrative_artifact_id,projection_manifest_artifact_id,
        generated_at,content_sha256,content_canonical_json,generation_json)
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb)
-     ON CONFLICT (generation_id) DO NOTHING`,
+    `,
     [
       generation.generationId,
       generation.content.selector.valuationScopeKey,
@@ -235,6 +267,7 @@ export function createPostgresGovernedPrivateEvaluationStagingRepository(depende
   readonly client: AflOutcomeSqlClient;
   readonly artifactRepository: AflTradeImmutableArtifactRepository;
   readonly maximumArtifactBytes: number;
+  readonly automatedPrincipalId?: string;
 }) {
   const repositoryAssurance = dependencies.artifactRepository.assurance;
   if (repositoryAssurance === 'durable_object_storage') {
@@ -246,6 +279,12 @@ export function createPostgresGovernedPrivateEvaluationStagingRepository(depende
     dependencies.maximumArtifactBytes <= 0
   ) {
     throw new TypeError('Private evaluation staging requires bounded private fixture custody.');
+  }
+  if (
+    dependencies.automatedPrincipalId !== undefined &&
+    !/^system:[a-z0-9][a-z0-9._:-]{0,199}$/u.test(dependencies.automatedPrincipalId)
+  ) {
+    throw new TypeError('Private evaluation staging received an invalid automated principal.');
   }
   const custody = {
     environment:
@@ -272,20 +311,45 @@ export function createPostgresGovernedPrivateEvaluationStagingRepository(depende
     },
 
     async stage(input: {
-      readonly intent: GovernedPrivateEvaluationTransitionIntent;
+      readonly intent: AnyGovernedPrivateEvaluationTransitionIntent;
       readonly intentArtifact: AflTradeArtifactRef;
       readonly materialization?: GovernedPrivateEvaluationGenerationMaterialization;
     }) {
-      const intent = governedPrivateEvaluationTransitionIntentSchema.parse(input.intent);
+      const intent = parseAnyGovernedPrivateEvaluationTransitionIntent(input.intent);
       const intentArtifact = aflTradeArtifactRefSchema.parse(input.intentArtifact);
       const constructing = intent.content.action.kind === 'construct_and_activate';
+      const automated = intent.content.schemaVersion === 'private-evaluation-transition-intent/v2';
+      const automatedAuthority = intent.content.schemaVersion ===
+        'private-evaluation-transition-intent/v2'
+        ? intent.content.constructionAuthority
+        : null;
       if (
-        constructing !== (input.materialization !== undefined) ||
-        (input.materialization !== undefined &&
-          (!verifyGovernedPrivateEvaluationGeneration(input.materialization) ||
-            input.materialization.generation.content.transitionIntentId !==
+        automated &&
+        (dependencies.automatedPrincipalId === undefined ||
+          automatedAuthority?.principalId !== dependencies.automatedPrincipalId)
+      ) {
+        throw new TypeError(
+          'Automated private staging requires the exact configured system principal.'
+        );
+      }
+      const materialization = input.materialization;
+      if (
+        constructing !== (materialization !== undefined) ||
+        (materialization !== undefined &&
+          (!verifyGovernedPrivateEvaluationGeneration(materialization) ||
+            materialization.generation.content.transitionIntentId !==
               intent.transitionIntentId ||
-            !same(input.materialization.generation.content.selector, intent.content.selector)))
+            !same(materialization.generation.content.selector, intent.content.selector))) ||
+        (automated &&
+          (materialization?.generation.content.schemaVersion !==
+            'local-private-trade-evaluation-generation/v2' ||
+            materialization.projectionManifest.content.schemaVersion !==
+              'governed-private-evaluation-projection-manifest/v2' ||
+            !('constructionAuthority' in materialization.generation.content) ||
+            !same(
+              materialization.generation.content.constructionAuthority,
+              automatedAuthority
+            )))
       ) {
         throw new TypeError('Construction staging requires one complete verified generation.');
       }
@@ -308,6 +372,10 @@ export function createPostgresGovernedPrivateEvaluationStagingRepository(depende
         );
       }
       return dependencies.client.transaction(async (transaction) => {
+        await transaction.query(
+          `SELECT pg_advisory_xact_lock(hashtextextended($1,0))`,
+          [intent.transitionIntentId]
+        );
         const verifiedAt = await loadTrustedTime(transaction);
         for (const artifact of retained) {
           await registerCustody(transaction, artifact.reference, verifiedAt, custody);

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationStagingRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationStagingRepository.ts
@@ -16,6 +16,7 @@ import {
   type GovernedPrivateEvaluationGenerationMaterialization,
   type GovernedPrivateEvaluationRetainedArtifact,
 } from '../governedPrivateEvaluationGeneration';
+import { AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID } from '../automatedPrivateEvaluationPolicy';
 import {
   parseAnyGovernedPrivateEvaluationTransitionIntent,
   type AnyGovernedPrivateEvaluationTransitionIntent,
@@ -267,8 +268,13 @@ export function createPostgresGovernedPrivateEvaluationStagingRepository(depende
   readonly client: AflOutcomeSqlClient;
   readonly artifactRepository: AflTradeImmutableArtifactRepository;
   readonly maximumArtifactBytes: number;
-  readonly automatedPrincipalId?: string;
+  readonly enableAutomatedPrivateCalculation?: true;
 }) {
+  if ('automatedPrincipalId' in dependencies) {
+    throw new TypeError(
+      'Private evaluation staging does not accept a caller-supplied automated principal.'
+    );
+  }
   const repositoryAssurance = dependencies.artifactRepository.assurance;
   if (repositoryAssurance === 'durable_object_storage') {
     throw new TypeError('Private evaluation staging requires private local custody.');
@@ -280,12 +286,8 @@ export function createPostgresGovernedPrivateEvaluationStagingRepository(depende
   ) {
     throw new TypeError('Private evaluation staging requires bounded private fixture custody.');
   }
-  if (
-    dependencies.automatedPrincipalId !== undefined &&
-    !/^system:[a-z0-9][a-z0-9._:-]{0,199}$/u.test(dependencies.automatedPrincipalId)
-  ) {
-    throw new TypeError('Private evaluation staging received an invalid automated principal.');
-  }
+  const automatedCalculationEnabled =
+    dependencies.enableAutomatedPrivateCalculation === true;
   const custody = {
     environment:
       dependencies.artifactRepository.assurance === 'local_non_production_filesystem'
@@ -325,8 +327,8 @@ export function createPostgresGovernedPrivateEvaluationStagingRepository(depende
         : null;
       if (
         automated &&
-        (dependencies.automatedPrincipalId === undefined ||
-          automatedAuthority?.principalId !== dependencies.automatedPrincipalId)
+        (!automatedCalculationEnabled ||
+          automatedAuthority?.principalId !== AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID)
       ) {
         throw new TypeError(
           'Automated private staging requires the exact configured system principal.'

--- a/src/server/aflTradeIntelligence/valuation/postgresCurrentValuationCohortPreparation.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresCurrentValuationCohortPreparation.ts
@@ -1,0 +1,429 @@
+import {
+  canonicalizeAflTradeJson,
+  sha256AflTradeCanonicalJson,
+} from '../artifacts/contentAddress';
+import type { AflTradeImmutableArtifactRepository } from '../artifacts/immutableArtifactRepository';
+import type { AflTradeValuationInputBundle } from '../artifacts/valuationInputBundle';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../outcomes/postgresOutcomeReleaseRepository';
+import type {
+  AflTradeCurrentValuationCohortConstructionContext,
+  AflTradeCurrentValuationCohortPreparationRequest,
+  AflTradeCurrentValuationCohortPreparationResult,
+} from './currentValuationCohortPreparation';
+import { aflTradeCurrentValuationCohortConstructionContextSchema } from './currentValuationCohortPreparation';
+import { aflTradePersistedCurrentValuationCohortConstructionContextSchema } from './currentValuationCohortPreparation';
+import { createAflTradeCurrentValuationCohortCoordinator } from './currentValuationCohortPreparation';
+import { createAflTradeCurrentValuationCohortPreparationOperationId } from './currentValuationCohortPreparation';
+import {
+  createAflTradeCurrentValuationTradePreparer,
+  type AflTradeCurrentValuationTradePreparationDependencies,
+} from './currentValuationTradePreparation';
+import { PostgresGovernedPrivateEvaluationMaterializationManifestRepository } from './internal/postgresGovernedPrivateEvaluationMaterializationManifestRepository';
+import { createPostgresGovernedPrivateEvaluationStagingRepository } from './internal/postgresGovernedPrivateEvaluationStagingRepository';
+import type {
+  AflTradeCurrentPreparedValuationInputHead,
+} from './postgresPreparedValuationInputSetStore';
+import { PostgresAflTradePreparedValuationInputSetStore } from './postgresPreparedValuationInputSetStore';
+import type { AflTradePreparedValuationInputSet } from './preparedValuationInputSet';
+
+interface ActiveReleaseRow {
+  readonly release_id: string;
+  readonly revision: number;
+}
+
+interface CurrentModelPairRow {
+  readonly revision: number;
+  readonly qualification_id: string;
+  readonly player_run_id: string;
+  readonly pick_run_id: string;
+  readonly work_id?: string;
+}
+
+interface TrustedTimeRow {
+  readonly captured_at: Date | string;
+}
+
+interface CohortOperationRow {
+  readonly context_json: unknown;
+}
+
+interface CohortOperationResultRow {
+  readonly prepared_input_set_id: string;
+  readonly head_revision: number;
+}
+
+export type AflTradeCurrentValuationCohortConstructionEvidence = Pick<
+  AflTradeCurrentValuationCohortConstructionContext,
+  | 'factualReleaseArtifact'
+  | 'releaseMembershipArtifact'
+  | 'releaseTradeIds'
+  | 'sourceQualificationReportId'
+  | 'sourceQualificationReportArtifact'
+  | 'sourceQualificationEvidenceRefs'
+  | 'valuationInputBundleId'
+  | 'valuationInputBundleArtifact'
+> & { readonly valuationInputBundle: AflTradeValuationInputBundle };
+
+function constructionContextFromPersisted(
+  value: unknown
+): AflTradeCurrentValuationCohortConstructionContext {
+  const persisted = aflTradePersistedCurrentValuationCohortConstructionContextSchema.parse(value);
+  const { valuationInputBundle: _retainedBundle, ...context } = persisted;
+  return aflTradeCurrentValuationCohortConstructionContextSchema.parse(context);
+}
+
+interface PreparedHeadRow {
+  readonly scope_key: string;
+  readonly prepared_input_set_id: string;
+  readonly revision: number;
+  readonly activated_at: Date | string;
+}
+
+function timestamp(value: Date | string): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    throw new TypeError('Current prepared cohort head has an invalid activation time.');
+  }
+  return date.toISOString();
+}
+
+function head(row: PreparedHeadRow): AflTradeCurrentPreparedValuationInputHead {
+  return {
+    scopeKey: row.scope_key,
+    preparedInputSetId: row.prepared_input_set_id,
+    revision: row.revision,
+    activatedAt: timestamp(row.activated_at),
+  };
+}
+
+async function loadHead(
+  transaction: AflOutcomeSqlTransaction,
+  scopeKey: string
+): Promise<AflTradeCurrentPreparedValuationInputHead | null> {
+  const result = await transaction.query<PreparedHeadRow>(
+    `SELECT scope_key,prepared_input_set_id,revision,activated_at
+       FROM outcome_current_prepared_valuation_input_set
+      WHERE scope_key=$1 FOR UPDATE`,
+    [scopeKey]
+  );
+  if (result.rows.length > 1) {
+    throw new TypeError('Current prepared cohort head is not unique.');
+  }
+  return result.rows[0] === undefined ? null : head(result.rows[0]);
+}
+
+export function createPostgresAflTradeCurrentValuationCohortAuthorityCapture(
+  dependencies: {
+    readonly client: AflOutcomeSqlClient;
+    readonly factualReleaseScopeKey: string;
+    readonly loadConstructionEvidence: (input: {
+      readonly transaction: AflOutcomeSqlTransaction;
+      readonly request: AflTradeCurrentValuationCohortPreparationRequest;
+      readonly factualReleaseId: string;
+      readonly capturedAt: string;
+      readonly modelQualificationId: string;
+      readonly modelQualificationWorkId: string;
+      readonly playerRunId: string;
+      readonly pickRunId: string;
+    }) => Promise<AflTradeCurrentValuationCohortConstructionEvidence>;
+  }
+) {
+  if (dependencies.factualReleaseScopeKey.trim() === '') {
+    throw new TypeError('Current cohort capture requires a factual release scope.');
+  }
+  return async function capture(
+    request: AflTradeCurrentValuationCohortPreparationRequest
+  ): Promise<AflTradeCurrentValuationCohortConstructionContext> {
+    return dependencies.client.transaction(async (transaction) => {
+      await transaction.query(`SET TRANSACTION ISOLATION LEVEL READ COMMITTED`);
+      await transaction.query(`SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, [
+        request.operationId,
+      ]);
+      const retainedOperation = await transaction.query<CohortOperationRow>(
+        `SELECT context_json
+           FROM outcome_current_valuation_cohort_operation
+          WHERE operation_id=$1 FOR KEY SHARE`,
+        [request.operationId]
+      );
+      if (retainedOperation.rows.length > 1) {
+        throw new TypeError('Current cohort operation identity is not unique.');
+      }
+      if (retainedOperation.rows[0] !== undefined) {
+        const retained = constructionContextFromPersisted(
+          retainedOperation.rows[0].context_json
+        );
+        if (retained.operationId !== request.operationId || retained.scopeKey !== request.scopeKey) {
+          throw new TypeError('Current cohort operation replay conflicts with retained authority.');
+        }
+        return retained;
+      }
+      const trusted = await transaction.query<TrustedTimeRow>(
+        `SELECT date_trunc('milliseconds',transaction_timestamp()) AS captured_at`
+      );
+      if (trusted.rows.length !== 1) {
+        throw new TypeError('Current cohort capture requires trusted PostgreSQL time.');
+      }
+      const capturedAt = timestamp(trusted.rows[0]!.captured_at);
+      const release = await transaction.query<ActiveReleaseRow>(
+        `SELECT release_id,revision FROM outcome_active_release
+          WHERE scope_key=$1 FOR KEY SHARE`,
+        [dependencies.factualReleaseScopeKey]
+      );
+      const model = await transaction.query<CurrentModelPairRow>(
+        `SELECT revision,qualification_id,player_run_id,pick_run_id,work_id
+           FROM outcome_current_governed_valuation_model_pair
+          WHERE scope_key=$1 FOR KEY SHARE`,
+        [request.scopeKey]
+      );
+      if (release.rows.length !== 1 || model.rows.length !== 1) {
+        throw new TypeError(
+          'Current cohort capture requires one active factual release and qualified model pair.'
+        );
+      }
+      const activeRelease = release.rows[0]!;
+      const currentModel = model.rows[0]!;
+      if (currentModel.work_id === undefined) {
+        throw new TypeError('Current qualified model authority omitted its work identity.');
+      }
+      const currentHead = await loadHead(transaction, request.scopeKey);
+      const expectedOperationId =
+        createAflTradeCurrentValuationCohortPreparationOperationId({
+          scopeKey: request.scopeKey,
+          factualReleaseId: activeRelease.release_id,
+          factualReleaseRevision: activeRelease.revision,
+          modelQualificationId: currentModel.qualification_id,
+          modelQualificationWorkId: currentModel.work_id,
+          modelQualificationRevision: currentModel.revision,
+          expectedPreparedInputRevision: currentHead?.revision ?? 0,
+        });
+      if (request.operationId !== expectedOperationId) {
+        throw new TypeError(
+          'Current cohort operation identity does not match its captured release, model, and head authority.'
+        );
+      }
+      const evidence = await dependencies.loadConstructionEvidence({
+        transaction,
+        request,
+        factualReleaseId: activeRelease.release_id,
+        capturedAt,
+        modelQualificationId: currentModel.qualification_id,
+        modelQualificationWorkId: currentModel.work_id,
+        playerRunId: currentModel.player_run_id,
+        pickRunId: currentModel.pick_run_id,
+      });
+      const persistedContext =
+        aflTradePersistedCurrentValuationCohortConstructionContextSchema.parse({
+        operationId: request.operationId,
+        scopeKey: request.scopeKey,
+        factualReleaseScopeKey: dependencies.factualReleaseScopeKey,
+        factualReleaseId: activeRelease.release_id,
+        factualReleaseRevision: activeRelease.revision,
+        modelQualificationId: currentModel.qualification_id,
+        modelQualificationWorkId: currentModel.work_id,
+        modelQualificationRevision: currentModel.revision,
+        playerRunId: currentModel.player_run_id,
+        pickRunId: currentModel.pick_run_id,
+        expectedPreparedInputRevision: currentHead?.revision ?? 0,
+        capturedAt,
+        ...evidence,
+      });
+      const context = constructionContextFromPersisted(persistedContext);
+      const canonicalContext = canonicalizeAflTradeJson(persistedContext);
+      await transaction.query(
+        `INSERT INTO outcome_current_valuation_cohort_operation
+          (operation_id,scope_key,factual_release_id,factual_release_revision,
+           model_qualification_id,model_qualification_work_id,model_qualification_revision,
+           expected_prepared_input_revision,captured_at,context_sha256,context_canonical_json,
+           context_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)
+         ON CONFLICT (operation_id) DO NOTHING`,
+        [
+          persistedContext.operationId,
+          persistedContext.scopeKey,
+          persistedContext.factualReleaseId,
+          persistedContext.factualReleaseRevision,
+          persistedContext.modelQualificationId,
+          persistedContext.modelQualificationWorkId,
+          persistedContext.modelQualificationRevision,
+          persistedContext.expectedPreparedInputRevision,
+          persistedContext.capturedAt,
+          sha256AflTradeCanonicalJson(persistedContext),
+          canonicalContext,
+          canonicalContext,
+        ]
+      );
+      const retained = await transaction.query<CohortOperationRow>(
+        `SELECT context_json
+           FROM outcome_current_valuation_cohort_operation
+          WHERE operation_id=$1 FOR KEY SHARE`,
+        [context.operationId]
+      );
+      if (
+        retained.rows.length !== 1 ||
+        canonicalizeAflTradeJson(retained.rows[0]!.context_json) !== canonicalContext
+      ) {
+        throw new TypeError('Current cohort operation registration conflicts with retained authority.');
+      }
+      return context;
+    });
+  };
+}
+
+export function createPostgresAflTradeCurrentValuationCohortCommitter(dependencies: {
+  readonly client: AflOutcomeSqlClient;
+  readonly registerPreparedInputSet: (
+    prepared: AflTradePreparedValuationInputSet
+  ) => Promise<AflTradePreparedValuationInputSet>;
+}) {
+  return async function commit(input: {
+    readonly context: AflTradeCurrentValuationCohortConstructionContext;
+    readonly preparedInputSet: AflTradePreparedValuationInputSet;
+  }): Promise<AflTradeCurrentValuationCohortPreparationResult> {
+    const registered = await dependencies.registerPreparedInputSet(input.preparedInputSet);
+    if (canonicalizeAflTradeJson(registered) !== canonicalizeAflTradeJson(input.preparedInputSet)) {
+      throw new TypeError('Prepared cohort registration changed its authenticated identity.');
+    }
+    return dependencies.client.transaction(async (transaction) => {
+      await transaction.query(`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`);
+      const retainedResult = await transaction.query<CohortOperationResultRow>(
+        `SELECT prepared_input_set_id,head_revision
+           FROM outcome_current_valuation_cohort_operation_result
+          WHERE operation_id=$1 FOR KEY SHARE`,
+        [input.context.operationId]
+      );
+      const release = await transaction.query<ActiveReleaseRow>(
+        `SELECT release_id,revision FROM outcome_active_release
+          WHERE scope_key=$1 FOR KEY SHARE`,
+        [input.context.factualReleaseScopeKey]
+      );
+      if (
+        release.rows.length !== 1 ||
+        release.rows[0]!.release_id !== input.context.factualReleaseId ||
+        release.rows[0]!.revision !== input.context.factualReleaseRevision
+      ) {
+        return {
+          state: 'stale_authority',
+          reason: 'The factual release changed while the cohort was being prepared.',
+        };
+      }
+      const model = await transaction.query<CurrentModelPairRow>(
+        `SELECT revision,qualification_id,player_run_id,pick_run_id,work_id
+           FROM outcome_current_governed_valuation_model_pair
+          WHERE scope_key=$1 FOR KEY SHARE`,
+        [input.context.scopeKey]
+      );
+      if (
+        model.rows.length !== 1 ||
+        model.rows[0]!.revision !== input.context.modelQualificationRevision ||
+        model.rows[0]!.qualification_id !== input.context.modelQualificationId ||
+        model.rows[0]!.work_id !== input.context.modelQualificationWorkId ||
+        model.rows[0]!.player_run_id !== input.context.playerRunId ||
+        model.rows[0]!.pick_run_id !== input.context.pickRunId
+      ) {
+        return {
+          state: 'stale_authority',
+          reason: 'The qualified model pair changed while the cohort was being prepared.',
+        };
+      }
+      const current = await loadHead(transaction, input.context.scopeKey);
+      if (retainedResult.rows[0] !== undefined) {
+        if (
+          retainedResult.rows.length !== 1 ||
+          retainedResult.rows[0].prepared_input_set_id !== registered.preparedInputSetId ||
+          current?.preparedInputSetId !== registered.preparedInputSetId ||
+          current.revision !== retainedResult.rows[0].head_revision
+        ) {
+          return {
+            state: 'stale_authority',
+            reason: 'The retained cohort operation result is no longer the current head.',
+          };
+        }
+        return { state: 'already_current', preparedInputSet: registered, head: current };
+      }
+      if (current?.preparedInputSetId === registered.preparedInputSetId) {
+        throw new TypeError('A current prepared cohort lacks its exact operation result custody.');
+      }
+      if ((current?.revision ?? 0) !== input.context.expectedPreparedInputRevision) {
+        return {
+          state: 'stale_authority',
+          reason: 'The prepared cohort head changed while the cohort was being prepared.',
+        };
+      }
+      await transaction.query(
+        `SELECT activate_outcome_current_prepared_valuation_input_set($1,$2,$3)`,
+        [
+          input.context.scopeKey,
+          registered.preparedInputSetId,
+          input.context.expectedPreparedInputRevision,
+        ]
+      );
+      const activated = await loadHead(transaction, input.context.scopeKey);
+      if (
+        activated === null ||
+        activated.preparedInputSetId !== registered.preparedInputSetId ||
+        activated.revision !== input.context.expectedPreparedInputRevision + 1
+      ) {
+        throw new TypeError('Prepared cohort activation returned an unexpected current head.');
+      }
+      await transaction.query(
+        `INSERT INTO outcome_current_valuation_cohort_operation_result
+          (operation_id,prepared_input_set_id,head_revision,completed_at)
+         VALUES ($1,$2,$3,$4)`,
+        [
+          input.context.operationId,
+          registered.preparedInputSetId,
+          activated.revision,
+          activated.activatedAt,
+        ]
+      );
+      return { state: 'advanced', preparedInputSet: registered, head: activated };
+    });
+  };
+}
+
+export function createPostgresAflTradeCurrentValuationCohortCoordinator(dependencies: {
+  readonly client: AflOutcomeSqlClient;
+  readonly artifactRepository: AflTradeImmutableArtifactRepository;
+  readonly maximumArtifactBytes: number;
+  readonly factualReleaseScopeKey: string;
+  readonly maximumConcurrency?: number;
+  readonly loadConstructionEvidence: Parameters<
+    typeof createPostgresAflTradeCurrentValuationCohortAuthorityCapture
+  >[0]['loadConstructionEvidence'];
+  readonly constructTrade: AflTradeCurrentValuationTradePreparationDependencies['construct'];
+}) {
+  const staging = createPostgresGovernedPrivateEvaluationStagingRepository({
+    client: dependencies.client,
+    artifactRepository: dependencies.artifactRepository,
+    maximumArtifactBytes: dependencies.maximumArtifactBytes,
+  });
+  const manifests = new PostgresGovernedPrivateEvaluationMaterializationManifestRepository(
+    dependencies.client
+  );
+  const preparedSets = new PostgresAflTradePreparedValuationInputSetStore(
+    dependencies.client
+  );
+  const tradePreparer = createAflTradeCurrentValuationTradePreparer({
+    construct: dependencies.constructTrade,
+    retainArtifact: (artifact) => staging.retainArtifact(artifact),
+    registerManifest: (manifest) => manifests.register(manifest),
+  });
+  return createAflTradeCurrentValuationCohortCoordinator({
+    ...(dependencies.maximumConcurrency === undefined
+      ? {}
+      : { maximumConcurrency: dependencies.maximumConcurrency }),
+    captureCurrent: createPostgresAflTradeCurrentValuationCohortAuthorityCapture({
+      client: dependencies.client,
+      factualReleaseScopeKey: dependencies.factualReleaseScopeKey,
+      loadConstructionEvidence: dependencies.loadConstructionEvidence,
+    }),
+    prepareTrade: (input) => tradePreparer.prepare(input),
+    commitIfCurrent: createPostgresAflTradeCurrentValuationCohortCommitter({
+      client: dependencies.client,
+      registerPreparedInputSet: (prepared) => preparedSets.register(prepared),
+    }),
+  });
+}

--- a/tests/outcomes-integration/afl-authenticated-prepared-valuation-input-postgres.test.ts
+++ b/tests/outcomes-integration/afl-authenticated-prepared-valuation-input-postgres.test.ts
@@ -5,9 +5,18 @@ import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelli
 import {
   canonicalizeAflTradeJson,
   createAflTradeContentAddress,
+  sha256AflTradeCanonicalJson,
 } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import { createLocalAflTradeOfficialAfl2026Authority } from '@/server/aflTradeIntelligence/development/localOfficialAfl2026Authority';
 import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import {
+  createAflTradeCurrentValuationCohortCoordinator,
+  createAflTradeCurrentValuationCohortPreparationOperationId,
+} from '@/server/aflTradeIntelligence/valuation/currentValuationCohortPreparation';
+import {
+  createPostgresAflTradeCurrentValuationCohortAuthorityCapture,
+  createPostgresAflTradeCurrentValuationCohortCommitter,
+} from '@/server/aflTradeIntelligence/valuation/postgresCurrentValuationCohortPreparation';
 import { aflTradeSourceRightsProposalSchema } from '@/server/aflTradeIntelligence/source/sourceRights';
 import {
   AFL_TRADE_PREPARED_VALUATION_INPUT_SET_V2_SCHEMA_VERSION,
@@ -23,6 +32,7 @@ import {
   createAflTradeValuationSourceQualificationReport,
 } from '@/server/aflTradeIntelligence/valuation/valuationSourceQualificationReport';
 import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+import { createAflTradeCurrentValuationBundleFixture } from '../testUtils/currentValuationCohortFixture';
 
 const databaseUrl =
   process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
@@ -339,7 +349,16 @@ beforeAll(async () => {
   await new PostgresAflTradeValuationSourceQualificationReportStore(
     createPgAflOutcomeSqlClient(pool)
   ).register(qualificationReport);
-  await Promise.all(['a', 'b', 'c', 'd'].map((character) => retainArtifact(artifact(character))));
+  await Promise.all([
+    ...['a', 'b', 'c', 'd'].map((character) => artifact(character)),
+    qualificationReport.content.factualReleaseArtifact,
+    qualificationReport.content.releaseMembershipArtifact,
+    createAflTradeCanonicalJsonArtifactRef(
+      qualificationReport,
+      qualificationReport.content.evaluatedAt
+    ),
+    ...qualificationReport.content.sourceRightsEvidenceRefs,
+  ].map(retainArtifact));
 });
 
 afterAll(async () => {
@@ -412,6 +431,251 @@ describe('PostgreSQL authenticated prepared valuation inputs', () => {
         materializationManifestId: manifest.manifestId,
       },
     });
+
+    const successorBlockerArtifact = artifact('f');
+    await retainArtifact(successorBlockerArtifact);
+    const playerRunId = `model-run:${digest('7')}`;
+    const pickRunId = `model-run:${digest('8')}`;
+    const valuationBundle = createAflTradeCurrentValuationBundleFixture({
+      scopeKey: first.content.scopeKey,
+      playerRunId,
+      pickRunId,
+    });
+    await Promise.all([
+      valuationBundle.valuationInputBundleArtifact,
+      valuationBundle.valuationInputBundle.content.packagePolicy.listSpotPolicyArtifact,
+      valuationBundle.valuationInputBundle.content.packagePolicy.scarcityPolicyArtifact,
+      valuationBundle.valuationInputBundle.content.packagePolicy.roleCongestionPolicyArtifact,
+    ].map(retainArtifact));
+    const modelQualificationId = `model-qualification:${digest('9')}`;
+    const modelQualificationWorkId = `model-qualification-work:${digest('0')}`;
+    const authoritySeed = await pool.connect();
+    try {
+      await authoritySeed.query('BEGIN');
+      await authoritySeed.query(`SET LOCAL session_replication_role='replica'`);
+      await authoritySeed.query(
+        `INSERT INTO outcome_active_release
+          (scope_key,release_id,activated_at,revision) VALUES ($1,$2,$3,1)`,
+        [first.content.factualReleaseScopeKey, first.content.factualReleaseId,
+          '2026-08-15T04:00:00.000Z']
+      );
+      for (const [index, component] of
+        valuationBundle.valuationInputBundle.content.components.entries()) {
+        await authoritySeed.query(
+          `INSERT INTO outcome_governed_valuation_component_run
+            (run_id,role,native_execution_kind,native_execution_id,artifact_id,
+             native_execution_artifact_id,protocol_id,protocol_artifact_id,dataset_id,
+             dataset_artifact_id,dataset_admission_id,dataset_admission_artifact_id,
+             dataset_admission_gate_ledger_revision,registered_at,content_sha256,
+             content_canonical_json,manifest_json)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,1,$13,$14,'{}','{}'::jsonb)`,
+          [
+            component.runId,
+            component.role,
+            component.role === 'player_contribution_and_availability'
+              ? 'admitted_player_model_run'
+              : 'pick_pav_model_execution',
+            component.role === 'player_contribution_and_availability'
+              ? `model-run:${digest('c')}`
+              : `pick-pav-model-execution:${digest('d')}`,
+            `artifact:${digest(index === 0 ? '6' : '7')}`,
+            `artifact:${digest(index === 0 ? '8' : '9')}`,
+            component.protocolId,
+            `artifact:${digest(index === 0 ? 'a' : 'b')}`,
+            component.datasetId,
+            `artifact:${digest(index === 0 ? 'c' : 'd')}`,
+            `dataset-admission:${digest(index === 0 ? 'e' : 'f')}`,
+            `artifact:${digest(index === 0 ? 'e' : 'f')}`,
+            '2026-08-15T04:00:00.000Z',
+            digest(index === 0 ? '7' : '8'),
+          ]
+        );
+      }
+      await authoritySeed.query(
+        `INSERT INTO outcome_governed_valuation_model_qualification
+          (qualification_id,scope_key,outcome,artifact_id,player_run_id,pick_run_id,
+           policy_artifact_id,player_criteria_artifact_id,pick_criteria_artifact_id,
+           player_evidence_artifact_id,pick_evidence_artifact_id,evaluated_at,
+           content_sha256,content_canonical_json,qualification_json)
+         VALUES ($1,$2,'qualified',$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'{}','{}'::jsonb)`,
+        [
+          modelQualificationId,
+          first.content.scopeKey,
+          `artifact:${digest('0')}`,
+          playerRunId,
+          pickRunId,
+          `artifact:${digest('1')}`,
+          `artifact:${digest('2')}`,
+          `artifact:${digest('3')}`,
+          `artifact:${digest('4')}`,
+          `artifact:${digest('5')}`,
+          '2026-08-15T04:00:00.000Z',
+          digest('9'),
+        ]
+      );
+      await authoritySeed.query(
+        `INSERT INTO outcome_governed_model_qualification_work
+          (work_id,scope_key,qualification_id,player_gate3_decision_id,
+           pick_gate3_decision_id,available_at,status,work_json)
+         VALUES ($1,$2,$3,$4,$5,$6,'pending','{}'::jsonb)`,
+        [
+          modelQualificationWorkId,
+          first.content.scopeKey,
+          modelQualificationId,
+          valuationBundle.valuationInputBundle.content.components[0]!.gate3DecisionId,
+          valuationBundle.valuationInputBundle.content.components[1]!.gate3DecisionId,
+          '2026-08-15T04:00:00.000Z',
+        ]
+      );
+      await authoritySeed.query(
+        `INSERT INTO outcome_current_governed_valuation_model_pair
+          (scope_key,revision,qualification_id,player_run_id,pick_run_id,
+           player_gate3_decision_id,pick_gate3_decision_id,work_id,advanced_at)
+         VALUES ($1,1,$2,$3,$4,$5,$6,$7,$8)`,
+        [
+          first.content.scopeKey,
+          modelQualificationId,
+          playerRunId,
+          pickRunId,
+          valuationBundle.valuationInputBundle.content.components[0]!.gate3DecisionId,
+          valuationBundle.valuationInputBundle.content.components[1]!.gate3DecisionId,
+          modelQualificationWorkId,
+          '2026-08-15T04:00:00.000Z',
+        ]
+      );
+      await authoritySeed.query('COMMIT');
+    } catch (error) {
+      await authoritySeed.query('ROLLBACK');
+      throw error;
+    } finally {
+      authoritySeed.release();
+    }
+    const operationId = createAflTradeCurrentValuationCohortPreparationOperationId({
+      scopeKey: first.content.scopeKey,
+      factualReleaseId: first.content.factualReleaseId,
+      factualReleaseRevision: 1,
+      modelQualificationId,
+      modelQualificationWorkId,
+      modelQualificationRevision: 1,
+      expectedPreparedInputRevision: 1,
+    });
+    const postgresClient = createPgAflOutcomeSqlClient(pool);
+    const coordinator = createAflTradeCurrentValuationCohortCoordinator({
+      captureCurrent: createPostgresAflTradeCurrentValuationCohortAuthorityCapture({
+        client: postgresClient,
+        factualReleaseScopeKey: first.content.factualReleaseScopeKey,
+        loadConstructionEvidence: async () => ({
+          factualReleaseArtifact: first.content.factualReleaseArtifact,
+          releaseMembershipArtifact: first.content.releaseMembershipArtifact,
+          releaseTradeIds: first.content.releaseTradeIds,
+          sourceQualificationReportId: first.content.qualificationReportId,
+          sourceQualificationReportArtifact: first.content.qualificationReportArtifact,
+          sourceQualificationEvidenceRefs: first.content.sourceQualificationEvidenceRefs,
+          ...valuationBundle,
+        }),
+      }),
+      prepareTrade: async ({ tradeId }) =>
+        tradeId === 'trade-a'
+          ? {
+              tradeId,
+              state: 'ready',
+              materializationManifestId: manifest.manifestId,
+              materializationManifestArtifact: createAflTradeCanonicalJsonArtifactRef(
+                manifest,
+                materializationManifestCreatedAt
+              ),
+            }
+          : {
+              tradeId,
+              state: 'blocked',
+              blockers: [{
+                code: 'lineage_unresolved',
+                subject: { kind: 'lineage', id: 'asset:pick-12' },
+                evidenceRefs: [successorBlockerArtifact],
+              }],
+            },
+      commitIfCurrent: createPostgresAflTradeCurrentValuationCohortCommitter({
+        client: postgresClient,
+        registerPreparedInputSet: (prepared) => store.register(prepared),
+      }),
+    });
+    await expect(coordinator.prepare({ operationId, scopeKey: first.content.scopeKey }))
+      .resolves.toMatchObject({
+        state: 'advanced',
+        head: { revision: 2 },
+        preparedInputSet: {
+          content: {
+            entries: [{ state: 'ready' }, { state: 'blocked' }],
+          },
+        },
+      });
+    await expect(coordinator.prepare({ operationId, scopeKey: first.content.scopeKey }))
+      .resolves.toMatchObject({ state: 'already_current', head: { revision: 2 } });
+
+    const retainedOperation = await pool.query<{ context_json: Record<string, unknown> }>(
+      `SELECT context_json FROM outcome_current_valuation_cohort_operation
+        WHERE operation_id=$1`,
+      [operationId]
+    );
+    const poisonedOperationId = createAflTradeCurrentValuationCohortPreparationOperationId({
+      scopeKey: first.content.scopeKey,
+      factualReleaseId: first.content.factualReleaseId,
+      factualReleaseRevision: 1,
+      modelQualificationId,
+      modelQualificationWorkId,
+      modelQualificationRevision: 1,
+      expectedPreparedInputRevision: 2,
+    });
+    const retainedBundle = retainedOperation.rows[0]!.context_json
+      .valuationInputBundle as { content: Record<string, unknown> };
+    const retainedBundleContent = retainedBundle.content;
+    const forgedBundleContent = {
+      ...retainedBundleContent,
+      packagePolicy: {
+        ...(retainedBundleContent.packagePolicy as Record<string, unknown>),
+        aggregation: 'independent_point_sum',
+      },
+    };
+    const forgedBundle = {
+      valuationInputBundleId: createAflTradeContentAddress(
+        'valuation-input-bundle',
+        forgedBundleContent
+      ),
+      content: forgedBundleContent,
+    };
+    const forgedBundleArtifact = createAflTradeCanonicalJsonArtifactRef(
+      forgedBundle,
+      forgedBundleContent.createdAt as string
+    );
+    await retainArtifact(forgedBundleArtifact);
+    const forgedContext = {
+      ...retainedOperation.rows[0]!.context_json,
+      operationId: poisonedOperationId,
+      expectedPreparedInputRevision: 2,
+      valuationInputBundleId: forgedBundle.valuationInputBundleId,
+      valuationInputBundleArtifact: forgedBundleArtifact,
+      valuationInputBundle: forgedBundle,
+    };
+    const forgedCanonical = canonicalizeAflTradeJson(forgedContext);
+    await expect(pool.query(
+      `INSERT INTO outcome_current_valuation_cohort_operation
+        (operation_id,scope_key,factual_release_id,factual_release_revision,
+         model_qualification_id,model_qualification_work_id,model_qualification_revision,
+         expected_prepared_input_revision,captured_at,context_sha256,context_canonical_json,
+         context_json)
+       VALUES ($1,$2,$3,1,$4,$5,1,2,$6,$7,$8,$9::jsonb)`,
+      [
+        poisonedOperationId,
+        first.content.scopeKey,
+        first.content.factualReleaseId,
+        modelQualificationId,
+        modelQualificationWorkId,
+        forgedContext.capturedAt,
+        sha256AflTradeCanonicalJson(forgedContext),
+        forgedCanonical,
+        forgedCanonical,
+      ]
+    )).rejects.toThrow(/identity disagrees with its context/i);
 
     await expect(
       pool.query(

--- a/tests/outcomes-integration/afl-authenticated-prepared-valuation-input-postgres.test.ts
+++ b/tests/outcomes-integration/afl-authenticated-prepared-valuation-input-postgres.test.ts
@@ -256,13 +256,13 @@ async function registerMaterializationManifest() {
   return { manifest, manifestArtifact };
 }
 
-function preparedSet(inputTraceArtifact = artifact('c')) {
+function preparedSet(inputTraceArtifact = artifact('2')) {
   const entries = [
     {
       tradeId: 'trade-a',
       state: 'ready' as const,
       calculationInputPackageId: `valuation-calculation-input:${digest('4')}`,
-      calculationInputArtifact: artifact('b'),
+      calculationInputArtifact: artifact('1'),
       inputTraceId: `private-evaluation-input-trace:${digest('5')}`,
       inputTraceArtifact,
     },
@@ -273,7 +273,7 @@ function preparedSet(inputTraceArtifact = artifact('c')) {
         {
           code: 'lineage_unresolved' as const,
           subject: { kind: 'lineage' as const, id: 'asset:pick-12' },
-          evidenceRefs: [artifact('d')],
+          evidenceRefs: [artifact('3')],
         },
       ],
     },
@@ -301,7 +301,7 @@ function preparedSet(inputTraceArtifact = artifact('c')) {
     ),
     sourceQualificationEvidenceRefs: qualificationReport.content.sourceRightsEvidenceRefs,
     valuationInputBundleId: `valuation-input-bundle:${digest('6')}`,
-    valuationInputBundleArtifact: artifact('a'),
+    valuationInputBundleArtifact: artifact('0'),
     releaseTradeIds: ['trade-a', 'trade-b'],
     entries,
     tradeCount: 2,
@@ -350,7 +350,7 @@ beforeAll(async () => {
     createPgAflOutcomeSqlClient(pool)
   ).register(qualificationReport);
   await Promise.all([
-    ...['a', 'b', 'c', 'd'].map((character) => artifact(character)),
+    ...['0', '1', '2', '3'].map((character) => artifact(character)),
     qualificationReport.content.factualReleaseArtifact,
     qualificationReport.content.releaseMembershipArtifact,
     createAflTradeCanonicalJsonArtifactRef(
@@ -446,6 +446,10 @@ describe('PostgreSQL authenticated prepared valuation inputs', () => {
       valuationBundle.valuationInputBundle.content.packagePolicy.listSpotPolicyArtifact,
       valuationBundle.valuationInputBundle.content.packagePolicy.scarcityPolicyArtifact,
       valuationBundle.valuationInputBundle.content.packagePolicy.roleCongestionPolicyArtifact,
+      valuationBundle.valuationInputBundle.content.simulation.lowReturnDefinitionArtifact,
+      valuationBundle.valuationInputBundle.content.simulation.eliteOutcomeDefinitionArtifact,
+      valuationBundle.valuationInputBundle.content.simulation.practicalEquivalenceDefinitionArtifact,
+      valuationBundle.valuationInputBundle.content.explanationPolicyArtifact,
     ].map(retainArtifact));
     const modelQualificationId = `model-qualification:${digest('9')}`;
     const modelQualificationWorkId = `model-qualification-work:${digest('0')}`;

--- a/tests/outcomes-integration/afl-current-valuation-cohort-postgres.test.ts
+++ b/tests/outcomes-integration/afl-current-valuation-cohort-postgres.test.ts
@@ -1,0 +1,275 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import {
+  createAflTradeCurrentValuationCohortCoordinator,
+  createAflTradeCurrentValuationCohortPreparationOperationId,
+} from '@/server/aflTradeIntelligence/valuation/currentValuationCohortPreparation';
+import {
+  createPostgresAflTradeCurrentValuationCohortAuthorityCapture,
+  createPostgresAflTradeCurrentValuationCohortCommitter,
+} from '@/server/aflTradeIntelligence/valuation/postgresCurrentValuationCohortPreparation';
+import type { AflTradePreparedValuationInputSet } from '@/server/aflTradeIntelligence/valuation/preparedValuationInputSet';
+import { createAflTradeCurrentValuationBundleFixture } from '../testUtils/currentValuationCohortFixture';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('AFL_OUTCOMES_TEST_DATABASE_URL must identify disposable PostgreSQL.');
+  })();
+const pool = new Pool({ connectionString: databaseUrl, max: 1 });
+const client = createPgAflOutcomeSqlClient(pool);
+const schemaName = `afl_current_cohort_${process.pid}_${Date.now()}`;
+const digest = (character: string) => character.repeat(64);
+const scopeKey = 'afl-men:automatic-cohort-pg-proof';
+const releaseScopeKey = 'public-afl-draft-trade-outcomes';
+
+function artifact(label: string, createdAt = '2026-08-19T08:00:00.000Z') {
+  return createAflTradeCanonicalJsonArtifactRef({ label }, createdAt);
+}
+
+beforeAll(async () => {
+  await pool.query(`CREATE SCHEMA "${schemaName}"`);
+  await pool.query(`SET search_path TO "${schemaName}"`);
+  await pool.query(`CREATE TABLE outcome_active_release (
+    scope_key text PRIMARY KEY, release_id text NOT NULL, revision integer NOT NULL
+  )`);
+  await pool.query(`CREATE TABLE outcome_current_governed_valuation_model_pair (
+    scope_key text PRIMARY KEY, revision integer NOT NULL, qualification_id text NOT NULL,
+    player_run_id text NOT NULL, pick_run_id text NOT NULL, work_id text NOT NULL
+  )`);
+  await pool.query(`CREATE TABLE outcome_current_prepared_valuation_input_set (
+    scope_key text PRIMARY KEY, prepared_input_set_id text NOT NULL,
+    revision integer NOT NULL, activated_at timestamptz NOT NULL
+  )`);
+  await pool.query(`CREATE TABLE registered_prepared_valuation_input_set (
+    prepared_input_set_id text PRIMARY KEY, prepared_json jsonb NOT NULL
+  )`);
+  await pool.query(`CREATE TABLE outcome_current_valuation_cohort_operation (
+    operation_id text PRIMARY KEY, scope_key text NOT NULL, factual_release_id text NOT NULL,
+    factual_release_revision integer NOT NULL, model_qualification_id text NOT NULL,
+    model_qualification_work_id text NOT NULL, model_qualification_revision integer NOT NULL,
+    expected_prepared_input_revision integer NOT NULL, captured_at timestamptz NOT NULL,
+    context_sha256 text NOT NULL, context_canonical_json text NOT NULL, context_json jsonb NOT NULL
+  )`);
+  await pool.query(`CREATE TABLE outcome_current_valuation_cohort_operation_result (
+    operation_id text PRIMARY KEY, prepared_input_set_id text NOT NULL,
+    head_revision integer NOT NULL, completed_at timestamptz NOT NULL
+  )`);
+  await pool.query(`CREATE OR REPLACE FUNCTION activate_outcome_current_prepared_valuation_input_set(
+    target_scope_key text, target_prepared_input_set_id text, expected_revision integer
+  ) RETURNS void LANGUAGE plpgsql AS $$
+  BEGIN
+    IF expected_revision = 0 THEN
+      INSERT INTO outcome_current_prepared_valuation_input_set
+        (scope_key,prepared_input_set_id,revision,activated_at)
+      VALUES (target_scope_key,target_prepared_input_set_id,1,transaction_timestamp());
+    ELSE
+      UPDATE outcome_current_prepared_valuation_input_set
+         SET prepared_input_set_id=target_prepared_input_set_id,
+             revision=revision+1,activated_at=transaction_timestamp()
+       WHERE scope_key=target_scope_key AND revision=expected_revision;
+      IF NOT FOUND THEN RAISE EXCEPTION 'stale prepared head'; END IF;
+    END IF;
+  END $$`);
+});
+
+afterAll(async () => {
+  await pool.query(`SET search_path TO public`);
+  await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  await pool.end();
+});
+
+async function seedAuthority() {
+  await pool.query(`TRUNCATE outcome_active_release,
+    outcome_current_governed_valuation_model_pair,
+    outcome_current_prepared_valuation_input_set,
+    outcome_current_valuation_cohort_operation_result,
+    outcome_current_valuation_cohort_operation,
+    registered_prepared_valuation_input_set`);
+  await pool.query(
+    `INSERT INTO outcome_active_release(scope_key,release_id,revision) VALUES ($1,$2,7)`,
+    [releaseScopeKey, `outcome-release:${digest('1')}`]
+  );
+  await pool.query(
+    `INSERT INTO outcome_current_governed_valuation_model_pair
+      (scope_key,revision,qualification_id,player_run_id,pick_run_id,work_id)
+     VALUES ($1,3,$2,$3,$4,$5)`,
+    [
+      scopeKey,
+      `model-qualification:${digest('2')}`,
+      `model-run:${digest('3')}`,
+      `model-run:${digest('4')}`,
+      `model-qualification-work:${digest('5')}`,
+    ]
+  );
+}
+
+function coordinator() {
+  const bundle = createAflTradeCurrentValuationBundleFixture({
+    scopeKey,
+    playerRunId: `model-run:${digest('3')}`,
+    pickRunId: `model-run:${digest('4')}`,
+  });
+  const captureCurrent = createPostgresAflTradeCurrentValuationCohortAuthorityCapture({
+    client,
+    factualReleaseScopeKey: releaseScopeKey,
+    loadConstructionEvidence: async () => ({
+      factualReleaseArtifact: artifact('release'),
+      releaseMembershipArtifact: artifact('membership'),
+      releaseTradeIds: ['trade-a', 'trade-b'],
+      sourceQualificationReportId:
+        `valuation-source-qualification:${digest('6')}`,
+      sourceQualificationReportArtifact: artifact('source-qualification'),
+      sourceQualificationEvidenceRefs: [artifact('source-evidence')],
+      ...bundle,
+    }),
+  });
+  const registerPreparedInputSet = async (prepared: AflTradePreparedValuationInputSet) => {
+    await pool.query(
+      `INSERT INTO registered_prepared_valuation_input_set
+        (prepared_input_set_id,prepared_json) VALUES ($1,$2::jsonb)
+       ON CONFLICT (prepared_input_set_id) DO NOTHING`,
+      [prepared.preparedInputSetId, JSON.stringify(prepared)]
+    );
+    return prepared;
+  };
+  return createAflTradeCurrentValuationCohortCoordinator({
+    captureCurrent,
+    prepareTrade: async ({ tradeId, context }) => ({
+      tradeId,
+      state: 'blocked',
+      blockers: [{
+        code: 'component_output_unavailable',
+        subject: { kind: 'trade', id: tradeId },
+        evidenceRefs: [context.valuationInputBundleArtifact],
+      }],
+    }),
+    commitIfCurrent: createPostgresAflTradeCurrentValuationCohortCommitter({
+      client,
+      registerPreparedInputSet,
+    }),
+  });
+}
+
+describe('automatic current valuation cohort PostgreSQL coordination', () => {
+  it('registers and advances once, then restart-safely replays without duplicate evidence', async () => {
+    await seedAuthority();
+    const operationId = createAflTradeCurrentValuationCohortPreparationOperationId({
+      scopeKey,
+      factualReleaseId: `outcome-release:${digest('1')}`,
+      factualReleaseRevision: 7,
+      modelQualificationId: `model-qualification:${digest('2')}`,
+      modelQualificationWorkId: `model-qualification-work:${digest('5')}`,
+      modelQualificationRevision: 3,
+      expectedPreparedInputRevision: 0,
+    });
+
+    await expect(coordinator().prepare({ operationId, scopeKey })).resolves.toMatchObject({
+      state: 'advanced',
+      head: { revision: 1 },
+      preparedInputSet: { content: { tradeCount: 2, blockedCount: 2 } },
+    });
+    await expect(coordinator().prepare({ operationId, scopeKey })).resolves.toMatchObject({
+      state: 'already_current',
+      head: { revision: 1 },
+    });
+    await expect(
+      pool.query(`SELECT count(*)::int AS count FROM registered_prepared_valuation_input_set`)
+    ).resolves.toMatchObject({ rows: [{ count: 1 }] });
+  });
+
+  it('fails closed when factual, model-work, or prepared-head authority changes before commit', async () => {
+    const bundle = createAflTradeCurrentValuationBundleFixture({
+      scopeKey,
+      playerRunId: `model-run:${digest('3')}`,
+      pickRunId: `model-run:${digest('4')}`,
+    });
+    const capture = createPostgresAflTradeCurrentValuationCohortAuthorityCapture({
+      client,
+      factualReleaseScopeKey: releaseScopeKey,
+      loadConstructionEvidence: async () => ({
+        factualReleaseArtifact: artifact('release'),
+        releaseMembershipArtifact: artifact('membership'),
+        releaseTradeIds: ['trade-a'],
+        sourceQualificationReportId:
+          `valuation-source-qualification:${digest('6')}`,
+        sourceQualificationReportArtifact: artifact('source-qualification'),
+        sourceQualificationEvidenceRefs: [artifact('source-evidence')],
+        ...bundle,
+      }),
+    });
+    const operationId = createAflTradeCurrentValuationCohortPreparationOperationId({
+      scopeKey,
+      factualReleaseId: `outcome-release:${digest('1')}`,
+      factualReleaseRevision: 7,
+      modelQualificationId: `model-qualification:${digest('2')}`,
+      modelQualificationWorkId: `model-qualification-work:${digest('5')}`,
+      modelQualificationRevision: 3,
+      expectedPreparedInputRevision: 0,
+    });
+    const commit = createPostgresAflTradeCurrentValuationCohortCommitter({
+      client,
+      registerPreparedInputSet: async (value) => value,
+    });
+    async function buildPrepared(context: Awaited<ReturnType<typeof capture>>) {
+      let retained: AflTradePreparedValuationInputSet | null = null;
+      await createAflTradeCurrentValuationCohortCoordinator({
+        captureCurrent: async () => context,
+        prepareTrade: async ({ tradeId }) => ({
+          tradeId,
+          state: 'blocked',
+          blockers: [{
+            code: 'component_output_unavailable',
+            subject: { kind: 'trade', id: tradeId },
+            evidenceRefs: [context.valuationInputBundleArtifact],
+          }],
+        }),
+        commitIfCurrent: async ({ preparedInputSet }) => {
+          retained = preparedInputSet;
+          return { state: 'stale_authority', reason: 'capture prepared input only' };
+        },
+      }).prepare({ operationId, scopeKey });
+      if (retained === null) throw new Error('Expected one constructed prepared input set.');
+      return retained as AflTradePreparedValuationInputSet;
+    }
+
+    await seedAuthority();
+    let context = await capture({ operationId, scopeKey });
+    let preparedInputSet = await buildPrepared(context);
+    await pool.query(
+      `UPDATE outcome_active_release SET release_id=$2,revision=8 WHERE scope_key=$1`,
+      [releaseScopeKey, `outcome-release:${digest('9')}`]
+    );
+    await expect(
+      commit({ context, preparedInputSet })
+    ).resolves.toMatchObject({ state: 'stale_authority' });
+
+    await seedAuthority();
+    context = await capture({ operationId, scopeKey });
+    preparedInputSet = await buildPrepared(context);
+    await pool.query(
+      `UPDATE outcome_current_governed_valuation_model_pair
+          SET work_id=$2 WHERE scope_key=$1`,
+      [scopeKey, `model-qualification-work:${digest('8')}`]
+    );
+    await expect(commit({ context, preparedInputSet })).resolves.toMatchObject({
+      state: 'stale_authority',
+    });
+
+    await seedAuthority();
+    context = await capture({ operationId, scopeKey });
+    preparedInputSet = await buildPrepared(context);
+    await pool.query(
+      `INSERT INTO outcome_current_prepared_valuation_input_set
+        (scope_key,prepared_input_set_id,revision,activated_at)
+       VALUES ($1,$2,1,transaction_timestamp())`,
+      [scopeKey, `prepared-valuation-input-set:${digest('a')}`]
+    );
+    await expect(commit({ context, preparedInputSet })).resolves.toMatchObject({
+      state: 'stale_authority',
+    });
+  });
+});

--- a/tests/outcomes-integration/afl-governed-private-evaluation-lifecycle-postgres.test.ts
+++ b/tests/outcomes-integration/afl-governed-private-evaluation-lifecycle-postgres.test.ts
@@ -588,13 +588,13 @@ beforeAll(async () => {
     client,
     artifactRepository,
     maximumArtifactBytes: 4 * 1024 * 1024,
-    automatedPrincipalId: 'system:weekly-valuation-coordinator',
+    enableAutomatedPrivateCalculation: true,
   });
   lifecycle = createPostgresGovernedPrivateEvaluationLifecycleRepository({
     client,
     artifactRepository,
     maximumArtifactBytes: 4 * 1024 * 1024,
-    automatedPrincipalId: 'system:weekly-valuation-coordinator',
+    enableAutomatedPrivateCalculation: true,
   });
   const automatedArtifactRepository = createLocalAflTradePrivateDerivedArtifactRepository({
     rootDirectory: artifactRoot,
@@ -605,13 +605,13 @@ beforeAll(async () => {
     client,
     artifactRepository: automatedArtifactRepository,
     maximumArtifactBytes: 4 * 1024 * 1024,
-    automatedPrincipalId: 'system:weekly-valuation-coordinator',
+    enableAutomatedPrivateCalculation: true,
   });
   automatedLifecycle = createPostgresGovernedPrivateEvaluationLifecycleRepository({
     client,
     artifactRepository: automatedArtifactRepository,
     maximumArtifactBytes: 4 * 1024 * 1024,
-    automatedPrincipalId: 'system:weekly-valuation-coordinator',
+    enableAutomatedPrivateCalculation: true,
   });
 });
 
@@ -886,13 +886,20 @@ describe('governed private evaluation PostgreSQL lifecycle', () => {
       ]
     )).rejects.toThrow(/invalid inspection authority/i);
     const intentArtifact = createAflTradeCanonicalJsonArtifactRef(intent, requestedAt);
-    const forgedIntent = createAutomatedGovernedPrivateEvaluationTransitionIntent({
+    const forgedIntentContent = {
       ...intent.content,
       constructionAuthority: {
-        kind: 'automated_private_calculation_agent',
+        kind: 'automated_private_calculation_agent' as const,
         principalId: 'system:unconfigured-agent',
       },
-    });
+    };
+    const forgedIntent = {
+      transitionIntentId: createAflTradeContentAddress(
+        'private-evaluation-transition-intent',
+        forgedIntentContent
+      ),
+      content: forgedIntentContent,
+    };
     const forgedArtifact = createAflTradeCanonicalJsonArtifactRef(forgedIntent, requestedAt);
     await automatedStaging.retainArtifact({
       reference: forgedArtifact,

--- a/tests/outcomes-integration/afl-governed-private-evaluation-lifecycle-postgres.test.ts
+++ b/tests/outcomes-integration/afl-governed-private-evaluation-lifecycle-postgres.test.ts
@@ -10,12 +10,23 @@ import {
   canonicalizeAflTradeJson,
   createAflTradeContentAddress,
 } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
-import { createLocalAflTradeArtifactRepository } from '@/server/aflTradeIntelligence/development/localFileConditionalObjectStore';
+import {
+  createLocalAflTradeArtifactRepository,
+  createLocalAflTradePrivateDerivedArtifactRepository,
+} from '@/server/aflTradeIntelligence/development/localFileConditionalObjectStore';
 import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
-import { createGovernedPrivateEvaluationGeneration } from '@/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration';
-import { createReadyFixtureGovernedPrivateEvaluationAuthorityInspection } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationAuthoritySnapshot';
+import {
+  createAutomatedGovernedPrivateEvaluationGeneration,
+  createGovernedPrivateEvaluationGeneration,
+} from '@/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration';
+import {
+  createReadyFixtureGovernedPrivateEvaluationAuthorityInspection,
+  createReadyGovernedPrivateEvaluationAuthorityInspectionV3,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationAuthoritySnapshot';
 import { createPostgresGovernedPrivateEvaluationWorkspace } from '@/server/aflTradeIntelligence/valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace';
 import {
+  createAutomatedGovernedPrivateEvaluationTransitionIntent,
+  createAutomatedGovernedPrivateEvaluationTransitionReceipt,
   createGovernedPrivateEvaluationTransitionIntent,
   createGovernedPrivateEvaluationTransitionReceipt,
 } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle';
@@ -39,6 +50,7 @@ const selector = {
   valuationScopeKey: 'afl-trade-history:test-fixture',
   tradeId: 'trade:adelaide-st-kilda',
 };
+const fixtureGenerationCreatedAt = '2026-08-19T09:00:00.000Z';
 const client = createPgAflOutcomeSqlClient(pool);
 let artifactRoot = '';
 let artifactRepository: ReturnType<
@@ -46,6 +58,12 @@ let artifactRepository: ReturnType<
 >;
 let staging: ReturnType<typeof createPostgresGovernedPrivateEvaluationStagingRepository>;
 let lifecycle: ReturnType<typeof createPostgresGovernedPrivateEvaluationLifecycleRepository>;
+let automatedStaging: ReturnType<
+  typeof createPostgresGovernedPrivateEvaluationStagingRepository
+>;
+let automatedLifecycle: ReturnType<
+  typeof createPostgresGovernedPrivateEvaluationLifecycleRepository
+>;
 
 type Head = {
   readonly status: 'absent' | 'active' | 'withdrawn';
@@ -62,6 +80,18 @@ function canonicalBytes(value: unknown): Uint8Array {
   return new TextEncoder().encode(canonicalizeAflTradeJson(value));
 }
 
+function createAutomatedNarrativeFixture() {
+  const fixture = createGovernedPrivateEvaluationNarrativeFixture();
+  const content = {
+    ...fixture.content,
+    valuationCaseId: `valuation-case:${'e'.repeat(64)}`,
+  };
+  return {
+    narrativeId: createAflTradeContentAddress('trade-calculation-narrative', content),
+    content,
+  };
+}
+
 async function trustedNow(): Promise<string> {
   const result = await pool.query<{ trusted_at: Date }>(
     `SELECT date_trunc('milliseconds',clock_timestamp()) AS trusted_at`
@@ -75,8 +105,15 @@ async function retainJson(value: unknown, createdAt: string) {
   return reference;
 }
 
-async function seedPrivateEvaluationOperator(authorizedAt: string) {
-  const principalId = 'firebase:test-operator';
+async function seedPrivateEvaluationOperator(
+  authorizedAt: string,
+  options: {
+    readonly principalId?: string;
+    readonly validThrough?: string;
+  } = {}
+) {
+  const principalId = options.principalId ?? 'firebase:test-operator';
+  const validThrough = options.validThrough ?? '2099-01-01T00:00:00.000Z';
   const authorityContent = {
     principalRef: principalId,
     role: 'afl_trade_private_evaluation_operator',
@@ -87,7 +124,7 @@ async function seedPrivateEvaluationOperator(authorizedAt: string) {
     validFromSeason: 1897,
     validThroughSeason: 2200,
     validFrom: authorizedAt,
-    validThrough: '2099-01-01T00:00:00.000Z',
+    validThrough,
   };
   const evidenceDocument = {
     evidenceKind: 'reviewer_authority_evidence',
@@ -146,7 +183,7 @@ async function seedPrivateEvaluationOperator(authorizedAt: string) {
         principalId,
         selector.valuationScopeKey,
         authorizedAt,
-        '2099-01-01T00:00:00.000Z',
+        validThrough,
       ]
     );
     await authorityClient.query('COMMIT');
@@ -158,28 +195,275 @@ async function seedPrivateEvaluationOperator(authorizedAt: string) {
   }
 }
 
-async function seedInspection(head: Head, inspectedAt: string) {
+async function seedInspection(
+  head: Head,
+  inspectedAt: string,
+  automated?: {
+    readonly materializationManifestId: string;
+    readonly materializationManifestArtifact: ReturnType<
+      typeof createAflTradeCanonicalJsonArtifactRef
+    >;
+    readonly valuationInputBundleArtifact: ReturnType<
+      typeof createAflTradeCanonicalJsonArtifactRef
+    >;
+  },
+  targetSelector = selector
+) {
   const validThrough = new Date(Date.parse(inspectedAt) + 300_000).toISOString();
-  const retained = createReadyFixtureGovernedPrivateEvaluationAuthorityInspection({
-    selector,
-    head,
-    capturedAt: inspectedAt,
-    validThrough,
-    lastTransitionId:
+  const lastTransitionId =
       head.status === 'absent'
         ? null
         : (
             await pool.query<{ last_transition_id: string }>(
               `SELECT last_transition_id FROM outcome_local_private_trade_evaluation_head
                 WHERE valuation_scope_key=$1 AND trade_id=$2`,
-              [selector.valuationScopeKey, selector.tradeId]
+              [targetSelector.valuationScopeKey, targetSelector.tradeId]
             )
-          ).rows[0]!.last_transition_id,
-    playerModelRunId: `model-run:${'1'.repeat(64)}`,
-    pickModelRunId: `model-run:${'2'.repeat(64)}`,
-  });
+          ).rows[0]!.last_transition_id;
+  const retained = automated === undefined
+    ? createReadyFixtureGovernedPrivateEvaluationAuthorityInspection({
+        selector: targetSelector,
+        head,
+        capturedAt: inspectedAt,
+        validThrough,
+        lastTransitionId,
+        playerModelRunId: `model-run:${'1'.repeat(64)}`,
+        pickModelRunId: `model-run:${'2'.repeat(64)}`,
+      })
+    : createReadyGovernedPrivateEvaluationAuthorityInspectionV3({
+        selector: targetSelector,
+        head,
+        capturedAt: inspectedAt,
+        validThrough,
+        lastTransitionId,
+        preparedInputHeadRevision: 1,
+        preparedInputSetId: `prepared-valuation-input-set:${'3'.repeat(64)}`,
+        factualRegistryRevision: 1,
+        factualReleaseId: `outcome-release:${'4'.repeat(64)}`,
+        activeFactualReleaseRevision: 1,
+        privateValuationDecisionId:
+          `private-valuation-evaluation-decision:${'5'.repeat(64)}`,
+        privateValuationDecisionRevision: 1,
+        materializationManifestId: automated.materializationManifestId,
+        materializationManifestArtifact: automated.materializationManifestArtifact,
+        valuationInputBundleId: `valuation-input-bundle:${'6'.repeat(64)}`,
+        valuationInputBundleArtifact: automated.valuationInputBundleArtifact,
+        gateLedgerRevision: 2,
+        components: [
+          {
+            role: 'player_contribution_and_availability',
+            runId: `model-run:${'7'.repeat(64)}`,
+            protocolId: `model-protocol:${'8'.repeat(64)}`,
+            datasetId: `dataset:${'9'.repeat(64)}`,
+            datasetAdmissionId: `dataset-admission:${'a'.repeat(64)}`,
+            datasetAdmissionGateLedgerRevision: 1,
+            gate3DecisionId: `gate-decision:${'b'.repeat(64)}`,
+            gate3DecisionVersion: 1,
+            qualificationId: `model-qualification:${'c'.repeat(64)}`,
+            qualificationPolicyVersion: `model-qualification-policy:${'d'.repeat(64)}`,
+          },
+          {
+            role: 'draft_pick_and_future_pick_distribution',
+            runId: `model-run:${'e'.repeat(64)}`,
+            protocolId: `model-protocol:${'f'.repeat(64)}`,
+            datasetId: `dataset:${'0'.repeat(64)}`,
+            datasetAdmissionId: `dataset-admission:${'1'.repeat(64)}`,
+            datasetAdmissionGateLedgerRevision: 2,
+            gate3DecisionId: `gate-decision:${'2'.repeat(64)}`,
+            gate3DecisionVersion: 1,
+            qualificationId: `model-qualification:${'c'.repeat(64)}`,
+            qualificationPolicyVersion: `model-qualification-policy:${'d'.repeat(64)}`,
+          },
+        ],
+      });
   const { snapshot, inspection } = retained;
-  const snapshotArtifact = await retainJson(snapshot, inspectedAt);
+  if (automated !== undefined) {
+    const authority = snapshot.content.calculationAuthority;
+    if (authority.state !== 'ready' || !('materializationManifestId' in authority)) {
+      throw new Error('Automated lifecycle fixture requires ready v3 authority.');
+    }
+    await automatedStaging.retainArtifact({
+      reference: authority.materializationManifestArtifact,
+      bytes: canonicalBytes({ manifestId: authority.materializationManifestId, kind: 'authenticated-materialization' }),
+    });
+    await automatedStaging.retainArtifact({
+      reference: authority.valuationInputBundleArtifact,
+      bytes: canonicalBytes({ kind: 'valuation-input-bundle' }),
+    });
+    const seed = await pool.connect();
+    try {
+      await seed.query('BEGIN');
+      await seed.query(`SET LOCAL session_replication_role='replica'`);
+      await seed.query(
+        `INSERT INTO outcome_prepared_valuation_input_set
+          (prepared_input_set_id,content_sha256,schema_version,environment,scope_key,
+           factual_release_scope_key,factual_release_id,qualification_report_id,trade_count,
+           ready_count,blocked_count,prepared_at,content_canonical_json,
+           prepared_set_canonical_json,prepared_set_json,finalized_at)
+         VALUES ($1,$2,'afl-trade-prepared-valuation-input-set/v3','non_production',$3,
+                 'fixture-release-scope',$5,$6,1,1,0,$4,
+                 '{}','{}','{}'::jsonb,$4)
+         ON CONFLICT DO NOTHING`,
+        [authority.preparedInputSetId, authority.preparedInputSetId.slice(
+          'prepared-valuation-input-set:'.length
+        ), targetSelector.valuationScopeKey, inspectedAt,
+          `outcome-release:${'4'.repeat(64)}`,
+          `valuation-source-qualification:${'5'.repeat(64)}`]
+      );
+      await seed.query(
+        `INSERT INTO outcome_prepared_valuation_input_entry
+         (prepared_input_set_id,ordinal,trade_id,state,entry_canonical_json,entry_json)
+         VALUES ($1,1,$2,'ready','{}',$3::jsonb)
+         ON CONFLICT DO NOTHING`,
+        [authority.preparedInputSetId, targetSelector.tradeId,
+          JSON.stringify({ materializationManifestId: authority.materializationManifestId })]
+      );
+      await seed.query(
+        `INSERT INTO outcome_private_evaluation_materialization_manifest
+          (materialization_manifest_id,content_sha256,valuation_scope_key,trade_id,
+           artifact_id,created_at,content_canonical_json,manifest_canonical_json,manifest_json)
+        VALUES ($1,$2,$3,$4,$5,$6,'{}','{}',$7::jsonb)
+        ON CONFLICT DO NOTHING`,
+        [authority.materializationManifestId,
+          authority.materializationManifestId.slice(
+            'private-evaluation-materialization-manifest:'.length
+          ),
+          targetSelector.valuationScopeKey,targetSelector.tradeId,
+          authority.materializationManifestArtifact.artifactId,inspectedAt,
+          JSON.stringify({ content: {
+            valuationInputBundleId: authority.valuationInputBundleId,
+            valuationInputBundleArtifact: authority.valuationInputBundleArtifact,
+          } })]
+      );
+      await seed.query(
+        `INSERT INTO outcome_current_prepared_valuation_input_set
+          (scope_key,prepared_input_set_id,revision,activated_at) VALUES ($1,$2,$3,$4)
+         ON CONFLICT DO NOTHING`,
+        [targetSelector.valuationScopeKey, authority.preparedInputSetId,
+          authority.preparedInputHeadRevision, inspectedAt]
+      );
+      for (const [index, component] of authority.components.entries()) {
+        await seed.query(
+          `INSERT INTO outcome_governed_valuation_component_run
+            (run_id,role,native_execution_kind,native_execution_id,artifact_id,
+             native_execution_artifact_id,protocol_id,protocol_artifact_id,dataset_id,
+             dataset_artifact_id,dataset_admission_id,dataset_admission_artifact_id,
+             dataset_admission_gate_ledger_revision,registered_at,content_sha256,
+             content_canonical_json,manifest_json)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,'{}','{}'::jsonb)
+           ON CONFLICT DO NOTHING`,
+          [
+            component.runId,
+            component.role,
+            component.role === 'player_contribution_and_availability'
+              ? 'admitted_player_model_run'
+              : 'pick_pav_model_execution',
+            component.role === 'player_contribution_and_availability'
+              ? `model-run:${'5'.repeat(64)}`
+              : `pick-pav-model-execution:${'6'.repeat(64)}`,
+            `artifact:${(index === 0 ? '7' : '8').repeat(64)}`,
+            `artifact:${(index === 0 ? '9' : 'a').repeat(64)}`,
+            component.protocolId,
+            `artifact:${(index === 0 ? 'b' : 'c').repeat(64)}`,
+            component.datasetId,
+            `artifact:${(index === 0 ? 'd' : 'e').repeat(64)}`,
+            component.datasetAdmissionId,
+            `artifact:${(index === 0 ? 'f' : '0').repeat(64)}`,
+            component.datasetAdmissionGateLedgerRevision,
+            inspectedAt,
+            component.runId.slice('model-run:'.length),
+          ]
+        );
+        const proposalId = `gate-proposal:${(index === 0 ? '1' : '2').repeat(64)}`;
+        const decisionKey = `automated-private-fixture-${index}`;
+        await seed.query(
+          `INSERT INTO outcome_gate_decision
+            (decision_id,proposal_id,gate,decision_key,version,environment,state,
+             decided_at,effective_at,revalidate_at,supersedes_decision_id,decision_json)
+           VALUES ($1,$2,'gate_3_model_approval',$3,$4,'non_production','approved',
+                   $5,$5,'2099-01-01T00:00:00.000Z',NULL,$6::jsonb)
+           ON CONFLICT DO NOTHING`,
+          [
+            component.gate3DecisionId,
+            proposalId,
+            decisionKey,
+            component.gate3DecisionVersion,
+            inspectedAt,
+            canonicalizeAflTradeJson({
+              decisionId: component.gate3DecisionId,
+              content: {
+                schemaVersion: 'afl-trade-gate-decision/v1',
+                proposalId,
+                gate: 'gate_3_model_approval',
+                decisionKey,
+                version: component.gate3DecisionVersion,
+                environment: 'non_production',
+                state: 'approved',
+                supersedesDecisionId: null,
+              },
+            }),
+          ]
+        );
+      }
+      await seed.query(
+        `INSERT INTO outcome_governed_valuation_model_qualification
+          (qualification_id,scope_key,outcome,artifact_id,player_run_id,pick_run_id,
+           policy_artifact_id,player_criteria_artifact_id,pick_criteria_artifact_id,
+           player_evidence_artifact_id,pick_evidence_artifact_id,evaluated_at,
+           content_sha256,content_canonical_json,qualification_json)
+         VALUES ($1,$2,'qualified',$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'{}',$13::jsonb)
+         ON CONFLICT DO NOTHING`,
+        [
+          authority.components[0]!.qualificationId,
+          targetSelector.valuationScopeKey,
+          `artifact:${'1'.repeat(64)}`,
+          authority.components[0]!.runId,
+          authority.components[1]!.runId,
+          `artifact:${'2'.repeat(64)}`,
+          `artifact:${'3'.repeat(64)}`,
+          `artifact:${'4'.repeat(64)}`,
+          `artifact:${'5'.repeat(64)}`,
+          `artifact:${'6'.repeat(64)}`,
+          inspectedAt,
+          'c'.repeat(64),
+          canonicalizeAflTradeJson({
+            content: {
+              policy: {
+                policyVersion: authority.components[0]!.qualificationPolicyVersion,
+              },
+            },
+          }),
+        ]
+      );
+      await seed.query(
+        `INSERT INTO outcome_current_governed_valuation_model_pair
+          (scope_key,revision,qualification_id,player_run_id,pick_run_id,
+           player_gate3_decision_id,pick_gate3_decision_id,work_id,advanced_at)
+         VALUES ($1,1,$2,$3,$4,$5,$6,$7,$8)
+         ON CONFLICT DO NOTHING`,
+        [targetSelector.valuationScopeKey, authority.components[0]!.qualificationId,
+          authority.components[0]!.runId,authority.components[1]!.runId,
+          authority.components[0]!.gate3DecisionId,authority.components[1]!.gate3DecisionId,
+          `model-qualification-work:${'4'.repeat(64)}`,inspectedAt]
+      );
+      await seed.query('COMMIT');
+    } catch (error) {
+      await seed.query('ROLLBACK');
+      throw error;
+    } finally {
+      seed.release();
+    }
+  }
+  const retainInspectionDocument = async (document: unknown) => {
+    if (automated === undefined) return retainJson(document, inspectedAt);
+    const reference = createAflTradeCanonicalJsonArtifactRef(document, inspectedAt);
+    await automatedStaging.retainArtifact({
+      reference,
+      bytes: canonicalBytes(document),
+    });
+    return reference;
+  };
+  const snapshotArtifact = await retainInspectionDocument(snapshot);
   await pool.query(
     `INSERT INTO outcome_private_evaluation_authority_snapshot
       (snapshot_id,valuation_scope_key,trade_id,artifact_id,captured_at,valid_through,
@@ -188,8 +472,8 @@ async function seedInspection(head: Head, inspectedAt: string) {
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
     [
       snapshot.snapshotId,
-      selector.valuationScopeKey,
-      selector.tradeId,
+      targetSelector.valuationScopeKey,
+      targetSelector.tradeId,
       snapshotArtifact.artifactId,
       inspectedAt,
       validThrough,
@@ -201,7 +485,7 @@ async function seedInspection(head: Head, inspectedAt: string) {
       canonicalizeAflTradeJson(snapshot),
     ]
   );
-  const inspectionArtifact = await retainJson(inspection, inspectedAt);
+  const inspectionArtifact = await retainInspectionDocument(inspection);
   await pool.query(
     `INSERT INTO outcome_private_evaluation_inspection_receipt
       (inspection_id,snapshot_id,valuation_scope_key,trade_id,artifact_id,state,
@@ -211,8 +495,8 @@ async function seedInspection(head: Head, inspectedAt: string) {
     [
       inspection.inspectionId,
       snapshot.snapshotId,
-      selector.valuationScopeKey,
-      selector.tradeId,
+      targetSelector.valuationScopeKey,
+      targetSelector.tradeId,
       inspectionArtifact.artifactId,
       inspectedAt,
       validThrough,
@@ -228,6 +512,8 @@ async function seedInspection(head: Head, inspectedAt: string) {
     inspectionId: inspection.inspectionId,
     snapshotId: snapshot.snapshotId,
     validThrough,
+    snapshot,
+    inspection,
   };
 }
 
@@ -262,7 +548,7 @@ async function transition(input: {
       ? createGovernedPrivateEvaluationGeneration({
           selector,
           transitionIntentId: intent.transitionIntentId,
-          generatedAt: input.generationCreatedAt ?? requestedAt,
+          generatedAt: input.generationCreatedAt ?? fixtureGenerationCreatedAt,
           narrative: createGovernedPrivateEvaluationNarrativeFixture(),
         })
       : undefined;
@@ -302,11 +588,30 @@ beforeAll(async () => {
     client,
     artifactRepository,
     maximumArtifactBytes: 4 * 1024 * 1024,
+    automatedPrincipalId: 'system:weekly-valuation-coordinator',
   });
   lifecycle = createPostgresGovernedPrivateEvaluationLifecycleRepository({
     client,
     artifactRepository,
     maximumArtifactBytes: 4 * 1024 * 1024,
+    automatedPrincipalId: 'system:weekly-valuation-coordinator',
+  });
+  const automatedArtifactRepository = createLocalAflTradePrivateDerivedArtifactRepository({
+    rootDirectory: artifactRoot,
+    repositoryId: 'governed-automated-lifecycle-postgres-proof',
+    maximumObjectBytes: 4 * 1024 * 1024,
+  });
+  automatedStaging = createPostgresGovernedPrivateEvaluationStagingRepository({
+    client,
+    artifactRepository: automatedArtifactRepository,
+    maximumArtifactBytes: 4 * 1024 * 1024,
+    automatedPrincipalId: 'system:weekly-valuation-coordinator',
+  });
+  automatedLifecycle = createPostgresGovernedPrivateEvaluationLifecycleRepository({
+    client,
+    artifactRepository: automatedArtifactRepository,
+    maximumArtifactBytes: 4 * 1024 * 1024,
+    automatedPrincipalId: 'system:weekly-valuation-coordinator',
   });
 });
 
@@ -318,9 +623,624 @@ afterAll(async () => {
 });
 
 describe('governed private evaluation PostgreSQL lifecycle', () => {
+  it('stages and exactly resumes one automated non-production generation', async () => {
+    const trustedAt = await trustedNow();
+    const expiredRequestedAt = new Date(
+      Date.parse(trustedAt) - 10 * 60 * 1_000
+    ).toISOString();
+    const automatedSelector = {
+      ...selector,
+      valuationScopeKey: 'afl-trade-history:automated-non-production',
+    };
+    const manifestId =
+      `private-evaluation-materialization-manifest:${'3'.repeat(64)}`;
+    const automatedAuthorityEvidence = {
+      materializationManifestId: manifestId,
+      materializationManifestArtifact: createAflTradeCanonicalJsonArtifactRef(
+        { manifestId, kind: 'authenticated-materialization' },
+        expiredRequestedAt
+      ),
+      valuationInputBundleArtifact: createAflTradeCanonicalJsonArtifactRef(
+        { kind: 'valuation-input-bundle' },
+        expiredRequestedAt
+      ),
+    };
+    const expiredInspection = await seedInspection(
+      { status: 'absent', revision: 0, generationId: null },
+      expiredRequestedAt,
+      automatedAuthorityEvidence,
+      automatedSelector
+    );
+    const constructionAuthority = {
+      kind: 'automated_private_calculation_agent' as const,
+      principalId: 'system:weekly-valuation-coordinator',
+    };
+    const expiredIntent = createAutomatedGovernedPrivateEvaluationTransitionIntent({
+      selector: automatedSelector,
+      inspectionId: expiredInspection.inspectionId,
+      authoritySnapshotId: expiredInspection.snapshotId,
+      operationId: createAflTradeContentAddress('private-evaluation-operation', {
+        marker: 'expired-automated-stage',
+      }),
+      action: { kind: 'construct_and_activate' },
+      expectedHead: { status: 'absent', revision: 0, generationId: null },
+      constructionAuthority,
+      requestedAt: expiredRequestedAt,
+      expiresAt: expiredInspection.validThrough,
+    });
+    const expiredMaterialization = createAutomatedGovernedPrivateEvaluationGeneration({
+      selector: automatedSelector,
+      transitionIntentId: expiredIntent.transitionIntentId,
+      generatedAt: fixtureGenerationCreatedAt,
+      constructionAuthority,
+      narrative: createAutomatedNarrativeFixture(),
+    });
+    await automatedStaging.stage({
+      intent: expiredIntent,
+      intentArtifact: createAflTradeCanonicalJsonArtifactRef(
+        expiredIntent,
+        expiredRequestedAt
+      ),
+      materialization: expiredMaterialization,
+    });
+    const expiredTransitionedAt = new Date(
+      Date.parse(expiredRequestedAt) + 1_000
+    ).toISOString();
+    const expiredReceipt = createAutomatedGovernedPrivateEvaluationTransitionReceipt({
+      intent: expiredIntent,
+      previousTransitionId: null,
+      toGenerationId: expiredMaterialization.generation.generationId,
+      transitionedAt: expiredTransitionedAt,
+    });
+    const expiredReceiptArtifact = createAflTradeCanonicalJsonArtifactRef(
+      expiredReceipt,
+      expiredTransitionedAt
+    );
+    await automatedStaging.retainArtifact({
+      reference: expiredReceiptArtifact,
+      bytes: canonicalBytes(expiredReceipt),
+    });
+    await expect(pool.query(
+      `INSERT INTO outcome_private_evaluation_transition_receipt
+        (transition_id,transition_intent_id,operation_id,valuation_scope_key,trade_id,
+         artifact_id,action,from_revision,from_status,from_generation_id,to_revision,
+         to_status,to_generation_id,transitioned_at,content_sha256,content_canonical_json,
+         receipt_json)
+       VALUES ($1,$2,$3,$4,$5,$6,'construct_and_activate',0,'absent',NULL,1,
+               'active',$7,$8,$9,$10,$11::jsonb)`,
+      [
+        expiredReceipt.transitionId,
+        expiredIntent.transitionIntentId,
+        expiredIntent.content.operationId,
+        automatedSelector.valuationScopeKey,
+        automatedSelector.tradeId,
+        expiredReceiptArtifact.artifactId,
+        expiredMaterialization.generation.generationId,
+        expiredTransitionedAt,
+        expiredReceipt.transitionId.slice('private-evaluation-transition:'.length),
+        canonicalizeAflTradeJson(expiredReceipt.content),
+        canonicalizeAflTradeJson(expiredReceipt),
+      ]
+    )).rejects.toThrow(/PostgreSQL authority authentication/i);
+    const requestedAt = await trustedNow();
+    const inspection = await seedInspection(
+      { status: 'absent', revision: 0, generationId: null },
+      requestedAt,
+      automatedAuthorityEvidence,
+      automatedSelector
+    );
+    const intent = createAutomatedGovernedPrivateEvaluationTransitionIntent({
+      selector: automatedSelector,
+      inspectionId: inspection.inspectionId,
+      authoritySnapshotId: inspection.snapshotId,
+      operationId: createAflTradeContentAddress('private-evaluation-operation', {
+        marker: 'automated-stage',
+      }),
+      action: { kind: 'construct_and_activate' },
+      expectedHead: { status: 'absent', revision: 0, generationId: null },
+      constructionAuthority,
+      requestedAt,
+      expiresAt: inspection.validThrough,
+    });
+    const materialization = createAutomatedGovernedPrivateEvaluationGeneration({
+      selector: automatedSelector,
+      transitionIntentId: intent.transitionIntentId,
+      generatedAt: fixtureGenerationCreatedAt,
+      constructionAuthority,
+      narrative: createAutomatedNarrativeFixture(),
+    });
+    await expect(pool.query<{ authenticated: boolean }>(
+      `SELECT validate_outcome_automated_ready_calculation_authority(
+        $1::jsonb,$2,$3
+      ) AS authenticated`,
+      [
+        canonicalizeAflTradeJson(inspection.snapshot.content.calculationAuthority),
+        automatedSelector.valuationScopeKey,
+        automatedSelector.tradeId,
+      ]
+    )).resolves.toMatchObject({ rows: [{ authenticated: true }] });
+    const fabricatedCalculationAuthority = {
+      ...inspection.snapshot.content.calculationAuthority,
+      components: inspection.snapshot.content.calculationAuthority.components.map(
+        (component) => ({
+          ...component,
+          qualificationPolicyVersion: `model-qualification-policy:${'f'.repeat(64)}`,
+          gate3DecisionVersion: component.gate3DecisionVersion + 1,
+        })
+      ),
+    };
+    const fabricatedSnapshotContent = {
+      ...inspection.snapshot.content,
+      calculationAuthority: fabricatedCalculationAuthority,
+    };
+    const fabricatedSnapshot = {
+      snapshotId: createAflTradeContentAddress(
+        'private-evaluation-authority-snapshot',
+        fabricatedSnapshotContent
+      ),
+      content: fabricatedSnapshotContent,
+    };
+    const fabricatedSnapshotArtifact = createAflTradeCanonicalJsonArtifactRef(
+      fabricatedSnapshot,
+      requestedAt
+    );
+    await automatedStaging.retainArtifact({
+      reference: fabricatedSnapshotArtifact,
+      bytes: canonicalBytes(fabricatedSnapshot),
+    });
+    await pool.query(
+      `INSERT INTO outcome_private_evaluation_authority_snapshot
+        (snapshot_id,valuation_scope_key,trade_id,artifact_id,captured_at,valid_through,
+         expected_head_status,expected_head_revision,expected_head_generation_id,
+         content_sha256,content_canonical_json,snapshot_json)
+       VALUES ($1,$2,$3,$4,$5,$6,'absent',0,NULL,$7,$8,$9::jsonb)`,
+      [
+        fabricatedSnapshot.snapshotId,
+        automatedSelector.valuationScopeKey,
+        automatedSelector.tradeId,
+        fabricatedSnapshotArtifact.artifactId,
+        requestedAt,
+        inspection.validThrough,
+        fabricatedSnapshot.snapshotId.slice(
+          'private-evaluation-authority-snapshot:'.length
+        ),
+        canonicalizeAflTradeJson(fabricatedSnapshotContent),
+        canonicalizeAflTradeJson(fabricatedSnapshot),
+      ]
+    );
+    const fabricatedInspectionContent = {
+      ...inspection.inspection.content,
+      snapshotId: fabricatedSnapshot.snapshotId,
+      calculationAuthority: fabricatedCalculationAuthority,
+    };
+    const fabricatedInspection = {
+      inspectionId: createAflTradeContentAddress(
+        'private-evaluation-inspection',
+        fabricatedInspectionContent
+      ),
+      content: fabricatedInspectionContent,
+    };
+    const fabricatedInspectionArtifact = createAflTradeCanonicalJsonArtifactRef(
+      fabricatedInspection,
+      requestedAt
+    );
+    await automatedStaging.retainArtifact({
+      reference: fabricatedInspectionArtifact,
+      bytes: canonicalBytes(fabricatedInspection),
+    });
+    await pool.query(
+      `INSERT INTO outcome_private_evaluation_inspection_receipt
+        (inspection_id,snapshot_id,valuation_scope_key,trade_id,artifact_id,state,
+         inspected_at,valid_through,expected_head_status,expected_head_revision,
+         expected_head_generation_id,content_sha256,content_canonical_json,receipt_json)
+       VALUES ($1,$2,$3,$4,$5,'ready',$6,$7,'absent',0,NULL,$8,$9,$10::jsonb)`,
+      [
+        fabricatedInspection.inspectionId,
+        fabricatedSnapshot.snapshotId,
+        automatedSelector.valuationScopeKey,
+        automatedSelector.tradeId,
+        fabricatedInspectionArtifact.artifactId,
+        requestedAt,
+        inspection.validThrough,
+        fabricatedInspection.inspectionId.slice('private-evaluation-inspection:'.length),
+        canonicalizeAflTradeJson(fabricatedInspectionContent),
+        canonicalizeAflTradeJson(fabricatedInspection),
+      ]
+    );
+    const fabricatedIntent = createAutomatedGovernedPrivateEvaluationTransitionIntent({
+      ...intent.content,
+      inspectionId: fabricatedInspection.inspectionId,
+      authoritySnapshotId: fabricatedSnapshot.snapshotId,
+    });
+    const fabricatedIntentArtifact = createAflTradeCanonicalJsonArtifactRef(
+      fabricatedIntent,
+      requestedAt
+    );
+    await automatedStaging.retainArtifact({
+      reference: fabricatedIntentArtifact,
+      bytes: canonicalBytes(fabricatedIntent),
+    });
+    await expect(pool.query(
+      `INSERT INTO outcome_private_evaluation_transition_intent
+        (transition_intent_id,inspection_id,authority_snapshot_id,operation_id,
+         valuation_scope_key,trade_id,artifact_id,action,expected_head_status,
+         expected_head_revision,expected_head_generation_id,target_generation_id,
+         requested_at,expires_at,content_sha256,content_canonical_json,intent_json)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,'construct_and_activate','absent',0,NULL,NULL,
+               $8,$9,$10,$11,$12::jsonb)`,
+      [
+        fabricatedIntent.transitionIntentId,
+        fabricatedInspection.inspectionId,
+        fabricatedSnapshot.snapshotId,
+        fabricatedIntent.content.operationId,
+        automatedSelector.valuationScopeKey,
+        automatedSelector.tradeId,
+        fabricatedIntentArtifact.artifactId,
+        requestedAt,
+        inspection.validThrough,
+        fabricatedIntent.transitionIntentId.slice(
+          'private-evaluation-transition-intent:'.length
+        ),
+        canonicalizeAflTradeJson(fabricatedIntent.content),
+        canonicalizeAflTradeJson(fabricatedIntent),
+      ]
+    )).rejects.toThrow(/invalid inspection authority/i);
+    const intentArtifact = createAflTradeCanonicalJsonArtifactRef(intent, requestedAt);
+    const forgedIntent = createAutomatedGovernedPrivateEvaluationTransitionIntent({
+      ...intent.content,
+      constructionAuthority: {
+        kind: 'automated_private_calculation_agent',
+        principalId: 'system:unconfigured-agent',
+      },
+    });
+    const forgedArtifact = createAflTradeCanonicalJsonArtifactRef(forgedIntent, requestedAt);
+    await automatedStaging.retainArtifact({
+      reference: forgedArtifact,
+      bytes: canonicalBytes(forgedIntent),
+    });
+    await expect(
+      pool.query(
+        `INSERT INTO outcome_private_evaluation_transition_intent
+          (transition_intent_id,inspection_id,authority_snapshot_id,operation_id,
+           valuation_scope_key,trade_id,artifact_id,action,expected_head_status,
+           expected_head_revision,expected_head_generation_id,target_generation_id,
+           requested_at,expires_at,content_sha256,content_canonical_json,intent_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,'construct_and_activate','absent',0,NULL,NULL,
+                 $8,$9,$10,$11,$12::jsonb)`,
+        [
+          forgedIntent.transitionIntentId,
+          forgedIntent.content.inspectionId,
+          forgedIntent.content.authoritySnapshotId,
+          forgedIntent.content.operationId,
+          forgedIntent.content.selector.valuationScopeKey,
+          forgedIntent.content.selector.tradeId,
+          forgedArtifact.artifactId,
+          forgedIntent.content.requestedAt,
+          forgedIntent.content.expiresAt,
+          forgedIntent.transitionIntentId.slice('private-evaluation-transition-intent:'.length),
+          canonicalizeAflTradeJson(forgedIntent.content),
+          canonicalizeAflTradeJson(forgedIntent),
+        ]
+      )
+    ).rejects.toThrow(/invalid shape or column binding/i);
+
+    const staged = await automatedStaging.stage({ intent, intentArtifact, materialization });
+    expect(staged).toMatchObject({
+      transitionIntentId: intent.transitionIntentId,
+      generationId: materialization.generation.generationId,
+    });
+    const receipt = createAutomatedGovernedPrivateEvaluationTransitionReceipt({
+      intent,
+      previousTransitionId: null,
+      toGenerationId: materialization.generation.generationId,
+      transitionedAt: requestedAt,
+    });
+    const receiptArtifact = createAflTradeCanonicalJsonArtifactRef(receipt, requestedAt);
+    await automatedStaging.retainArtifact({
+      reference: receiptArtifact,
+      bytes: canonicalBytes(receipt),
+    });
+    await expect(
+      automatedLifecycle.commitAutomated({ receipt, receiptArtifact })
+    ).resolves.toMatchObject({
+      state: 'committed',
+      head: {
+        status: 'active',
+        revision: 1,
+        generationId: materialization.generation.generationId,
+      },
+    });
+    await expect(
+      automatedLifecycle.commitAutomated({ receipt, receiptArtifact })
+    ).resolves.toMatchObject({ state: 'replayed' });
+    const wrongPredecessorContent = {
+      ...receipt.content,
+      previousTransitionId: `private-evaluation-transition:${'f'.repeat(64)}`,
+    };
+    const wrongPredecessorReceipt = {
+      transitionId: createAflTradeContentAddress(
+        'private-evaluation-transition',
+        wrongPredecessorContent
+      ),
+      content: wrongPredecessorContent,
+    };
+    const wrongPredecessorArtifact = createAflTradeCanonicalJsonArtifactRef(
+      wrongPredecessorReceipt,
+      requestedAt
+    );
+    await automatedStaging.retainArtifact({
+      reference: wrongPredecessorArtifact,
+      bytes: canonicalBytes(wrongPredecessorReceipt),
+    });
+    await expect(pool.query(
+      `INSERT INTO outcome_private_evaluation_transition_receipt
+        (transition_id,transition_intent_id,operation_id,valuation_scope_key,trade_id,
+         artifact_id,action,from_revision,from_status,from_generation_id,to_revision,
+         to_status,to_generation_id,transitioned_at,content_sha256,content_canonical_json,
+         receipt_json)
+       VALUES ($1,$2,$3,$4,$5,$6,'construct_and_activate',0,'absent',NULL,1,
+               'active',$7,$8,$9,$10,$11::jsonb)`,
+      [
+        wrongPredecessorReceipt.transitionId,
+        intent.transitionIntentId,
+        intent.content.operationId,
+        automatedSelector.valuationScopeKey,
+        automatedSelector.tradeId,
+        wrongPredecessorArtifact.artifactId,
+        materialization.generation.generationId,
+        requestedAt,
+        wrongPredecessorReceipt.transitionId.slice(
+          'private-evaluation-transition:'.length
+        ),
+        canonicalizeAflTradeJson(wrongPredecessorContent),
+        canonicalizeAflTradeJson(wrongPredecessorReceipt),
+      ]
+    )).rejects.toThrow(/PostgreSQL authority authentication/i);
+    await expect(
+      automatedStaging.stage({ intent, intentArtifact, materialization })
+    ).resolves.toMatchObject({
+      generationId: materialization.generation.generationId,
+    });
+    const retained = await pool.query<{ intent_version: string; generation_version: string }>(
+      `SELECT intent.intent_json->'content'->>'schemaVersion' AS intent_version,
+              generation.generation_json->'content'->>'schemaVersion' AS generation_version
+         FROM outcome_private_evaluation_transition_intent intent
+         JOIN outcome_local_private_trade_evaluation_generation generation
+           ON generation.transition_intent_id=intent.transition_intent_id
+        WHERE intent.operation_id=$1`,
+      [intent.content.operationId]
+    );
+    expect(retained.rows).toEqual([{
+      intent_version: 'private-evaluation-transition-intent/v2',
+      generation_version: 'local-private-trade-evaluation-generation/v2',
+    }]);
+    await expect(
+      pool.query(
+        `SELECT revision,status,generation_id
+           FROM outcome_local_private_trade_evaluation_head
+          WHERE valuation_scope_key=$1 AND trade_id=$2`,
+        [automatedSelector.valuationScopeKey, automatedSelector.tradeId]
+      )
+    ).resolves.toMatchObject({
+      rows: [{
+        revision: 1,
+        status: 'active',
+        generation_id: materialization.generation.generationId,
+      }],
+    });
+    await expect(
+      pool.query(
+        `UPDATE outcome_local_private_trade_evaluation_head
+            SET revision=revision+1
+          WHERE valuation_scope_key=$1 AND trade_id=$2`,
+        [automatedSelector.valuationScopeKey, automatedSelector.tradeId]
+      )
+    ).rejects.toThrow(/exact retained receipt/i);
+  });
+
   it('stages, activates, exactly replays, withdraws, verifies, and blocks unavailable reactivation', async () => {
-    const operatorAuthorizedAt = new Date(Date.parse(await trustedNow()) - 1_000).toISOString();
+    const currentTrustedAt = await trustedNow();
+    const expiredOperatorRequestedAt = new Date(
+      Date.parse(currentTrustedAt) - 2 * 60 * 1_000
+    ).toISOString();
+    const expiredOperatorValidFrom = new Date(
+      Date.parse(currentTrustedAt) - 5 * 60 * 1_000
+    ).toISOString();
+    const expiredOperatorValidThrough = new Date(
+      Date.parse(currentTrustedAt) - 60 * 1_000
+    ).toISOString();
+    await seedPrivateEvaluationOperator(expiredOperatorValidFrom, {
+      principalId: 'firebase:expired-operator',
+      validThrough: expiredOperatorValidThrough,
+    });
+    const expiredOperatorInspection = await seedInspection(
+      { status: 'absent', revision: 0, generationId: null },
+      expiredOperatorRequestedAt
+    );
+    const expiredOperatorIntent = createGovernedPrivateEvaluationTransitionIntent({
+      selector,
+      inspectionId: expiredOperatorInspection.inspectionId,
+      authoritySnapshotId: expiredOperatorInspection.snapshotId,
+      operationId: createAflTradeContentAddress('private-evaluation-operation', {
+        marker: 'expired-operator-receipt',
+      }),
+      action: { kind: 'construct_and_activate' },
+      expectedHead: { status: 'absent', revision: 0, generationId: null },
+      review: {
+        principalId: 'firebase:expired-operator',
+        rationale: 'A backdated receipt must not revive expired operator authority.',
+      },
+      requestedAt: expiredOperatorRequestedAt,
+      expiresAt: expiredOperatorInspection.validThrough,
+    });
+    const expiredOperatorMaterialization = createGovernedPrivateEvaluationGeneration({
+      selector,
+      transitionIntentId: expiredOperatorIntent.transitionIntentId,
+      generatedAt: fixtureGenerationCreatedAt,
+      narrative: createGovernedPrivateEvaluationNarrativeFixture(),
+    });
+    await staging.stage({
+      intent: expiredOperatorIntent,
+      intentArtifact: createAflTradeCanonicalJsonArtifactRef(
+        expiredOperatorIntent,
+        expiredOperatorRequestedAt
+      ),
+      materialization: expiredOperatorMaterialization,
+    });
+    const expiredOperatorTransitionedAt = new Date(
+      Date.parse(expiredOperatorRequestedAt) + 30_000
+    ).toISOString();
+    const expiredOperatorReceipt = createGovernedPrivateEvaluationTransitionReceipt({
+      intent: expiredOperatorIntent,
+      previousTransitionId: null,
+      toGenerationId: expiredOperatorMaterialization.generation.generationId,
+      transitionedAt: expiredOperatorTransitionedAt,
+    });
+    const expiredOperatorReceiptArtifact = await retainJson(
+      expiredOperatorReceipt,
+      expiredOperatorTransitionedAt
+    );
+    await expect(pool.query(
+      `INSERT INTO outcome_private_evaluation_transition_receipt
+        (transition_id,transition_intent_id,operation_id,valuation_scope_key,trade_id,
+         artifact_id,action,from_revision,from_status,from_generation_id,to_revision,
+         to_status,to_generation_id,transitioned_at,content_sha256,content_canonical_json,
+         receipt_json)
+       VALUES ($1,$2,$3,$4,$5,$6,'construct_and_activate',0,'absent',NULL,1,
+               'active',$7,$8,$9,$10,$11::jsonb)`,
+      [
+        expiredOperatorReceipt.transitionId,
+        expiredOperatorIntent.transitionIntentId,
+        expiredOperatorIntent.content.operationId,
+        selector.valuationScopeKey,
+        selector.tradeId,
+        expiredOperatorReceiptArtifact.artifactId,
+        expiredOperatorMaterialization.generation.generationId,
+        expiredOperatorTransitionedAt,
+        expiredOperatorReceipt.transitionId.slice(
+          'private-evaluation-transition:'.length
+        ),
+        canonicalizeAflTradeJson(expiredOperatorReceipt.content),
+        canonicalizeAflTradeJson(expiredOperatorReceipt),
+      ]
+    )).rejects.toThrow(/Legacy private receipt failed exact test-fixture authentication/i);
+    const operatorAuthorizedAt = new Date(Date.parse(currentTrustedAt) - 1_000).toISOString();
     await seedPrivateEvaluationOperator(operatorAuthorizedAt);
+    const forgedAt = await trustedNow();
+    const forgedInspection = await seedInspection(
+      { status: 'absent', revision: 0, generationId: null },
+      forgedAt
+    );
+    const validLegacyIntent = createGovernedPrivateEvaluationTransitionIntent({
+      selector,
+      inspectionId: forgedInspection.inspectionId,
+      authoritySnapshotId: forgedInspection.snapshotId,
+      operationId: createAflTradeContentAddress('private-evaluation-operation', {
+        marker: 'forged-legacy-intent',
+      }),
+      action: { kind: 'construct_and_activate' },
+      expectedHead: { status: 'absent', revision: 0, generationId: null },
+      review: {
+        principalId: 'firebase:test-operator',
+        rationale: 'This direct SQL fixture must fail closed.',
+      },
+      requestedAt: forgedAt,
+      expiresAt: forgedInspection.validThrough,
+    });
+    const forgedLegacyContent = {
+      ...validLegacyIntent.content,
+      publicationProhibited: 'true',
+    };
+    const forgedLegacyIntent = {
+      transitionIntentId: createAflTradeContentAddress(
+        'private-evaluation-transition-intent',
+        forgedLegacyContent
+      ),
+      content: forgedLegacyContent,
+    };
+    const forgedLegacyArtifact = createAflTradeCanonicalJsonArtifactRef(
+      forgedLegacyIntent,
+      forgedAt
+    );
+    await staging.retainArtifact({
+      reference: forgedLegacyArtifact,
+      bytes: canonicalBytes(forgedLegacyIntent),
+    });
+    await expect(pool.query(
+      `INSERT INTO outcome_private_evaluation_transition_intent
+        (transition_intent_id,inspection_id,authority_snapshot_id,operation_id,
+         valuation_scope_key,trade_id,artifact_id,action,expected_head_status,
+         expected_head_revision,expected_head_generation_id,target_generation_id,
+         requested_at,expires_at,content_sha256,content_canonical_json,intent_json)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,'construct_and_activate','absent',0,NULL,NULL,
+               $8,$9,$10,$11,$12::jsonb)`,
+      [
+        forgedLegacyIntent.transitionIntentId,
+        forgedInspection.inspectionId,
+        forgedInspection.snapshotId,
+        validLegacyIntent.content.operationId,
+        selector.valuationScopeKey,
+        selector.tradeId,
+        forgedLegacyArtifact.artifactId,
+        forgedAt,
+        forgedInspection.validThrough,
+        forgedLegacyIntent.transitionIntentId.slice(
+          'private-evaluation-transition-intent:'.length
+        ),
+        canonicalizeAflTradeJson(forgedLegacyContent),
+        canonicalizeAflTradeJson(forgedLegacyIntent),
+      ]
+    )).rejects.toThrow(/Legacy private intent failed exact test-fixture authentication/i);
+    const unauthorizedLegacyContent = {
+      ...validLegacyIntent.content,
+      operationId: createAflTradeContentAddress('private-evaluation-operation', {
+        marker: 'unauthorized-legacy-intent',
+      }),
+      review: {
+        principalId: 'firebase:unauthorized-operator',
+        rationale: 'This direct SQL authority forgery must fail closed.',
+      },
+    };
+    const unauthorizedLegacyIntent = {
+      transitionIntentId: createAflTradeContentAddress(
+        'private-evaluation-transition-intent',
+        unauthorizedLegacyContent
+      ),
+      content: unauthorizedLegacyContent,
+    };
+    const unauthorizedLegacyArtifact = createAflTradeCanonicalJsonArtifactRef(
+      unauthorizedLegacyIntent,
+      forgedAt
+    );
+    await staging.retainArtifact({
+      reference: unauthorizedLegacyArtifact,
+      bytes: canonicalBytes(unauthorizedLegacyIntent),
+    });
+    await expect(pool.query(
+      `INSERT INTO outcome_private_evaluation_transition_intent
+        (transition_intent_id,inspection_id,authority_snapshot_id,operation_id,
+         valuation_scope_key,trade_id,artifact_id,action,expected_head_status,
+         expected_head_revision,expected_head_generation_id,target_generation_id,
+         requested_at,expires_at,content_sha256,content_canonical_json,intent_json)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,'construct_and_activate','absent',0,NULL,NULL,
+               $8,$9,$10,$11,$12::jsonb)`,
+      [
+        unauthorizedLegacyIntent.transitionIntentId,
+        forgedInspection.inspectionId,
+        forgedInspection.snapshotId,
+        unauthorizedLegacyContent.operationId,
+        selector.valuationScopeKey,
+        selector.tradeId,
+        unauthorizedLegacyArtifact.artifactId,
+        forgedAt,
+        forgedInspection.validThrough,
+        unauthorizedLegacyIntent.transitionIntentId.slice(
+          'private-evaluation-transition-intent:'.length
+        ),
+        canonicalizeAflTradeJson(unauthorizedLegacyContent),
+        canonicalizeAflTradeJson(unauthorizedLegacyIntent),
+      ]
+    )).rejects.toThrow(/Legacy private intent failed exact test-fixture authentication/i);
     const activation = await transition({
       marker: 'activate',
       action: { kind: 'construct_and_activate' },
@@ -328,6 +1248,73 @@ describe('governed private evaluation PostgreSQL lifecycle', () => {
       previousTransitionId: null,
     });
     expect(activation.result).toMatchObject({ state: 'committed' });
+    const activeHead = {
+      status: 'active' as const,
+      revision: 1,
+      generationId: activation.generationId,
+    };
+    const crossIntentAt = await trustedNow();
+    const crossIntentInspection = await seedInspection(activeHead, crossIntentAt);
+    const createCrossIntent = (marker: string) =>
+      createGovernedPrivateEvaluationTransitionIntent({
+        selector,
+        inspectionId: crossIntentInspection.inspectionId,
+        authoritySnapshotId: crossIntentInspection.snapshotId,
+        operationId: createAflTradeContentAddress('private-evaluation-operation', { marker }),
+        action: { kind: 'construct_and_activate' },
+        expectedHead: activeHead,
+        review: {
+          principalId: 'firebase:test-operator',
+          rationale: 'Prove generation ancestry remains bound to its exact intent.',
+        },
+        requestedAt: crossIntentAt,
+        expiresAt: crossIntentInspection.validThrough,
+      });
+    const crossIntentA = createCrossIntent('cross-intent-a');
+    const crossMaterializationA = createGovernedPrivateEvaluationGeneration({
+      selector,
+      transitionIntentId: crossIntentA.transitionIntentId,
+      generatedAt: fixtureGenerationCreatedAt,
+      narrative: createGovernedPrivateEvaluationNarrativeFixture(),
+    });
+    await staging.stage({
+      intent: crossIntentA,
+      intentArtifact: createAflTradeCanonicalJsonArtifactRef(crossIntentA, crossIntentAt),
+      materialization: crossMaterializationA,
+    });
+    const crossIntentReceipt = createGovernedPrivateEvaluationTransitionReceipt({
+      intent: crossIntentA,
+      previousTransitionId: activation.receipt.transitionId,
+      toGenerationId: activation.generationId,
+      transitionedAt: crossIntentAt,
+    });
+    const crossIntentReceiptArtifact = await retainJson(
+      crossIntentReceipt,
+      crossIntentAt
+    );
+    await expect(pool.query(
+      `INSERT INTO outcome_private_evaluation_transition_receipt
+        (transition_id,transition_intent_id,operation_id,valuation_scope_key,trade_id,
+         artifact_id,action,from_revision,from_status,from_generation_id,to_revision,
+         to_status,to_generation_id,transitioned_at,content_sha256,content_canonical_json,
+         receipt_json)
+       VALUES ($1,$2,$3,$4,$5,$6,'construct_and_activate',1,'active',$7,2,
+               'active',$8,$9,$10,$11,$12::jsonb)`,
+      [
+        crossIntentReceipt.transitionId,
+        crossIntentA.transitionIntentId,
+        crossIntentA.content.operationId,
+        selector.valuationScopeKey,
+        selector.tradeId,
+        crossIntentReceiptArtifact.artifactId,
+        activation.generationId,
+        activation.generationId,
+        crossIntentAt,
+        crossIntentReceipt.transitionId.slice('private-evaluation-transition:'.length),
+        canonicalizeAflTradeJson(crossIntentReceipt.content),
+        canonicalizeAflTradeJson(crossIntentReceipt),
+      ]
+    )).rejects.toThrow(/Legacy private receipt failed exact test-fixture authentication/i);
     await expect(
       lifecycle.commit({
         receipt: activation.receipt,
@@ -451,7 +1438,9 @@ describe('governed private evaluation PostgreSQL lifecycle', () => {
 
     const head = await pool.query(
       `SELECT valuation_scope_key,trade_id,revision,status,generation_id,last_transition_id
-         FROM outcome_local_private_trade_evaluation_head`
+         FROM outcome_local_private_trade_evaluation_head
+        WHERE valuation_scope_key=$1 AND trade_id=$2`,
+      [selector.valuationScopeKey, selector.tradeId]
     );
     expect(head.rows).toEqual([
       {

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1091,6 +1091,7 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0062_authenticated_prepared_v3_ancestry',
       '0063_governed_pick_pav_model_execution',
       '0064_automated_model_pair_qualification',
+      '0065_automated_private_evaluation_authority',
     ]);
 
     const tables = await query<{ table_name: string }>(
@@ -1100,6 +1101,8 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
     const tableNames = new Set(tables.rows.map(({ table_name }) => table_name));
     for (const expected of [
       'outcome_artifact_custody',
+      'outcome_current_valuation_cohort_operation',
+      'outcome_current_valuation_cohort_operation_result',
       'outcome_governed_pick_pav_model_execution',
       'outcome_source_capture_attempt',
       'outcome_source_capture_season',

--- a/tests/testUtils/currentValuationCohortFixture.ts
+++ b/tests/testUtils/currentValuationCohortFixture.ts
@@ -1,0 +1,175 @@
+import { createAflTradePreparedValuationInputSet } from '@/server/aflTradeIntelligence/valuation/preparedValuationInputSet';
+import { createAflTradeCurrentValuationCohortPreparationOperationId } from '@/server/aflTradeIntelligence/valuation/currentValuationCohortPreparation';
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+
+const digest = (character: string) => character.repeat(64);
+const artifact = (character: string) => ({
+  artifactId: `artifact:${digest(character)}`,
+  contentSha256: digest(character),
+  storageUri: `artifact://sha256/${digest(character)}`,
+  mediaType: 'application/json',
+  byteLength: 256,
+  createdAt: '2026-08-20T08:00:00.000Z',
+});
+
+export function createAflTradeCurrentValuationBundleFixture(input: {
+  readonly scopeKey: string;
+  readonly playerRunId: string;
+  readonly pickRunId: string;
+}) {
+  const content = {
+    schemaVersion: 'afl-trade-valuation-input-bundle/v1' as const,
+    publicAssetBoundary: 'source_native_afl_assets_no_user_or_fantasy_ownership' as const,
+    environment: 'non_production' as const,
+    scopeKey: input.scopeKey,
+    valueUnitId: 'contribution-above-replacement-v1',
+    createdAt: '2026-08-20T08:30:00.000Z',
+    components: [
+      {
+        role: 'player_contribution_and_availability' as const,
+        modelKind: 'player_contribution_and_availability' as const,
+        protocolId: `model-protocol:${digest('1')}`,
+        runId: input.playerRunId,
+        datasetId: `dataset:${digest('2')}`,
+        gate3DecisionId: `gate-decision:${digest('3')}`,
+      },
+      {
+        role: 'draft_pick_and_future_pick_distribution' as const,
+        modelKind: 'draft_pick_and_future_pick_distribution' as const,
+        protocolId: `model-protocol:${digest('4')}`,
+        runId: input.pickRunId,
+        datasetId: `dataset:${digest('5')}`,
+        gate3DecisionId: `gate-decision:${digest('6')}`,
+      },
+    ],
+    viewPolicy: {
+      atTrade: {
+        modelVintage: 'historical_restatement' as const,
+        knowledgeCutoff: 'transaction_effective_at_exclusive' as const,
+      },
+      current: {
+        modelVintage: 'current' as const,
+        effectiveAt: '2026-08-21T07:00:00.000Z',
+        knowledgeCutoffAt: '2026-08-21T07:00:00.000Z',
+        valuationAsOf: '2026-08-21T08:00:00.000Z',
+      },
+      currentViewsShareOneTemporalContext: true as const,
+    },
+    packagePolicy: {
+      calculationUnit: 'complete_multi_party_trade' as const,
+      attribution: 'lineage_frontier_exactly_once' as const,
+      aggregation: 'joint_simulation_not_independent_point_sum' as const,
+      currentOutcomeIdentity: 'realized_club_value_plus_remaining_asset_value' as const,
+      unresolvedAssetTreatment: 'exclude_with_explicit_reason_no_fallback_value' as const,
+      listSpotPolicyArtifact: artifact('7'),
+      scarcityPolicyArtifact: artifact('8'),
+      roleCongestionPolicyArtifact: artifact('9'),
+    },
+    simulation: {
+      mode: 'deterministic_counter_sample' as const,
+      draws: 10_000,
+      seed: 'current-cohort-fixture-seed',
+      samplingAlgorithmVersion: 'counter_sha256_rejection_v1' as const,
+      centralIntervalLevel: 0.8 as const,
+      downsideQuantile: 0.1 as const,
+      upsideQuantile: 0.9 as const,
+      lowReturnDefinitionArtifact: artifact('a'),
+      eliteOutcomeDefinitionArtifact: artifact('b'),
+      practicalEquivalenceDefinitionArtifact: artifact('c'),
+    },
+    explanationPolicyArtifact: artifact('d'),
+    publicationEligible: false as const,
+    limitation:
+      'Approved calculation inputs only; not execution evidence, numerical validity, publication approval, or activation authority.' as const,
+  };
+  const valuationInputBundle = {
+    valuationInputBundleId: createAflTradeContentAddress('valuation-input-bundle', content),
+    content,
+  };
+  return {
+    valuationInputBundle,
+    valuationInputBundleId: valuationInputBundle.valuationInputBundleId,
+    valuationInputBundleArtifact: createAflTradeCanonicalJsonArtifactRef(
+      valuationInputBundle,
+      content.createdAt
+    ),
+  };
+}
+
+export function createAflTradeCurrentValuationCohortFixture() {
+  const playerRunId = `model-run:${digest('9')}`;
+  const pickRunId = `model-run:${digest('a')}`;
+  const bundle = createAflTradeCurrentValuationBundleFixture({
+    scopeKey: 'afl-men:2026-trades',
+    playerRunId,
+    pickRunId,
+  });
+  const operationId = createAflTradeCurrentValuationCohortPreparationOperationId({
+    scopeKey: 'afl-men:2026-trades',
+    factualReleaseId: `outcome-release:${digest('2')}`,
+    factualReleaseRevision: 7,
+    modelQualificationId: `model-qualification:${digest('8')}`,
+    modelQualificationWorkId: `model-qualification-work:${digest('0')}`,
+    modelQualificationRevision: 3,
+    expectedPreparedInputRevision: 11,
+  });
+  const context = {
+    operationId,
+    scopeKey: 'afl-men:2026-trades',
+    factualReleaseScopeKey: 'public-afl-draft-trade-outcomes',
+    factualReleaseId: `outcome-release:${digest('2')}`,
+    factualReleaseRevision: 7,
+    factualReleaseArtifact: artifact('3'),
+    releaseMembershipArtifact: artifact('4'),
+    releaseTradeIds: ['trade-a'],
+    sourceQualificationReportId: `valuation-source-qualification:${digest('5')}`,
+    sourceQualificationReportArtifact: artifact('6'),
+    sourceQualificationEvidenceRefs: [artifact('7')],
+    modelQualificationId: `model-qualification:${digest('8')}`,
+    modelQualificationWorkId: `model-qualification-work:${digest('0')}`,
+    modelQualificationRevision: 3,
+    playerRunId,
+    pickRunId,
+    expectedPreparedInputRevision: 11,
+    valuationInputBundleId: bundle.valuationInputBundleId,
+    valuationInputBundleArtifact: bundle.valuationInputBundleArtifact,
+    capturedAt: '2026-08-21T09:00:00.000Z',
+  } as const;
+  const preparedInputSet = createAflTradePreparedValuationInputSet({
+    schemaVersion: 'afl-trade-prepared-valuation-input-set/v3',
+    environment: 'non_production',
+    scopeKey: context.scopeKey,
+    factualReleaseScopeKey: context.factualReleaseScopeKey,
+    factualReleaseId: context.factualReleaseId,
+    factualReleaseArtifact: context.factualReleaseArtifact,
+    releaseMembershipArtifact: context.releaseMembershipArtifact,
+    preparationAuthority: 'authenticated_calculation_evidence_snapshot',
+    qualificationOperation: 'valuation_model_training_and_derived_feature_creation',
+    qualificationReportId: context.sourceQualificationReportId,
+    qualificationReportArtifact: context.sourceQualificationReportArtifact,
+    sourceQualificationEvidenceRefs: context.sourceQualificationEvidenceRefs,
+    valuationInputBundleId: context.valuationInputBundleId,
+    valuationInputBundleArtifact: context.valuationInputBundleArtifact,
+    releaseTradeIds: context.releaseTradeIds,
+    entries: [{
+      tradeId: 'trade-a',
+      state: 'ready',
+      materializationManifestId: `private-evaluation-materialization-manifest:${digest('d')}`,
+      materializationManifestArtifact: artifact('e'),
+    }],
+    tradeCount: 1,
+    readyCount: 1,
+    blockedCount: 0,
+    preparedAt: context.capturedAt,
+    publicationEligible: false,
+    limitation:
+      'Private preparation evidence only; not a valuation result, publication approval, or activation authority.',
+  });
+  return {
+    context,
+    valuationInputBundle: bundle.valuationInputBundle,
+    preparedInputSet,
+    commitInput: { context, preparedInputSet },
+  };
+}

--- a/tests/unit/afl-trade-intelligence-automated-private-evaluation-lifecycle.test.ts
+++ b/tests/unit/afl-trade-intelligence-automated-private-evaluation-lifecycle.test.ts
@@ -1,0 +1,57 @@
+import {
+  createAutomatedGovernedPrivateEvaluationTransitionIntent,
+  createAutomatedGovernedPrivateEvaluationTransitionReceipt,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle';
+
+const addressed = (prefix: string, value: string) => `${prefix}:${value.repeat(64).slice(0, 64)}`;
+
+describe('automated governed private evaluation lifecycle', () => {
+  it('authorizes only non-production construct-and-activate under a narrow system principal', () => {
+    const intent = createAutomatedGovernedPrivateEvaluationTransitionIntent({
+      selector: {
+        valuationScopeKey: 'afl.mens.trade-value:2026',
+        tradeId: 'trade:2026-001',
+      },
+      inspectionId: addressed('private-evaluation-inspection', 'a'),
+      authoritySnapshotId: addressed('private-evaluation-authority-snapshot', 'b'),
+      operationId: addressed('private-evaluation-operation', 'c'),
+      action: { kind: 'construct_and_activate' },
+      expectedHead: { status: 'absent', revision: 0, generationId: null },
+      constructionAuthority: {
+        kind: 'automated_private_calculation_agent',
+        principalId: 'system:weekly-valuation-coordinator',
+      },
+      requestedAt: '2026-08-21T09:00:00.000Z',
+      expiresAt: '2026-08-21T09:10:00.000Z',
+    });
+    const receipt = createAutomatedGovernedPrivateEvaluationTransitionReceipt({
+      intent,
+      previousTransitionId: null,
+      toGenerationId: addressed('local-private-trade-evaluation-generation', 'd'),
+      transitionedAt: '2026-08-21T09:01:00.000Z',
+    });
+
+    expect(intent.content).toMatchObject({
+      schemaVersion: 'private-evaluation-transition-intent/v2',
+      environment: 'non_production',
+      action: { kind: 'construct_and_activate' },
+      publicationProhibited: true,
+    });
+    expect(intent.content).not.toHaveProperty('review');
+    expect(receipt.content).toMatchObject({
+      schemaVersion: 'private-evaluation-transition-receipt/v2',
+      environment: 'non_production',
+      toHead: {
+        status: 'active',
+        revision: 1,
+        generationId: addressed('local-private-trade-evaluation-generation', 'd'),
+      },
+      publicationProhibited: true,
+    });
+
+    expect(() => createAutomatedGovernedPrivateEvaluationTransitionIntent({
+      ...intent.content,
+      action: { kind: 'withdraw', reason: 'not allowed' },
+    } as never)).toThrow();
+  });
+});

--- a/tests/unit/afl-trade-intelligence-automated-private-evaluation-lifecycle.test.ts
+++ b/tests/unit/afl-trade-intelligence-automated-private-evaluation-lifecycle.test.ts
@@ -53,5 +53,14 @@ describe('automated governed private evaluation lifecycle', () => {
       ...intent.content,
       action: { kind: 'withdraw', reason: 'not allowed' },
     } as never)).toThrow();
+    expect(() =>
+      createAutomatedGovernedPrivateEvaluationTransitionIntent({
+        ...intent.content,
+        constructionAuthority: {
+          kind: 'automated_private_calculation_agent',
+          principalId: 'system:unconfigured-agent',
+        },
+      })
+    ).toThrow(/weekly-valuation-coordinator/i);
   });
 });

--- a/tests/unit/afl-trade-intelligence-automated-private-evaluation-staging.test.ts
+++ b/tests/unit/afl-trade-intelligence-automated-private-evaluation-staging.test.ts
@@ -18,8 +18,7 @@ describe('automated private evaluation staging', () => {
         generationId: input.materialization.generation.generationId,
       };
     });
-    const service = createAutomatedGovernedPrivateEvaluationStagingService({
-      principalId: 'system:weekly-valuation-coordinator',
+    const dependencies = {
       trustedNow: async () => '2026-08-21T09:00:00.000Z',
       loadStaged: async () => staged === null ? null : ({
         selector: staged.intent.content.selector,
@@ -49,7 +48,15 @@ describe('automated private evaluation staging', () => {
         head: receipt.content.toHead,
         transitionId: receipt.transitionId,
       }),
-    });
+    };
+    const legacyDependencies = {
+      ...dependencies,
+      principalId: 'system:weekly-valuation-coordinator',
+    };
+    expect(() =>
+      createAutomatedGovernedPrivateEvaluationStagingService(legacyDependencies)
+    ).toThrow('does not accept a caller-supplied principal');
+    const service = createAutomatedGovernedPrivateEvaluationStagingService(dependencies);
     const request = {
       selector: fixture.materializationManifest.content.selector,
       operationId: `private-evaluation-operation:${'c'.repeat(64)}`,

--- a/tests/unit/afl-trade-intelligence-automated-private-evaluation-staging.test.ts
+++ b/tests/unit/afl-trade-intelligence-automated-private-evaluation-staging.test.ts
@@ -1,0 +1,79 @@
+import { replayGovernedPrivateEvaluationMaterialization } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationMaterializer';
+import { createAutomatedGovernedPrivateEvaluationStagingService } from '@/server/aflTradeIntelligence/valuation/internal/automatedGovernedPrivateEvaluationStagingService';
+import type { GovernedPrivateEvaluationGenerationMaterialization } from '@/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration';
+import type { AutomatedGovernedPrivateEvaluationTransitionIntent } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle';
+import { createGovernedPrivateEvaluationAuthenticatedCalculationFixture } from '../testUtils/governedPrivateEvaluationAuthenticatedCalculationFixture';
+
+describe('automated private evaluation staging', () => {
+  it('constructs without manual scoring and resumes the same staged operation', async () => {
+    const fixture = createGovernedPrivateEvaluationAuthenticatedCalculationFixture();
+    let staged: {
+      intent: AutomatedGovernedPrivateEvaluationTransitionIntent;
+      materialization: GovernedPrivateEvaluationGenerationMaterialization;
+    } | null = null;
+    const stage = vi.fn(async (input) => {
+      staged = input;
+      return {
+        transitionIntentId: input.intent.transitionIntentId,
+        generationId: input.materialization.generation.generationId,
+      };
+    });
+    const service = createAutomatedGovernedPrivateEvaluationStagingService({
+      principalId: 'system:weekly-valuation-coordinator',
+      trustedNow: async () => '2026-08-21T09:00:00.000Z',
+      loadStaged: async () => staged === null ? null : ({
+        selector: staged.intent.content.selector,
+        principalId: staged.intent.content.constructionAuthority.principalId,
+        generationId: staged.materialization.generation.generationId,
+        intent: staged.intent,
+        previousTransitionId: null,
+      }),
+      captureAuthority: async ({ selector }) => ({
+        state: 'ready',
+        selector,
+        inspectionId: `private-evaluation-inspection:${'a'.repeat(64)}`,
+        authoritySnapshotId: `private-evaluation-authority-snapshot:${'b'.repeat(64)}`,
+        validThrough: '2026-08-21T09:10:00.000Z',
+        head: { status: 'absent', revision: 0, generationId: null },
+        previousTransitionId: null,
+        materializationManifestId: fixture.materializationManifest.manifestId,
+      }),
+      replayMaterialization: async () => replayGovernedPrivateEvaluationMaterialization({
+        ...fixture,
+        playerObservations: [],
+      }),
+      stage,
+      retainArtifact: async ({ reference }) => reference,
+      commit: async ({ receipt }) => ({
+        state: 'committed',
+        head: receipt.content.toHead,
+        transitionId: receipt.transitionId,
+      }),
+    });
+    const request = {
+      selector: fixture.materializationManifest.content.selector,
+      operationId: `private-evaluation-operation:${'c'.repeat(64)}`,
+    };
+
+    const first = await service.stage(request);
+    const replay = await service.stage(request);
+
+    expect(first).toEqual(replay);
+    expect(first).toMatchObject({
+      state: 'activated',
+      selector: request.selector,
+      head: { status: 'active', revision: 1 },
+    });
+    expect(stage).toHaveBeenCalledTimes(1);
+    expect(staged?.intent.content).toMatchObject({
+      schemaVersion: 'private-evaluation-transition-intent/v2',
+      environment: 'non_production',
+      constructionAuthority: { principalId: 'system:weekly-valuation-coordinator' },
+    });
+    expect(staged?.materialization.generation.content).toMatchObject({
+      schemaVersion: 'local-private-trade-evaluation-generation/v2',
+      environment: 'non_production',
+      publicationProhibited: true,
+    });
+  });
+});

--- a/tests/unit/afl-trade-intelligence-current-valuation-cohort-preparation.test.ts
+++ b/tests/unit/afl-trade-intelligence-current-valuation-cohort-preparation.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AflTradeCurrentValuationTradeUnavailableError,
+  createAflTradeCurrentValuationCohortCoordinator,
+} from '@/server/aflTradeIntelligence/valuation/currentValuationCohortPreparation';
+import { createAflTradeCurrentValuationBundleFixture } from '../testUtils/currentValuationCohortFixture';
+
+const digest = (character: string) => character.repeat(64);
+
+function artifact(character: string, createdAt = '2026-08-21T08:00:00.000Z') {
+  const contentSha256 = digest(character);
+  return {
+    artifactId: `artifact:${contentSha256}`,
+    contentSha256,
+    storageUri: `artifact://sha256/${contentSha256}`,
+    mediaType: 'application/json',
+    byteLength: 256,
+    createdAt,
+  };
+}
+
+describe('current AFL trade valuation cohort preparation', () => {
+  it('classifies every current factual-release trade in one authenticated prepared-v3 cohort', async () => {
+    const attempted: string[] = [];
+    const bundle = createAflTradeCurrentValuationBundleFixture({
+      scopeKey: 'afl-men:2026-trades',
+      playerRunId: 'model-run:' + digest('9'),
+      pickRunId: 'model-run:' + digest('a'),
+    });
+    const coordinator = createAflTradeCurrentValuationCohortCoordinator({
+      captureCurrent: async () => ({
+        operationId: 'valuation-cohort-preparation-operation:' + digest('1'),
+        scopeKey: 'afl-men:2026-trades',
+        factualReleaseScopeKey: 'public-afl-draft-trade-outcomes',
+        factualReleaseId: 'outcome-release:' + digest('2'),
+        factualReleaseRevision: 7,
+        factualReleaseArtifact: artifact('3'),
+        releaseMembershipArtifact: artifact('4'),
+        releaseTradeIds: ['trade-a', 'trade-b'],
+        sourceQualificationReportId: 'valuation-source-qualification:' + digest('5'),
+        sourceQualificationReportArtifact: artifact('6'),
+        sourceQualificationEvidenceRefs: [artifact('7')],
+        modelQualificationId: 'model-qualification:' + digest('8'),
+        modelQualificationWorkId: 'model-qualification-work:' + digest('0'),
+        modelQualificationRevision: 3,
+        playerRunId: 'model-run:' + digest('9'),
+        pickRunId: 'model-run:' + digest('a'),
+        expectedPreparedInputRevision: 11,
+        valuationInputBundleId: bundle.valuationInputBundleId,
+        valuationInputBundleArtifact: bundle.valuationInputBundleArtifact,
+        capturedAt: '2026-08-21T09:00:00.000Z',
+      }),
+      prepareTrade: async ({ tradeId }) => {
+        attempted.push(tradeId);
+        if (tradeId === 'trade-b') {
+          throw new AflTradeCurrentValuationTradeUnavailableError(
+            'isolated construction failure'
+          );
+        }
+        return {
+              tradeId,
+              state: 'ready',
+              materializationManifestId:
+                'private-evaluation-materialization-manifest:' + digest('d'),
+              materializationManifestArtifact: artifact(
+                'e',
+                '2026-08-21T08:30:00.000Z'
+              ),
+            };
+      },
+      commitIfCurrent: async ({ preparedInputSet }) => ({
+        state: 'advanced',
+        preparedInputSet,
+        head: {
+          scopeKey: preparedInputSet.content.scopeKey,
+          preparedInputSetId: preparedInputSet.preparedInputSetId,
+          revision: 12,
+          activatedAt: preparedInputSet.content.preparedAt,
+        },
+      }),
+    });
+
+    const result = await coordinator.prepare({
+      operationId: 'valuation-cohort-preparation-operation:' + digest('1'),
+      scopeKey: 'afl-men:2026-trades',
+    });
+
+    expect(result.state).toBe('advanced');
+    if (result.state !== 'advanced') throw new Error('Expected an advanced cohort.');
+    expect(result.preparedInputSet.content).toMatchObject({
+      schemaVersion: 'afl-trade-prepared-valuation-input-set/v3',
+      releaseTradeIds: ['trade-a', 'trade-b'],
+      tradeCount: 2,
+      readyCount: 1,
+      blockedCount: 1,
+      preparedAt: '2026-08-21T08:30:00.000Z',
+      publicationEligible: false,
+    });
+    expect(result.preparedInputSet.content.entries.map(({ tradeId, state }) => ({
+      tradeId,
+      state,
+    }))).toEqual([
+      { tradeId: 'trade-a', state: 'ready' },
+      { tradeId: 'trade-b', state: 'blocked' },
+    ]);
+    expect(attempted.sort()).toEqual(['trade-a', 'trade-b']);
+    expect(result.preparedInputSet.content.entries[1]).toMatchObject({
+      blockers: [{ code: 'component_output_unavailable' }],
+    });
+  });
+
+  it('aborts without committing when trade preparation reports an unexpected defect', async () => {
+    const commitIfCurrent = vi.fn();
+    const bundle = createAflTradeCurrentValuationBundleFixture({
+      scopeKey: 'afl-men:2026-trades',
+      playerRunId: 'model-run:' + digest('9'),
+      pickRunId: 'model-run:' + digest('a'),
+    });
+    const coordinator = createAflTradeCurrentValuationCohortCoordinator({
+      captureCurrent: async () => ({
+        operationId: 'valuation-cohort-preparation-operation:' + digest('1'),
+        scopeKey: 'afl-men:2026-trades',
+        factualReleaseScopeKey: 'public-afl-draft-trade-outcomes',
+        factualReleaseId: 'outcome-release:' + digest('2'),
+        factualReleaseRevision: 7,
+        factualReleaseArtifact: artifact('3'),
+        releaseMembershipArtifact: artifact('4'),
+        releaseTradeIds: ['trade-a'],
+        sourceQualificationReportId: 'valuation-source-qualification:' + digest('5'),
+        sourceQualificationReportArtifact: artifact('6'),
+        sourceQualificationEvidenceRefs: [artifact('7')],
+        modelQualificationId: 'model-qualification:' + digest('8'),
+        modelQualificationWorkId: 'model-qualification-work:' + digest('0'),
+        modelQualificationRevision: 3,
+        playerRunId: 'model-run:' + digest('9'),
+        pickRunId: 'model-run:' + digest('a'),
+        expectedPreparedInputRevision: 11,
+        valuationInputBundleId: bundle.valuationInputBundleId,
+        valuationInputBundleArtifact: bundle.valuationInputBundleArtifact,
+        capturedAt: '2026-08-21T09:00:00.000Z',
+      }),
+      prepareTrade: async () => {
+        throw new TypeError('retained ancestry mismatch');
+      },
+      commitIfCurrent,
+    });
+
+    await expect(coordinator.prepare({
+      operationId: 'valuation-cohort-preparation-operation:' + digest('1'),
+      scopeKey: 'afl-men:2026-trades',
+    })).rejects.toThrow('retained ancestry mismatch');
+    expect(commitIfCurrent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/afl-trade-intelligence-current-valuation-trade-preparer.test.ts
+++ b/tests/unit/afl-trade-intelligence-current-valuation-trade-preparer.test.ts
@@ -1,0 +1,155 @@
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { createAflTradeCurrentValuationTradePreparer } from '@/server/aflTradeIntelligence/valuation/currentValuationTradePreparation';
+import { createGovernedPrivateEvaluationAuthenticatedCalculationFixture } from '../testUtils/governedPrivateEvaluationAuthenticatedCalculationFixture';
+import { createAflTradeCurrentValuationCohortFixture } from '../testUtils/currentValuationCohortFixture';
+
+describe('current valuation trade preparation', () => {
+  it('retains and registers exact constructed parents idempotently', async () => {
+    const fixture = createGovernedPrivateEvaluationAuthenticatedCalculationFixture();
+    const cohort = createAflTradeCurrentValuationCohortFixture();
+    const artifact = createAflTradeCanonicalJsonArtifactRef(
+      fixture.materializationManifest,
+      fixture.materializationManifest.content.createdAt
+    );
+    const retained: string[] = [];
+    const registered: string[] = [];
+    const retainedParents = [
+      {
+        reference: fixture.materializationManifest.content.calculationInputArtifact,
+        value: fixture.calculationInputPackage,
+      },
+      {
+        reference: fixture.materializationManifest.content.inputTraceArtifact,
+        value: fixture.trace,
+      },
+      {
+        reference: fixture.materializationManifest.content.explanationPolicyArtifact,
+        value: fixture.explanationPolicy,
+      },
+      {
+        reference: fixture.materializationManifest.content.lineageGraphArtifact,
+        value: fixture.lineageGraph,
+      },
+      {
+        reference: fixture.materializationManifest.content.pickBenchmarks[0]!.artifact,
+        value: fixture.pickBenchmarks[0],
+      },
+    ].map(({ reference, value }) => ({
+      reference,
+      bytes: new TextEncoder().encode(canonicalizeAflTradeJson(value)),
+    }));
+    const preparer = createAflTradeCurrentValuationTradePreparer({
+      construct: async () => ({
+        state: 'ready',
+        manifest: fixture.materializationManifest,
+        manifestArtifact: artifact,
+        retainedParents,
+      }),
+      retainArtifact: async ({ reference }) => {
+        retained.push(reference.artifactId);
+        return reference;
+      },
+      registerManifest: async ({ manifest, artifact: registeredArtifact }) => {
+        registered.push(manifest.manifestId);
+        return { manifest, artifact: registeredArtifact };
+      },
+    });
+
+    const input = {
+      context: {
+        ...cohort.context,
+        scopeKey: fixture.materializationManifest.content.selector.valuationScopeKey,
+        factualReleaseId: fixture.trace.content.factualReleaseId,
+        releaseTradeIds: [fixture.materializationManifest.content.selector.tradeId],
+        playerRunId: fixture.trace.content.components.find(
+          ({ role }) => role === 'player_contribution_and_availability'
+        )!.runId,
+        pickRunId: fixture.trace.content.components.find(
+          ({ role }) => role === 'draft_pick_and_future_pick_distribution'
+        )!.runId,
+        valuationInputBundleId: fixture.trace.content.valuationInputBundleId,
+      },
+      tradeId: fixture.materializationManifest.content.selector.tradeId,
+    };
+    const first = await preparer.prepare(input);
+    const replay = await preparer.prepare(input);
+
+    expect(first).toEqual(replay);
+    expect(first).toMatchObject({
+      tradeId: input.tradeId,
+      state: 'ready',
+      materializationManifestId: fixture.materializationManifest.manifestId,
+      materializationManifestArtifact: artifact,
+    });
+    const expectedRetention = [
+      ...retainedParents
+        .map(({ reference }) => reference.artifactId)
+        .sort((left, right) => left.localeCompare(right)),
+      artifact.artifactId,
+    ];
+    expect(retained).toEqual([...expectedRetention, ...expectedRetention]);
+    expect(registered).toEqual([
+      fixture.materializationManifest.manifestId,
+      fixture.materializationManifest.manifestId,
+    ]);
+  });
+
+  it('rejects retained construction from a stale captured release before retention', async () => {
+    const fixture = createGovernedPrivateEvaluationAuthenticatedCalculationFixture();
+    const cohort = createAflTradeCurrentValuationCohortFixture();
+    const manifestArtifact = createAflTradeCanonicalJsonArtifactRef(
+      fixture.materializationManifest,
+      fixture.materializationManifest.content.createdAt
+    );
+    const retainedParents = [
+      [
+        fixture.materializationManifest.content.calculationInputArtifact,
+        fixture.calculationInputPackage,
+      ],
+      [fixture.materializationManifest.content.inputTraceArtifact, fixture.trace],
+      [
+        fixture.materializationManifest.content.explanationPolicyArtifact,
+        fixture.explanationPolicy,
+      ],
+      [fixture.materializationManifest.content.lineageGraphArtifact, fixture.lineageGraph],
+      [
+        fixture.materializationManifest.content.pickBenchmarks[0]!.artifact,
+        fixture.pickBenchmarks[0],
+      ],
+    ].map(([reference, value]) => ({
+      reference: reference!,
+      bytes: new TextEncoder().encode(canonicalizeAflTradeJson(value)),
+    }));
+    const retainArtifact = vi.fn(async ({ reference }) => reference);
+    const preparer = createAflTradeCurrentValuationTradePreparer({
+      construct: async () => ({
+        state: 'ready',
+        manifest: fixture.materializationManifest,
+        manifestArtifact,
+        retainedParents,
+      }),
+      retainArtifact,
+      registerManifest: async ({ manifest, artifact }) => ({ manifest, artifact }),
+    });
+
+    await expect(
+      preparer.prepare({
+        context: {
+          ...cohort.context,
+          scopeKey: fixture.trace.content.selector.valuationScopeKey,
+          releaseTradeIds: [fixture.trace.content.selector.tradeId],
+          valuationInputBundleId: fixture.trace.content.valuationInputBundleId,
+          playerRunId: fixture.trace.content.components.find(
+            ({ role }) => role === 'player_contribution_and_availability'
+          )!.runId,
+          pickRunId: fixture.trace.content.components.find(
+            ({ role }) => role === 'draft_pick_and_future_pick_distribution'
+          )!.runId,
+        },
+        tradeId: fixture.trace.content.selector.tradeId,
+      })
+    ).rejects.toThrow(/captured release, model, or bundle authority/u);
+    expect(retainArtifact).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-generation.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-generation.test.ts
@@ -4,6 +4,7 @@ import {
   parseGovernedPrivateEvaluationProjectionManifest,
   verifyGovernedPrivateEvaluationGeneration,
 } from '@/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration';
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import { createGovernedPrivateEvaluationNarrativeFixture } from '../testUtils/governedPrivateEvaluationFixture';
 
 describe('automated governed private evaluation generation', () => {
@@ -44,5 +45,52 @@ describe('automated governed private evaluation generation', () => {
       },
     });
     expect(verifyGovernedPrivateEvaluationGeneration(materialization)).toBe(true);
+  });
+
+  it('rejects every non-canonical automated principal in construction and retained bytes', () => {
+    const narrative = createGovernedPrivateEvaluationNarrativeFixture();
+    const input = {
+      selector: {
+        valuationScopeKey: 'afl.mens.trade-value:2026',
+        tradeId: narrative.content.tradeId,
+      },
+      transitionIntentId: `private-evaluation-transition-intent:${'a'.repeat(64)}`,
+      generatedAt: '2026-08-21T09:00:00.000Z',
+      narrative,
+    };
+
+    expect(() =>
+      createAutomatedGovernedPrivateEvaluationGeneration({
+        ...input,
+        constructionAuthority: {
+          kind: 'automated_private_calculation_agent',
+          principalId: 'system:unconfigured-agent',
+        },
+      })
+    ).toThrow();
+
+    const retained = createAutomatedGovernedPrivateEvaluationGeneration({
+      ...input,
+      constructionAuthority: {
+        kind: 'automated_private_calculation_agent',
+        principalId: 'system:weekly-valuation-coordinator',
+      },
+    }).generation;
+    const forgedContent = {
+      ...retained.content,
+      constructionAuthority: {
+        kind: 'automated_private_calculation_agent',
+        principalId: 'system:unconfigured-agent',
+      },
+    };
+    const forged = {
+      generationId: createAflTradeContentAddress(
+        'local-private-trade-evaluation-generation',
+        forgedContent
+      ),
+      content: forgedContent,
+    };
+
+    expect(() => parseGovernedPrivateEvaluationGeneration(forged)).toThrow();
   });
 });

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-generation.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-generation.test.ts
@@ -1,0 +1,48 @@
+import {
+  createAutomatedGovernedPrivateEvaluationGeneration,
+  parseGovernedPrivateEvaluationGeneration,
+  parseGovernedPrivateEvaluationProjectionManifest,
+  verifyGovernedPrivateEvaluationGeneration,
+} from '@/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration';
+import { createGovernedPrivateEvaluationNarrativeFixture } from '../testUtils/governedPrivateEvaluationFixture';
+
+describe('automated governed private evaluation generation', () => {
+  it('retains a publication-prohibited non-production generation under narrow agent authority', () => {
+    const narrative = createGovernedPrivateEvaluationNarrativeFixture();
+    const materialization = createAutomatedGovernedPrivateEvaluationGeneration({
+      selector: {
+        valuationScopeKey: 'afl.mens.trade-value:2026',
+        tradeId: narrative.content.tradeId,
+      },
+      transitionIntentId: `private-evaluation-transition-intent:${'a'.repeat(64)}`,
+      generatedAt: '2026-08-21T09:00:00.000Z',
+      constructionAuthority: {
+        kind: 'automated_private_calculation_agent',
+        principalId: 'system:weekly-valuation-coordinator',
+      },
+      narrative,
+    });
+
+    expect(parseGovernedPrivateEvaluationGeneration(materialization.generation)).toMatchObject({
+      content: {
+        schemaVersion: 'local-private-trade-evaluation-generation/v2',
+        environment: 'non_production',
+        constructionAuthority: {
+          kind: 'automated_private_calculation_agent',
+          principalId: 'system:weekly-valuation-coordinator',
+        },
+        publicationProhibited: true,
+      },
+    });
+    expect(
+      parseGovernedPrivateEvaluationProjectionManifest(materialization.projectionManifest)
+    ).toMatchObject({
+      content: {
+        schemaVersion: 'governed-private-evaluation-projection-manifest/v2',
+        environment: 'non_production',
+        publicationProhibited: true,
+      },
+    });
+    expect(verifyGovernedPrivateEvaluationGeneration(materialization)).toBe(true);
+  });
+});

--- a/tests/unit/afl-trade-intelligence-governed-private-evaluation-workspace.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-private-evaluation-workspace.test.ts
@@ -61,10 +61,15 @@ function createWorkspace() {
 }
 
 describe('GovernedPrivateEvaluationWorkspace', () => {
-  it('exposes only inspect, execute, and read', () => {
+  it('exposes only governed inspection, execution, automated staging, and reads', () => {
     const { workspace } = createWorkspace();
 
-    expect(Object.keys(workspace).sort()).toEqual(['execute', 'inspect', 'read']);
+    expect(Object.keys(workspace).sort()).toEqual([
+      'execute',
+      'inspect',
+      'read',
+      'stageAutomated',
+    ]);
   });
 
   it('keeps the internal composition constructor out of production imports', () => {

--- a/tests/unit/afl-trade-intelligence-postgres-current-valuation-cohort-commit.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-current-valuation-cohort-commit.test.ts
@@ -1,0 +1,138 @@
+import type {
+  AflOutcomeSqlQueryResult,
+  AflOutcomeSqlTransaction,
+} from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import {
+  createPostgresAflTradeCurrentValuationCohortAuthorityCapture,
+  createPostgresAflTradeCurrentValuationCohortCommitter,
+} from '@/server/aflTradeIntelligence/valuation/postgresCurrentValuationCohortPreparation';
+import { createAflTradeCurrentValuationCohortFixture } from '../testUtils/currentValuationCohortFixture';
+
+class CommitTransaction implements AflOutcomeSqlTransaction {
+  modelRevision = 3;
+  activated = false;
+  activatedPreparedInputSetId: string | null = null;
+  retainedContext: unknown | null = null;
+  retainedResult: { prepared_input_set_id: string; head_revision: number } | null = null;
+
+  async query<Row>(
+    sql: string,
+    parameters: readonly unknown[] = []
+  ): Promise<AflOutcomeSqlQueryResult<Row>> {
+    if (sql.includes('SET TRANSACTION ISOLATION LEVEL')) return { rows: [], rowCount: 0 };
+    if (sql.includes('pg_advisory_xact_lock')) return { rows: [{}], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+    if (sql.includes('FROM outcome_current_valuation_cohort_operation_result')) {
+      return {
+        rows: this.retainedResult === null ? [] : [this.retainedResult],
+        rowCount: this.retainedResult === null ? 0 : 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('FROM outcome_current_valuation_cohort_operation')) {
+      return {
+        rows: this.retainedContext === null ? [] : [{ context_json: this.retainedContext }],
+        rowCount: this.retainedContext === null ? 0 : 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('INSERT INTO outcome_current_valuation_cohort_operation_result')) {
+      this.retainedResult = {
+        prepared_input_set_id: String(parameters[1]),
+        head_revision: Number(parameters[2]),
+      };
+      return { rows: [], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('INSERT INTO outcome_current_valuation_cohort_operation')) {
+      this.retainedContext = JSON.parse(String(parameters[11]));
+      return { rows: [], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('transaction_timestamp()')) {
+      return { rows: [{ captured_at: '2026-08-21T09:00:00.000Z' }], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('FROM outcome_active_release')) {
+      return { rows: [{ release_id: `outcome-release:${'2'.repeat(64)}`, revision: 7 }], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('FROM outcome_current_governed_valuation_model_pair')) {
+      return {
+        rows: [{
+          revision: this.modelRevision,
+          qualification_id: `model-qualification:${'8'.repeat(64)}`,
+          player_run_id: `model-run:${'9'.repeat(64)}`,
+          pick_run_id: `model-run:${'a'.repeat(64)}`,
+          work_id: `model-qualification-work:${'0'.repeat(64)}`,
+        }],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('activate_outcome_current_prepared_valuation_input_set')) {
+      this.activated = true;
+      this.activatedPreparedInputSetId = String(parameters[1]);
+      return { rows: [{ activate_outcome_current_prepared_valuation_input_set: 12 }], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+    }
+    if (sql.includes('FROM outcome_current_prepared_valuation_input_set')) {
+      return {
+        rows: [{
+          scope_key: 'afl-men:2026-trades',
+          prepared_input_set_id:
+            this.activatedPreparedInputSetId ??
+            `prepared-valuation-input-set:${'f'.repeat(64)}`,
+          revision: this.activated ? 12 : 11,
+          activated_at: '2026-08-21T09:00:00.000Z',
+        }],
+        rowCount: 1,
+      } as AflOutcomeSqlQueryResult<Row>;
+    }
+    throw new Error(`Unexpected SQL: ${sql}`);
+  }
+}
+
+describe('PostgreSQL current valuation cohort commit', () => {
+  it('captures one exact factual, model, and prepared-head authority snapshot', async () => {
+    const fixture = createAflTradeCurrentValuationCohortFixture();
+    const transaction = new CommitTransaction();
+    const capture = createPostgresAflTradeCurrentValuationCohortAuthorityCapture({
+      client: { query: transaction.query.bind(transaction), transaction: async (work) => work(transaction) },
+      factualReleaseScopeKey: fixture.context.factualReleaseScopeKey,
+      loadConstructionEvidence: async () => ({
+        factualReleaseArtifact: fixture.context.factualReleaseArtifact,
+        releaseMembershipArtifact: fixture.context.releaseMembershipArtifact,
+        releaseTradeIds: fixture.context.releaseTradeIds,
+        sourceQualificationReportId: fixture.context.sourceQualificationReportId,
+        sourceQualificationReportArtifact: fixture.context.sourceQualificationReportArtifact,
+        sourceQualificationEvidenceRefs: fixture.context.sourceQualificationEvidenceRefs,
+        valuationInputBundleId: fixture.context.valuationInputBundleId,
+        valuationInputBundleArtifact: fixture.context.valuationInputBundleArtifact,
+        valuationInputBundle: fixture.valuationInputBundle,
+      }),
+    });
+
+    const request = {
+      operationId: fixture.context.operationId,
+      scopeKey: fixture.context.scopeKey,
+    };
+    await expect(capture(request)).resolves.toEqual(fixture.context);
+    transaction.activated = true;
+    await expect(capture(request)).resolves.toEqual(fixture.context);
+  });
+
+  it('recaptures exact factual and qualified-model authority before advancing', async () => {
+    const fixture = createAflTradeCurrentValuationCohortFixture();
+    const transaction = new CommitTransaction();
+    const commit = createPostgresAflTradeCurrentValuationCohortCommitter({
+      client: { query: transaction.query.bind(transaction), transaction: async (work) => work(transaction) },
+      registerPreparedInputSet: async () => fixture.preparedInputSet,
+    });
+
+    await expect(commit(fixture.commitInput)).resolves.toMatchObject({
+      state: 'advanced',
+      head: { revision: 12 },
+    });
+    expect(transaction.activated).toBe(true);
+
+    transaction.modelRevision = 4;
+    transaction.activated = false;
+    await expect(commit(fixture.commitInput)).resolves.toEqual({
+      state: 'stale_authority',
+      reason: 'The qualified model pair changed while the cohort was being prepared.',
+    });
+    expect(transaction.activated).toBe(false);
+  });
+});

--- a/tests/unit/afl-trade-intelligence-postgres-current-valuation-cohort-commit.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-current-valuation-cohort-commit.test.ts
@@ -15,40 +15,45 @@ class CommitTransaction implements AflOutcomeSqlTransaction {
   retainedContext: unknown | null = null;
   retainedResult: { prepared_input_set_id: string; head_revision: number } | null = null;
 
-  async query<Row>(
+  private operationResultQuery(
     sql: string,
     parameters: readonly unknown[] = []
-  ): Promise<AflOutcomeSqlQueryResult<Row>> {
-    if (sql.includes('SET TRANSACTION ISOLATION LEVEL')) return { rows: [], rowCount: 0 };
-    if (sql.includes('pg_advisory_xact_lock')) return { rows: [{}], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+  ): AflOutcomeSqlQueryResult<unknown> | null {
     if (sql.includes('FROM outcome_current_valuation_cohort_operation_result')) {
       return {
         rows: this.retainedResult === null ? [] : [this.retainedResult],
         rowCount: this.retainedResult === null ? 0 : 1,
-      } as AflOutcomeSqlQueryResult<Row>;
+      };
     }
     if (sql.includes('FROM outcome_current_valuation_cohort_operation')) {
       return {
         rows: this.retainedContext === null ? [] : [{ context_json: this.retainedContext }],
         rowCount: this.retainedContext === null ? 0 : 1,
-      } as AflOutcomeSqlQueryResult<Row>;
+      };
     }
     if (sql.includes('INSERT INTO outcome_current_valuation_cohort_operation_result')) {
       this.retainedResult = {
         prepared_input_set_id: String(parameters[1]),
         head_revision: Number(parameters[2]),
       };
-      return { rows: [], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+      return { rows: [], rowCount: 1 };
     }
     if (sql.includes('INSERT INTO outcome_current_valuation_cohort_operation')) {
       this.retainedContext = JSON.parse(String(parameters[11]));
-      return { rows: [], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+      return { rows: [], rowCount: 1 };
     }
+    return null;
+  }
+
+  private currentAuthorityQuery(sql: string): AflOutcomeSqlQueryResult<unknown> | null {
     if (sql.includes('transaction_timestamp()')) {
-      return { rows: [{ captured_at: '2026-08-21T09:00:00.000Z' }], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+      return { rows: [{ captured_at: '2026-08-21T09:00:00.000Z' }], rowCount: 1 };
     }
     if (sql.includes('FROM outcome_active_release')) {
-      return { rows: [{ release_id: `outcome-release:${'2'.repeat(64)}`, revision: 7 }], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+      return {
+        rows: [{ release_id: `outcome-release:${'2'.repeat(64)}`, revision: 7 }],
+        rowCount: 1,
+      };
     }
     if (sql.includes('FROM outcome_current_governed_valuation_model_pair')) {
       return {
@@ -60,12 +65,7 @@ class CommitTransaction implements AflOutcomeSqlTransaction {
           work_id: `model-qualification-work:${'0'.repeat(64)}`,
         }],
         rowCount: 1,
-      } as AflOutcomeSqlQueryResult<Row>;
-    }
-    if (sql.includes('activate_outcome_current_prepared_valuation_input_set')) {
-      this.activated = true;
-      this.activatedPreparedInputSetId = String(parameters[1]);
-      return { rows: [{ activate_outcome_current_prepared_valuation_input_set: 12 }], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+      };
     }
     if (sql.includes('FROM outcome_current_prepared_valuation_input_set')) {
       return {
@@ -78,8 +78,37 @@ class CommitTransaction implements AflOutcomeSqlTransaction {
           activated_at: '2026-08-21T09:00:00.000Z',
         }],
         rowCount: 1,
-      } as AflOutcomeSqlQueryResult<Row>;
+      };
     }
+    return null;
+  }
+
+  private activationQuery(
+    sql: string,
+    parameters: readonly unknown[]
+  ): AflOutcomeSqlQueryResult<unknown> | null {
+    if (!sql.includes('activate_outcome_current_prepared_valuation_input_set')) return null;
+    this.activated = true;
+    this.activatedPreparedInputSetId = String(parameters[1]);
+    return {
+      rows: [{ activate_outcome_current_prepared_valuation_input_set: 12 }],
+      rowCount: 1,
+    };
+  }
+
+  async query<Row>(
+    sql: string,
+    parameters: readonly unknown[] = []
+  ): Promise<AflOutcomeSqlQueryResult<Row>> {
+    if (sql.includes('SET TRANSACTION ISOLATION LEVEL')) return { rows: [], rowCount: 0 };
+    if (sql.includes('pg_advisory_xact_lock')) {
+      return { rows: [{}], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+    }
+    const result =
+      this.operationResultQuery(sql, parameters) ??
+      this.currentAuthorityQuery(sql) ??
+      this.activationQuery(sql, parameters);
+    if (result !== null) return result as AflOutcomeSqlQueryResult<Row>;
     throw new Error(`Unexpected SQL: ${sql}`);
   }
 }

--- a/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-staging.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-staging.test.ts
@@ -233,7 +233,7 @@ describe('PostgreSQL governed private evaluation staging repository', () => {
         artifactClass: 'derived_private',
       }),
       maximumArtifactBytes: 1_000_000,
-      automatedPrincipalId: 'system:weekly-valuation-coordinator',
+      enableAutomatedPrivateCalculation: true,
     });
 
     await expect(
@@ -241,7 +241,7 @@ describe('PostgreSQL governed private evaluation staging repository', () => {
     ).rejects.toThrow(/complete verified generation/i);
   });
 
-  it('rejects automated construction from a principal other than the configured agent', async () => {
+  it('rejects automated construction when automated calculation is not enabled', async () => {
     const automatedSelector = {
       valuationScopeKey: selector.valuationScopeKey,
       tradeId: 'trade:adelaide-st-kilda',
@@ -255,7 +255,7 @@ describe('PostgreSQL governed private evaluation staging repository', () => {
       expectedHead: { status: 'absent', revision: 0, generationId: null },
       constructionAuthority: {
         kind: 'automated_private_calculation_agent',
-        principalId: 'system:unconfigured-agent',
+        principalId: 'system:weekly-valuation-coordinator',
       },
       requestedAt: now,
       expiresAt: '2026-08-19T10:05:00.000Z',
@@ -267,7 +267,6 @@ describe('PostgreSQL governed private evaluation staging repository', () => {
         artifactClass: 'derived_private',
       }),
       maximumArtifactBytes: 1_000_000,
-      automatedPrincipalId: 'system:weekly-valuation-coordinator',
     });
 
     await expect(repository.stage({ intent, intentArtifact })).rejects.toThrow(

--- a/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-staging.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-staging.test.ts
@@ -29,6 +29,7 @@ class StagingSqlClient implements AflOutcomeSqlClient {
   readonly custodyParameters: readonly unknown[][] = [];
   intentParameters: readonly unknown[] | null = null;
   private readonly artifacts = new Map<string, AflTradeArtifactRef>();
+  private intentRegistered = false;
 
   constructor(
     private readonly retainedIntent: unknown,
@@ -46,6 +47,9 @@ class StagingSqlClient implements AflOutcomeSqlClient {
     parameters: readonly unknown[] = []
   ): Promise<AflOutcomeSqlQueryResult<Row>> {
     this.sql.push(statement);
+    if (statement.includes('pg_advisory_xact_lock(hashtextextended($1,0))')) {
+      return { rows: [], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
+    }
     if (statement.includes("date_trunc('milliseconds',transaction_timestamp())")) {
       return {
         rows: [{ trusted_at: new Date(now) }],
@@ -74,9 +78,13 @@ class StagingSqlClient implements AflOutcomeSqlClient {
     }
     if (statement.includes('INSERT INTO outcome_private_evaluation_transition_intent')) {
       this.intentParameters = parameters;
+      this.intentRegistered = true;
       return { rows: [], rowCount: 1 } as AflOutcomeSqlQueryResult<Row>;
     }
     if (statement.includes('FROM outcome_private_evaluation_transition_intent')) {
+      if (!this.intentRegistered) {
+        return { rows: [], rowCount: 0 } as AflOutcomeSqlQueryResult<Row>;
+      }
       return {
         rows: [
           {
@@ -141,6 +149,9 @@ describe('PostgreSQL governed private evaluation staging repository', () => {
     expect(client.sql.some((sql) => sql.includes('INSERT INTO outcome_artifact_custody'))).toBe(
       true
     );
+    expect(
+      client.sql.some((sql) => sql.includes('pg_advisory_xact_lock(hashtextextended($1,0))'))
+    ).toBe(true);
     expect(
       client.sql.some((sql) =>
         sql.includes('authority_snapshot_id')

--- a/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-staging.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-staging.test.ts
@@ -10,8 +10,13 @@ import type {
   AflOutcomeSqlQueryResult,
   AflOutcomeSqlTransaction,
 } from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
-import { createGovernedPrivateEvaluationTransitionIntent } from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle';
+import { createGovernedPrivateEvaluationGeneration } from '@/server/aflTradeIntelligence/valuation/governedPrivateEvaluationGeneration';
+import {
+  createAutomatedGovernedPrivateEvaluationTransitionIntent,
+  createGovernedPrivateEvaluationTransitionIntent,
+} from '@/server/aflTradeIntelligence/valuation/internal/governedPrivateEvaluationLifecycle';
 import { createPostgresGovernedPrivateEvaluationStagingRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationStagingRepository';
+import { createGovernedPrivateEvaluationNarrativeFixture } from '../testUtils/governedPrivateEvaluationFixture';
 
 const selector = {
   valuationScopeKey: 'afl-trade-history:test-fixture',
@@ -182,6 +187,80 @@ describe('PostgreSQL governed private evaluation staging repository', () => {
 
     await expect(repository.stage({ intent, intentArtifact: artifact })).rejects.toThrow(
       /complete verified generation/i
+    );
+  });
+
+  it('rejects a legacy generation presented under automated construction authority', async () => {
+    const automatedSelector = {
+      valuationScopeKey: selector.valuationScopeKey,
+      tradeId: 'trade:adelaide-st-kilda',
+    };
+    const intent = createAutomatedGovernedPrivateEvaluationTransitionIntent({
+      selector: automatedSelector,
+      inspectionId: `private-evaluation-inspection:${'a'.repeat(64)}`,
+      authoritySnapshotId: `private-evaluation-authority-snapshot:${'b'.repeat(64)}`,
+      operationId: `private-evaluation-operation:${'c'.repeat(64)}`,
+      action: { kind: 'construct_and_activate' },
+      expectedHead: { status: 'absent', revision: 0, generationId: null },
+      constructionAuthority: {
+        kind: 'automated_private_calculation_agent',
+        principalId: 'system:weekly-valuation-coordinator',
+      },
+      requestedAt: now,
+      expiresAt: '2026-08-19T10:05:00.000Z',
+    });
+    const intentArtifact = createAflTradeCanonicalJsonArtifactRef(intent, now);
+    const legacy = createGovernedPrivateEvaluationGeneration({
+      selector: automatedSelector,
+      transitionIntentId: intent.transitionIntentId,
+      generatedAt: now,
+      narrative: createGovernedPrivateEvaluationNarrativeFixture(),
+    });
+    const repository = createPostgresGovernedPrivateEvaluationStagingRepository({
+      client: new StagingSqlClient(intent, intentArtifact),
+      artifactRepository: createAflTradeFixtureArtifactRepository({
+        artifactClass: 'derived_private',
+      }),
+      maximumArtifactBytes: 1_000_000,
+      automatedPrincipalId: 'system:weekly-valuation-coordinator',
+    });
+
+    await expect(
+      repository.stage({ intent, intentArtifact, materialization: legacy })
+    ).rejects.toThrow(/complete verified generation/i);
+  });
+
+  it('rejects automated construction from a principal other than the configured agent', async () => {
+    const automatedSelector = {
+      valuationScopeKey: selector.valuationScopeKey,
+      tradeId: 'trade:adelaide-st-kilda',
+    };
+    const intent = createAutomatedGovernedPrivateEvaluationTransitionIntent({
+      selector: automatedSelector,
+      inspectionId: `private-evaluation-inspection:${'a'.repeat(64)}`,
+      authoritySnapshotId: `private-evaluation-authority-snapshot:${'b'.repeat(64)}`,
+      operationId: `private-evaluation-operation:${'c'.repeat(64)}`,
+      action: { kind: 'construct_and_activate' },
+      expectedHead: { status: 'absent', revision: 0, generationId: null },
+      constructionAuthority: {
+        kind: 'automated_private_calculation_agent',
+        principalId: 'system:unconfigured-agent',
+      },
+      requestedAt: now,
+      expiresAt: '2026-08-19T10:05:00.000Z',
+    });
+    const intentArtifact = createAflTradeCanonicalJsonArtifactRef(intent, now);
+    const repository = createPostgresGovernedPrivateEvaluationStagingRepository({
+      client: new StagingSqlClient(intent, intentArtifact),
+      artifactRepository: createAflTradeFixtureArtifactRepository({
+        artifactClass: 'derived_private',
+      }),
+      maximumArtifactBytes: 1_000_000,
+      automatedPrincipalId: 'system:weekly-valuation-coordinator',
+    });
+
+    await expect(repository.stage({ intent, intentArtifact })).rejects.toThrow(
+      /exact configured system principal/i
     );
   });
 

--- a/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-workspace.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-private-evaluation-workspace.test.ts
@@ -1,0 +1,38 @@
+import { createAflTradeFixtureArtifactRepository } from '@/server/aflTradeIntelligence/artifacts/immutableArtifactRepository';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlQueryResult,
+  AflOutcomeSqlTransaction,
+} from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { createPostgresGovernedPrivateEvaluationWorkspace } from '@/server/aflTradeIntelligence/valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace';
+
+class UnusedSqlClient implements AflOutcomeSqlClient {
+  async query<Row>(): Promise<AflOutcomeSqlQueryResult<Row>> {
+    throw new Error('Workspace construction must not query PostgreSQL.');
+  }
+
+  async transaction<T>(
+    work: (transaction: AflOutcomeSqlTransaction) => Promise<T>
+  ): Promise<T> {
+    return work(this);
+  }
+}
+
+describe('PostgreSQL governed private evaluation workspace', () => {
+  it('rejects caller-supplied automated principal identity', () => {
+    const dependencies = {
+      client: new UnusedSqlClient(),
+      artifactRepository: createAflTradeFixtureArtifactRepository({
+        artifactClass: 'derived_private' as const,
+      }),
+      maximumArtifactBytes: 1_000_000,
+      principalId: 'fixture-reader',
+      automatedPrincipalId: 'system:weekly-valuation-coordinator',
+      authorizeReader: async () => true,
+    };
+
+    expect(() => createPostgresGovernedPrivateEvaluationWorkspace(dependencies)).toThrow(
+      'does not accept a caller-supplied automated principal'
+    );
+  });
+});


### PR DESCRIPTION
Closes #535

## Summary
- capture and durably bind the exact current factual release, qualified model pair, prepared-head revision, and valuation bundle
- prepare every release trade with bounded concurrency, deterministic blocked isolation, append-only materialization replay, and restart-safe cohort CAS
- stage and activate automated private non-production generations through authenticated lifecycle authority
- add migration 0065 to fail closed on forged cohort, bundle, operator, model-lineage, expiry, and lifecycle evidence

## Verification
- npm run typecheck -- --pretty false
- npm run lint:ci
- focused valuation unit tests
- npm run test:outcomes:int
- independent spec review: PASS
- independent standards/security review: PASS

## Summary by Sourcery

Automatically prepare the current valuation cohort and securely activate authenticated private non-production generations while failing closed on stale or forged authority.

New Features:
- Add automatic current valuation cohort preparation across every factual-release trade with bounded concurrency and deterministic blocked entries.
- Add authenticated automated private non-production evaluation staging and activation under a fixed system principal.

Bug Fixes:
- Fail closed on forged cohort authority, valuation bundles, model lineage, lifecycle evidence, expiry, and head transitions.

Enhancements:
- Make cohort preparation and private evaluation lifecycle operations append-only, content-addressed, restart-safe, and protected by compare-and-set authority checks.
- Add exact materialization ancestry retention and replay for prepared valuation inputs and private evaluation generations.
- Extend private evaluation contracts with non-production automated intent, generation, projection, and receipt versions while preserving legacy fixture flows.

Tests:
- Add unit and PostgreSQL integration coverage for cohort classification, concurrency, stale-authority handling, idempotent replay, automated lifecycle authentication, and forged evidence rejection.

Chores:
- Add migration 0065 and corresponding Prisma schema support for cohort operations and database-bound automated authority validation.