### PR TITLE
Add durable retries and bounded cohort processing

### DIFF
--- a/prisma/afl-trade-outcomes/migrations/0068_durable_private_evaluation_execution/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0068_durable_private_evaluation_execution/migration.sql
@@ -1,0 +1,494 @@
+-- Durable local execution cycles and fenced trade attempts. Earlier migrations remain immutable.
+
+CREATE TABLE "outcome_private_evaluation_execution_cycle" (
+  "cycle_id" TEXT PRIMARY KEY,
+  "input_fingerprint" TEXT NOT NULL,
+  "scope_key" TEXT NOT NULL,
+  "prepared_input_set_id" TEXT NOT NULL REFERENCES "outcome_prepared_valuation_input_set"("prepared_input_set_id") ON DELETE RESTRICT,
+  "prepared_input_set_revision" INTEGER NOT NULL CHECK ("prepared_input_set_revision">0),
+  "factual_release_revision" INTEGER NOT NULL CHECK ("factual_release_revision">0),
+  "model_qualification_work_id" TEXT NOT NULL REFERENCES "outcome_governed_model_qualification_work"("work_id") ON DELETE RESTRICT,
+  "model_pair_revision" INTEGER NOT NULL CHECK ("model_pair_revision">0),
+  "repair_sequence" INTEGER NOT NULL CHECK ("repair_sequence">=0),
+  "opening_cause" TEXT NOT NULL CHECK ("opening_cause" IN ('authenticated_inputs_changed','explicit_repair')),
+  "opening_principal_id" TEXT NOT NULL CHECK ("opening_principal_id"='system:weekly-valuation-coordinator'),
+  "repair_operation_id" TEXT UNIQUE CHECK ("repair_operation_id" IS NULL OR "repair_operation_id" ~ '^cohort-execution-repair:[a-f0-9]{64}$'),
+  "repair_reason" TEXT,
+  "repairs_cycle_id" TEXT REFERENCES "outcome_private_evaluation_execution_cycle"("cycle_id") ON DELETE RESTRICT,
+  "maximum_attempts" INTEGER NOT NULL CHECK ("maximum_attempts"=3),
+  "opened_at" TIMESTAMPTZ(3) NOT NULL,
+  "cycle_json" JSONB NOT NULL,
+  CONSTRAINT "outcome_private_evaluation_execution_cycle_identity" UNIQUE ("input_fingerprint","repair_sequence"),
+  CONSTRAINT "outcome_private_evaluation_execution_cycle_id_check" CHECK ("cycle_id" ~ '^cohort-execution-cycle:[a-f0-9]{64}$'),
+  CONSTRAINT "outcome_private_evaluation_execution_fingerprint_check" CHECK ("input_fingerprint" ~ '^cohort-execution-input:[a-f0-9]{64}$')
+);
+
+CREATE TABLE "outcome_private_evaluation_execution_work" (
+  "cycle_id" TEXT NOT NULL REFERENCES "outcome_private_evaluation_execution_cycle"("cycle_id") ON DELETE RESTRICT,
+  "trade_id" TEXT NOT NULL,
+  "status" TEXT NOT NULL CHECK ("status" IN ('pending','leased','retry_wait','succeeded','unavailable','exhausted')),
+  "attempt_count" INTEGER NOT NULL DEFAULT 0 CHECK ("attempt_count" BETWEEN 0 AND 3),
+  "available_at" TIMESTAMPTZ(3) NOT NULL,
+  "current_claim_id" TEXT,
+  "lease_token_sha256" CHAR(64),
+  "lease_expires_at" TIMESTAMPTZ(3),
+  "heartbeat_at" TIMESTAMPTZ(3),
+  "terminal_stage" TEXT,
+  "terminal_cause_json" JSONB,
+  "result_json" JSONB,
+  PRIMARY KEY ("cycle_id","trade_id"),
+  CONSTRAINT "outcome_private_evaluation_execution_work_lease_shape" CHECK (
+    ("status"='leased')=("current_claim_id" IS NOT NULL AND "lease_token_sha256" IS NOT NULL AND "lease_expires_at" IS NOT NULL AND "heartbeat_at" IS NOT NULL)
+  ),
+  CONSTRAINT "outcome_private_evaluation_execution_work_terminal_shape" CHECK (
+    ("status"='exhausted')=("terminal_stage" IS NOT NULL AND "terminal_cause_json" IS NOT NULL)
+  )
+);
+
+CREATE INDEX "outcome_private_evaluation_execution_work_claim_idx"
+  ON "outcome_private_evaluation_execution_work"("cycle_id","status","available_at","trade_id");
+
+CREATE TABLE "outcome_private_evaluation_execution_attempt" (
+  "claim_id" TEXT PRIMARY KEY,
+  "cycle_id" TEXT NOT NULL,
+  "trade_id" TEXT NOT NULL,
+  "attempt_number" INTEGER NOT NULL CHECK ("attempt_number" BETWEEN 1 AND 3),
+  "worker_id" TEXT NOT NULL,
+  "lease_token_sha256" CHAR(64) NOT NULL CHECK ("lease_token_sha256" ~ '^[a-f0-9]{64}$'),
+  "claimed_at" TIMESTAMPTZ(3) NOT NULL,
+  "lease_expires_at" TIMESTAMPTZ(3) NOT NULL,
+  "heartbeat_at" TIMESTAMPTZ(3) NOT NULL,
+  "finished_at" TIMESTAMPTZ(3),
+  "outcome" TEXT CHECK ("outcome" IN ('succeeded','unavailable','transient_failure','permanent_failure','lease_expired')),
+  "terminal_stage" TEXT,
+  "cause_json" JSONB,
+  "result_json" JSONB,
+  FOREIGN KEY ("cycle_id","trade_id") REFERENCES "outcome_private_evaluation_execution_work"("cycle_id","trade_id") ON DELETE RESTRICT,
+  CONSTRAINT "outcome_private_evaluation_execution_attempt_number" UNIQUE ("cycle_id","trade_id","attempt_number"),
+  CONSTRAINT "outcome_private_evaluation_execution_attempt_id_check" CHECK ("claim_id" ~ '^cohort-execution-claim:[a-f0-9]{64}$'),
+  CONSTRAINT "outcome_private_evaluation_execution_attempt_result_shape" CHECK (("finished_at" IS NULL)=("outcome" IS NULL))
+);
+
+CREATE OR REPLACE FUNCTION "outcome_private_evaluation_json_object_key_count"(value JSONB)
+RETURNS INTEGER LANGUAGE SQL IMMUTABLE STRICT AS $$
+  SELECT count(*)::INTEGER FROM jsonb_object_keys(value)
+$$;
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_evaluation_execution_cycle"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE content JSONB:=NEW."cycle_json"->'content'; expected_fingerprint TEXT; expected_cycle TEXT;
+BEGIN
+  expected_fingerprint:='cohort-execution-input:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(jsonb_build_object(
+      'scopeKey',NEW."scope_key",'preparedInputSetId',NEW."prepared_input_set_id",
+      'preparedInputSetRevision',NEW."prepared_input_set_revision",
+      'factualReleaseRevision',NEW."factual_release_revision",
+      'modelQualificationWorkId',NEW."model_qualification_work_id",
+      'modelPairRevision',NEW."model_pair_revision")),'UTF8')),'hex');
+  expected_cycle:='cohort-execution-cycle:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(jsonb_build_object(
+      'inputFingerprint',NEW."input_fingerprint",'repairSequence',NEW."repair_sequence")),'UTF8')),'hex');
+  IF NEW."repair_sequence">0 AND NOT EXISTS (
+    SELECT 1 FROM "outcome_private_evaluation_execution_cycle" prior
+     WHERE prior."cycle_id"=NEW."repairs_cycle_id"
+       AND prior."input_fingerprint"=NEW."input_fingerprint"
+       AND prior."repair_sequence"=NEW."repair_sequence"-1
+       AND NEW."opened_at">=prior."opened_at"
+       AND NEW."opened_at">=COALESCE((
+         SELECT max(attempt."finished_at")
+           FROM "outcome_private_evaluation_execution_attempt" attempt
+          WHERE attempt."cycle_id"=prior."cycle_id"
+       ),prior."opened_at")
+       AND EXISTS (SELECT 1 FROM "outcome_private_evaluation_execution_work" work
+                    WHERE work."cycle_id"=prior."cycle_id")
+       AND NOT EXISTS (SELECT 1 FROM "outcome_private_evaluation_execution_work" work
+                        WHERE work."cycle_id"=prior."cycle_id"
+                          AND work."status" NOT IN ('succeeded','unavailable','exhausted')))
+  THEN RAISE EXCEPTION 'Private evaluation execution repair lacks a terminal predecessor'; END IF;
+  IF jsonb_typeof(NEW."cycle_json") IS DISTINCT FROM 'object'
+    OR "outcome_private_evaluation_json_object_key_count"(NEW."cycle_json") IS DISTINCT FROM 2
+    OR jsonb_typeof(content) IS DISTINCT FROM 'object'
+    OR "outcome_private_evaluation_json_object_key_count"(content) IS DISTINCT FROM 14
+    OR jsonb_typeof(content->'authority') IS DISTINCT FROM 'object'
+    OR "outcome_private_evaluation_json_object_key_count"(content->'authority') IS DISTINCT FROM 6
+    OR jsonb_typeof(content->'repairSequence') IS DISTINCT FROM 'number'
+    OR jsonb_typeof(content->'maximumAttemptsPerTrade') IS DISTINCT FROM 'number'
+    OR NEW."input_fingerprint" IS DISTINCT FROM expected_fingerprint
+    OR NEW."cycle_id" IS DISTINCT FROM expected_cycle
+    OR NEW."maximum_attempts"<>3
+    OR NEW."opened_at">transaction_timestamp()
+    OR (NEW."repair_sequence">0
+      AND NEW."opened_at" IS DISTINCT FROM date_trunc('milliseconds',transaction_timestamp())
+      AND NOT EXISTS (SELECT 1 FROM "outcome_private_evaluation_execution_cycle" retained
+                       WHERE retained."cycle_id"=NEW."cycle_id"
+                         AND retained."cycle_json"=NEW."cycle_json"))
+    OR NEW."cycle_json"->>'cycleId' IS DISTINCT FROM NEW."cycle_id"
+    OR content->>'schemaVersion' IS DISTINCT FROM 'private-evaluation-cohort-execution-cycle/v1'
+    OR content->>'environment' IS DISTINCT FROM 'non_production'
+    OR content->'publicationEligible' IS DISTINCT FROM 'false'::JSONB
+    OR content->>'inputFingerprint' IS DISTINCT FROM NEW."input_fingerprint"
+    OR content->'authority' IS DISTINCT FROM jsonb_build_object(
+      'scopeKey',NEW."scope_key",'preparedInputSetId',NEW."prepared_input_set_id",
+      'preparedInputSetRevision',NEW."prepared_input_set_revision",
+      'factualReleaseRevision',NEW."factual_release_revision",
+      'modelQualificationWorkId',NEW."model_qualification_work_id",
+      'modelPairRevision',NEW."model_pair_revision")
+    OR (content->>'repairSequence')::INTEGER IS DISTINCT FROM NEW."repair_sequence"
+    OR content->>'openingCause' IS DISTINCT FROM NEW."opening_cause"
+    OR content->>'openingPrincipalId' IS DISTINCT FROM NEW."opening_principal_id"
+    OR content->>'repairOperationId' IS DISTINCT FROM NEW."repair_operation_id"
+    OR content->>'repairReason' IS DISTINCT FROM NEW."repair_reason"
+    OR content->>'repairsCycleId' IS DISTINCT FROM NEW."repairs_cycle_id"
+    OR (content->>'maximumAttemptsPerTrade')::INTEGER IS DISTINCT FROM 3
+    OR (content->>'openedAt')::TIMESTAMPTZ IS DISTINCT FROM NEW."opened_at"
+    OR content->>'limitation' IS DISTINCT FROM 'Private local execution control only; it grants no factual, model, production, or publication authority.'
+    OR (NEW."repair_sequence"=0) IS DISTINCT FROM (NEW."repairs_cycle_id" IS NULL AND NEW."opening_cause"='authenticated_inputs_changed')
+    OR (NEW."repair_sequence"=0) IS DISTINCT FROM (NEW."repair_operation_id" IS NULL)
+    OR (NEW."repair_sequence"=0) IS DISTINCT FROM (NEW."repair_reason" IS NULL)
+    OR (NEW."repair_sequence">0 AND (NEW."repair_reason" IS NULL OR btrim(NEW."repair_reason")=''
+      OR length(NEW."repair_reason")>2000))
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_current_prepared_valuation_input_set" prepared
+      JOIN "outcome_prepared_valuation_input_set" parent ON parent."prepared_input_set_id"=prepared."prepared_input_set_id"
+      JOIN "outcome_active_release" release ON release."scope_key"=parent."factual_release_scope_key" AND release."release_id"=parent."factual_release_id"
+      JOIN "outcome_current_governed_valuation_model_pair" model ON model."scope_key"=prepared."scope_key"
+       WHERE prepared."scope_key"=NEW."scope_key" AND prepared."prepared_input_set_id"=NEW."prepared_input_set_id"
+         AND prepared."revision"=NEW."prepared_input_set_revision" AND release."revision"=NEW."factual_release_revision"
+         AND parent."scope_key"=NEW."scope_key"
+         AND parent."schema_version"='afl-trade-prepared-valuation-input-set/v3'
+         AND parent."environment"='non_production' AND parent."finalized_at" IS NOT NULL
+         AND model."work_id"=NEW."model_qualification_work_id" AND model."revision"=NEW."model_pair_revision")
+  THEN RAISE EXCEPTION 'Private evaluation execution cycle is not exact current authority'; END IF;
+  RETURN NEW;
+EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+  RAISE EXCEPTION 'Private evaluation execution cycle is malformed';
+END $$;
+CREATE TRIGGER "outcome_private_evaluation_execution_cycle_validate"
+BEFORE INSERT ON "outcome_private_evaluation_execution_cycle"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_evaluation_execution_cycle"();
+
+CREATE OR REPLACE FUNCTION "reject_outcome_private_evaluation_execution_history_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'Private evaluation execution history is append-only'; END $$;
+CREATE TRIGGER "outcome_private_evaluation_execution_cycle_no_mutation"
+BEFORE UPDATE OR DELETE ON "outcome_private_evaluation_execution_cycle"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_evaluation_execution_history_mutation"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_evaluation_execution_work_insert"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW."status" IS DISTINCT FROM 'pending'
+    OR NEW."attempt_count" IS DISTINCT FROM 0
+    OR NEW."available_at">transaction_timestamp()
+    OR NEW."current_claim_id" IS NOT NULL
+    OR NEW."lease_token_sha256" IS NOT NULL
+    OR NEW."lease_expires_at" IS NOT NULL
+    OR NEW."heartbeat_at" IS NOT NULL
+    OR NEW."terminal_stage" IS NOT NULL
+    OR NEW."terminal_cause_json" IS NOT NULL
+    OR NEW."result_json" IS NOT NULL
+    OR NOT EXISTS (
+      SELECT 1
+        FROM "outcome_private_evaluation_execution_cycle" cycle
+        JOIN "outcome_prepared_valuation_input_entry" entry
+          ON entry."prepared_input_set_id"=cycle."prepared_input_set_id"
+         AND entry."trade_id"=NEW."trade_id"
+       WHERE cycle."cycle_id"=NEW."cycle_id"
+         AND entry."state"='ready')
+  THEN
+    RAISE EXCEPTION 'Private evaluation execution work is not exact ready cycle membership';
+  END IF;
+  RETURN NEW;
+END $$;
+CREATE TRIGGER "outcome_private_evaluation_execution_work_validate_insert"
+BEFORE INSERT ON "outcome_private_evaluation_execution_work"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_evaluation_execution_work_insert"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_evaluation_execution_work_update"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF current_user IS DISTINCT FROM 'afl_trade_private_evaluation_execution_owner'
+    OR NEW."cycle_id" IS DISTINCT FROM OLD."cycle_id"
+    OR NEW."trade_id" IS DISTINCT FROM OLD."trade_id"
+    OR NEW."attempt_count"<OLD."attempt_count"
+    OR NEW."attempt_count">OLD."attempt_count"+1
+    OR OLD."status" IN ('succeeded','unavailable','exhausted')
+    OR (OLD."status"='leased' AND NEW."status" NOT IN ('leased','retry_wait','succeeded','unavailable','exhausted'))
+    OR (OLD."status" IN ('pending','retry_wait') AND NEW."status"<>'leased')
+    OR (NEW."status"='leased' AND NEW."attempt_count"<>OLD."attempt_count"+CASE WHEN OLD."status"='leased' THEN 0 ELSE 1 END)
+    OR (NEW."status"<>'leased' AND (
+      NEW."current_claim_id" IS NOT NULL OR NEW."lease_token_sha256" IS NOT NULL
+      OR NEW."lease_expires_at" IS NOT NULL OR NEW."heartbeat_at" IS NOT NULL))
+    OR (NEW."status" NOT IN ('succeeded','unavailable') AND NEW."result_json" IS NOT NULL)
+    OR (NEW."status"='leased' AND NOT EXISTS (
+      SELECT 1 FROM "outcome_private_evaluation_execution_attempt" attempt
+       WHERE attempt."claim_id"=NEW."current_claim_id" AND attempt."cycle_id"=NEW."cycle_id"
+         AND attempt."trade_id"=NEW."trade_id" AND attempt."attempt_number"=NEW."attempt_count"
+         AND attempt."lease_token_sha256"=NEW."lease_token_sha256"
+         AND attempt."lease_expires_at"=NEW."lease_expires_at"
+         AND attempt."heartbeat_at"=NEW."heartbeat_at" AND attempt."finished_at" IS NULL))
+    OR (OLD."status"='leased' AND NEW."status"<>'leased' AND NOT EXISTS (
+      SELECT 1 FROM "outcome_private_evaluation_execution_attempt" attempt
+       WHERE attempt."claim_id"=OLD."current_claim_id" AND attempt."cycle_id"=OLD."cycle_id"
+         AND attempt."trade_id"=OLD."trade_id" AND attempt."finished_at" IS NOT NULL
+         AND ((NEW."status"='succeeded' AND attempt."outcome"='succeeded')
+           OR (NEW."status"='unavailable' AND attempt."outcome"='unavailable')
+           OR (NEW."status"='retry_wait' AND attempt."outcome" IN ('transient_failure','lease_expired'))
+           OR (NEW."status"='exhausted' AND attempt."outcome" IN ('transient_failure','permanent_failure','lease_expired')))
+         AND attempt."result_json" IS NOT DISTINCT FROM NEW."result_json"
+         AND (NEW."status"<>'exhausted' OR (
+           attempt."terminal_stage" IS NOT DISTINCT FROM NEW."terminal_stage"
+           AND attempt."cause_json" IS NOT DISTINCT FROM NEW."terminal_cause_json"))))
+  THEN
+    RAISE EXCEPTION 'Private evaluation execution work transition is invalid';
+  END IF;
+  RETURN NEW;
+END $$;
+CREATE TRIGGER "outcome_private_evaluation_execution_work_validate_update"
+BEFORE UPDATE ON "outcome_private_evaluation_execution_work"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_evaluation_execution_work_update"();
+CREATE TRIGGER "outcome_private_evaluation_execution_work_no_delete"
+BEFORE DELETE ON "outcome_private_evaluation_execution_work"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_evaluation_execution_history_mutation"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_evaluation_execution_attempt_insert"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE work RECORD; expected_claim_id TEXT;
+BEGIN
+  SELECT * INTO work FROM "outcome_private_evaluation_execution_work"
+   WHERE "cycle_id"=NEW."cycle_id" AND "trade_id"=NEW."trade_id" FOR KEY SHARE;
+  expected_claim_id:='cohort-execution-claim:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(jsonb_build_object(
+      'cycleId',NEW."cycle_id",'tradeId',NEW."trade_id",
+      'attemptNumber',NEW."attempt_number",'leaseTokenSha256',NEW."lease_token_sha256")),
+    'UTF8')),'hex');
+  IF current_user IS DISTINCT FROM 'afl_trade_private_evaluation_execution_owner'
+    OR NOT FOUND OR work."status" NOT IN ('pending','retry_wait')
+    OR NEW."claim_id" IS DISTINCT FROM expected_claim_id
+    OR NEW."attempt_number" IS DISTINCT FROM work."attempt_count"+1
+    OR btrim(NEW."worker_id")='' OR length(NEW."worker_id")>400
+    OR NEW."claimed_at" IS DISTINCT FROM date_trunc('milliseconds',transaction_timestamp())
+    OR NEW."heartbeat_at" IS DISTINCT FROM NEW."claimed_at"
+    OR NEW."lease_expires_at" IS DISTINCT FROM NEW."claimed_at"+INTERVAL '120 seconds'
+    OR NEW."finished_at" IS NOT NULL OR NEW."outcome" IS NOT NULL
+    OR NEW."terminal_stage" IS NOT NULL OR NEW."cause_json" IS NOT NULL OR NEW."result_json" IS NOT NULL
+  THEN RAISE EXCEPTION 'Private evaluation execution attempt lacks exact claim custody'; END IF;
+  RETURN NEW;
+END $$;
+CREATE TRIGGER "outcome_private_evaluation_execution_attempt_validate_insert"
+BEFORE INSERT ON "outcome_private_evaluation_execution_attempt"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_evaluation_execution_attempt_insert"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_evaluation_execution_attempt_update"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF current_user IS DISTINCT FROM 'afl_trade_private_evaluation_execution_owner'
+    OR NEW."claim_id" IS DISTINCT FROM OLD."claim_id"
+    OR NEW."cycle_id" IS DISTINCT FROM OLD."cycle_id"
+    OR NEW."trade_id" IS DISTINCT FROM OLD."trade_id"
+    OR NEW."attempt_number" IS DISTINCT FROM OLD."attempt_number"
+    OR NEW."worker_id" IS DISTINCT FROM OLD."worker_id"
+    OR NEW."lease_token_sha256" IS DISTINCT FROM OLD."lease_token_sha256"
+    OR NEW."claimed_at" IS DISTINCT FROM OLD."claimed_at"
+    OR OLD."finished_at" IS NOT NULL
+    OR NEW."heartbeat_at"<OLD."heartbeat_at"
+    OR NEW."lease_expires_at"<OLD."lease_expires_at"
+    OR (NEW."finished_at" IS NULL AND (
+      NEW."outcome" IS NOT NULL OR NEW."terminal_stage" IS NOT NULL
+      OR NEW."cause_json" IS NOT NULL OR NEW."result_json" IS NOT NULL))
+    OR (NEW."finished_at" IS NOT NULL AND (
+      NEW."outcome" IS NULL OR NEW."finished_at"<NEW."claimed_at"
+      OR (NEW."outcome" IN ('transient_failure','permanent_failure','lease_expired')
+        AND (NEW."terminal_stage" IS NULL OR NEW."cause_json" IS NULL))))
+  THEN
+    RAISE EXCEPTION 'Private evaluation execution attempt transition is invalid';
+  END IF;
+  RETURN NEW;
+END $$;
+CREATE TRIGGER "outcome_private_evaluation_execution_attempt_validate_update"
+BEFORE UPDATE ON "outcome_private_evaluation_execution_attempt"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_evaluation_execution_attempt_update"();
+CREATE TRIGGER "outcome_private_evaluation_execution_attempt_no_delete"
+BEFORE DELETE ON "outcome_private_evaluation_execution_attempt"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_evaluation_execution_history_mutation"();
+
+CREATE OR REPLACE FUNCTION "claim_outcome_private_evaluation_work"(
+  target_cycle_id TEXT,target_trade_id TEXT,target_worker_id TEXT,target_lease_token_sha256 TEXT
+) RETURNS TABLE(claim_id TEXT,attempt_number INTEGER,lease_expires_at TIMESTAMPTZ) LANGUAGE plpgsql AS $$
+DECLARE work RECORD; now_at TIMESTAMPTZ:=date_trunc('milliseconds',transaction_timestamp()); next_attempt INTEGER; new_claim TEXT;
+BEGIN
+  SELECT * INTO work FROM "outcome_private_evaluation_execution_work"
+   WHERE "cycle_id"=target_cycle_id AND "trade_id"=target_trade_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Private evaluation execution work was not found'; END IF;
+  IF work."status"='leased' AND work."lease_expires_at">now_at THEN RETURN; END IF;
+  IF work."status"='leased' THEN
+    UPDATE "outcome_private_evaluation_execution_attempt" attempt SET "finished_at"=now_at,"outcome"='lease_expired',
+      "terminal_stage"='stage_automated',"cause_json"=jsonb_build_object('code','lease_expired','message','Worker lease expired before completion.','retryable',true)
+     WHERE attempt."claim_id"=work."current_claim_id";
+    IF work."attempt_count">=3 THEN
+      UPDATE "outcome_private_evaluation_execution_work" SET "status"='exhausted',"available_at"=now_at,
+        "current_claim_id"=NULL,"lease_token_sha256"=NULL,"lease_expires_at"=NULL,"heartbeat_at"=NULL,
+        "terminal_stage"='stage_automated',
+        "terminal_cause_json"=jsonb_build_object('code','lease_expired','message','Worker lease expired before completion.','retryable',true),
+        "result_json"=NULL
+       WHERE "cycle_id"=target_cycle_id AND "trade_id"=target_trade_id;
+      RETURN;
+    END IF;
+    UPDATE "outcome_private_evaluation_execution_work" SET "status"='retry_wait',"available_at"=now_at,
+      "current_claim_id"=NULL,"lease_token_sha256"=NULL,"lease_expires_at"=NULL,"heartbeat_at"=NULL
+     WHERE "cycle_id"=target_cycle_id AND "trade_id"=target_trade_id;
+  ELSIF work."status" NOT IN ('pending','retry_wait') OR work."available_at">now_at THEN RETURN; END IF;
+  next_attempt:=work."attempt_count"+1;
+  IF next_attempt>3 THEN RETURN; END IF;
+  new_claim:='cohort-execution-claim:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(jsonb_build_object('cycleId',target_cycle_id,'tradeId',target_trade_id,
+      'attemptNumber',next_attempt,'leaseTokenSha256',target_lease_token_sha256)),'UTF8')),'hex');
+  INSERT INTO "outcome_private_evaluation_execution_attempt"
+    ("claim_id","cycle_id","trade_id","attempt_number","worker_id","lease_token_sha256","claimed_at","lease_expires_at","heartbeat_at")
+   VALUES (new_claim,target_cycle_id,target_trade_id,next_attempt,target_worker_id,target_lease_token_sha256,now_at,now_at+INTERVAL '120 seconds',now_at);
+  UPDATE "outcome_private_evaluation_execution_work" SET "status"='leased',"attempt_count"=next_attempt,
+    "current_claim_id"=new_claim,"lease_token_sha256"=target_lease_token_sha256,
+    "lease_expires_at"=now_at+INTERVAL '120 seconds',"heartbeat_at"=now_at
+   WHERE "cycle_id"=target_cycle_id AND "trade_id"=target_trade_id;
+  RETURN QUERY SELECT new_claim,next_attempt,now_at+INTERVAL '120 seconds';
+END $$;
+
+CREATE OR REPLACE FUNCTION "heartbeat_outcome_private_evaluation_work"(
+  target_claim_id TEXT,target_lease_token_sha256 TEXT
+) RETURNS TIMESTAMPTZ LANGUAGE plpgsql AS $$
+DECLARE renewed TIMESTAMPTZ:=date_trunc('milliseconds',transaction_timestamp())+INTERVAL '120 seconds'; updated INTEGER;
+BEGIN
+  UPDATE "outcome_private_evaluation_execution_attempt" SET "heartbeat_at"=transaction_timestamp(),"lease_expires_at"=renewed
+   WHERE "claim_id"=target_claim_id AND "lease_token_sha256"=target_lease_token_sha256
+     AND "finished_at" IS NULL AND "lease_expires_at">transaction_timestamp();
+  GET DIAGNOSTICS updated=ROW_COUNT;
+  IF updated<>1 THEN RAISE EXCEPTION 'Private evaluation execution lease was lost'; END IF;
+  UPDATE "outcome_private_evaluation_execution_work" SET "heartbeat_at"=transaction_timestamp(),"lease_expires_at"=renewed
+   WHERE "current_claim_id"=target_claim_id AND "status"='leased'
+     AND "lease_token_sha256"=target_lease_token_sha256;
+  RETURN renewed;
+END $$;
+
+CREATE OR REPLACE FUNCTION "complete_outcome_private_evaluation_work"(
+  target_claim_id TEXT,target_lease_token_sha256 TEXT,target_outcome TEXT,
+  target_stage TEXT,target_cause JSONB,target_result JSONB
+) RETURNS TEXT LANGUAGE plpgsql AS $$
+DECLARE work RECORD; now_at TIMESTAMPTZ:=date_trunc('milliseconds',transaction_timestamp()); next_status TEXT; delay_seconds INTEGER; expected_operation_id TEXT;
+BEGIN
+  SELECT candidate.* INTO work FROM "outcome_private_evaluation_execution_work" candidate
+   WHERE candidate."current_claim_id"=target_claim_id FOR UPDATE;
+  IF NOT FOUND OR work."status"<>'leased' OR work."lease_token_sha256"<>target_lease_token_sha256
+    OR work."lease_expires_at"<=now_at THEN RAISE EXCEPTION 'Private evaluation execution lease was lost'; END IF;
+  IF target_outcome NOT IN ('succeeded','unavailable','transient_failure','permanent_failure') THEN
+    RAISE EXCEPTION 'Private evaluation execution outcome is invalid'; END IF;
+  expected_operation_id:='private-evaluation-operation:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(jsonb_build_object(
+      'cycleId',work."cycle_id",'tradeId',work."trade_id")),'UTF8')),'hex');
+  IF (target_outcome='succeeded' AND (
+      jsonb_typeof(target_result) IS DISTINCT FROM 'object'
+      OR "outcome_private_evaluation_json_object_key_count"(target_result) IS DISTINCT FROM 3
+      OR target_result->>'state' IS DISTINCT FROM 'activated'
+      OR target_result->>'generationId' !~ '^local-private-trade-evaluation-generation:[a-f0-9]{64}$'
+      OR NOT EXISTS (SELECT 1 FROM "outcome_local_private_trade_evaluation_generation" generation
+          JOIN "outcome_private_evaluation_execution_cycle" cycle ON cycle."cycle_id"=work."cycle_id"
+          JOIN "outcome_private_evaluation_transition_intent" intent
+            ON intent."transition_intent_id"=generation."transition_intent_id"
+          JOIN "outcome_private_evaluation_transition_receipt" receipt
+            ON receipt."transition_intent_id"=intent."transition_intent_id"
+         WHERE generation."generation_id"=target_result->>'generationId'
+           AND generation."valuation_scope_key"=cycle."scope_key"
+           AND generation."trade_id"=work."trade_id"
+           AND generation."generated_at"=(target_result->>'generatedAt')::TIMESTAMPTZ
+           AND intent."operation_id"=expected_operation_id
+           AND intent."valuation_scope_key"=cycle."scope_key"
+           AND intent."trade_id"=work."trade_id" AND intent."action"='construct_and_activate'
+           AND receipt."operation_id"=expected_operation_id
+           AND receipt."valuation_scope_key"=cycle."scope_key"
+           AND receipt."trade_id"=work."trade_id" AND receipt."action"='construct_and_activate'
+           AND receipt."to_status"='active'
+           AND receipt."to_generation_id"=generation."generation_id"))
+    OR (target_outcome='unavailable' AND (
+      jsonb_typeof(target_result) IS DISTINCT FROM 'object'
+      OR "outcome_private_evaluation_json_object_key_count"(target_result) IS DISTINCT FROM 2
+      OR target_result->>'state' IS DISTINCT FROM 'unavailable'
+      OR jsonb_typeof(target_result->'blockers') IS DISTINCT FROM 'array'
+      OR jsonb_array_length(target_result->'blockers') NOT BETWEEN 1 AND 10000
+      OR EXISTS (SELECT 1 FROM jsonb_array_elements(target_result->'blockers') blocker
+                  WHERE jsonb_typeof(blocker) IS DISTINCT FROM 'object'
+                     OR "outcome_private_evaluation_json_object_key_count"(blocker) IS DISTINCT FROM 2
+                     OR jsonb_typeof(blocker->'code') IS DISTINCT FROM 'string'
+                     OR length(btrim(blocker->>'code')) NOT BETWEEN 1 AND 200
+                     OR jsonb_typeof(blocker->'message') IS DISTINCT FROM 'string'
+                     OR length(btrim(blocker->>'message')) NOT BETWEEN 1 AND 2000)))
+    OR (target_outcome IN ('transient_failure','permanent_failure') AND (
+      target_stage IS NULL OR jsonb_typeof(target_cause) IS DISTINCT FROM 'object'
+      OR "outcome_private_evaluation_json_object_key_count"(target_cause) IS DISTINCT FROM 3
+      OR target_cause->>'code' IS NULL
+      OR length(btrim(target_cause->>'code')) NOT BETWEEN 1 AND 200
+      OR target_cause->>'message' IS NULL
+      OR length(btrim(target_cause->>'message')) NOT BETWEEN 1 AND 4000
+      OR jsonb_typeof(target_cause->'retryable') IS DISTINCT FROM 'boolean'
+      OR (target_cause->'retryable') IS DISTINCT FROM to_jsonb(target_outcome='transient_failure')))
+    OR (target_outcome IN ('succeeded','unavailable') AND (target_stage IS NOT NULL OR target_cause IS NOT NULL))
+    OR (target_outcome IN ('transient_failure','permanent_failure') AND target_result IS NOT NULL))
+  THEN RAISE EXCEPTION 'Private evaluation execution completion custody is invalid'; END IF;
+  IF target_outcome='transient_failure' AND work."attempt_count"<3 THEN next_status:='retry_wait';
+  ELSIF target_outcome IN ('transient_failure','permanent_failure') THEN next_status:='exhausted';
+  ELSE next_status:=target_outcome; END IF;
+  delay_seconds:=LEAST(60,(5*power(2,GREATEST(0,work."attempt_count"-1)))::INTEGER);
+  UPDATE "outcome_private_evaluation_execution_attempt" SET "finished_at"=now_at,"outcome"=target_outcome,
+    "terminal_stage"=target_stage,"cause_json"=target_cause,"result_json"=target_result
+   WHERE "claim_id"=target_claim_id;
+  UPDATE "outcome_private_evaluation_execution_work" SET "status"=next_status,
+    "available_at"=CASE WHEN next_status='retry_wait' THEN now_at+make_interval(secs=>delay_seconds) ELSE now_at END,
+    "current_claim_id"=NULL,"lease_token_sha256"=NULL,"lease_expires_at"=NULL,"heartbeat_at"=NULL,
+    "terminal_stage"=CASE WHEN next_status='exhausted' THEN target_stage ELSE NULL END,
+    "terminal_cause_json"=CASE WHEN next_status='exhausted' THEN target_cause ELSE NULL END,
+    "result_json"=CASE WHEN next_status IN ('succeeded','unavailable') THEN target_result ELSE NULL END
+   WHERE "cycle_id"=work."cycle_id" AND "trade_id"=work."trade_id";
+  RETURN next_status;
+END $$;
+
+DO $roles$ BEGIN
+  BEGIN CREATE ROLE afl_trade_private_evaluation_execution_owner NOLOGIN;
+  EXCEPTION WHEN duplicate_object THEN NULL; END;
+  BEGIN CREATE ROLE afl_trade_private_evaluation_coordinator NOLOGIN;
+  EXCEPTION WHEN duplicate_object THEN NULL; END;
+  EXECUTE format('GRANT afl_trade_private_evaluation_execution_owner TO %I',current_user);
+  EXECUTE format('GRANT afl_trade_private_evaluation_coordinator TO %I',current_user);
+  EXECUTE format('GRANT USAGE,CREATE ON SCHEMA %I TO afl_trade_private_evaluation_execution_owner',current_schema());
+  EXECUTE format('GRANT USAGE ON SCHEMA %I TO afl_trade_private_evaluation_coordinator',current_schema());
+END $roles$;
+
+ALTER TABLE "outcome_private_evaluation_execution_cycle" OWNER TO afl_trade_private_evaluation_execution_owner;
+ALTER TABLE "outcome_private_evaluation_execution_work" OWNER TO afl_trade_private_evaluation_execution_owner;
+ALTER TABLE "outcome_private_evaluation_execution_attempt" OWNER TO afl_trade_private_evaluation_execution_owner;
+ALTER FUNCTION "claim_outcome_private_evaluation_work"(TEXT,TEXT,TEXT,TEXT) OWNER TO afl_trade_private_evaluation_execution_owner;
+ALTER FUNCTION "heartbeat_outcome_private_evaluation_work"(TEXT,TEXT) OWNER TO afl_trade_private_evaluation_execution_owner;
+ALTER FUNCTION "complete_outcome_private_evaluation_work"(TEXT,TEXT,TEXT,TEXT,JSONB,JSONB) OWNER TO afl_trade_private_evaluation_execution_owner;
+
+DO $paths$ BEGIN
+  EXECUTE format('REVOKE CREATE ON SCHEMA %I FROM PUBLIC,afl_trade_private_evaluation_coordinator',current_schema());
+  EXECUTE format('ALTER FUNCTION %I.claim_outcome_private_evaluation_work(TEXT,TEXT,TEXT,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+  EXECUTE format('ALTER FUNCTION %I.heartbeat_outcome_private_evaluation_work(TEXT,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+  EXECUTE format('ALTER FUNCTION %I.complete_outcome_private_evaluation_work(TEXT,TEXT,TEXT,TEXT,JSONB,JSONB) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+END $paths$;
+
+REVOKE ALL ON "outcome_private_evaluation_execution_attempt" FROM PUBLIC,afl_trade_private_evaluation_coordinator;
+REVOKE UPDATE,DELETE ON "outcome_private_evaluation_execution_work" FROM PUBLIC,afl_trade_private_evaluation_coordinator;
+REVOKE ALL ON FUNCTION "claim_outcome_private_evaluation_work"(TEXT,TEXT,TEXT,TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION "heartbeat_outcome_private_evaluation_work"(TEXT,TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION "complete_outcome_private_evaluation_work"(TEXT,TEXT,TEXT,TEXT,JSONB,JSONB) FROM PUBLIC;
+GRANT SELECT,INSERT ON "outcome_private_evaluation_execution_cycle","outcome_private_evaluation_execution_work" TO afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_private_evaluation_execution_attempt" TO afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_current_prepared_valuation_input_set","outcome_prepared_valuation_input_set",
+  "outcome_prepared_valuation_input_entry","outcome_active_release",
+  "outcome_current_governed_valuation_model_pair","outcome_local_private_trade_evaluation_generation",
+  "outcome_private_evaluation_transition_intent","outcome_private_evaluation_transition_receipt"
+  TO afl_trade_private_evaluation_execution_owner,afl_trade_private_evaluation_coordinator;
+GRANT EXECUTE ON FUNCTION "claim_outcome_private_evaluation_work"(TEXT,TEXT,TEXT,TEXT),
+  "heartbeat_outcome_private_evaluation_work"(TEXT,TEXT),
+  "complete_outcome_private_evaluation_work"(TEXT,TEXT,TEXT,TEXT,JSONB,JSONB)
+  TO afl_trade_private_evaluation_coordinator;
+DO $membership$ BEGIN
+  EXECUTE format('REVOKE afl_trade_private_evaluation_execution_owner FROM %I',current_user);
+END $membership$;

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -4401,6 +4401,7 @@ model OutcomePreparedValuationInputSet {
   entries                      OutcomePreparedValuationInputEntry[]
   currentHeads                 OutcomeCurrentPreparedValuationInputSet[]
   currentValuationCohortResult OutcomeCurrentValuationCohortOperationResult?
+  privateExecutionCycles       OutcomePrivateEvaluationExecutionCycle[]
 
   @@index([environment, scopeKey, preparedAt], map: "outcome_prepared_valuation_input_set_scope_idx")
   @@index([factualReleaseId, preparedAt], map: "outcome_prepared_valuation_input_set_release_idx")
@@ -5003,6 +5004,7 @@ model OutcomeGovernedModelQualificationWork {
   workJson                         Json                                     @map("work_json")
   recordedAt                       DateTime                                 @default(dbgenerated("clock_timestamp()")) @map("recorded_at") @outcomes.Timestamptz(3)
   currentValuationCohortOperations OutcomeCurrentValuationCohortOperation[]
+  privateExecutionCycles           OutcomePrivateEvaluationExecutionCycle[]
 
   @@index([status, availableAt, scopeKey], map: "outcome_governed_model_qualification_work_pending_idx")
   @@map("outcome_governed_model_qualification_work")
@@ -5294,6 +5296,76 @@ model OutcomePrivateEvaluationCohortFailure {
   capture                   OutcomePrivateEvaluationCohortCapture @relation(fields: [operationId], references: [operationId], onDelete: Restrict)
 
   @@map("outcome_private_evaluation_cohort_failure")
+}
+
+model OutcomePrivateEvaluationExecutionCycle {
+  cycleId                  String                                   @id @map("cycle_id") @outcomes.Text
+  inputFingerprint         String                                   @map("input_fingerprint") @outcomes.Text
+  scopeKey                 String                                   @map("scope_key") @outcomes.Text
+  preparedInputSetId       String                                   @map("prepared_input_set_id") @outcomes.Text
+  preparedInputSetRevision Int                                      @map("prepared_input_set_revision")
+  factualReleaseRevision   Int                                      @map("factual_release_revision")
+  modelQualificationWorkId String                                   @map("model_qualification_work_id") @outcomes.Text
+  modelPairRevision        Int                                      @map("model_pair_revision")
+  repairSequence           Int                                      @map("repair_sequence")
+  openingCause             String                                   @map("opening_cause") @outcomes.Text
+  openingPrincipalId       String                                   @map("opening_principal_id") @outcomes.Text
+  repairOperationId        String?                                  @unique @map("repair_operation_id") @outcomes.Text
+  repairReason             String?                                  @map("repair_reason") @outcomes.Text
+  repairsCycleId           String?                                  @map("repairs_cycle_id") @outcomes.Text
+  maximumAttempts          Int                                      @map("maximum_attempts")
+  openedAt                 DateTime                                 @map("opened_at") @outcomes.Timestamptz(3)
+  cycleJson                Json                                     @map("cycle_json")
+  preparedInputSet         OutcomePreparedValuationInputSet         @relation(fields: [preparedInputSetId], references: [preparedInputSetId], onDelete: Restrict)
+  modelQualificationWork   OutcomeGovernedModelQualificationWork    @relation(fields: [modelQualificationWorkId], references: [workId], onDelete: Restrict)
+  repairsCycle             OutcomePrivateEvaluationExecutionCycle?  @relation("PrivateExecutionCycleRepair", fields: [repairsCycleId], references: [cycleId], onDelete: Restrict)
+  repairCycles             OutcomePrivateEvaluationExecutionCycle[] @relation("PrivateExecutionCycleRepair")
+  work                     OutcomePrivateEvaluationExecutionWork[]
+
+  @@unique([inputFingerprint, repairSequence], map: "outcome_private_evaluation_execution_cycle_identity")
+  @@map("outcome_private_evaluation_execution_cycle")
+}
+
+model OutcomePrivateEvaluationExecutionWork {
+  cycleId           String                                     @map("cycle_id") @outcomes.Text
+  tradeId           String                                     @map("trade_id") @outcomes.Text
+  status            String                                     @outcomes.Text
+  attemptCount      Int                                        @default(0) @map("attempt_count")
+  availableAt       DateTime                                   @map("available_at") @outcomes.Timestamptz(3)
+  currentClaimId    String?                                    @map("current_claim_id") @outcomes.Text
+  leaseTokenSha256  String?                                    @map("lease_token_sha256") @outcomes.Char(64)
+  leaseExpiresAt    DateTime?                                  @map("lease_expires_at") @outcomes.Timestamptz(3)
+  heartbeatAt       DateTime?                                  @map("heartbeat_at") @outcomes.Timestamptz(3)
+  terminalStage     String?                                    @map("terminal_stage") @outcomes.Text
+  terminalCauseJson Json?                                      @map("terminal_cause_json")
+  resultJson        Json?                                      @map("result_json")
+  cycle             OutcomePrivateEvaluationExecutionCycle     @relation(fields: [cycleId], references: [cycleId], onDelete: Restrict)
+  attempts          OutcomePrivateEvaluationExecutionAttempt[]
+
+  @@id([cycleId, tradeId])
+  @@index([cycleId, status, availableAt, tradeId], map: "outcome_private_evaluation_execution_work_claim_idx")
+  @@map("outcome_private_evaluation_execution_work")
+}
+
+model OutcomePrivateEvaluationExecutionAttempt {
+  claimId          String                                @id @map("claim_id") @outcomes.Text
+  cycleId          String                                @map("cycle_id") @outcomes.Text
+  tradeId          String                                @map("trade_id") @outcomes.Text
+  attemptNumber    Int                                   @map("attempt_number")
+  workerId         String                                @map("worker_id") @outcomes.Text
+  leaseTokenSha256 String                                @map("lease_token_sha256") @outcomes.Char(64)
+  claimedAt        DateTime                              @map("claimed_at") @outcomes.Timestamptz(3)
+  leaseExpiresAt   DateTime                              @map("lease_expires_at") @outcomes.Timestamptz(3)
+  heartbeatAt      DateTime                              @map("heartbeat_at") @outcomes.Timestamptz(3)
+  finishedAt       DateTime?                             @map("finished_at") @outcomes.Timestamptz(3)
+  outcome          String?                               @outcomes.Text
+  terminalStage    String?                               @map("terminal_stage") @outcomes.Text
+  causeJson        Json?                                 @map("cause_json")
+  resultJson       Json?                                 @map("result_json")
+  work             OutcomePrivateEvaluationExecutionWork @relation(fields: [cycleId, tradeId], references: [cycleId, tradeId], onDelete: Restrict)
+
+  @@unique([cycleId, tradeId, attemptNumber], map: "outcome_private_evaluation_execution_attempt_number")
+  @@map("outcome_private_evaluation_execution_attempt")
 }
 
 model OutcomePrivateEvaluationTransitionReceipt {

--- a/src/server/aflTradeIntelligence/valuation/currentValuationCohortRunner.ts
+++ b/src/server/aflTradeIntelligence/valuation/currentValuationCohortRunner.ts
@@ -136,6 +136,12 @@ interface Dependencies {
         state: 'unavailable';
         blockers: readonly Readonly<{ code: string; message: string }>[];
       }>
+    | Readonly<{ state: 'retry_pending'; availableAt: string }>
+    | Readonly<{
+        state: 'exhausted';
+        stage: string;
+        cause: Readonly<{ code: string; message: string }>;
+      }>
     | Readonly<{ state: 'stale_authority' }>
   >;
   readonly retainUnexpectedDiagnostics: (input: {
@@ -221,6 +227,8 @@ export function createAflTradePrivateEvaluationCohortRunner(dependencies: Depend
 
       const diagnostics: AflTradePrivateEvaluationCohortUnexpectedDiagnostic[] = [];
       let stale = false;
+      const pendingTradeIds: string[] = [];
+      const exhaustedTradeIds: string[] = [];
       type CompletedEntry = Readonly<{
         entry: GovernedPrivateEvaluationBatch['content']['entries'][number];
         generatedAt: string | null;
@@ -260,6 +268,14 @@ export function createAflTradePrivateEvaluationCohortRunner(dependencies: Depend
           }
           if (result.state === 'stale_authority') {
             stale = true;
+            return null;
+          }
+          if (result.state === 'retry_pending') {
+            pendingTradeIds.push(entry.tradeId);
+            return null;
+          }
+          if (result.state === 'exhausted') {
+            exhaustedTradeIds.push(entry.tradeId);
             return null;
           }
           return {
@@ -312,7 +328,18 @@ export function createAflTradePrivateEvaluationCohortRunner(dependencies: Depend
           diagnostics: retained ?? diagnostics,
         };
       }
-      if (stale || entries.some((entry) => entry === null)) {
+      if (stale) {
+        return { state: 'stale_authority' as const };
+      }
+      pendingTradeIds.sort();
+      if (pendingTradeIds.length > 0) {
+        return { state: 'retry_pending' as const, pendingTradeIds };
+      }
+      exhaustedTradeIds.sort();
+      if (exhaustedTradeIds.length > 0) {
+        return { state: 'exhausted' as const, exhaustedTradeIds };
+      }
+      if (entries.some((entry) => entry === null)) {
         return { state: 'stale_authority' as const };
       }
       const completed = entries.filter(

--- a/src/server/aflTradeIntelligence/valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace.ts
@@ -13,6 +13,7 @@ import { createPostgresGovernedPrivateEvaluationReconstructionRepository } from 
 import { createPostgresGovernedPrivateEvaluationStagingRepository } from './postgresGovernedPrivateEvaluationStagingRepository';
 import { createPostgresGovernedPrivateEvaluationMaterializationReplay } from './postgresGovernedPrivateEvaluationMaterializationReplay';
 import type { GovernedPrivateEvaluationReadRequest } from './governedPrivateEvaluationWorkspaceContracts';
+import { AflTradePreparedValuationInputCohortCache } from '../postgresPreparedValuationInputSetStore';
 
 export function createPostgresGovernedPrivateEvaluationWorkspace(dependencies: {
   readonly client: AflOutcomeSqlClient;
@@ -45,6 +46,7 @@ export function createPostgresGovernedPrivateEvaluationWorkspace(dependencies: {
     createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture({
       artifactRepository: dependencies.artifactRepository,
       maximumArtifactBytes: dependencies.maximumArtifactBytes,
+      preparedInputCache: new AflTradePreparedValuationInputCohortCache(),
     });
   const inspection = createPostgresGovernedPrivateEvaluationInspectionRepository({
     client: dependencies.client,
@@ -178,9 +180,7 @@ export function createPostgresGovernedPrivateEvaluationWorkspace(dependencies: {
 
   return createGovernedPrivateEvaluationWorkspaceForInternalComposition({
     stageAutomated:
-      automatedStaging === undefined
-        ? undefined
-        : (request) => automatedStaging.stage(request),
+      automatedStaging === undefined ? undefined : (request) => automatedStaging.stage(request),
     inspect: (request) => inspection.inspect(request),
     execute: (request) => execution.execute(request),
     read: (request) => read.read(request),

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationCalculationAuthority.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationCalculationAuthority.ts
@@ -14,7 +14,11 @@ import type {
   AflOutcomeSqlClient,
   AflOutcomeSqlTransaction,
 } from '../../outcomes/postgresOutcomeReleaseRepository';
-import { loadCurrentAflTradePreparedValuationInputTradeFromTransaction } from '../postgresPreparedValuationInputSetStore';
+import { aflTradePreparedValuationInputEntryV3Schema } from '../preparedValuationInputSet';
+import {
+  AflTradePreparedValuationInputCohortCache,
+  loadCurrentAflTradePreparedValuationInputTradeFromTransaction,
+} from '../postgresPreparedValuationInputSetStore';
 import { aflTradeValuationCalculationInputPackageSchema } from '../valuationCalculationInputPackage';
 import { governedPrivateEvaluationInputTraceSchema } from './governedPrivateEvaluationInputTrace';
 import { capturePostgresGovernedPrivateEvaluationCurrentAuthority } from './postgresGovernedPrivateEvaluationCurrentAuthority';
@@ -39,12 +43,10 @@ type CapturedBlocker = Extract<
   { state: 'unavailable' }
 >['blockers'][number];
 
-function inspectionBlocker(
-  blocker: {
-    readonly code: keyof typeof BLOCKER_MESSAGES;
-    readonly subject: { readonly kind: string; readonly id: string };
-  }
-): CapturedBlocker {
+function inspectionBlocker(blocker: {
+  readonly code: keyof typeof BLOCKER_MESSAGES;
+  readonly subject: { readonly kind: string; readonly id: string };
+}): CapturedBlocker {
   const code =
     blocker.code === 'component_output_unavailable'
       ? 'model_not_approved'
@@ -86,12 +88,11 @@ async function loadJsonArtifact(input: {
   }
 }
 
-export function createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture(
-  dependencies: {
-    readonly artifactRepository: AflTradeImmutableArtifactRepository;
-    readonly maximumArtifactBytes: number;
-  }
-) {
+export function createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture(dependencies: {
+  readonly artifactRepository: AflTradeImmutableArtifactRepository;
+  readonly maximumArtifactBytes: number;
+  readonly preparedInputCache?: AflTradePreparedValuationInputCohortCache;
+}) {
   if (
     dependencies.artifactRepository.artifactClass !== 'derived_private' ||
     !Number.isSafeInteger(dependencies.maximumArtifactBytes) ||
@@ -108,7 +109,8 @@ export function createPostgresGovernedPrivateEvaluationCalculationAuthorityCaptu
   }): Promise<GovernedPrivateEvaluationCapturedCalculationAuthority> {
     const current = await loadCurrentAflTradePreparedValuationInputTradeFromTransaction(
       input.transaction,
-      { scopeKey: input.selector.valuationScopeKey, tradeId: input.selector.tradeId }
+      { scopeKey: input.selector.valuationScopeKey, tradeId: input.selector.tradeId },
+      dependencies.preparedInputCache
     );
     if (current === null) {
       return {
@@ -125,10 +127,7 @@ export function createPostgresGovernedPrivateEvaluationCalculationAuthorityCaptu
     if (prepared.schemaVersion !== 'afl-trade-prepared-valuation-input-set/v3') {
       throw new TypeError('Current calculation authority is not an authenticated v3 prepared set.');
     }
-    const entry = prepared.entries.find(({ tradeId }) => tradeId === input.selector.tradeId);
-    if (entry === undefined) {
-      throw new TypeError('Authenticated prepared authority omitted its selected trade.');
-    }
+    const entry = aflTradePreparedValuationInputEntryV3Schema.parse(current.entry);
     if (entry.state === 'blocked') {
       return {
         state: 'unavailable',
@@ -189,9 +188,7 @@ export function createPostgresGovernedPrivateEvaluationCalculationAuthorityCaptu
       })
     );
     if (!valuationInputBundle.success) {
-      throw new TypeError(
-        'Retained valuation input bundle failed exact contract authentication.'
-      );
+      throw new TypeError('Retained valuation input bundle failed exact contract authentication.');
     }
     const bundle = valuationInputBundle.data;
     const nestedBundleArtifacts = [
@@ -257,13 +254,9 @@ export function createPostgresGovernedPrivateEvaluationCalculationAuthorityCaptu
       trace.content.selector.tradeId !== input.selector.tradeId ||
       trace.content.factualReleaseId !== prepared.factualReleaseId ||
       trace.content.valuationInputBundleId !== bundle.valuationInputBundleId ||
-      canonicalizeAflTradeJson(traceComponents) !==
-        canonicalizeAflTradeJson(bundleComponents) ||
+      canonicalizeAflTradeJson(traceComponents) !== canonicalizeAflTradeJson(bundleComponents) ||
       calculation.calculationInputPackageId !== manifest.calculationInputPackageId ||
-      !doesAflTradeArtifactRefMatchCanonicalJson(
-        manifest.calculationInputArtifact,
-        calculation
-      ) ||
+      !doesAflTradeArtifactRefMatchCanonicalJson(manifest.calculationInputArtifact, calculation) ||
       calculation.content.tradeId !== input.selector.tradeId ||
       calculation.content.valuationInputBundleId !== bundle.valuationInputBundleId ||
       calculation.content.authority.kind !== 'authenticated_non_production' ||

--- a/src/server/aflTradeIntelligence/valuation/postgresCurrentValuationCohortRunner.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresCurrentValuationCohortRunner.ts
@@ -20,6 +20,14 @@ import {
   GovernedPrivateEvaluationBatchConflictError,
   type PostgresGovernedPrivateEvaluationBatchRepository,
 } from './internal/postgresGovernedPrivateEvaluationBatchRepository';
+import {
+  AFL_TRADE_PRIVATE_EVALUATION_COHORT_EXECUTION_POLICY,
+  classifyAflTradePrivateEvaluationExecutionError,
+} from './privateEvaluationCohortExecution';
+import {
+  PostgresAflTradePrivateEvaluationCohortExecutionRepository,
+  createAflTradePrivateEvaluationExecutionOperationId,
+} from './postgresPrivateEvaluationCohortExecutionRepository';
 
 interface CaptureRow {
   readonly prepared_input_set_id: string;
@@ -59,11 +67,22 @@ function instant(value: Date | string): string {
   return parsed.toISOString();
 }
 
+function boundedExecutionMessage(value: unknown): string {
+  const normalized = String(value).trim() || 'Unknown thrown value.';
+  return Array.from(normalized).slice(0, 4_000).join('');
+}
+
 export function createPostgresAflTradePrivateEvaluationCohortRunner(dependencies: {
   readonly client: AflOutcomeSqlClient;
   readonly workspace: GovernedPrivateEvaluationWorkspace;
   readonly batchRepository: PostgresGovernedPrivateEvaluationBatchRepository;
+  readonly executionRepository?: PostgresAflTradePrivateEvaluationCohortExecutionRepository;
+  readonly workerId?: string;
 }) {
+  const executionRepository =
+    dependencies.executionRepository ??
+    new PostgresAflTradePrivateEvaluationCohortExecutionRepository(dependencies.client);
+  const workerId = dependencies.workerId ?? 'system:weekly-valuation-coordinator';
   const captureCurrent = async (scopeKey: string) =>
     dependencies.client.transaction(async (transaction) => {
       await transaction.query(`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ`);
@@ -251,39 +270,199 @@ export function createPostgresAflTradePrivateEvaluationCohortRunner(dependencies
         modelPairRevision: captured.capture.modelPairRevision,
         expectedBatchRevision: captured.capture.expectedBatchRevision,
       });
+      let executionCyclePromise: ReturnType<
+        PostgresAflTradePrivateEvaluationCohortExecutionRepository['openAutomatic']
+      > | null = null;
+      const loadExecutionCycle = () => {
+        executionCyclePromise ??= executionRepository.openAutomatic({
+          authority: {
+            scopeKey,
+            preparedInputSetId: captured.capture.preparedInputSetId,
+            preparedInputSetRevision: captured.capture.preparedInputSetRevision,
+            factualReleaseRevision: captured.capture.factualReleaseRevision,
+            modelQualificationWorkId: captured.capture.modelQualificationWorkId,
+            modelPairRevision: captured.capture.modelPairRevision,
+          },
+          readyTradeIds: captured.capture.entries
+            .filter((entry) => entry.state === 'ready')
+            .map(({ tradeId }) => tradeId),
+          openedAt: captured.capture.capturedAt,
+        });
+        return executionCyclePromise;
+      };
       const runner = createAflTradePrivateEvaluationCohortRunner({
         captureCurrent: async () => captured,
         stageTrade: async (input) => {
-          const staged = await dependencies.workspace.stageAutomated(input);
-          if (staged.state !== 'activated') return staged;
-          const retained = await dependencies.client.query<{ readonly generation_json: unknown }>(
-            `SELECT generation_json
-               FROM outcome_local_private_trade_evaluation_generation
-              WHERE valuation_scope_key=$1 AND trade_id=$2 AND generation_id=$3`,
-            [input.selector.valuationScopeKey, input.selector.tradeId, staged.generationId]
+          const executionCycle = await loadExecutionCycle();
+          const existing = await executionRepository.loadWork(
+            executionCycle.cycleId,
+            input.selector.tradeId
           );
-          if (retained.rows.length !== 1) {
-            throw new TypeError(
-              'Activated private evaluation generation is missing exact retained custody.'
-            );
+          if (existing.result !== null) return existing.result;
+          if (existing.status === 'exhausted') {
+            return {
+              state: 'exhausted' as const,
+              stage: existing.terminalStage ?? 'stage_automated',
+              cause: existing.terminalCause ?? {
+                code: 'execution_exhausted',
+                message: 'Durable execution exhausted without retained cause.',
+                retryable: false,
+              },
+            };
           }
-          const generation = parseGovernedPrivateEvaluationGeneration(
-            retained.rows[0]!.generation_json
-          );
-          if (
-            generation.generationId !== staged.generationId ||
-            generation.content.selector.valuationScopeKey !== input.selector.valuationScopeKey ||
-            generation.content.selector.tradeId !== input.selector.tradeId
-          ) {
-            throw new TypeError(
-              'Activated private evaluation generation escaped its retained selector custody.'
+          const claim = await executionRepository.claim({
+            cycleId: executionCycle.cycleId,
+            tradeId: input.selector.tradeId,
+            workerId,
+          });
+          if (claim === null) {
+            const work = await executionRepository.loadWork(
+              executionCycle.cycleId,
+              input.selector.tradeId
             );
+            if (work.result !== null) return work.result;
+            if (work.status === 'exhausted') {
+              return {
+                state: 'exhausted' as const,
+                stage: work.terminalStage ?? 'stage_automated',
+                cause: work.terminalCause ?? {
+                  code: 'execution_exhausted',
+                  message: 'Durable execution exhausted without retained cause.',
+                  retryable: false,
+                },
+              };
+            }
+            return { state: 'retry_pending' as const, availableAt: work.availableAt };
           }
-          return {
-            state: 'activated' as const,
-            generationId: staged.generationId,
-            generatedAt: generation.content.generatedAt,
+          let heartbeatFailure: unknown = null;
+          let heartbeatInFlight: Promise<void> = Promise.resolve();
+          const heartbeatTimer = setInterval(() => {
+            heartbeatInFlight = heartbeatInFlight
+              .then(async () => {
+                if (heartbeatFailure === null) await executionRepository.heartbeat(claim);
+              })
+              .catch((error: unknown) => {
+                heartbeatFailure = error;
+              });
+          }, AFL_TRADE_PRIVATE_EVALUATION_COHORT_EXECUTION_POLICY.heartbeatSeconds * 1_000);
+          heartbeatTimer.unref?.();
+          const stopHeartbeat = async () => {
+            clearInterval(heartbeatTimer);
+            await heartbeatInFlight;
+            if (heartbeatFailure !== null) throw heartbeatFailure;
           };
+          let completing = false;
+          try {
+            const staged = await dependencies.workspace.stageAutomated({
+              ...input,
+              operationId: createAflTradePrivateEvaluationExecutionOperationId({
+                cycleId: executionCycle.cycleId,
+                tradeId: input.selector.tradeId,
+              }),
+            });
+            if (heartbeatFailure !== null) throw heartbeatFailure;
+            if (staged.state === 'stale_authority') {
+              completing = true;
+              await stopHeartbeat();
+              await executionRepository.complete({
+                claim,
+                outcome: 'permanent_failure',
+                stage: 'stage_automated',
+                cause: {
+                  code: 'stale_authority',
+                  message: 'Governed authority changed while the trade was staged.',
+                  retryable: false,
+                },
+                result: null,
+              });
+              return staged;
+            }
+            if (staged.state === 'unavailable') {
+              const result = { state: 'unavailable' as const, blockers: staged.blockers };
+              completing = true;
+              await stopHeartbeat();
+              await executionRepository.complete({
+                claim,
+                outcome: 'unavailable',
+                stage: null,
+                cause: null,
+                result,
+              });
+              return result;
+            }
+            if (staged.state !== 'activated') return staged;
+            const retained = await dependencies.client.query<{
+              readonly generation_json: unknown;
+            }>(
+              `SELECT generation_json
+                 FROM outcome_local_private_trade_evaluation_generation
+                WHERE valuation_scope_key=$1 AND trade_id=$2 AND generation_id=$3`,
+              [input.selector.valuationScopeKey, input.selector.tradeId, staged.generationId]
+            );
+            if (retained.rows.length !== 1) {
+              throw new TypeError(
+                'Activated private evaluation generation is missing exact retained custody.'
+              );
+            }
+            const generation = parseGovernedPrivateEvaluationGeneration(
+              retained.rows[0]!.generation_json
+            );
+            if (
+              generation.generationId !== staged.generationId ||
+              generation.content.selector.valuationScopeKey !== input.selector.valuationScopeKey ||
+              generation.content.selector.tradeId !== input.selector.tradeId
+            ) {
+              throw new TypeError(
+                'Activated private evaluation generation escaped its retained selector custody.'
+              );
+            }
+            const result = {
+              state: 'activated' as const,
+              generationId: staged.generationId,
+              generatedAt: generation.content.generatedAt,
+            };
+            completing = true;
+            await stopHeartbeat();
+            await executionRepository.complete({
+              claim,
+              outcome: 'succeeded',
+              stage: null,
+              cause: null,
+              result,
+            });
+            return result;
+          } catch (error) {
+            if (completing) throw error;
+            const transientCause = classifyAflTradePrivateEvaluationExecutionError(error);
+            const cause =
+              transientCause ??
+              ({
+                code: 'unexpected_execution_failure',
+                message: boundedExecutionMessage(error instanceof Error ? error.message : error),
+                retryable: false,
+              } as const);
+            await stopHeartbeat();
+            const status = await executionRepository.complete({
+              claim,
+              outcome: cause.retryable ? 'transient_failure' : 'permanent_failure',
+              stage: 'stage_automated',
+              cause,
+              result: null,
+            });
+            if (cause.retryable) {
+              const work = await executionRepository.loadWork(
+                executionCycle.cycleId,
+                input.selector.tradeId
+              );
+              return status === 'exhausted'
+                ? { state: 'exhausted' as const, stage: 'stage_automated', cause }
+                : { state: 'retry_pending' as const, availableAt: work.availableAt };
+            }
+            throw error;
+          } finally {
+            clearInterval(heartbeatTimer);
+            await heartbeatInFlight;
+          }
         },
         retainUnexpectedDiagnostics: async ({ request, capture, diagnostics }) => {
           const existing = await dependencies.client.query<{
@@ -395,6 +574,34 @@ export function createPostgresAflTradePrivateEvaluationCohortRunner(dependencies
         },
       });
       return runner.run({ scopeKey, operationId });
+    },
+    async repairCurrent(scopeKey: string, reason: string, repairOperationId: string) {
+      const replay = await executionRepository.loadRepair(repairOperationId);
+      if (replay !== null) {
+        if (
+          replay.content.authority.scopeKey !== scopeKey ||
+          replay.content.repairReason !== reason
+        ) {
+          throw new TypeError('Explicit repair replay conflicts with retained custody.');
+        }
+        return replay;
+      }
+      const captured = await captureCurrent(scopeKey);
+      return executionRepository.openRepair({
+        authority: {
+          scopeKey,
+          preparedInputSetId: captured.capture.preparedInputSetId,
+          preparedInputSetRevision: captured.capture.preparedInputSetRevision,
+          factualReleaseRevision: captured.capture.factualReleaseRevision,
+          modelQualificationWorkId: captured.capture.modelQualificationWorkId,
+          modelPairRevision: captured.capture.modelPairRevision,
+        },
+        readyTradeIds: captured.capture.entries
+          .filter((entry) => entry.state === 'ready')
+          .map(({ tradeId }) => tradeId),
+        repairOperationId,
+        reason,
+      });
     },
   };
 }

--- a/src/server/aflTradeIntelligence/valuation/postgresPreparedValuationInputSetStore.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPreparedValuationInputSetStore.ts
@@ -57,9 +57,31 @@ export interface AflTradeCurrentPreparedValuationInputSet {
   readonly preparedInputSet: AflTradePreparedValuationInputSet;
 }
 
-export interface AflTradeCurrentPreparedValuationInputTrade
-  extends AflTradeCurrentPreparedValuationInputSet {
+export interface AflTradeCurrentPreparedValuationInputTrade extends AflTradeCurrentPreparedValuationInputSet {
   readonly entry: AflTradePreparedValuationInputEntry;
+}
+
+export class AflTradePreparedValuationInputCohortCache {
+  private key: string | null = null;
+  private value: Promise<AflTradePreparedValuationInputSet> | null = null;
+
+  load(
+    head: AflTradeCurrentPreparedValuationInputHead,
+    loader: () => Promise<AflTradePreparedValuationInputSet>
+  ): Promise<AflTradePreparedValuationInputSet> {
+    const key = `${head.scopeKey}\u0000${head.preparedInputSetId}\u0000${head.revision}`;
+    if (this.key !== key || this.value === null) {
+      this.key = key;
+      this.value = loader().catch((error: unknown) => {
+        if (this.key === key) {
+          this.key = null;
+          this.value = null;
+        }
+        throw error;
+      });
+    }
+    return this.value;
+  }
 }
 
 export class AflTradePreparedValuationInputSetStoreError extends Error {
@@ -216,8 +238,7 @@ async function loadCurrentFromClient(
   const head = authenticateCurrentHead(row);
   const preparedInputSet = await loadExactFromClient(client, head.preparedInputSetId);
   if (
-    preparedInputSet.content.schemaVersion !==
-      'afl-trade-prepared-valuation-input-set/v3' ||
+    preparedInputSet.content.schemaVersion !== 'afl-trade-prepared-valuation-input-set/v3' ||
     preparedInputSet.content.scopeKey !== scopeKey ||
     head.scopeKey !== scopeKey
   ) {
@@ -231,17 +252,57 @@ async function loadCurrentFromClient(
 
 export async function loadCurrentAflTradePreparedValuationInputTradeFromTransaction(
   transaction: AflOutcomeSqlTransaction,
-  input: { readonly scopeKey: string; readonly tradeId: string }
+  input: { readonly scopeKey: string; readonly tradeId: string },
+  cache?: AflTradePreparedValuationInputCohortCache
 ): Promise<AflTradeCurrentPreparedValuationInputTrade | null> {
   if (input.scopeKey.trim() === '' || input.tradeId.trim() === '') {
     throw new TypeError('Current prepared trade authority requires a complete selector.');
   }
-  const current = await loadCurrentFromClient(transaction, input.scopeKey);
-  if (!current) return null;
-  const entry = current.preparedInputSet.content.entries.find(
-    ({ tradeId }) => tradeId === input.tradeId
+  const headResult = await transaction.query<CurrentPreparedSetHeadRow>(
+    `SELECT scope_key,prepared_input_set_id,revision,activated_at
+       FROM outcome_current_prepared_valuation_input_set WHERE scope_key=$1`,
+    [input.scopeKey]
   );
-  return entry ? { ...current, entry } : null;
+  const headRow = headResult.rows[0];
+  if (headRow === undefined) return null;
+  const head = authenticateCurrentHead(headRow);
+  const preparedInputSet = await (cache?.load(head, () =>
+    loadExactFromClient(transaction, head.preparedInputSetId)
+  ) ?? loadExactFromClient(transaction, head.preparedInputSetId));
+  if (
+    preparedInputSet.content.schemaVersion !== 'afl-trade-prepared-valuation-input-set/v3' ||
+    preparedInputSet.content.scopeKey !== input.scopeKey ||
+    head.scopeKey !== input.scopeKey
+  ) {
+    throw new AflTradePreparedValuationInputSetStoreError(
+      'INTEGRITY_MISMATCH',
+      'Current prepared valuation input head does not authenticate finalized v3 scope authority.'
+    );
+  }
+  const entryResult = await transaction.query<PreparedEntryRow>(
+    `SELECT ordinal,trade_id,state,entry_canonical_json,entry_json
+       FROM outcome_prepared_valuation_input_entry
+      WHERE prepared_input_set_id=$1 AND trade_id=$2`,
+    [head.preparedInputSetId, input.tradeId]
+  );
+  const row = entryResult.rows[0];
+  if (row === undefined) return null;
+  const expected = preparedInputSet.content.entries[row.ordinal - 1];
+  if (
+    entryResult.rows.length !== 1 ||
+    row.ordinal < 1 ||
+    row.trade_id !== input.tradeId ||
+    expected?.tradeId !== row.trade_id ||
+    expected.state !== row.state ||
+    row.entry_canonical_json !== canonicalizeAflTradeJson(expected) ||
+    canonicalizeAflTradeJson(row.entry_json) !== canonicalizeAflTradeJson(expected)
+  ) {
+    throw new AflTradePreparedValuationInputSetStoreError(
+      'INTEGRITY_MISMATCH',
+      'Targeted prepared trade custody disagrees with its authenticated parent.'
+    );
+  }
+  return { head, preparedInputSet, entry: expected };
 }
 
 export interface AflTradePreparedValuationInputSetStore {
@@ -418,10 +479,7 @@ export class PostgresAflTradePreparedValuationInputSetStore implements AflTradeP
     }
     return this.client.transaction(async (transaction) => {
       await transaction.query(`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ`);
-      return loadCurrentAflTradePreparedValuationInputTradeFromTransaction(
-        transaction,
-        input
-      );
+      return loadCurrentAflTradePreparedValuationInputTradeFromTransaction(transaction, input);
     });
   }
 }

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateEvaluationCohortExecutionRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateEvaluationCohortExecutionRepository.ts
@@ -1,0 +1,458 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+import { z } from 'zod';
+
+import {
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '../artifacts/contentAddress';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../outcomes/postgresOutcomeReleaseRepository';
+import {
+  AFL_TRADE_PRIVATE_EVALUATION_COHORT_EXECUTION_POLICY,
+  aflTradePrivateEvaluationCohortExecutionCycleSchema,
+  aflTradePrivateEvaluationExecutionCauseSchema,
+  aflTradePrivateEvaluationExecutionResultSchema,
+  createAflTradePrivateEvaluationCohortExecutionCycle,
+  createAflTradePrivateEvaluationCohortInputFingerprint,
+  type AflTradePrivateEvaluationCohortExecutionCycle,
+  type AflTradePrivateEvaluationExecutionCause,
+  type AflTradePrivateEvaluationExecutionResult,
+} from './privateEvaluationCohortExecution';
+
+const idSchema = z.string().trim().min(1).max(400);
+const EXECUTION_DATABASE_ROLE = 'afl_trade_private_evaluation_coordinator';
+const tradeIdsSchema = z
+  .array(idSchema)
+  .max(10_000)
+  .superRefine((ids, context) => {
+    if (
+      new Set(ids).size !== ids.length ||
+      ids.some((id, index) => index > 0 && ids[index - 1]! > id)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Execution-cycle trade IDs must be unique and ordered.',
+      });
+    }
+  });
+
+type Authority = AflTradePrivateEvaluationCohortExecutionCycle['content']['authority'];
+type WorkStatus = 'pending' | 'leased' | 'retry_wait' | 'succeeded' | 'unavailable' | 'exhausted';
+
+interface CycleRow {
+  readonly cycle_json: unknown;
+}
+
+interface ClaimRow {
+  readonly claim_id: string;
+  readonly attempt_number: number;
+  readonly lease_expires_at: Date | string;
+}
+
+interface WorkRow {
+  readonly status: WorkStatus;
+  readonly attempt_count: number;
+  readonly available_at: Date | string;
+  readonly lease_expires_at: Date | string | null;
+  readonly terminal_stage: string | null;
+  readonly terminal_cause_json: unknown | null;
+  readonly result_json: unknown | null;
+}
+
+function instant(value: Date | string): string {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(parsed.getTime())) {
+    throw new TypeError('Private evaluation execution received invalid PostgreSQL time.');
+  }
+  return parsed.toISOString();
+}
+
+function tokenDigest(token: string): string {
+  return createHash('sha256').update(token, 'utf8').digest('hex');
+}
+
+async function loadExactCycle(
+  transaction: AflOutcomeSqlTransaction,
+  cycleId: string
+): Promise<AflTradePrivateEvaluationCohortExecutionCycle> {
+  const result = await transaction.query<CycleRow>(
+    `SELECT cycle_json FROM outcome_private_evaluation_execution_cycle
+      WHERE cycle_id=$1`,
+    [cycleId]
+  );
+  if (result.rows.length !== 1) {
+    throw new TypeError('Private evaluation execution did not retain one exact cycle.');
+  }
+  return aflTradePrivateEvaluationCohortExecutionCycleSchema.parse(result.rows[0]!.cycle_json);
+}
+
+async function registerCycle(
+  transaction: AflOutcomeSqlTransaction,
+  cycle: AflTradePrivateEvaluationCohortExecutionCycle,
+  tradeIds: readonly string[]
+): Promise<AflTradePrivateEvaluationCohortExecutionCycle> {
+  await transaction.query(
+    `INSERT INTO outcome_private_evaluation_execution_cycle
+      (cycle_id,input_fingerprint,scope_key,prepared_input_set_id,
+       prepared_input_set_revision,factual_release_revision,
+       model_qualification_work_id,model_pair_revision,repair_sequence,
+       opening_cause,opening_principal_id,repair_operation_id,repair_reason,repairs_cycle_id,
+       maximum_attempts,opened_at,cycle_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17::jsonb)
+     ON CONFLICT (cycle_id) DO NOTHING`,
+    [
+      cycle.cycleId,
+      cycle.content.inputFingerprint,
+      cycle.content.authority.scopeKey,
+      cycle.content.authority.preparedInputSetId,
+      cycle.content.authority.preparedInputSetRevision,
+      cycle.content.authority.factualReleaseRevision,
+      cycle.content.authority.modelQualificationWorkId,
+      cycle.content.authority.modelPairRevision,
+      cycle.content.repairSequence,
+      cycle.content.openingCause,
+      cycle.content.openingPrincipalId,
+      cycle.content.repairOperationId,
+      cycle.content.repairReason,
+      cycle.content.repairsCycleId,
+      cycle.content.maximumAttemptsPerTrade,
+      cycle.content.openedAt,
+      canonicalizeAflTradeJson(cycle),
+    ]
+  );
+  for (const tradeId of tradeIds) {
+    await transaction.query(
+      `INSERT INTO outcome_private_evaluation_execution_work
+        (cycle_id,trade_id,status,attempt_count,available_at)
+       VALUES ($1,$2,'pending',0,$3)
+       ON CONFLICT (cycle_id,trade_id) DO NOTHING`,
+      [cycle.cycleId, tradeId, cycle.content.openedAt]
+    );
+  }
+  const retained = await loadExactCycle(transaction, cycle.cycleId);
+  if (canonicalizeAflTradeJson(retained) !== canonicalizeAflTradeJson(cycle)) {
+    throw new TypeError('Private evaluation execution cycle replay conflicts with custody.');
+  }
+  await authenticateCycleWork(transaction, cycle.cycleId, tradeIds);
+  return retained;
+}
+
+async function authenticateCycleWork(
+  transaction: AflOutcomeSqlTransaction,
+  cycleId: string,
+  tradeIds: readonly string[]
+): Promise<void> {
+  const retainedWork = await transaction.query<{ readonly trade_id: string }>(
+    `SELECT trade_id FROM outcome_private_evaluation_execution_work
+      WHERE cycle_id=$1 ORDER BY trade_id`,
+    [cycleId]
+  );
+  if (
+    retainedWork.rows.length !== tradeIds.length ||
+    retainedWork.rows.some(({ trade_id }, index) => trade_id !== tradeIds[index])
+  ) {
+    throw new TypeError('Private evaluation execution cycle work replay conflicts with custody.');
+  }
+}
+
+async function authenticateRetainedCycleWork(
+  transaction: AflOutcomeSqlTransaction,
+  cycle: AflTradePrivateEvaluationCohortExecutionCycle
+): Promise<void> {
+  const expectedWork = await transaction.query<{ readonly trade_id: string }>(
+    `SELECT entry.trade_id
+       FROM outcome_prepared_valuation_input_entry entry
+      WHERE entry.prepared_input_set_id=$1 AND entry.state='ready'
+      ORDER BY entry.trade_id`,
+    [cycle.content.authority.preparedInputSetId]
+  );
+  await authenticateCycleWork(
+    transaction,
+    cycle.cycleId,
+    expectedWork.rows.map(({ trade_id }) => trade_id)
+  );
+}
+
+export interface AflTradePrivateEvaluationExecutionClaim {
+  readonly claimId: string;
+  readonly cycleId: string;
+  readonly tradeId: string;
+  readonly attemptNumber: number;
+  readonly leaseToken: string;
+  readonly leaseExpiresAt: string;
+}
+
+export interface AflTradePrivateEvaluationExecutionWork {
+  readonly status: WorkStatus;
+  readonly attemptCount: number;
+  readonly availableAt: string;
+  readonly leaseExpiresAt: string | null;
+  readonly terminalStage: string | null;
+  readonly terminalCause: AflTradePrivateEvaluationExecutionCause | null;
+  readonly result: AflTradePrivateEvaluationExecutionResult | null;
+}
+
+export class PostgresAflTradePrivateEvaluationCohortExecutionRepository {
+  constructor(private readonly client: AflOutcomeSqlClient) {}
+
+  async openAutomatic(input: {
+    readonly authority: Authority;
+    readonly readyTradeIds: readonly string[];
+    readonly openedAt: string;
+  }): Promise<AflTradePrivateEvaluationCohortExecutionCycle> {
+    const tradeIds = tradeIdsSchema.parse(input.readyTradeIds);
+    const fingerprint = createAflTradePrivateEvaluationCohortInputFingerprint(input.authority);
+    return this.client.transaction(async (transaction) => {
+      await transaction.query(`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`);
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      await transaction.query(`SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, [
+        fingerprint,
+      ]);
+      const existing = await transaction.query<CycleRow>(
+        `SELECT cycle_json FROM outcome_private_evaluation_execution_cycle
+          WHERE input_fingerprint=$1 ORDER BY repair_sequence DESC LIMIT 1`,
+        [fingerprint]
+      );
+      const cycle =
+        existing.rows[0] === undefined
+          ? createAflTradePrivateEvaluationCohortExecutionCycle({
+              authority: input.authority,
+              repairSequence: 0,
+              openedAt: input.openedAt,
+            })
+          : aflTradePrivateEvaluationCohortExecutionCycleSchema.parse(existing.rows[0].cycle_json);
+      return registerCycle(transaction, cycle, tradeIds);
+    });
+  }
+
+  async openRepair(input: {
+    readonly authority: Authority;
+    readonly readyTradeIds: readonly string[];
+    readonly repairOperationId: string;
+    readonly reason: string;
+  }): Promise<AflTradePrivateEvaluationCohortExecutionCycle> {
+    const tradeIds = tradeIdsSchema.parse(input.readyTradeIds);
+    const fingerprint = createAflTradePrivateEvaluationCohortInputFingerprint(input.authority);
+    return this.client.transaction(async (transaction) => {
+      await transaction.query(`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`);
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      await transaction.query(`SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, [
+        fingerprint,
+      ]);
+      const existing = await transaction.query<CycleRow>(
+        `SELECT cycle_json FROM outcome_private_evaluation_execution_cycle
+          WHERE repair_operation_id=$1`,
+        [input.repairOperationId]
+      );
+      if (existing.rows[0] !== undefined) {
+        const retained = aflTradePrivateEvaluationCohortExecutionCycleSchema.parse(
+          existing.rows[0].cycle_json
+        );
+        if (
+          retained.content.inputFingerprint !== fingerprint ||
+          retained.content.repairReason !== input.reason
+        ) {
+          throw new TypeError('Explicit repair replay conflicts with retained custody.');
+        }
+        await authenticateCycleWork(transaction, retained.cycleId, tradeIds);
+        return retained;
+      }
+      const prior = await transaction.query<{ readonly repair_sequence: number }>(
+        `SELECT repair_sequence FROM outcome_private_evaluation_execution_cycle
+          WHERE input_fingerprint=$1 ORDER BY repair_sequence DESC LIMIT 1`,
+        [fingerprint]
+      );
+      if (prior.rows.length !== 1) {
+        throw new TypeError('Explicit repair requires one prior execution cycle.');
+      }
+      const nonterminal = await transaction.query<{ readonly count: number }>(
+        `SELECT count(*)::int AS count
+           FROM outcome_private_evaluation_execution_work
+          WHERE cycle_id=(SELECT cycle_id FROM outcome_private_evaluation_execution_cycle
+                           WHERE input_fingerprint=$1 AND repair_sequence=$2)
+            AND status NOT IN ('succeeded','unavailable','exhausted')`,
+        [fingerprint, prior.rows[0]!.repair_sequence]
+      );
+      if (nonterminal.rows[0]?.count !== 0) {
+        throw new TypeError('Explicit repair requires a terminal predecessor cycle.');
+      }
+      const trustedTime = await transaction.query<{ readonly opened_at: Date | string }>(
+        `SELECT date_trunc('milliseconds',transaction_timestamp()) AS opened_at`
+      );
+      const cycle = createAflTradePrivateEvaluationCohortExecutionCycle({
+        authority: input.authority,
+        repairSequence: prior.rows[0]!.repair_sequence + 1,
+        openedAt: instant(trustedTime.rows[0]!.opened_at),
+        repairOperationId: input.repairOperationId,
+        repairReason: input.reason,
+      });
+      return registerCycle(transaction, cycle, tradeIds);
+    });
+  }
+
+  async claim(input: {
+    readonly cycleId: string;
+    readonly tradeId: string;
+    readonly workerId: string;
+  }): Promise<AflTradePrivateEvaluationExecutionClaim | null> {
+    const cycleId = idSchema.parse(input.cycleId);
+    const tradeId = idSchema.parse(input.tradeId);
+    const workerId = idSchema.parse(input.workerId);
+    const leaseToken = randomBytes(32).toString('hex');
+    const result = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<ClaimRow>(
+        `SELECT * FROM claim_outcome_private_evaluation_work($1,$2,$3,$4)`,
+        [cycleId, tradeId, workerId, tokenDigest(leaseToken)]
+      );
+    });
+    const row = result.rows[0];
+    return row === undefined
+      ? null
+      : {
+          claimId: row.claim_id,
+          cycleId,
+          tradeId,
+          attemptNumber: row.attempt_number,
+          leaseToken,
+          leaseExpiresAt: instant(row.lease_expires_at),
+        };
+  }
+
+  async loadRepair(
+    repairOperationId: string
+  ): Promise<AflTradePrivateEvaluationCohortExecutionCycle | null> {
+    return this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      const result = await transaction.query<CycleRow>(
+        `SELECT cycle_json FROM outcome_private_evaluation_execution_cycle
+          WHERE repair_operation_id=$1`,
+        [idSchema.parse(repairOperationId)]
+      );
+      if (result.rows.length === 0) return null;
+      if (result.rows.length !== 1) {
+        throw new TypeError('Explicit repair operation resolved ambiguous retained custody.');
+      }
+      const retained = aflTradePrivateEvaluationCohortExecutionCycleSchema.parse(
+        result.rows[0]!.cycle_json
+      );
+      await authenticateRetainedCycleWork(transaction, retained);
+      return retained;
+    });
+  }
+
+  async heartbeat(claim: AflTradePrivateEvaluationExecutionClaim): Promise<string> {
+    const result = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<{ readonly renewed_at: Date | string }>(
+        `SELECT heartbeat_outcome_private_evaluation_work($1,$2) AS renewed_at`,
+        [claim.claimId, tokenDigest(claim.leaseToken)]
+      );
+    });
+    if (result.rows.length !== 1) {
+      throw new Error('Private evaluation execution heartbeat returned no lease.');
+    }
+    return instant(result.rows[0]!.renewed_at);
+  }
+
+  async complete(input: {
+    readonly claim: AflTradePrivateEvaluationExecutionClaim;
+    readonly outcome: 'succeeded' | 'unavailable' | 'transient_failure' | 'permanent_failure';
+    readonly stage: string | null;
+    readonly cause: AflTradePrivateEvaluationExecutionCause | null;
+    readonly result: AflTradePrivateEvaluationExecutionResult | null;
+  }): Promise<WorkStatus> {
+    const cause =
+      input.cause === null
+        ? null
+        : aflTradePrivateEvaluationExecutionCauseSchema.parse(input.cause);
+    const result =
+      input.result === null
+        ? null
+        : aflTradePrivateEvaluationExecutionResultSchema.parse(input.result);
+    if (
+      (input.outcome === 'succeeded' && result?.state !== 'activated') ||
+      (input.outcome === 'unavailable' && result?.state !== 'unavailable') ||
+      (input.outcome.endsWith('_failure') && cause === null)
+    ) {
+      throw new TypeError('Private evaluation execution completion shape is invalid.');
+    }
+    const completed = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<{ readonly status: WorkStatus }>(
+        `SELECT complete_outcome_private_evaluation_work($1,$2,$3,$4,$5::jsonb,$6::jsonb) AS status`,
+        [
+          input.claim.claimId,
+          tokenDigest(input.claim.leaseToken),
+          input.outcome,
+          input.stage,
+          cause === null ? null : canonicalizeAflTradeJson(cause),
+          result === null ? null : canonicalizeAflTradeJson(result),
+        ]
+      );
+    });
+    const status = completed.rows[0]?.status;
+    if (status === undefined) {
+      throw new Error('Private evaluation execution completion returned no status.');
+    }
+    return status;
+  }
+
+  async loadWork(
+    cycleId: string,
+    tradeId: string
+  ): Promise<AflTradePrivateEvaluationExecutionWork> {
+    const result = await this.client.query<WorkRow>(
+      `SELECT status,attempt_count,available_at,lease_expires_at,
+              terminal_stage,terminal_cause_json,result_json
+         FROM outcome_private_evaluation_execution_work
+        WHERE cycle_id=$1 AND trade_id=$2`,
+      [idSchema.parse(cycleId), idSchema.parse(tradeId)]
+    );
+    if (result.rows.length !== 1) {
+      throw new TypeError('Private evaluation execution work was not found.');
+    }
+    const row = result.rows[0]!;
+    return {
+      status: row.status,
+      attemptCount: row.attempt_count,
+      availableAt: instant(row.available_at),
+      leaseExpiresAt: row.lease_expires_at === null ? null : instant(row.lease_expires_at),
+      terminalStage: row.terminal_stage,
+      terminalCause:
+        row.terminal_cause_json === null
+          ? null
+          : aflTradePrivateEvaluationExecutionCauseSchema.parse(row.terminal_cause_json),
+      result:
+        row.result_json === null
+          ? null
+          : aflTradePrivateEvaluationExecutionResultSchema.parse(row.result_json),
+    };
+  }
+
+  async explainTargetedPreparedTradeLookup(
+    preparedInputSetId: string,
+    tradeId: string
+  ): Promise<readonly string[]> {
+    const result = await this.client.query<{ readonly 'QUERY PLAN': string }>(
+      `EXPLAIN (COSTS TRUE, FORMAT TEXT)
+       SELECT entry_json FROM outcome_prepared_valuation_input_entry
+        WHERE prepared_input_set_id=$1 AND trade_id=$2`,
+      [idSchema.parse(preparedInputSetId), idSchema.parse(tradeId)]
+    );
+    return result.rows.map((row) => row['QUERY PLAN']);
+  }
+}
+
+export const AFL_TRADE_PRIVATE_EVALUATION_MAXIMUM_CONCURRENCY =
+  AFL_TRADE_PRIVATE_EVALUATION_COHORT_EXECUTION_POLICY.maximumConcurrency;
+
+export function createAflTradePrivateEvaluationExecutionOperationId(input: {
+  readonly cycleId: string;
+  readonly tradeId: string;
+}): string {
+  return createAflTradeContentAddress('private-evaluation-operation', input);
+}

--- a/src/server/aflTradeIntelligence/valuation/preparedValuationInputSet.ts
+++ b/src/server/aflTradeIntelligence/valuation/preparedValuationInputSet.ts
@@ -71,9 +71,7 @@ const readyEntryV2Schema = z
   .object({
     tradeId: publicIdSchema,
     state: z.literal('ready'),
-    calculationInputPackageId: aflTradeContentAddressedIdSchema(
-      'valuation-calculation-input'
-    ),
+    calculationInputPackageId: aflTradeContentAddressedIdSchema('valuation-calculation-input'),
     calculationInputArtifact: aflTradeArtifactRefSchema,
     inputTraceId: aflTradeContentAddressedIdSchema('private-evaluation-input-trace'),
     inputTraceArtifact: aflTradeArtifactRefSchema,
@@ -131,7 +129,7 @@ const aflTradePreparedValuationInputEntryV2Schema = z.discriminatedUnion('state'
   blockedEntrySchema,
 ]);
 
-const aflTradePreparedValuationInputEntryV3Schema = z.discriminatedUnion('state', [
+export const aflTradePreparedValuationInputEntryV3Schema = z.discriminatedUnion('state', [
   readyEntryV3Schema,
   blockedEntrySchema,
 ]);
@@ -160,9 +158,7 @@ const aflTradePreparedValuationInputSetContentV1Schema = z
     factualReleaseArtifact: aflTradeArtifactRefSchema,
     releaseMembershipArtifact: aflTradeArtifactRefSchema,
     preparationAuthority: z.literal('source_policy_preflight_only'),
-    qualificationOperation: z.literal(
-      'valuation_model_training_and_derived_feature_creation'
-    ),
+    qualificationOperation: z.literal('valuation_model_training_and_derived_feature_creation'),
     qualificationReportId: aflTradeContentAddressedIdSchema('valuation-source-qualification'),
     qualificationReportArtifact: aflTradeArtifactRefSchema,
     sourceQualificationEvidenceRefs: z.array(aflTradeArtifactRefSchema).min(1).max(1_000),
@@ -290,9 +286,7 @@ const aflTradePreparedValuationInputSetContentV2Schema = z
     factualReleaseArtifact: aflTradeArtifactRefSchema,
     releaseMembershipArtifact: aflTradeArtifactRefSchema,
     preparationAuthority: z.literal('authenticated_calculation_evidence_snapshot'),
-    qualificationOperation: z.literal(
-      'valuation_model_training_and_derived_feature_creation'
-    ),
+    qualificationOperation: z.literal('valuation_model_training_and_derived_feature_creation'),
     qualificationReportId: aflTradeContentAddressedIdSchema('valuation-source-qualification'),
     qualificationReportArtifact: aflTradeArtifactRefSchema,
     sourceQualificationEvidenceRefs: z.array(aflTradeArtifactRefSchema).min(1).max(1_000),
@@ -425,9 +419,7 @@ const aflTradePreparedValuationInputSetContentV3Schema = z
     factualReleaseArtifact: aflTradeArtifactRefSchema,
     releaseMembershipArtifact: aflTradeArtifactRefSchema,
     preparationAuthority: z.literal('authenticated_calculation_evidence_snapshot'),
-    qualificationOperation: z.literal(
-      'valuation_model_training_and_derived_feature_creation'
-    ),
+    qualificationOperation: z.literal('valuation_model_training_and_derived_feature_creation'),
     qualificationReportId: aflTradeContentAddressedIdSchema('valuation-source-qualification'),
     qualificationReportArtifact: aflTradeArtifactRefSchema,
     sourceQualificationEvidenceRefs: z.array(aflTradeArtifactRefSchema).min(1).max(1_000),
@@ -497,8 +489,8 @@ const aflTradePreparedValuationInputSetContentV3Schema = z
         message: 'Prepared input-set counts must match the exact entry classifications.',
       });
     }
-    const manifestIds = readyEntries.map(({ materializationManifestId }) =>
-      materializationManifestId
+    const manifestIds = readyEntries.map(
+      ({ materializationManifestId }) => materializationManifestId
     );
     if (new Set(manifestIds).size !== manifestIds.length) {
       context.addIssue({
@@ -507,8 +499,8 @@ const aflTradePreparedValuationInputSetContentV3Schema = z
         message: 'Ready prepared entries require unique materialization manifest identities.',
       });
     }
-    const readyArtifacts = readyEntries.map(({ materializationManifestArtifact }) =>
-      materializationManifestArtifact
+    const readyArtifacts = readyEntries.map(
+      ({ materializationManifestArtifact }) => materializationManifestArtifact
     );
     const artifactIds = [
       content.valuationInputBundleArtifact.artifactId,

--- a/src/server/aflTradeIntelligence/valuation/privateEvaluationCohortExecution.ts
+++ b/src/server/aflTradeIntelligence/valuation/privateEvaluationCohortExecution.ts
@@ -1,0 +1,266 @@
+import { z } from 'zod';
+
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  createAflTradeContentAddress,
+} from '../artifacts/contentAddress';
+
+const idSchema = z.string().trim().min(1).max(400);
+const authoritySchema = z
+  .object({
+    scopeKey: idSchema,
+    preparedInputSetId: aflTradeContentAddressedIdSchema('prepared-valuation-input-set'),
+    preparedInputSetRevision: z.number().int().positive(),
+    factualReleaseRevision: z.number().int().positive(),
+    modelQualificationWorkId: aflTradeContentAddressedIdSchema('model-qualification-work'),
+    modelPairRevision: z.number().int().positive(),
+  })
+  .strict();
+
+export const AFL_TRADE_PRIVATE_EVALUATION_COHORT_EXECUTION_POLICY = {
+  schemaVersion: 'private-evaluation-cohort-execution-policy/v1',
+  maximumAttemptsPerCycle: 3,
+  maximumConcurrency: 8,
+  leaseSeconds: 120,
+  heartbeatSeconds: 30,
+  retryBaseSeconds: 5,
+  retryMaximumSeconds: 60,
+  concurrencyPolicy: 'bounded_local_workers',
+} as const;
+
+const cycleContentSchema = z
+  .object({
+    schemaVersion: z.literal('private-evaluation-cohort-execution-cycle/v1'),
+    environment: z.literal('non_production'),
+    inputFingerprint: aflTradeContentAddressedIdSchema('cohort-execution-input'),
+    authority: authoritySchema,
+    repairSequence: z.number().int().nonnegative(),
+    openingCause: z.enum(['authenticated_inputs_changed', 'explicit_repair']),
+    openingPrincipalId: z.literal('system:weekly-valuation-coordinator'),
+    repairOperationId: aflTradeContentAddressedIdSchema('cohort-execution-repair').nullable(),
+    repairReason: z.string().trim().min(1).max(2_000).nullable(),
+    repairsCycleId: aflTradeContentAddressedIdSchema('cohort-execution-cycle').nullable(),
+    maximumAttemptsPerTrade: z.literal(3),
+    openedAt: z.iso.datetime({ offset: true }),
+    publicationEligible: z.literal(false),
+    limitation: z.literal(
+      'Private local execution control only; it grants no factual, model, production, or publication authority.'
+    ),
+  })
+  .strict()
+  .superRefine((content, context) => {
+    if (
+      (content.repairSequence === 0) !==
+        (content.openingCause === 'authenticated_inputs_changed') ||
+      (content.repairSequence === 0) !== (content.repairsCycleId === null) ||
+      (content.repairSequence === 0) !== (content.repairOperationId === null) ||
+      (content.repairSequence === 0) !== (content.repairReason === null)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['repairSequence'],
+        message: 'Only an explicit repair may follow an existing execution cycle.',
+      });
+    }
+    const expectedFingerprint = createAflTradePrivateEvaluationCohortInputFingerprint(
+      content.authority
+    );
+    if (content.inputFingerprint !== expectedFingerprint) {
+      context.addIssue({
+        code: 'custom',
+        path: ['inputFingerprint'],
+        message: 'Execution fingerprint must bind exact authenticated cohort authority.',
+      });
+    }
+    if (
+      content.repairSequence > 0 &&
+      content.repairsCycleId !==
+        createAflTradeContentAddress('cohort-execution-cycle', {
+          inputFingerprint: content.inputFingerprint,
+          repairSequence: content.repairSequence - 1,
+        })
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['repairsCycleId'],
+        message: 'A repair must name the immediately preceding immutable cycle.',
+      });
+    }
+  });
+
+export const aflTradePrivateEvaluationCohortExecutionCycleSchema = z
+  .object({
+    cycleId: aflTradeContentAddressedIdSchema('cohort-execution-cycle'),
+    content: cycleContentSchema,
+  })
+  .strict()
+  .superRefine((cycle, context) => {
+    addAflTradeContentAddressIssue(
+      'cohort-execution-cycle',
+      cycle.cycleId,
+      {
+        inputFingerprint: cycle.content.inputFingerprint,
+        repairSequence: cycle.content.repairSequence,
+      },
+      context,
+      ['cycleId']
+    );
+  });
+
+export type AflTradePrivateEvaluationCohortExecutionCycle = z.infer<
+  typeof aflTradePrivateEvaluationCohortExecutionCycleSchema
+>;
+
+export const aflTradePrivateEvaluationExecutionCauseSchema = z
+  .object({
+    code: z.string().trim().min(1).max(200),
+    message: z.string().trim().min(1).max(4_000),
+    retryable: z.boolean(),
+  })
+  .strict();
+
+export const aflTradePrivateEvaluationExecutionResultSchema = z.discriminatedUnion('state', [
+  z
+    .object({
+      state: z.literal('activated'),
+      generationId: aflTradeContentAddressedIdSchema('local-private-trade-evaluation-generation'),
+      generatedAt: z.iso.datetime({ offset: true }),
+    })
+    .strict(),
+  z
+    .object({
+      state: z.literal('unavailable'),
+      blockers: z
+        .array(
+          z
+            .object({
+              code: z.string().trim().min(1).max(200),
+              message: z.string().trim().min(1).max(2_000),
+            })
+            .strict()
+        )
+        .min(1)
+        .max(10_000),
+    })
+    .strict(),
+]);
+
+export type AflTradePrivateEvaluationExecutionCause = z.infer<
+  typeof aflTradePrivateEvaluationExecutionCauseSchema
+>;
+export type AflTradePrivateEvaluationExecutionResult = z.infer<
+  typeof aflTradePrivateEvaluationExecutionResultSchema
+>;
+
+export class AflTradePrivateEvaluationTransientExecutionError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'AflTradePrivateEvaluationTransientExecutionError';
+    this.code = z.string().trim().min(1).max(200).parse(code);
+  }
+}
+
+const transientPostgresCodes = new Set([
+  '40001',
+  '40P01',
+  '55P03',
+  '57014',
+  '57P01',
+  '57P02',
+  '57P03',
+  '58030',
+]);
+const transientTransportCodes = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'EPIPE',
+  'ENETDOWN',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+]);
+
+function boundedErrorMessage(error: unknown): string {
+  const normalized = String(error instanceof Error ? error.message : error).trim();
+  return Array.from(normalized || 'Unknown transient execution failure.')
+    .slice(0, 4_000)
+    .join('');
+}
+
+export function classifyAflTradePrivateEvaluationExecutionError(
+  error: unknown
+): AflTradePrivateEvaluationExecutionCause | null {
+  if (error instanceof AflTradePrivateEvaluationTransientExecutionError) {
+    return { code: error.code, message: boundedErrorMessage(error), retryable: true };
+  }
+  if (typeof error !== 'object' || error === null || !('code' in error)) return null;
+  const code = String(error.code);
+  if (code.startsWith('08') || code.startsWith('53') || transientPostgresCodes.has(code)) {
+    return { code: `postgres_${code}`, message: boundedErrorMessage(error), retryable: true };
+  }
+  if (transientTransportCodes.has(code)) {
+    return { code: `transport_${code}`, message: boundedErrorMessage(error), retryable: true };
+  }
+  return null;
+}
+
+export function createAflTradePrivateEvaluationCohortInputFingerprint(
+  input: z.input<typeof authoritySchema>
+): string {
+  return createAflTradeContentAddress('cohort-execution-input', authoritySchema.parse(input));
+}
+
+export function createAflTradePrivateEvaluationCohortExecutionCycle(input: {
+  readonly authority: z.input<typeof authoritySchema>;
+  readonly repairSequence: number;
+  readonly openedAt: string;
+  readonly repairOperationId?: string;
+  readonly repairReason?: string;
+}): AflTradePrivateEvaluationCohortExecutionCycle {
+  const authority = authoritySchema.parse(input.authority);
+  const repairSequence = z.number().int().nonnegative().parse(input.repairSequence);
+  const inputFingerprint = createAflTradePrivateEvaluationCohortInputFingerprint(authority);
+  const content = {
+    schemaVersion: 'private-evaluation-cohort-execution-cycle/v1' as const,
+    environment: 'non_production' as const,
+    inputFingerprint,
+    authority,
+    repairSequence,
+    openingCause:
+      repairSequence === 0
+        ? ('authenticated_inputs_changed' as const)
+        : ('explicit_repair' as const),
+    openingPrincipalId: 'system:weekly-valuation-coordinator' as const,
+    repairOperationId:
+      repairSequence === 0
+        ? null
+        : aflTradeContentAddressedIdSchema('cohort-execution-repair').parse(
+            input.repairOperationId
+          ),
+    repairReason:
+      repairSequence === 0 ? null : z.string().trim().min(1).max(2_000).parse(input.repairReason),
+    repairsCycleId:
+      repairSequence === 0
+        ? null
+        : createAflTradeContentAddress('cohort-execution-cycle', {
+            inputFingerprint,
+            repairSequence: repairSequence - 1,
+          }),
+    maximumAttemptsPerTrade:
+      AFL_TRADE_PRIVATE_EVALUATION_COHORT_EXECUTION_POLICY.maximumAttemptsPerCycle,
+    openedAt: input.openedAt,
+    publicationEligible: false as const,
+    limitation:
+      'Private local execution control only; it grants no factual, model, production, or publication authority.' as const,
+  };
+  return aflTradePrivateEvaluationCohortExecutionCycleSchema.parse({
+    cycleId: createAflTradeContentAddress('cohort-execution-cycle', {
+      inputFingerprint,
+      repairSequence,
+    }),
+    content,
+  });
+}

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1094,6 +1094,7 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0065_automated_private_evaluation_authority',
       '0066_atomic_private_evaluation_batches',
       '0067_private_evaluation_cohort_runner',
+      '0068_durable_private_evaluation_execution',
     ]);
 
     const tables = await query<{ table_name: string }>(

--- a/tests/outcomes-integration/afl-private-evaluation-batch-postgres.test.ts
+++ b/tests/outcomes-integration/afl-private-evaluation-batch-postgres.test.ts
@@ -1,5 +1,5 @@
 import { Pool } from 'pg';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   canonicalizeAflTradeJson,
@@ -170,6 +170,11 @@ afterAll(async () => {
   await pool.end();
   await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
   await adminPool.end();
+});
+
+beforeEach(async () => {
+  await pool.query(`TRUNCATE outcome_private_evaluation_execution_attempt,
+    outcome_private_evaluation_execution_work,outcome_private_evaluation_execution_cycle`);
 });
 
 function batch(at: string) {
@@ -489,6 +494,30 @@ async function seedReadyRunnerGeneration(input: {
         canonicalizeAflTradeJson(generation),
       ]
     );
+    const transitionId = createAflTradeContentAddress('private-evaluation-transition', {
+      operationId: input.operationId,
+      tradeId: input.tradeId,
+    });
+    await seed.query(
+      `INSERT INTO outcome_private_evaluation_transition_receipt
+        (transition_id,transition_intent_id,operation_id,valuation_scope_key,trade_id,
+         artifact_id,action,from_revision,from_status,from_generation_id,to_revision,
+         to_status,to_generation_id,transitioned_at,content_sha256,content_canonical_json,receipt_json)
+       VALUES ($1,$2,$3,$4,$5,$6,'construct_and_activate',0,'absent',NULL,1,
+               'active',$7,$8,$9,'{}','{}'::jsonb)
+       ON CONFLICT DO NOTHING`,
+      [
+        transitionId,
+        transitionIntentId,
+        input.operationId,
+        scopeKey,
+        input.tradeId,
+        `artifact:${(input.tradeId === 'trade-a' ? 'a' : 'b').repeat(64)}`,
+        generationId,
+        input.generatedAt,
+        transitionId.slice('private-evaluation-transition:'.length),
+      ]
+    );
     await seed.query('COMMIT');
   } catch (error) {
     await seed.query('ROLLBACK');
@@ -799,9 +828,9 @@ describe('PostgreSQL atomic private evaluation batches', () => {
         },
       },
     });
-    await expect(conflictingReplay.runCurrent(scopeKey)).resolves.toMatchObject({
-      state: 'unexpected_failure',
-      diagnostics: [{ tradeId: 'trade-a', message: 'exact retained ancestry failure' }],
+    await expect(conflictingReplay.runCurrent(scopeKey)).resolves.toEqual({
+      state: 'exhausted',
+      exhaustedTradeIds: ['trade-a'],
     });
     await expect(
       pool.query(`SELECT diagnostic_json FROM outcome_private_evaluation_cohort_failure`)
@@ -892,6 +921,128 @@ describe('PostgreSQL atomic private evaluation batches', () => {
     await expect(repository.loadCurrent(scopeKey)).resolves.toMatchObject({
       head: { revision: 4 },
     });
+  });
+
+  it('classifies PostgreSQL serialization failures and resumes attempts two and three after restart', async () => {
+    const manifestDigest = '5'.repeat(64);
+    const readyEntry = {
+      tradeId: 'trade-a',
+      state: 'ready' as const,
+      materializationManifestId: `private-evaluation-materialization-manifest:${manifestDigest}`,
+      materializationManifestArtifact: artifactRef('5', createdAt),
+    };
+    const setup = await pool.connect();
+    try {
+      await setup.query('BEGIN');
+      await setup.query(`SET LOCAL session_replication_role='replica'`);
+      await setup.query(
+        `UPDATE outcome_prepared_valuation_input_entry
+            SET state='ready',entry_canonical_json=$2::text,entry_json=$2::jsonb
+          WHERE prepared_input_set_id=$1 AND trade_id='trade-a'`,
+        [preparedInputSetId, canonicalizeAflTradeJson(readyEntry)]
+      );
+      await setup.query(
+        `UPDATE outcome_current_prepared_valuation_input_set SET revision=5 WHERE scope_key=$1`,
+        [scopeKey]
+      );
+      await setup.query('COMMIT');
+    } finally {
+      setup.release();
+    }
+    const createRunner = () =>
+      createPostgresAflTradePrivateEvaluationCohortRunner({
+        client: createPgAflOutcomeSqlClient(pool),
+        batchRepository: new PostgresGovernedPrivateEvaluationBatchRepository(
+          createPgAflOutcomeSqlClient(pool),
+          async () => true
+        ),
+        workspace: {
+          stageAutomated: async ({ selector }) => {
+            if (selector.tradeId === 'trade-a') {
+              throw Object.assign(new Error('serialization conflict'), { code: '40001' });
+            }
+            return {
+              state: 'unavailable' as const,
+              blockers: [{ code: 'insufficient_data', message: 'No retained observations.' }],
+            };
+          },
+          inspect: async () => {
+            throw new Error('Not used by the cohort runner.');
+          },
+          execute: async () => {
+            throw new Error('Not used by the cohort runner.');
+          },
+          read: async () => {
+            throw new Error('Not used by the cohort runner.');
+          },
+        },
+      });
+
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      const result = await createRunner().runCurrent(scopeKey);
+      expect(result).toEqual(
+        attempt < 3
+          ? { state: 'retry_pending', pendingTradeIds: ['trade-a'] }
+          : { state: 'exhausted', exhaustedTradeIds: ['trade-a'] }
+      );
+      if (attempt < 3) {
+        const due = await pool.connect();
+        try {
+          await due.query('BEGIN');
+          await due.query(`SET LOCAL session_replication_role='replica'`);
+          await due.query(
+            `UPDATE outcome_private_evaluation_execution_work
+                SET available_at=transaction_timestamp()-interval '1 second'
+              WHERE trade_id='trade-a' AND status='retry_wait'`
+          );
+          await due.query('COMMIT');
+        } finally {
+          due.release();
+        }
+      }
+    }
+    await expect(
+      pool.query(
+        `SELECT attempt_number,outcome,cause_json FROM outcome_private_evaluation_execution_attempt
+          WHERE trade_id='trade-a' ORDER BY attempt_number`
+      )
+    ).resolves.toMatchObject({
+      rows: [
+        { attempt_number: 1, outcome: 'transient_failure', cause_json: { code: 'postgres_40001' } },
+        { attempt_number: 2, outcome: 'transient_failure', cause_json: { code: 'postgres_40001' } },
+        { attempt_number: 3, outcome: 'transient_failure', cause_json: { code: 'postgres_40001' } },
+      ],
+    });
+    const repairRunner = createRunner();
+    const repairOperationId = `cohort-execution-repair:${'5'.repeat(64)}`;
+    const repairReason = 'The retained serialization outage was corrected by the backend operator.';
+    const repaired = await repairRunner.repairCurrent(scopeKey, repairReason, repairOperationId);
+    expect(repaired).toMatchObject({
+      content: {
+        repairSequence: 1,
+        openingPrincipalId: 'system:weekly-valuation-coordinator',
+        repairReason,
+      },
+    });
+    await expect(repairRunner.runCurrent(scopeKey)).resolves.toEqual({
+      state: 'retry_pending',
+      pendingTradeIds: ['trade-a'],
+    });
+    const shifted = await pool.connect();
+    try {
+      await shifted.query('BEGIN');
+      await shifted.query(`SET LOCAL session_replication_role='replica'`);
+      await shifted.query(
+        `UPDATE outcome_current_prepared_valuation_input_set SET revision=6 WHERE scope_key=$1`,
+        [scopeKey]
+      );
+      await shifted.query('COMMIT');
+    } finally {
+      shifted.release();
+    }
+    await expect(
+      repairRunner.repairCurrent(scopeKey, repairReason, repairOperationId)
+    ).resolves.toEqual(repaired);
   });
 
   it.each(['factual release', 'model pair'] as const)(

--- a/tests/outcomes-integration/afl-private-evaluation-execution-postgres.test.ts
+++ b/tests/outcomes-integration/afl-private-evaluation-execution-postgres.test.ts
@@ -1,0 +1,450 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+import { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import {
+  PostgresAflTradePrivateEvaluationCohortExecutionRepository,
+  type AflTradePrivateEvaluationExecutionClaim,
+} from '@/server/aflTradeIntelligence/valuation/postgresPrivateEvaluationCohortExecutionRepository';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('AFL_OUTCOMES_TEST_DATABASE_URL must identify disposable PostgreSQL.');
+  })();
+const schemaName = `afl_execution_${process.pid}_${Date.now()}`;
+const migrationRoleName = `afl_execution_migrator_${process.pid}_${Date.now()}`;
+const executionRoleName = 'afl_trade_private_evaluation_coordinator';
+const pool = new Pool({
+  connectionString: databaseUrl,
+  max: 4,
+  options: `-c search_path=${schemaName}`,
+});
+const client = createPgAflOutcomeSqlClient(pool);
+const repository = new PostgresAflTradePrivateEvaluationCohortExecutionRepository(client);
+const digest = (character: string) => character.repeat(64);
+const authority = {
+  scopeKey: 'afl-men:durable-execution',
+  preparedInputSetId: `prepared-valuation-input-set:${digest('1')}`,
+  preparedInputSetRevision: 4,
+  factualReleaseRevision: 3,
+  modelQualificationWorkId: `model-qualification-work:${digest('2')}`,
+  modelPairRevision: 5,
+} as const;
+
+beforeAll(async () => {
+  await pool.query(`CREATE ROLE "${migrationRoleName}" NOLOGIN CREATEROLE`);
+  await pool.query(`GRANT "${migrationRoleName}" TO CURRENT_USER`);
+  await pool.query(`DO $roles$ BEGIN
+    BEGIN CREATE ROLE afl_trade_private_evaluation_execution_owner NOLOGIN;
+    EXCEPTION WHEN duplicate_object THEN NULL; END;
+    BEGIN CREATE ROLE afl_trade_private_evaluation_coordinator NOLOGIN;
+    EXCEPTION WHEN duplicate_object THEN NULL; END;
+  END $roles$`);
+  await pool.query(
+    `GRANT afl_trade_private_evaluation_execution_owner,
+      afl_trade_private_evaluation_coordinator TO "${migrationRoleName}" WITH ADMIN OPTION`
+  );
+  await pool.query(`CREATE SCHEMA "${schemaName}" AUTHORIZATION "${migrationRoleName}"`);
+  const migration = await pool.connect();
+  await migration.query(`SET ROLE "${migrationRoleName}"`);
+  await migration.query(`SET search_path TO "${schemaName}"`);
+  const canonicalFunction = readFileSync(
+    join(
+      process.cwd(),
+      'prisma/afl-trade-outcomes/migrations/0037_valuation_publication_custody_index/migration.sql'
+    ),
+    'utf8'
+  ).match(
+    /CREATE FUNCTION "outcome_afl_trade_canonical_json"[\s\S]*?\$\$ LANGUAGE plpgsql IMMUTABLE STRICT;/
+  )?.[0];
+  if (canonicalFunction === undefined)
+    throw new Error('Canonical JSON SQL function was not found.');
+  await migration.query(canonicalFunction);
+  await migration.query(`CREATE TABLE outcome_prepared_valuation_input_set (
+    prepared_input_set_id text PRIMARY KEY,scope_key text NOT NULL,
+    factual_release_scope_key text NOT NULL,factual_release_id text NOT NULL,
+    schema_version text NOT NULL,environment text NOT NULL,finalized_at timestamptz
+  )`);
+  await migration.query(`CREATE TABLE outcome_prepared_valuation_input_entry (
+    prepared_input_set_id text NOT NULL REFERENCES outcome_prepared_valuation_input_set,
+    ordinal integer NOT NULL,trade_id text NOT NULL,state text NOT NULL,entry_json jsonb,
+    PRIMARY KEY(prepared_input_set_id,ordinal),UNIQUE(prepared_input_set_id,trade_id)
+  )`);
+  await migration.query(`CREATE TABLE outcome_current_prepared_valuation_input_set (
+    scope_key text PRIMARY KEY,prepared_input_set_id text NOT NULL,revision integer NOT NULL
+  )`);
+  await migration.query(`CREATE TABLE outcome_active_release (
+    scope_key text PRIMARY KEY,release_id text NOT NULL,revision integer NOT NULL
+  )`);
+  await migration.query(`CREATE TABLE outcome_governed_model_qualification_work (
+    work_id text PRIMARY KEY
+  )`);
+  await migration.query(`CREATE TABLE outcome_current_governed_valuation_model_pair (
+    scope_key text PRIMARY KEY,work_id text NOT NULL,revision integer NOT NULL
+  )`);
+  await migration.query(`CREATE TABLE outcome_private_evaluation_transition_intent (
+    transition_intent_id text PRIMARY KEY,operation_id text NOT NULL,
+    valuation_scope_key text NOT NULL,trade_id text NOT NULL,action text NOT NULL
+  )`);
+  await migration.query(`CREATE TABLE outcome_local_private_trade_evaluation_generation (
+    generation_id text PRIMARY KEY,valuation_scope_key text NOT NULL,trade_id text NOT NULL,
+    transition_intent_id text NOT NULL,generated_at timestamptz NOT NULL
+  )`);
+  await migration.query(`CREATE TABLE outcome_private_evaluation_transition_receipt (
+    transition_intent_id text PRIMARY KEY,operation_id text NOT NULL,
+    valuation_scope_key text NOT NULL,trade_id text NOT NULL,action text NOT NULL,
+    to_status text NOT NULL,to_generation_id text
+  )`);
+  await migration.query(
+    readFileSync(
+      join(
+        process.cwd(),
+        'prisma/afl-trade-outcomes/migrations/0068_durable_private_evaluation_execution/migration.sql'
+      ),
+      'utf8'
+    )
+  );
+  await migration.query('RESET ROLE');
+  migration.release();
+});
+
+afterAll(async () => {
+  await pool.query(`SET search_path TO public`);
+  await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  await pool.query(`DROP OWNED BY "${migrationRoleName}"`);
+  await pool.query(`REVOKE afl_trade_private_evaluation_coordinator FROM "${migrationRoleName}"`);
+  await pool.query(
+    `REVOKE afl_trade_private_evaluation_execution_owner FROM "${migrationRoleName}"`
+  );
+  await pool.query(`REVOKE "${migrationRoleName}" FROM CURRENT_USER`);
+  await pool.query(`DROP ROLE IF EXISTS "${migrationRoleName}"`);
+  await pool.end();
+});
+
+beforeEach(async () => {
+  await pool.query(`TRUNCATE outcome_private_evaluation_execution_attempt,
+    outcome_private_evaluation_execution_work,outcome_private_evaluation_execution_cycle,
+    outcome_private_evaluation_transition_receipt,outcome_private_evaluation_transition_intent,
+    outcome_local_private_trade_evaluation_generation,
+    outcome_prepared_valuation_input_entry,outcome_current_prepared_valuation_input_set,
+    outcome_prepared_valuation_input_set,outcome_active_release,
+    outcome_current_governed_valuation_model_pair,outcome_governed_model_qualification_work`);
+  await pool.query(
+    `INSERT INTO outcome_prepared_valuation_input_set
+      (prepared_input_set_id,scope_key,factual_release_scope_key,factual_release_id,
+       schema_version,environment,finalized_at)
+     VALUES ($1,$2,'public-afl',$3,'afl-trade-prepared-valuation-input-set/v3',
+             'non_production',transaction_timestamp())`,
+    [authority.preparedInputSetId, authority.scopeKey, `outcome-release:${digest('3')}`]
+  );
+  await pool.query(
+    `INSERT INTO outcome_prepared_valuation_input_entry
+      (prepared_input_set_id,ordinal,trade_id,state,entry_json)
+     VALUES ($1,1,'trade-a','ready','{}'::jsonb),($1,2,'trade-b','ready','{}'::jsonb)`,
+    [authority.preparedInputSetId]
+  );
+  await pool.query(`INSERT INTO outcome_current_prepared_valuation_input_set VALUES ($1,$2,$3)`, [
+    authority.scopeKey,
+    authority.preparedInputSetId,
+    authority.preparedInputSetRevision,
+  ]);
+  await pool.query(`INSERT INTO outcome_active_release VALUES ('public-afl',$1,$2)`, [
+    `outcome-release:${digest('3')}`,
+    authority.factualReleaseRevision,
+  ]);
+  await pool.query(`INSERT INTO outcome_governed_model_qualification_work VALUES ($1)`, [
+    authority.modelQualificationWorkId,
+  ]);
+  await pool.query(`INSERT INTO outcome_current_governed_valuation_model_pair VALUES ($1,$2,$3)`, [
+    authority.scopeKey,
+    authority.modelQualificationWorkId,
+    authority.modelPairRevision,
+  ]);
+});
+
+async function openCycle() {
+  const openedAt = (
+    await pool.query<{ trusted_at: Date }>(
+      `SELECT date_trunc('milliseconds',transaction_timestamp()) AS trusted_at`
+    )
+  ).rows[0]!.trusted_at.toISOString();
+  return repository.openAutomatic({ authority, readyTradeIds: ['trade-a', 'trade-b'], openedAt });
+}
+
+async function expire(claim: AflTradePrivateEvaluationExecutionClaim) {
+  await pool.query(`ALTER TABLE outcome_private_evaluation_execution_attempt
+    DISABLE TRIGGER outcome_private_evaluation_execution_attempt_validate_update`);
+  await pool.query(`ALTER TABLE outcome_private_evaluation_execution_work
+    DISABLE TRIGGER outcome_private_evaluation_execution_work_validate_update`);
+  await pool.query(
+    `UPDATE outcome_private_evaluation_execution_attempt
+        SET lease_expires_at=transaction_timestamp()-interval '1 second'
+      WHERE claim_id=$1`,
+    [claim.claimId]
+  );
+  await pool.query(
+    `UPDATE outcome_private_evaluation_execution_work
+        SET lease_expires_at=transaction_timestamp()-interval '1 second'
+      WHERE current_claim_id=$1`,
+    [claim.claimId]
+  );
+  await pool.query(`ALTER TABLE outcome_private_evaluation_execution_attempt
+    ENABLE TRIGGER outcome_private_evaluation_execution_attempt_validate_update`);
+  await pool.query(`ALTER TABLE outcome_private_evaluation_execution_work
+    ENABLE TRIGGER outcome_private_evaluation_execution_work_validate_update`);
+}
+
+describe('durable private evaluation execution PostgreSQL boundary', () => {
+  it('serializes two workers, renews heartbeat, reclaims expiry, and fences stale completion', async () => {
+    const cycle = await openCycle();
+    const first = await repository.claim({
+      cycleId: cycle.cycleId,
+      tradeId: 'trade-a',
+      workerId: 'worker-a',
+    });
+    expect(first).not.toBeNull();
+    await expect(
+      repository.claim({ cycleId: cycle.cycleId, tradeId: 'trade-a', workerId: 'worker-b' })
+    ).resolves.toBeNull();
+    await expect(repository.heartbeat(first!)).resolves.toMatch(/Z$/);
+
+    await expire(first!);
+    const reclaimed = await repository.claim({
+      cycleId: cycle.cycleId,
+      tradeId: 'trade-a',
+      workerId: 'worker-b',
+    });
+    expect(reclaimed).toMatchObject({ attemptNumber: 2 });
+    await expect(
+      repository.complete({
+        claim: first!,
+        outcome: 'permanent_failure',
+        stage: 'stage_automated',
+        cause: { code: 'late', message: 'Late worker.', retryable: false },
+        result: null,
+      })
+    ).rejects.toThrow('lease was lost');
+  });
+
+  it('never exceeds three persisted attempts and retains the exact exhausted cause', async () => {
+    const cycle = await openCycle();
+    let claim = await repository.claim({
+      cycleId: cycle.cycleId,
+      tradeId: 'trade-a',
+      workerId: 'worker-a',
+    });
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      expect(claim).toMatchObject({ attemptNumber: attempt });
+      const status = await repository.complete({
+        claim: claim!,
+        outcome: 'transient_failure',
+        stage: 'stage_automated',
+        cause: {
+          code: `transient-${attempt}`,
+          message: `Transient failure ${attempt}.`,
+          retryable: true,
+        },
+        result: null,
+      });
+      if (attempt < 3) {
+        expect(status).toBe('retry_wait');
+        await pool.query(`ALTER TABLE outcome_private_evaluation_execution_work
+          DISABLE TRIGGER outcome_private_evaluation_execution_work_validate_update`);
+        await pool.query(
+          `UPDATE outcome_private_evaluation_execution_work
+              SET available_at=transaction_timestamp()-interval '1 second'
+            WHERE cycle_id=$1 AND trade_id='trade-a'`,
+          [cycle.cycleId]
+        );
+        await pool.query(`ALTER TABLE outcome_private_evaluation_execution_work
+          ENABLE TRIGGER outcome_private_evaluation_execution_work_validate_update`);
+        claim = await repository.claim({
+          cycleId: cycle.cycleId,
+          tradeId: 'trade-a',
+          workerId: 'worker-a',
+        });
+      } else {
+        expect(status).toBe('exhausted');
+      }
+    }
+    await expect(repository.loadWork(cycle.cycleId, 'trade-a')).resolves.toMatchObject({
+      status: 'exhausted',
+      attemptCount: 3,
+      terminalStage: 'stage_automated',
+      terminalCause: {
+        code: 'transient-3',
+        message: 'Transient failure 3.',
+        retryable: true,
+      },
+    });
+    await expect(
+      repository.claim({ cycleId: cycle.cycleId, tradeId: 'trade-a', workerId: 'worker-c' })
+    ).resolves.toBeNull();
+  });
+
+  it('preserves prior exhausted history when an explicit repair opens a fresh budget', async () => {
+    const original = await openCycle();
+    const claim = await repository.claim({
+      cycleId: original.cycleId,
+      tradeId: 'trade-a',
+      workerId: 'worker-a',
+    });
+    await repository.complete({
+      claim: claim!,
+      outcome: 'permanent_failure',
+      stage: 'stage_automated',
+      cause: { code: 'repair_me', message: 'Repair required.', retryable: false },
+      result: null,
+    });
+    const completedPeer = await repository.claim({
+      cycleId: original.cycleId,
+      tradeId: 'trade-b',
+      workerId: 'worker-a',
+    });
+    await repository.complete({
+      claim: completedPeer!,
+      outcome: 'unavailable',
+      stage: null,
+      cause: null,
+      result: {
+        state: 'unavailable',
+        blockers: [{ code: 'insufficient_data', message: 'No retained observations.' }],
+      },
+    });
+    const repair = await repository.openRepair({
+      authority,
+      readyTradeIds: ['trade-a', 'trade-b'],
+      repairOperationId: `cohort-execution-repair:${digest('9')}`,
+      reason: 'The retained upstream outage was corrected.',
+    });
+    expect(repair.content).toMatchObject({
+      repairSequence: 1,
+      openingPrincipalId: 'system:weekly-valuation-coordinator',
+      repairOperationId: `cohort-execution-repair:${digest('9')}`,
+      repairReason: 'The retained upstream outage was corrected.',
+      repairsCycleId: original.cycleId,
+    });
+    await expect(repository.loadWork(original.cycleId, 'trade-a')).resolves.toMatchObject({
+      status: 'exhausted',
+      attemptCount: 1,
+    });
+    await expect(repository.loadWork(repair.cycleId, 'trade-a')).resolves.toMatchObject({
+      status: 'pending',
+      attemptCount: 0,
+    });
+    await expect(
+      repository.openRepair({
+        authority,
+        readyTradeIds: ['trade-a', 'trade-b'],
+        repairOperationId: `cohort-execution-repair:${digest('9')}`,
+        reason: 'The retained upstream outage was corrected.',
+      })
+    ).resolves.toEqual(repair);
+
+    await pool.query(`ALTER TABLE outcome_private_evaluation_execution_work
+      DISABLE TRIGGER outcome_private_evaluation_execution_work_no_delete`);
+    await pool.query(
+      `DELETE FROM outcome_private_evaluation_execution_work
+        WHERE cycle_id=$1 AND trade_id='trade-b'`,
+      [repair.cycleId]
+    );
+    await pool.query(`ALTER TABLE outcome_private_evaluation_execution_work
+      ENABLE TRIGGER outcome_private_evaluation_execution_work_no_delete`);
+    await expect(repository.loadRepair(`cohort-execution-repair:${digest('9')}`)).rejects.toThrow(
+      'work replay conflicts with custody'
+    );
+  });
+
+  it('rejects repair while any predecessor work remains nonterminal', async () => {
+    await openCycle();
+    await expect(
+      repository.openRepair({
+        authority,
+        readyTradeIds: ['trade-a', 'trade-b'],
+        repairOperationId: `cohort-execution-repair:${digest('8')}`,
+        reason: 'Requested before the original cycle completed.',
+      })
+    ).rejects.toThrow('terminal predecessor');
+  });
+
+  it('rejects direct SQL claims and invalid terminal result custody', async () => {
+    const cycle = await openCycle();
+    const restricted = await pool.connect();
+    try {
+      await restricted.query('BEGIN');
+      await restricted.query(`SET LOCAL ROLE ${executionRoleName}`);
+      await expect(
+        restricted.query(`CREATE TABLE "${schemaName}".coordinator_shadow(id integer)`)
+      ).rejects.toThrow('permission denied for schema');
+      await restricted.query('ROLLBACK');
+
+      await restricted.query('BEGIN');
+      await restricted.query(`SET LOCAL ROLE ${executionRoleName}`);
+      await expect(
+        restricted.query(
+          `INSERT INTO outcome_private_evaluation_execution_attempt
+            (claim_id,cycle_id,trade_id,attempt_number,worker_id,lease_token_sha256,
+             claimed_at,lease_expires_at,heartbeat_at)
+           SELECT $1,$2,'trade-a',1,'forged-worker',$3,trusted_at,
+                  trusted_at+interval '120 seconds',trusted_at
+             FROM (SELECT date_trunc('milliseconds',transaction_timestamp()) AS trusted_at) clock`,
+          [`cohort-execution-claim:${digest('c')}`, cycle.cycleId, digest('d')]
+        )
+      ).rejects.toThrow('permission denied');
+      await restricted.query('ROLLBACK');
+
+      await restricted.query('BEGIN');
+      await restricted.query(`CREATE TEMP TABLE outcome_private_evaluation_execution_work (
+        current_claim_id text,status text,lease_token_sha256 text,lease_expires_at timestamptz
+      )`);
+      await restricted.query(`SET LOCAL ROLE ${executionRoleName}`);
+      await expect(
+        restricted.query(`SELECT * FROM claim_outcome_private_evaluation_work($1,$2,$3,$4)`, [
+          cycle.cycleId,
+          'trade-a',
+          'restricted-runtime-worker',
+          digest('e'),
+        ])
+      ).resolves.toMatchObject({ rows: [{ attempt_number: 1 }] });
+      await restricted.query('ROLLBACK');
+    } finally {
+      restricted.release();
+    }
+    await expect(
+      pool.query(
+        `UPDATE outcome_private_evaluation_execution_work
+            SET status='leased',attempt_count=1,current_claim_id=$3,lease_token_sha256=$4,
+                lease_expires_at=transaction_timestamp()+interval '120 seconds',
+                heartbeat_at=transaction_timestamp()
+          WHERE cycle_id=$1 AND trade_id=$2`,
+        [cycle.cycleId, 'trade-a', `cohort-execution-claim:${digest('a')}`, digest('b')]
+      )
+    ).rejects.toThrow('work transition is invalid');
+
+    const claim = await repository.claim({
+      cycleId: cycle.cycleId,
+      tradeId: 'trade-a',
+      workerId: 'worker-a',
+    });
+    await expect(
+      pool.query(
+        `SELECT complete_outcome_private_evaluation_work($1,$2,'succeeded',NULL,NULL,NULL)`,
+        [claim!.claimId, createHash('sha256').update(claim!.leaseToken).digest('hex')]
+      )
+    ).rejects.toThrow('completion custody');
+  });
+
+  it('records an indexed targeted lookup plan without a wall-clock assertion', async () => {
+    const plan = await repository.explainTargetedPreparedTradeLookup(
+      authority.preparedInputSetId,
+      'trade-a'
+    );
+    expect(plan.join('\n')).toMatch(/Index Scan|Bitmap Index Scan/);
+    expect(plan.join('\n')).toContain('prepared_input_set_id');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-cohort-execution-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-cohort-execution-migration.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const sql = readFileSync(
+  join(
+    process.cwd(),
+    'prisma/afl-trade-outcomes/migrations/0068_durable_private_evaluation_execution/migration.sql'
+  ),
+  'utf8'
+);
+
+describe('durable private evaluation execution migration', () => {
+  it('owns cycles, attempts, leases, heartbeats, fencing, exhaustion, and repair history', () => {
+    expect(sql).toContain('outcome_private_evaluation_execution_cycle');
+    expect(sql).toContain('outcome_private_evaluation_execution_work');
+    expect(sql).toContain('outcome_private_evaluation_execution_attempt');
+    expect(sql).toContain('claim_outcome_private_evaluation_work');
+    expect(sql).toContain('heartbeat_outcome_private_evaluation_work');
+    expect(sql).toContain('complete_outcome_private_evaluation_work');
+    expect(sql).toContain('maximum_attempts"=3');
+    expect(sql).toContain("'lease_expired'");
+    expect(sql).toContain('lease_token_sha256');
+    expect(sql).toContain('current_claim_id');
+    expect(sql).toContain('repair_sequence');
+  });
+
+  it('reuses the existing unique prepared-set/trade index without duplicating it', () => {
+    expect(sql).not.toContain('outcome_prepared_valuation_input_entry_targeted_lookup_idx');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-current-valuation-cohort-runner.test.ts
+++ b/tests/unit/afl-trade-intelligence-current-valuation-cohort-runner.test.ts
@@ -44,6 +44,75 @@ function requestFor(authority: ReturnType<typeof capture>) {
 }
 
 describe('automatic private evaluation cohort runner', () => {
+  it('leaves the batch unchanged while durable transient work is waiting for retry', async () => {
+    const authority = capture(['trade-a', 'trade-b']);
+    const registerBatch = vi.fn();
+    const advanceBatch = vi.fn();
+    const runner = createAflTradePrivateEvaluationCohortRunner({
+      captureCurrent: async () => ({ capture: authority, currentBatch: null }),
+      stageTrade: async ({ selector }) =>
+        selector.tradeId === 'trade-a'
+          ? { state: 'retry_pending', availableAt: '2026-08-21T09:00:05.000Z' }
+          : {
+              state: 'activated',
+              generationId: `local-private-trade-evaluation-generation:${digest('b')}`,
+              generatedAt: '2026-08-21T09:01:00.000Z',
+            },
+      retainUnexpectedDiagnostics: vi.fn(),
+      registerBatch,
+      advanceBatch,
+    });
+
+    await expect(runner.run(requestFor(authority))).resolves.toEqual({
+      state: 'retry_pending',
+      pendingTradeIds: ['trade-a'],
+    });
+    expect(registerBatch).not.toHaveBeenCalled();
+    expect(advanceBatch).not.toHaveBeenCalled();
+  });
+
+  it('enforces the versioned maximum concurrency', async () => {
+    const authority = capture(
+      Array.from({ length: 783 }, (_, index) =>
+        `trade-${index.toString().padStart(3, '0')}`
+      )
+    );
+    let active = 0;
+    let observedMaximum = 0;
+    const runner = createAflTradePrivateEvaluationCohortRunner({
+      captureCurrent: async () => ({ capture: authority, currentBatch: null }),
+      stageTrade: async ({ selector }) => {
+        active += 1;
+        observedMaximum = Math.max(observedMaximum, active);
+        await Promise.resolve();
+        active -= 1;
+        return {
+          state: 'activated',
+          generationId: `local-private-trade-evaluation-generation:${Number(
+            selector.tradeId.slice('trade-'.length)
+          )
+            .toString(16)
+            .padStart(64, '0')}`,
+          generatedAt: '2026-08-21T09:01:00.000Z',
+        };
+      },
+      retainUnexpectedDiagnostics: vi.fn(),
+      registerBatch: async (batch) => batch,
+      advanceBatch: async ({ batchId, expectedRevision }) => ({
+        scopeKey,
+        batchId,
+        revision: expectedRevision + 1,
+        transitionId: `private-evaluation-batch-transition:${digest('f')}`,
+        activatedAt: '2026-08-21T09:01:00.000Z',
+      }),
+    });
+
+    await expect(runner.run(requestFor(authority))).resolves.toMatchObject({
+      state: 'activated',
+    });
+    expect(observedMaximum).toBe(8);
+  });
+
   it('attempts every trade, retains unexpected diagnostics, and does not activate', async () => {
     const authority = capture(['trade-a', 'trade-b', 'trade-c', 'trade-d']);
     const attempted: string[] = [];

--- a/tests/unit/afl-trade-intelligence-postgres-governed-calculation-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-governed-calculation-authority.test.ts
@@ -10,6 +10,10 @@ import type {
 } from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
 import { createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedPrivateEvaluationCalculationAuthority';
 import { createAflTradePreparedValuationInputSet } from '@/server/aflTradeIntelligence/valuation/preparedValuationInputSet';
+import {
+  AflTradePreparedValuationInputCohortCache,
+  loadCurrentAflTradePreparedValuationInputTradeFromTransaction,
+} from '@/server/aflTradeIntelligence/valuation/postgresPreparedValuationInputSetStore';
 
 import { createGovernedPrivateEvaluationAuthenticatedCalculationFixture } from '../testUtils/governedPrivateEvaluationAuthenticatedCalculationFixture';
 
@@ -143,9 +147,10 @@ class ReadyPreparedAuthorityTransaction implements AflOutcomeSqlTransaction {
     if (sql.includes('FROM outcome_private_evaluation_materialization_manifest')) {
       if (this.retainManifestRow) {
         const manifest = this.fixture.calculation.materializationManifest;
-        const artifact = prepared.content.entries[0]!.state === 'ready'
-          ? prepared.content.entries[0]!.materializationManifestArtifact
-          : undefined;
+        const artifact =
+          prepared.content.entries[0]!.state === 'ready'
+            ? prepared.content.entries[0]!.materializationManifestArtifact
+            : undefined;
         if (artifact === undefined) throw new Error('Expected ready manifest artifact.');
         return {
           rows: [
@@ -215,6 +220,34 @@ async function retainReadyFixtureArtifacts(
 }
 
 describe('PostgreSQL governed calculation-authority capture', () => {
+  it('authenticates shared prepared parents once and uses one targeted lookup per trade', async () => {
+    const transaction = new ReadyPreparedAuthorityTransaction();
+    const cache = new AflTradePreparedValuationInputCohortCache();
+    const selector = transaction.fixture.calculation.trace.content.selector;
+
+    await loadCurrentAflTradePreparedValuationInputTradeFromTransaction(
+      transaction,
+      { scopeKey: selector.valuationScopeKey, tradeId: selector.tradeId },
+      cache
+    );
+    await loadCurrentAflTradePreparedValuationInputTradeFromTransaction(
+      transaction,
+      { scopeKey: selector.valuationScopeKey, tradeId: selector.tradeId },
+      cache
+    );
+
+    expect(
+      transaction.calls.filter(({ sql }) =>
+        sql.includes('FROM outcome_prepared_valuation_input_set prepared')
+      )
+    ).toHaveLength(1);
+    expect(
+      transaction.calls.filter(({ sql }) =>
+        sql.includes('WHERE prepared_input_set_id=$1 AND trade_id=$2')
+      )
+    ).toHaveLength(2);
+  });
+
   it('fails closed when no current authenticated v3 prepared trade exists', async () => {
     const transaction = new NoPreparedAuthorityTransaction();
     const capture = createPostgresGovernedPrivateEvaluationCalculationAuthorityCapture({
@@ -238,8 +271,7 @@ describe('PostgreSQL governed calculation-authority capture', () => {
       blockers: [
         {
           code: 'insufficient_data',
-          message:
-            'No current authenticated v3 prepared calculation inputs cover this trade.',
+          message: 'No current authenticated v3 prepared calculation inputs cover this trade.',
         },
       ],
     });
@@ -288,10 +320,7 @@ describe('PostgreSQL governed calculation-authority capture', () => {
       artifactClass: 'derived_private',
     });
     const manifest = transaction.fixture.calculation.materializationManifest;
-    const reference = createAflTradeCanonicalJsonArtifactRef(
-      manifest,
-      manifest.content.createdAt
-    );
+    const reference = createAflTradeCanonicalJsonArtifactRef(manifest, manifest.content.createdAt);
     await artifactRepository.putIfAbsent(
       reference,
       new TextEncoder().encode(canonicalizeAflTradeJson(manifest))

--- a/tests/unit/afl-trade-intelligence-private-evaluation-cohort-execution.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-evaluation-cohort-execution.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AFL_TRADE_PRIVATE_EVALUATION_COHORT_EXECUTION_POLICY,
+  classifyAflTradePrivateEvaluationExecutionError,
+  createAflTradePrivateEvaluationCohortExecutionCycle,
+  createAflTradePrivateEvaluationCohortInputFingerprint,
+} from '@/server/aflTradeIntelligence/valuation/privateEvaluationCohortExecution';
+
+const digest = (marker: string) => marker.repeat(64);
+const authority = {
+  scopeKey: 'afl-men:2026-trades',
+  preparedInputSetId: `prepared-valuation-input-set:${digest('1')}`,
+  preparedInputSetRevision: 4,
+  factualReleaseRevision: 3,
+  modelQualificationWorkId: `model-qualification-work:${digest('2')}`,
+  modelPairRevision: 5,
+} as const;
+
+describe('private evaluation cohort durable execution policy', () => {
+  it('fixes bounded local execution to three persisted attempts', () => {
+    expect(AFL_TRADE_PRIVATE_EVALUATION_COHORT_EXECUTION_POLICY).toEqual({
+      schemaVersion: 'private-evaluation-cohort-execution-policy/v1',
+      maximumAttemptsPerCycle: 3,
+      maximumConcurrency: 8,
+      leaseSeconds: 120,
+      heartbeatSeconds: 30,
+      retryBaseSeconds: 5,
+      retryMaximumSeconds: 60,
+      concurrencyPolicy: 'bounded_local_workers',
+    });
+  });
+
+  it('opens a new automatic cycle only when authenticated inputs change', () => {
+    const first = createAflTradePrivateEvaluationCohortInputFingerprint(authority);
+    expect(createAflTradePrivateEvaluationCohortInputFingerprint(authority)).toBe(first);
+    expect(
+      createAflTradePrivateEvaluationCohortInputFingerprint({
+        ...authority,
+        preparedInputSetRevision: authority.preparedInputSetRevision + 1,
+      })
+    ).not.toBe(first);
+
+    const cycle = createAflTradePrivateEvaluationCohortExecutionCycle({
+      authority,
+      repairSequence: 0,
+      openedAt: '2026-08-21T10:00:00.000Z',
+    });
+    expect(cycle.content).toMatchObject({
+      inputFingerprint: first,
+      repairSequence: 0,
+      openingCause: 'authenticated_inputs_changed',
+      openingPrincipalId: 'system:weekly-valuation-coordinator',
+      repairOperationId: null,
+      repairReason: null,
+      maximumAttemptsPerTrade: 3,
+      publicationEligible: false,
+    });
+  });
+
+  it('opens an explicit repair cycle without changing or deleting prior history', () => {
+    const original = createAflTradePrivateEvaluationCohortExecutionCycle({
+      authority,
+      repairSequence: 0,
+      openedAt: '2026-08-21T10:00:00.000Z',
+    });
+    const repair = createAflTradePrivateEvaluationCohortExecutionCycle({
+      authority,
+      repairSequence: 1,
+      openedAt: '2026-08-21T11:00:00.000Z',
+      repairOperationId: `cohort-execution-repair:${digest('9')}`,
+      repairReason: 'Retry after the retained upstream outage was corrected.',
+    });
+
+    expect(repair.cycleId).not.toBe(original.cycleId);
+    expect(repair.content.inputFingerprint).toBe(original.content.inputFingerprint);
+    expect(repair.content).toMatchObject({
+      repairSequence: 1,
+      openingCause: 'explicit_repair',
+      openingPrincipalId: 'system:weekly-valuation-coordinator',
+      repairOperationId: `cohort-execution-repair:${digest('9')}`,
+      repairReason: 'Retry after the retained upstream outage was corrected.',
+      repairsCycleId: original.cycleId,
+    });
+  });
+
+  it('classifies only bounded infrastructure failures as transient', () => {
+    expect(
+      classifyAflTradePrivateEvaluationExecutionError(
+        Object.assign(new Error('serialization conflict'), { code: '40001' })
+      )
+    ).toEqual({
+      code: 'postgres_40001',
+      message: 'serialization conflict',
+      retryable: true,
+    });
+    expect(
+      classifyAflTradePrivateEvaluationExecutionError(
+        Object.assign(new Error('connection reset'), { code: 'ECONNRESET' })
+      )
+    ).toEqual({
+      code: 'transport_ECONNRESET',
+      message: 'connection reset',
+      retryable: true,
+    });
+    expect(
+      classifyAflTradePrivateEvaluationExecutionError(new TypeError('bad custody'))
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #538

## Summary
- persist bounded three-attempt execution cycles with leases, heartbeats, stale-worker fencing, and exact terminal causes
- resume retryable work across restarts and expose idempotent backend-only repair cycles
- use targeted prepared-entry reads, cohort parent caching, and bounded concurrency
- harden the PostgreSQL role/function boundary and authenticate exact lifecycle ancestry

## Verification
- 21 focused unit tests
- 16 focused disposable PostgreSQL integration tests
- npm run typecheck -- --pretty false
- npm run lint:ci -- --quiet
- git diff --check

The full outcomes suite retains one pre-existing failure from the stacked base in afl-authenticated-prepared-valuation-input-postgres.test.ts (current valuation cohort operation identity mismatch); it reproduces without this ticket.

## Summary by Sourcery

Persist and secure bounded private valuation cohort execution so retryable work can resume safely across restarts and repaired cycles can be replayed idempotently.

New Features:
- Add durable private valuation cohort execution with persisted cycles, bounded retries, leases, heartbeats, stale-worker fencing, and terminal outcomes.
- Support restart-resilient execution and idempotent backend-only repair cycles.
- Bound cohort processing concurrency and report pending or exhausted trades without advancing incomplete batches.

Bug Fixes:
- Prevent stale workers and invalid database transitions from mutating execution state.
- Authenticate exact prepared-input entries, retained generations, and lifecycle ancestry before accepting results.

Enhancements:
- Optimize prepared-input access with targeted entry reads and shared cohort-parent caching.
- Strengthen PostgreSQL role boundaries, security-definer execution functions, and append-only execution history.

Tests:
- Add focused unit and disposable PostgreSQL integration coverage for retries, leases, fencing, exhaustion, repairs, authorization, targeted lookups, and concurrency limits.