### PR TITLE
Add weekly, immediate, and ad-hoc valuation execution

### DIFF
--- a/Scripts/dev/full-local-stack.sh
+++ b/Scripts/dev/full-local-stack.sh
@@ -58,7 +58,7 @@ if [[ "$STATLY_LOCAL_REUSE_OUTCOMES_DATABASE" == "true" ]]; then
     }
   '
 else
-  export AFL_OUTCOMES_DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:55432/postgres?sslmode=disable"
+  export AFL_OUTCOMES_DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:55432/statly_outcomes_test?sslmode=disable"
 fi
 export AFL_TRADE_LOCAL_ARTIFACT_ROOT="${AFL_TRADE_LOCAL_ARTIFACT_ROOT:-$ROOT_DIR/.statly-local/afl-trade-artifacts}"
 OUTCOMES_NONCE_PATH="$ROOT_DIR/.statly-local/afl-trade-outcomes-runtime-nonce"
@@ -176,7 +176,8 @@ if [[ "$STATLY_NEXT_DEV_BUNDLER" == "webpack" ]]; then
   WEB_COMMAND="./node_modules/.bin/next dev --webpack"
 fi
 
-npx concurrently -k -n web,socket,draft-worker -c blue,magenta,green \
+npx concurrently -k -n web,socket,draft-worker,valuation-worker -c blue,magenta,green,cyan \
   "$WEB_COMMAND" \
   "npm:socket" \
-  "npm:draft-worker:dev"
+  "npm:draft-worker:dev" \
+  "npm:outcomes:valuation:worker-local"

--- a/Scripts/dev/run-local-afl-private-valuation-worker.ts
+++ b/Scripts/dev/run-local-afl-private-valuation-worker.ts
@@ -1,0 +1,111 @@
+import { pathToFileURL } from 'node:url';
+
+import { Pool } from 'pg';
+
+import { assertLocalAflTradeOutcomesRuntimeIdentity } from '../../src/server/aflTradeIntelligence/development/localOutcomesRuntimeIdentity';
+import { createLocalAflTradePrivateValuationRuntime } from '../../src/server/aflTradeIntelligence/development/localPrivateValuationRuntime';
+
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
+const POLL_MILLISECONDS = 30_000;
+
+function localConfiguration(environment: NodeJS.ProcessEnv) {
+  const databaseUrl = environment.AFL_OUTCOMES_DATABASE_URL?.trim();
+  const runtimeNonce = environment.STATLY_LOCAL_OUTCOMES_RUNTIME_NONCE?.trim();
+  const artifactRoot = environment.AFL_TRADE_LOCAL_ARTIFACT_ROOT?.trim();
+  if (!databaseUrl || !runtimeNonce || !artifactRoot || !/^[a-f0-9]{64}$/u.test(runtimeNonce)) {
+    throw new Error('The admitted local outcomes database, runtime nonce, and artifact root are required.');
+  }
+  const database = new URL(databaseUrl);
+  if (
+    !['postgres:', 'postgresql:'].includes(database.protocol) ||
+    !LOOPBACK_HOSTS.has(database.hostname) ||
+    database.pathname !== '/statly_outcomes_test'
+  ) {
+    throw new Error('The valuation worker requires disposable loopback PostgreSQL.');
+  }
+  return { databaseUrl, runtimeNonce, artifactRoot };
+}
+
+function wait(milliseconds: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) return resolve();
+    const timeout = setTimeout(resolve, milliseconds);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true }
+    );
+  });
+}
+
+export async function runLocalAflPrivateValuationWorker(input: {
+  readonly env: NodeJS.ProcessEnv;
+  readonly signal: AbortSignal;
+  readonly writeOutput?: (line: string) => void;
+  readonly now?: () => string;
+  readonly pollMilliseconds?: number;
+  readonly createPool?: (databaseUrl: string) => Pool;
+  readonly authenticateRuntime?: typeof assertLocalAflTradeOutcomesRuntimeIdentity;
+  readonly createRuntime?: typeof createLocalAflTradePrivateValuationRuntime;
+}) {
+  const config = localConfiguration(input.env);
+  const output = input.writeOutput ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const pool =
+    input.createPool?.(config.databaseUrl) ??
+    new Pool({
+      connectionString: config.databaseUrl,
+      application_name: 'statly-local-private-valuation-worker',
+      connectionTimeoutMillis: 5_000,
+      max: 8,
+    });
+  try {
+    await (input.authenticateRuntime ?? assertLocalAflTradeOutcomesRuntimeIdentity)(
+      pool,
+      config.runtimeNonce
+    );
+    const runtime = (input.createRuntime ?? createLocalAflTradePrivateValuationRuntime)({
+      pool,
+      artifactRoot: config.artifactRoot,
+    });
+    await runtime.enqueueStartupCatchUp((input.now ?? (() => new Date().toISOString()))());
+    while (!input.signal.aborted) {
+      let dispatched = 0;
+      try {
+        for (;;) {
+          const result = await runtime.dispatchOne();
+          if (result.state === 'idle') break;
+          dispatched += 1;
+          output(JSON.stringify(result));
+        }
+      } catch (error) {
+        output(
+          JSON.stringify({
+            state: 'dispatch_failed',
+            message: error instanceof Error ? error.message : 'Unknown valuation worker failure.',
+          })
+        );
+      }
+      if (!input.signal.aborted) {
+        await wait(input.pollMilliseconds ?? POLL_MILLISECONDS, input.signal);
+        await runtime.enqueueStartupCatchUp((input.now ?? (() => new Date().toISOString()))());
+      }
+      if (dispatched === 0 && (input.pollMilliseconds ?? POLL_MILLISECONDS) === 0) break;
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath !== undefined && import.meta.url === pathToFileURL(invokedPath).href) {
+  const controller = new AbortController();
+  process.once('SIGINT', () => controller.abort());
+  process.once('SIGTERM', () => controller.abort());
+  runLocalAflPrivateValuationWorker({ env: process.env, signal: controller.signal }).catch(() => {
+    process.stderr.write('Local private valuation worker failed closed.\n');
+    process.exitCode = 1;
+  });
+}

--- a/Scripts/dev/run-local-afl-private-valuation.ts
+++ b/Scripts/dev/run-local-afl-private-valuation.ts
@@ -1,0 +1,112 @@
+import { pathToFileURL } from 'node:url';
+
+import { Pool } from 'pg';
+import { z } from 'zod';
+
+import { assertLocalAflTradeOutcomesRuntimeIdentity } from '../../src/server/aflTradeIntelligence/development/localOutcomesRuntimeIdentity';
+import { createLocalAflTradePrivateValuationRuntime } from '../../src/server/aflTradeIntelligence/development/localPrivateValuationRuntime';
+
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
+const idSchema = z.string().trim().min(1).max(400);
+
+function argument(argv: readonly string[], name: string): string | undefined {
+  const index = argv.indexOf(name);
+  return index === -1 ? undefined : argv[index + 1]?.trim();
+}
+
+function parseArguments(argv: readonly string[]) {
+  const scopeKey = idSchema.parse(argument(argv, '--scope'));
+  const operationKey = argument(argv, '--operation');
+  const repairReason = argument(argv, '--repair-reason');
+  const repairOperationId = argument(argv, '--repair-operation');
+  if ((repairReason === undefined) !== (repairOperationId === undefined)) {
+    throw new TypeError('Repair requires both --repair-reason and --repair-operation.');
+  }
+  if (operationKey === undefined) {
+    throw new TypeError('Ad-hoc execution requires a stable --operation key for crash replay.');
+  }
+  return {
+    scopeKey,
+    operationKey: idSchema.parse(operationKey),
+    repairReason:
+      repairReason === undefined ? null : z.string().trim().min(1).max(2_000).parse(repairReason),
+    repairOperationId:
+      repairOperationId === undefined
+        ? null
+        : z.string().regex(/^cohort-execution-repair:[a-f0-9]{64}$/).parse(repairOperationId),
+  };
+}
+
+function localConfiguration(environment: NodeJS.ProcessEnv) {
+  const databaseUrl = environment.AFL_OUTCOMES_DATABASE_URL?.trim();
+  const runtimeNonce = environment.STATLY_LOCAL_OUTCOMES_RUNTIME_NONCE?.trim();
+  const artifactRoot = environment.AFL_TRADE_LOCAL_ARTIFACT_ROOT?.trim();
+  if (!databaseUrl || !runtimeNonce || !artifactRoot || !/^[a-f0-9]{64}$/u.test(runtimeNonce)) {
+    throw new Error('The admitted local outcomes database, runtime nonce, and artifact root are required.');
+  }
+  const database = new URL(databaseUrl);
+  if (
+    !['postgres:', 'postgresql:'].includes(database.protocol) ||
+    !LOOPBACK_HOSTS.has(database.hostname) ||
+    database.pathname !== '/statly_outcomes_test'
+  ) {
+    throw new Error('Private valuation execution requires disposable loopback PostgreSQL.');
+  }
+  return { databaseUrl, runtimeNonce, artifactRoot };
+}
+
+export async function runLocalAflPrivateValuationCommand(input: {
+  readonly argv: readonly string[];
+  readonly env: NodeJS.ProcessEnv;
+  readonly writeOutput?: (line: string) => void;
+}) {
+  const command = parseArguments(input.argv);
+  const config = localConfiguration(input.env);
+  const pool = new Pool({
+    connectionString: config.databaseUrl,
+    application_name: 'statly-local-private-valuation-command',
+    connectionTimeoutMillis: 5_000,
+    max: 4,
+  });
+  try {
+    await assertLocalAflTradeOutcomesRuntimeIdentity(pool, config.runtimeNonce);
+    const runtime = createLocalAflTradePrivateValuationRuntime({
+      pool,
+      artifactRoot: config.artifactRoot,
+      workerId: 'system:ad-hoc-valuation-command',
+    });
+    if (command.repairReason !== null && command.repairOperationId !== null) {
+      await runtime.repairCurrent(
+        command.scopeKey,
+        command.repairReason,
+        command.repairOperationId
+      );
+    }
+    const requestId = await runtime.enqueueAdHoc({
+      scopeKey: command.scopeKey,
+      operationKey: command.operationKey,
+    });
+    let dispatched: Awaited<ReturnType<typeof runtime.dispatchRequest>>;
+    for (;;) {
+      dispatched = await runtime.dispatchRequest(requestId);
+      if (dispatched.state === 'completed') break;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    (input.writeOutput ?? ((line) => process.stdout.write(`${line}\n`)))(
+      JSON.stringify({ requestId, result: dispatched.result })
+    );
+    return dispatched.result;
+  } finally {
+    await pool.end();
+  }
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath !== undefined && import.meta.url === pathToFileURL(invokedPath).href) {
+  runLocalAflPrivateValuationCommand({ argv: process.argv.slice(2), env: process.env }).catch(
+    () => {
+      process.stderr.write('Local private valuation execution failed closed.\n');
+      process.exitCode = 1;
+    }
+  );
+}

--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
     "outcomes:modeling:prepare-local-source-qualification": "tsx Scripts/dev/prepare-local-afl-trade-valuation-source-qualification.ts",
     "outcomes:modeling:record-private-evaluation-authority": "tsx Scripts/dev/record-local-afl-trade-private-valuation-evaluation.ts",
     "outcomes:modeling:record-private-reviewed-evaluation-authority": "tsx Scripts/dev/record-local-afl-trade-private-reviewed-evaluation.ts",
+    "outcomes:valuation:run-local": "tsx Scripts/dev/run-local-afl-private-valuation.ts",
+    "outcomes:valuation:worker-local": "tsx Scripts/dev/run-local-afl-private-valuation-worker.ts",
     "init-firebase-db": "tsx Scripts/initialize-firebase-db.ts",
     "check:etl": "tsx Scripts/check-etl-setup.ts",
     "player-data:dry-run": "tsx Scripts/player-data-convergence-dry-run.ts",

--- a/prisma/afl-trade-outcomes/migrations/0069_private_valuation_dispatch/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0069_private_valuation_dispatch/migration.sql
@@ -1,0 +1,276 @@
+-- Durable local-only triggers for weekly, newly-qualified, and ad-hoc private valuation execution.
+
+CREATE TABLE "outcome_private_valuation_dispatch_request" (
+  "request_id" TEXT PRIMARY KEY,
+  "scope_key" TEXT NOT NULL,
+  "trigger_kind" TEXT NOT NULL CHECK ("trigger_kind" IN ('weekly','model_qualified','ad_hoc')),
+  "scheduled_for" TIMESTAMPTZ(3) NOT NULL,
+  "authority_key" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'pending' CHECK ("status" IN ('pending','claimed','completed')),
+  "available_at" TIMESTAMPTZ(3) NOT NULL,
+  "claim_id" TEXT,
+  "lease_token_sha256" CHAR(64),
+  "lease_expires_at" TIMESTAMPTZ(3),
+  "claimed_at" TIMESTAMPTZ(3),
+  "completed_at" TIMESTAMPTZ(3),
+  "result_json" JSONB,
+  "request_json" JSONB NOT NULL,
+  CONSTRAINT "outcome_private_valuation_dispatch_claim_shape" CHECK (
+    ("status"='claimed')=("claim_id" IS NOT NULL AND "lease_token_sha256" IS NOT NULL AND "lease_expires_at" IS NOT NULL AND "claimed_at" IS NOT NULL)
+  ),
+  CONSTRAINT "outcome_private_valuation_dispatch_result_shape" CHECK (
+    ("status"='completed')=("completed_at" IS NOT NULL AND "result_json" IS NOT NULL)
+  )
+);
+
+CREATE INDEX "outcome_private_valuation_dispatch_due_idx"
+  ON "outcome_private_valuation_dispatch_request"("status","available_at","scope_key");
+CREATE UNIQUE INDEX "outcome_private_valuation_dispatch_ad_hoc_operation_idx"
+  ON "outcome_private_valuation_dispatch_request"("scope_key","authority_key")
+  WHERE "trigger_kind"='ad_hoc';
+
+CREATE OR REPLACE FUNCTION "create_outcome_private_valuation_dispatch_id"(
+  target_scope_key TEXT,target_trigger TEXT,target_scheduled_for TIMESTAMPTZ,target_authority_key TEXT
+) RETURNS TEXT LANGUAGE SQL IMMUTABLE STRICT AS $$
+  SELECT 'private-valuation-dispatch:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(jsonb_build_object(
+      'scopeKey',target_scope_key,'trigger',target_trigger,
+      'scheduledFor',to_char(target_scheduled_for AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+      'authorityKey',target_authority_key)), 'UTF8')), 'hex')
+$$;
+
+CREATE OR REPLACE FUNCTION "enqueue_outcome_private_valuation_dispatch"(
+  target_scope_key TEXT,target_trigger TEXT,target_scheduled_for TIMESTAMPTZ,target_authority_key TEXT
+) RETURNS TEXT LANGUAGE plpgsql AS $$
+DECLARE target_id TEXT; target_json JSONB;
+BEGIN
+  IF target_scope_key IS NULL OR btrim(target_scope_key)='' OR length(target_scope_key)>400
+    OR target_trigger NOT IN ('weekly','model_qualified','ad_hoc')
+    OR target_scheduled_for IS NULL OR target_authority_key IS NULL
+    OR btrim(target_authority_key)='' OR length(target_authority_key)>400
+  THEN RAISE EXCEPTION 'Private valuation dispatch request is malformed'; END IF;
+  target_id:="create_outcome_private_valuation_dispatch_id"(
+    target_scope_key,target_trigger,target_scheduled_for,target_authority_key);
+  target_json:=jsonb_build_object(
+    'requestId',target_id,'scopeKey',target_scope_key,'trigger',target_trigger,
+    'scheduledFor',to_char(target_scheduled_for AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'authorityKey',target_authority_key);
+  INSERT INTO "outcome_private_valuation_dispatch_request"
+    (request_id,scope_key,trigger_kind,scheduled_for,authority_key,available_at,request_json)
+  VALUES (target_id,target_scope_key,target_trigger,target_scheduled_for,target_authority_key,target_scheduled_for,target_json)
+  ON CONFLICT (request_id) DO NOTHING;
+  RETURN target_id;
+END $$;
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_valuation_dispatch_request"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE expected_id TEXT;
+BEGIN
+  expected_id:="create_outcome_private_valuation_dispatch_id"(
+    NEW."scope_key",NEW."trigger_kind",NEW."scheduled_for",NEW."authority_key");
+  IF NEW."request_id" IS DISTINCT FROM expected_id
+    OR NEW."request_json" IS DISTINCT FROM jsonb_build_object(
+      'requestId',expected_id,'scopeKey',NEW."scope_key",'trigger',NEW."trigger_kind",
+      'scheduledFor',to_char(NEW."scheduled_for" AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+      'authorityKey',NEW."authority_key")
+    OR NEW."available_at" IS DISTINCT FROM NEW."scheduled_for"
+    OR NEW."status"<>'pending' OR NEW."claim_id" IS NOT NULL
+    OR NEW."lease_token_sha256" IS NOT NULL OR NEW."lease_expires_at" IS NOT NULL
+    OR NEW."claimed_at" IS NOT NULL OR NEW."completed_at" IS NOT NULL OR NEW."result_json" IS NOT NULL
+  THEN RAISE EXCEPTION 'Private valuation dispatch request custody is invalid'; END IF;
+  RETURN NEW;
+END $$;
+CREATE TRIGGER "outcome_private_valuation_dispatch_request_validate"
+BEFORE INSERT ON "outcome_private_valuation_dispatch_request"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_valuation_dispatch_request"();
+
+CREATE OR REPLACE FUNCTION "coalesce_outcome_private_valuation_weekly_dispatch"(
+  target_scope_key TEXT,target_scheduled_for TIMESTAMPTZ
+) RETURNS TEXT LANGUAGE plpgsql AS $$
+DECLARE target_id TEXT; trusted_at TIMESTAMPTZ(3):=date_trunc('milliseconds',transaction_timestamp());
+BEGIN
+  IF target_scheduled_for>trusted_at
+    OR extract(isodow FROM target_scheduled_for AT TIME ZONE 'Australia/Melbourne')<>1
+    OR extract(hour FROM target_scheduled_for AT TIME ZONE 'Australia/Melbourne')<>19
+    OR extract(minute FROM target_scheduled_for AT TIME ZONE 'Australia/Melbourne')<>0
+    OR date_trunc('minute',target_scheduled_for) IS DISTINCT FROM target_scheduled_for
+    OR NOT EXISTS (SELECT 1 FROM "outcome_current_prepared_valuation_input_set"
+                    WHERE scope_key=target_scope_key)
+  THEN RAISE EXCEPTION 'Weekly private valuation occurrence is not exact current schedule'; END IF;
+  target_id:="enqueue_outcome_private_valuation_dispatch"(
+    target_scope_key,'weekly',target_scheduled_for,'scheduled');
+  UPDATE "outcome_private_valuation_dispatch_request" SET
+    status='completed',completed_at=trusted_at,
+    result_json=jsonb_build_object('state','superseded_by_startup_catch_up','latestRequestId',target_id),
+    claim_id=NULL,lease_token_sha256=NULL,lease_expires_at=NULL,claimed_at=NULL
+   WHERE scope_key=target_scope_key AND trigger_kind='weekly'
+     AND scheduled_for<target_scheduled_for
+     AND (status='pending' OR (status='claimed' AND lease_expires_at<trusted_at));
+  RETURN target_id;
+END $$;
+
+CREATE OR REPLACE FUNCTION "enqueue_outcome_private_valuation_ad_hoc_dispatch"(
+  target_scope_key TEXT,target_operation_key TEXT
+) RETURNS TABLE(request_id TEXT,request_json JSONB) LANGUAGE plpgsql AS $$
+DECLARE trusted_at TIMESTAMPTZ(3):=date_trunc('milliseconds',transaction_timestamp()); target_id TEXT;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM "outcome_current_prepared_valuation_input_set"
+                  WHERE scope_key=target_scope_key)
+  THEN RAISE EXCEPTION 'Ad-hoc private valuation scope is not current'; END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(target_scope_key||chr(31)||target_operation_key,0));
+  RETURN QUERY SELECT request.request_id,request.request_json
+    FROM "outcome_private_valuation_dispatch_request" request
+   WHERE request.scope_key=target_scope_key AND request.trigger_kind='ad_hoc'
+     AND request.authority_key=target_operation_key;
+  IF FOUND THEN RETURN; END IF;
+  target_id:="enqueue_outcome_private_valuation_dispatch"(
+    target_scope_key,'ad_hoc',trusted_at,target_operation_key);
+  RETURN QUERY SELECT target_id,request.request_json
+    FROM "outcome_private_valuation_dispatch_request" request WHERE request.request_id=target_id;
+END $$;
+
+CREATE OR REPLACE FUNCTION "claim_outcome_private_valuation_dispatch"(
+  target_worker_id TEXT,target_lease_token_sha256 TEXT,target_lease_seconds INTEGER,
+  target_request_id TEXT DEFAULT NULL
+) RETURNS TABLE(request_id TEXT,request_json JSONB,claim_id TEXT,lease_expires_at TIMESTAMPTZ)
+LANGUAGE plpgsql AS $$
+DECLARE candidate "outcome_private_valuation_dispatch_request"%ROWTYPE; trusted_at TIMESTAMPTZ(3);
+BEGIN
+  trusted_at:=date_trunc('milliseconds',transaction_timestamp());
+  IF target_worker_id IS NULL OR btrim(target_worker_id)='' OR length(target_worker_id)>240
+    OR target_lease_token_sha256 !~ '^[a-f0-9]{64}$' OR target_lease_seconds NOT BETWEEN 5 AND 3600
+  THEN RAISE EXCEPTION 'Private valuation dispatch claim is malformed'; END IF;
+  SELECT * INTO candidate FROM "outcome_private_valuation_dispatch_request" request
+     WHERE request."available_at"<=trusted_at
+     AND (request."status"='pending' OR (request."status"='claimed' AND request."lease_expires_at"<trusted_at))
+     AND (target_request_id IS NULL OR request."request_id"=target_request_id)
+   ORDER BY request."scheduled_for",request."request_id" FOR UPDATE SKIP LOCKED LIMIT 1;
+  IF NOT FOUND THEN RETURN; END IF;
+  request_id:=candidate."request_id";
+  claim_id:='private-valuation-dispatch-claim:'||encode(sha256(convert_to(
+    candidate."request_id"||E'\n'||target_worker_id||E'\n'||trusted_at::TEXT,'UTF8')),'hex');
+  lease_expires_at:=trusted_at+make_interval(secs=>target_lease_seconds);
+  UPDATE "outcome_private_valuation_dispatch_request" SET
+    status='claimed',claim_id=claim_outcome_private_valuation_dispatch.claim_id,
+    lease_token_sha256=target_lease_token_sha256,claimed_at=trusted_at,
+    lease_expires_at=claim_outcome_private_valuation_dispatch.lease_expires_at,
+    completed_at=NULL,result_json=NULL
+   WHERE outcome_private_valuation_dispatch_request.request_id=candidate.request_id;
+  request_json:=candidate."request_json";
+  RETURN NEXT;
+END $$;
+
+CREATE OR REPLACE FUNCTION "complete_outcome_private_valuation_dispatch"(
+  target_claim_id TEXT,target_lease_token_sha256 TEXT,target_result JSONB
+) RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE trusted_at TIMESTAMPTZ(3):=date_trunc('milliseconds',transaction_timestamp());
+BEGIN
+  IF jsonb_typeof(target_result) IS DISTINCT FROM 'object'
+    OR target_result->>'state' NOT IN ('activated','already_current','exhausted','unexpected_failure')
+    OR target_result IS DISTINCT FROM jsonb_build_object('state',target_result->>'state')
+  THEN RAISE EXCEPTION 'Private valuation dispatch result is invalid'; END IF;
+  UPDATE "outcome_private_valuation_dispatch_request" SET
+    status='completed',completed_at=trusted_at,result_json=target_result,
+    claim_id=NULL,lease_token_sha256=NULL,lease_expires_at=NULL,claimed_at=NULL
+   WHERE claim_id=target_claim_id AND lease_token_sha256=target_lease_token_sha256
+     AND status='claimed' AND lease_expires_at>=trusted_at;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Private valuation dispatch claim was lost'; END IF;
+END $$;
+
+CREATE OR REPLACE FUNCTION "reschedule_outcome_private_valuation_dispatch"(
+  target_claim_id TEXT,target_lease_token_sha256 TEXT,target_state TEXT
+) RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE trusted_at TIMESTAMPTZ(3):=date_trunc('milliseconds',transaction_timestamp());
+BEGIN
+  IF target_state NOT IN ('retry_pending','stale_authority')
+  THEN RAISE EXCEPTION 'Private valuation dispatch reschedule state is invalid'; END IF;
+  UPDATE "outcome_private_valuation_dispatch_request" SET
+    status='pending',available_at=trusted_at+CASE target_state
+      WHEN 'retry_pending' THEN interval '5 seconds' ELSE interval '30 seconds' END,
+    claim_id=NULL,lease_token_sha256=NULL,lease_expires_at=NULL,claimed_at=NULL
+   WHERE claim_id=target_claim_id AND lease_token_sha256=target_lease_token_sha256
+     AND status='claimed' AND lease_expires_at>=trusted_at;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Private valuation dispatch claim was lost'; END IF;
+END $$;
+
+CREATE OR REPLACE FUNCTION "heartbeat_outcome_private_valuation_dispatch"(
+  target_claim_id TEXT,target_lease_token_sha256 TEXT
+) RETURNS TIMESTAMPTZ LANGUAGE plpgsql AS $$
+DECLARE trusted_at TIMESTAMPTZ(3):=date_trunc('milliseconds',transaction_timestamp()); renewed_until TIMESTAMPTZ(3);
+BEGIN
+  renewed_until:=trusted_at+interval '120 seconds';
+  UPDATE "outcome_private_valuation_dispatch_request" SET lease_expires_at=renewed_until
+   WHERE claim_id=target_claim_id AND lease_token_sha256=target_lease_token_sha256
+     AND status='claimed' AND lease_expires_at>=trusted_at;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Private valuation dispatch claim was lost'; END IF;
+  RETURN renewed_until;
+END $$;
+
+CREATE OR REPLACE FUNCTION "enqueue_outcome_private_valuation_after_model_pair"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP='INSERT' OR OLD."work_id" IS DISTINCT FROM NEW."work_id"
+    OR OLD."revision" IS DISTINCT FROM NEW."revision"
+  THEN
+    PERFORM "enqueue_outcome_private_valuation_dispatch"(
+      NEW."scope_key",'model_qualified',date_trunc('milliseconds',transaction_timestamp()),NEW."work_id");
+  END IF;
+  RETURN NEW;
+END $$;
+CREATE TRIGGER "outcome_current_model_pair_enqueue_private_valuation"
+AFTER INSERT OR UPDATE ON "outcome_current_governed_valuation_model_pair"
+FOR EACH ROW EXECUTE FUNCTION "enqueue_outcome_private_valuation_after_model_pair"();
+
+CREATE OR REPLACE FUNCTION "reject_outcome_private_valuation_dispatch_delete"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'Private valuation dispatch history is append-only'; END $$;
+CREATE TRIGGER "outcome_private_valuation_dispatch_no_delete"
+BEFORE DELETE ON "outcome_private_valuation_dispatch_request"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_valuation_dispatch_delete"();
+
+DO $roles$ BEGIN
+  BEGIN CREATE ROLE afl_trade_private_valuation_scheduler_owner NOLOGIN;
+  EXCEPTION WHEN duplicate_object THEN NULL; END;
+  EXECUTE format('GRANT afl_trade_private_valuation_scheduler_owner TO %I',current_user);
+  EXECUTE format('GRANT USAGE,CREATE ON SCHEMA %I TO afl_trade_private_valuation_scheduler_owner',current_schema());
+  EXECUTE format('GRANT USAGE ON SCHEMA %I TO afl_trade_private_evaluation_coordinator',current_schema());
+END $roles$;
+ALTER TABLE "outcome_private_valuation_dispatch_request" OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "enqueue_outcome_private_valuation_dispatch"(TEXT,TEXT,TIMESTAMPTZ,TEXT) OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "coalesce_outcome_private_valuation_weekly_dispatch"(TEXT,TIMESTAMPTZ) OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "enqueue_outcome_private_valuation_ad_hoc_dispatch"(TEXT,TEXT) OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "claim_outcome_private_valuation_dispatch"(TEXT,TEXT,INTEGER,TEXT) OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "complete_outcome_private_valuation_dispatch"(TEXT,TEXT,JSONB) OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "reschedule_outcome_private_valuation_dispatch"(TEXT,TEXT,TEXT) OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "heartbeat_outcome_private_valuation_dispatch"(TEXT,TEXT) OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "enqueue_outcome_private_valuation_after_model_pair"() OWNER TO afl_trade_private_valuation_scheduler_owner;
+DO $paths$ BEGIN
+  EXECUTE format('ALTER FUNCTION %I.enqueue_outcome_private_valuation_dispatch(TEXT,TEXT,TIMESTAMPTZ,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+  EXECUTE format('ALTER FUNCTION %I.coalesce_outcome_private_valuation_weekly_dispatch(TEXT,TIMESTAMPTZ) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+  EXECUTE format('ALTER FUNCTION %I.enqueue_outcome_private_valuation_ad_hoc_dispatch(TEXT,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+  EXECUTE format('ALTER FUNCTION %I.claim_outcome_private_valuation_dispatch(TEXT,TEXT,INTEGER,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+  EXECUTE format('ALTER FUNCTION %I.complete_outcome_private_valuation_dispatch(TEXT,TEXT,JSONB) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+  EXECUTE format('ALTER FUNCTION %I.reschedule_outcome_private_valuation_dispatch(TEXT,TEXT,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+  EXECUTE format('ALTER FUNCTION %I.heartbeat_outcome_private_valuation_dispatch(TEXT,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+  EXECUTE format('ALTER FUNCTION %I.enqueue_outcome_private_valuation_after_model_pair() SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+END $paths$;
+REVOKE ALL ON "outcome_private_valuation_dispatch_request" FROM PUBLIC,afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_private_valuation_dispatch_request" TO afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_current_prepared_valuation_input_set"
+  TO afl_trade_private_evaluation_coordinator,afl_trade_private_valuation_scheduler_owner;
+REVOKE ALL ON FUNCTION "enqueue_outcome_private_valuation_dispatch"(TEXT,TEXT,TIMESTAMPTZ,TEXT),
+  "coalesce_outcome_private_valuation_weekly_dispatch"(TEXT,TIMESTAMPTZ),
+  "enqueue_outcome_private_valuation_ad_hoc_dispatch"(TEXT,TEXT),
+  "claim_outcome_private_valuation_dispatch"(TEXT,TEXT,INTEGER,TEXT),
+  "complete_outcome_private_valuation_dispatch"(TEXT,TEXT,JSONB),
+  "reschedule_outcome_private_valuation_dispatch"(TEXT,TEXT,TEXT),
+  "heartbeat_outcome_private_valuation_dispatch"(TEXT,TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "coalesce_outcome_private_valuation_weekly_dispatch"(TEXT,TIMESTAMPTZ),
+  "enqueue_outcome_private_valuation_ad_hoc_dispatch"(TEXT,TEXT),
+  "claim_outcome_private_valuation_dispatch"(TEXT,TEXT,INTEGER,TEXT),
+  "complete_outcome_private_valuation_dispatch"(TEXT,TEXT,JSONB),
+  "reschedule_outcome_private_valuation_dispatch"(TEXT,TEXT,TEXT),
+  "heartbeat_outcome_private_valuation_dispatch"(TEXT,TEXT)
+  TO afl_trade_private_evaluation_coordinator;
+DO $membership$ BEGIN
+  EXECUTE format('REVOKE afl_trade_private_valuation_scheduler_owner FROM %I',current_user);
+END $membership$;

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -5368,6 +5368,26 @@ model OutcomePrivateEvaluationExecutionAttempt {
   @@map("outcome_private_evaluation_execution_attempt")
 }
 
+model OutcomePrivateValuationDispatchRequest {
+  requestId        String    @id @map("request_id") @outcomes.Text
+  scopeKey         String    @map("scope_key") @outcomes.Text
+  triggerKind      String    @map("trigger_kind") @outcomes.Text
+  scheduledFor     DateTime  @map("scheduled_for") @outcomes.Timestamptz(3)
+  authorityKey     String    @map("authority_key") @outcomes.Text
+  status           String    @default("pending") @outcomes.Text
+  availableAt      DateTime  @map("available_at") @outcomes.Timestamptz(3)
+  claimId          String?   @map("claim_id") @outcomes.Text
+  leaseTokenSha256 String?   @map("lease_token_sha256") @outcomes.Char(64)
+  leaseExpiresAt   DateTime? @map("lease_expires_at") @outcomes.Timestamptz(3)
+  claimedAt        DateTime? @map("claimed_at") @outcomes.Timestamptz(3)
+  completedAt      DateTime? @map("completed_at") @outcomes.Timestamptz(3)
+  resultJson       Json?     @map("result_json")
+  requestJson      Json      @map("request_json")
+
+  @@index([status, availableAt, scopeKey], map: "outcome_private_valuation_dispatch_due_idx")
+  @@map("outcome_private_valuation_dispatch_request")
+}
+
 model OutcomePrivateEvaluationTransitionReceipt {
   transitionId         String                                        @id @map("transition_id") @outcomes.Text
   transitionIntentId   String                                        @unique @map("transition_intent_id") @outcomes.Text

--- a/src/server/aflTradeIntelligence/development/localOutcomesRuntime.ts
+++ b/src/server/aflTradeIntelligence/development/localOutcomesRuntime.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'node:buffer';
 
 export const AFL_TRADE_LOCAL_OUTCOMES_PORT = 55432;
-export const AFL_TRADE_LOCAL_OUTCOMES_DATABASE_URL = `postgresql://postgres:postgres@127.0.0.1:${AFL_TRADE_LOCAL_OUTCOMES_PORT}/postgres?sslmode=disable`;
+export const AFL_TRADE_LOCAL_OUTCOMES_DATABASE_URL = `postgresql://postgres:postgres@127.0.0.1:${AFL_TRADE_LOCAL_OUTCOMES_PORT}/statly_outcomes_test?sslmode=disable`;
 
 const cursorSecret = Buffer.from('statly-local-only-cursor-secret-v1', 'utf8').toString('base64');
 

--- a/src/server/aflTradeIntelligence/development/localPrivateValuationRuntime.ts
+++ b/src/server/aflTradeIntelligence/development/localPrivateValuationRuntime.ts
@@ -1,0 +1,49 @@
+import type { Pool } from 'pg';
+
+import { createPgAflOutcomeSqlClient } from '../outcomes/pgOutcomeSqlClient';
+import { createPostgresAflTradePrivateEvaluationCohortRunner } from '../valuation/postgresCurrentValuationCohortRunner';
+import { createPostgresGovernedPrivateEvaluationWorkspace } from '../valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace';
+import { PostgresGovernedPrivateEvaluationBatchRepository } from '../valuation/internal/postgresGovernedPrivateEvaluationBatchRepository';
+import {
+  PostgresAflTradePrivateValuationScheduleRepository,
+  createPostgresAflTradePrivateValuationDispatcher,
+} from '../valuation/postgresPrivateValuationScheduling';
+import { createLocalAflTradePrivateDerivedArtifactRepository } from './localFileConditionalObjectStore';
+
+const AUTOMATED_PRINCIPAL = 'system:weekly-valuation-coordinator';
+const MAXIMUM_ARTIFACT_BYTES = 4 * 1024 * 1024;
+
+export function createLocalAflTradePrivateValuationRuntime(input: {
+  readonly pool: Pool;
+  readonly artifactRoot: string;
+  readonly workerId?: string;
+}) {
+  const client = createPgAflOutcomeSqlClient(input.pool);
+  const artifacts = createLocalAflTradePrivateDerivedArtifactRepository({
+    rootDirectory: input.artifactRoot,
+    repositoryId: 'governed-private-evaluation',
+    maximumObjectBytes: MAXIMUM_ARTIFACT_BYTES,
+  });
+  const workspace = createPostgresGovernedPrivateEvaluationWorkspace({
+    client,
+    artifactRepository: artifacts,
+    maximumArtifactBytes: MAXIMUM_ARTIFACT_BYTES,
+    principalId: AUTOMATED_PRINCIPAL,
+    automatedPrincipalId: AUTOMATED_PRINCIPAL,
+    authorizeReader: async () => false,
+  });
+  const runner = createPostgresAflTradePrivateEvaluationCohortRunner({
+    client,
+    workspace,
+    batchRepository: new PostgresGovernedPrivateEvaluationBatchRepository(
+      client,
+      async () => false
+    ),
+    workerId: input.workerId,
+  });
+  return createPostgresAflTradePrivateValuationDispatcher({
+    repository: new PostgresAflTradePrivateValuationScheduleRepository(client),
+    runner,
+    workerId: input.workerId,
+  });
+}

--- a/src/server/aflTradeIntelligence/development/localPrivateValuationRuntime.ts
+++ b/src/server/aflTradeIntelligence/development/localPrivateValuationRuntime.ts
@@ -1,6 +1,7 @@
 import type { Pool } from 'pg';
 
 import { createPgAflOutcomeSqlClient } from '../outcomes/pgOutcomeSqlClient';
+import { AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID } from '../valuation/automatedPrivateEvaluationPolicy';
 import { createPostgresAflTradePrivateEvaluationCohortRunner } from '../valuation/postgresCurrentValuationCohortRunner';
 import { createPostgresGovernedPrivateEvaluationWorkspace } from '../valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace';
 import { PostgresGovernedPrivateEvaluationBatchRepository } from '../valuation/internal/postgresGovernedPrivateEvaluationBatchRepository';
@@ -10,7 +11,6 @@ import {
 } from '../valuation/postgresPrivateValuationScheduling';
 import { createLocalAflTradePrivateDerivedArtifactRepository } from './localFileConditionalObjectStore';
 
-const AUTOMATED_PRINCIPAL = 'system:weekly-valuation-coordinator';
 const MAXIMUM_ARTIFACT_BYTES = 4 * 1024 * 1024;
 
 export function createLocalAflTradePrivateValuationRuntime(input: {
@@ -28,8 +28,7 @@ export function createLocalAflTradePrivateValuationRuntime(input: {
     client,
     artifactRepository: artifacts,
     maximumArtifactBytes: MAXIMUM_ARTIFACT_BYTES,
-    principalId: AUTOMATED_PRINCIPAL,
-    automatedPrincipalId: AUTOMATED_PRINCIPAL,
+    principalId: AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID,
     authorizeReader: async () => false,
   });
   const runner = createPostgresAflTradePrivateEvaluationCohortRunner({

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationScheduling.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationScheduling.ts
@@ -1,0 +1,282 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+import { z } from 'zod';
+
+import type { AflOutcomeSqlClient } from '../outcomes/postgresOutcomeReleaseRepository';
+import {
+  aflTradePrivateValuationDispatchRequestSchema,
+  createAflTradePrivateValuationDispatchRequestId,
+  planAflTradePrivateValuationStartupCatchUp,
+} from './privateValuationScheduling';
+
+const EXECUTION_DATABASE_ROLE = 'afl_trade_private_evaluation_coordinator';
+const idSchema = z.string().trim().min(1).max(400);
+const instantSchema = z.string().datetime({ offset: true });
+const terminalResultSchema = z
+  .object({
+    state: z.enum(['activated', 'already_current', 'exhausted', 'unexpected_failure']),
+  })
+  .strict();
+
+interface ClaimRow {
+  readonly request_id: string;
+  readonly request_json: unknown;
+  readonly claim_id: string;
+  readonly lease_expires_at: Date | string;
+}
+
+export interface AflTradePrivateValuationDispatchRunner {
+  runCurrent(scopeKey: string): Promise<unknown>;
+  repairCurrent(scopeKey: string, reason: string, repairOperationId: string): Promise<unknown>;
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+export class PostgresAflTradePrivateValuationScheduleRepository {
+  constructor(private readonly client: AflOutcomeSqlClient) {}
+
+  async enqueueStartupCatchUp(now: string): Promise<readonly string[]> {
+    const observedAt = instantSchema.parse(now);
+    return this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      const scopes = await transaction.query<{
+        readonly scope_key: string;
+        readonly last_scheduled_for: Date | string | null;
+      }>(
+        `SELECT current.scope_key,max(request.scheduled_for) FILTER (
+                  WHERE request.trigger_kind='weekly') AS last_scheduled_for
+           FROM outcome_current_prepared_valuation_input_set current
+           LEFT JOIN outcome_private_valuation_dispatch_request request
+             ON request.scope_key=current.scope_key
+          GROUP BY current.scope_key ORDER BY current.scope_key`
+      );
+      const requestIds: string[] = [];
+      for (const row of scopes.rows) {
+        const latest = planAflTradePrivateValuationStartupCatchUp({
+          now: observedAt,
+          lastScheduledFor:
+            row.last_scheduled_for === null
+              ? null
+              : new Date(row.last_scheduled_for).toISOString(),
+        });
+        if (latest === null) continue;
+        const result = await transaction.query<{ readonly request_id: string }>(
+          `SELECT coalesce_outcome_private_valuation_weekly_dispatch($1,$2) AS request_id`,
+          [row.scope_key, latest]
+        );
+        requestIds.push(result.rows[0]!.request_id);
+      }
+      return requestIds;
+    });
+  }
+
+  async enqueueAdHoc(input: {
+    readonly scopeKey: string;
+    readonly operationKey: string;
+  }): Promise<string> {
+    const scopeKey = idSchema.parse(input.scopeKey);
+    const operationKey = idSchema.parse(input.operationKey);
+    const result = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<{ readonly request_id: string; readonly request_json: unknown }>(
+        `SELECT * FROM enqueue_outcome_private_valuation_ad_hoc_dispatch($1,$2)`,
+        [scopeKey, operationKey]
+      );
+    });
+    const retained = aflTradePrivateValuationDispatchRequestSchema.parse(
+      result.rows[0]?.request_json
+    );
+    const expected = createAflTradePrivateValuationDispatchRequestId({
+      scopeKey,
+      trigger: 'ad_hoc',
+      scheduledFor: retained.scheduledFor,
+      authorityKey: operationKey,
+    });
+    if (result.rows.length !== 1 || result.rows[0]!.request_id !== expected) {
+      throw new TypeError('Ad-hoc valuation dispatch did not retain its exact request.');
+    }
+    return expected;
+  }
+
+  async claim(workerId: string, requestId?: string): Promise<
+    | {
+        readonly request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>;
+        readonly claimId: string;
+        readonly leaseToken: string;
+      }
+    | null
+  > {
+    const worker = idSchema.parse(workerId);
+    const leaseToken = randomBytes(32).toString('hex');
+    const result = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<ClaimRow>(
+        `SELECT * FROM claim_outcome_private_valuation_dispatch($1,$2,120,$3)`,
+        [worker, sha256(leaseToken), requestId === undefined ? null : idSchema.parse(requestId)]
+      );
+    });
+    const row = result.rows[0];
+    if (row === undefined) return null;
+    const request = aflTradePrivateValuationDispatchRequestSchema.parse(row.request_json);
+    if (request.requestId !== row.request_id) {
+      throw new TypeError('Claimed valuation dispatch disagrees with retained custody.');
+    }
+    return { request, claimId: row.claim_id, leaseToken };
+  }
+
+  async load(requestId: string): Promise<
+    | { readonly status: 'pending' | 'claimed'; readonly result: null }
+    | { readonly status: 'completed'; readonly result: unknown }
+    | null
+  > {
+    const result = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<{
+        readonly status: 'pending' | 'claimed' | 'completed';
+        readonly result_json: unknown | null;
+      }>(
+        `SELECT status,result_json FROM outcome_private_valuation_dispatch_request
+          WHERE request_id=$1`,
+        [idSchema.parse(requestId)]
+      );
+    });
+    const row = result.rows[0];
+    if (row === undefined) return null;
+    return row.status === 'completed'
+      ? { status: 'completed', result: row.result_json }
+      : { status: row.status, result: null };
+  }
+
+  async complete(input: {
+    readonly claimId: string;
+    readonly leaseToken: string;
+    readonly result: z.infer<typeof terminalResultSchema>;
+  }): Promise<void> {
+    await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      await transaction.query(`SELECT complete_outcome_private_valuation_dispatch($1,$2,$3::jsonb)`, [
+        idSchema.parse(input.claimId),
+        sha256(input.leaseToken),
+        JSON.stringify(terminalResultSchema.parse(input.result)),
+      ]);
+    });
+  }
+
+  async heartbeat(input: { readonly claimId: string; readonly leaseToken: string }): Promise<void> {
+    await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      await transaction.query(`SELECT heartbeat_outcome_private_valuation_dispatch($1,$2)`, [
+        idSchema.parse(input.claimId),
+        sha256(input.leaseToken),
+      ]);
+    });
+  }
+
+  async reschedule(input: {
+    readonly claimId: string;
+    readonly leaseToken: string;
+    readonly state: 'retry_pending' | 'stale_authority';
+  }): Promise<void> {
+    await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      await transaction.query(`SELECT reschedule_outcome_private_valuation_dispatch($1,$2,$3)`, [
+        idSchema.parse(input.claimId),
+        sha256(input.leaseToken),
+        input.state,
+      ]);
+    });
+  }
+}
+
+export function createPostgresAflTradePrivateValuationDispatcher(dependencies: {
+  readonly repository: PostgresAflTradePrivateValuationScheduleRepository;
+  readonly runner: AflTradePrivateValuationDispatchRunner;
+  readonly workerId?: string;
+  readonly heartbeatMilliseconds?: number;
+}) {
+  const workerId = dependencies.workerId ?? 'system:weekly-valuation-coordinator';
+  const heartbeatMilliseconds = dependencies.heartbeatMilliseconds ?? 30_000;
+  const processClaim = async (
+    claim: NonNullable<Awaited<ReturnType<typeof dependencies.repository.claim>>>
+  ) => {
+    let heartbeatFailure: unknown = null;
+    let heartbeatInFlight: Promise<void> = Promise.resolve();
+    const heartbeatTimer = setInterval(() => {
+      heartbeatInFlight = heartbeatInFlight
+        .then(async () => {
+          if (heartbeatFailure === null) await dependencies.repository.heartbeat(claim);
+        })
+        .catch((error: unknown) => {
+          heartbeatFailure = error;
+        });
+    }, heartbeatMilliseconds);
+    heartbeatTimer.unref?.();
+    const stopHeartbeat = async () => {
+      clearInterval(heartbeatTimer);
+      await heartbeatInFlight;
+      if (heartbeatFailure !== null) throw heartbeatFailure;
+    };
+    try {
+      const result = await dependencies.runner.runCurrent(claim.request.scopeKey);
+      await stopHeartbeat();
+      if (
+        typeof result === 'object' &&
+        result !== null &&
+        'state' in result &&
+        (result.state === 'retry_pending' || result.state === 'stale_authority')
+      ) {
+        await dependencies.repository.reschedule({
+          claimId: claim.claimId,
+          leaseToken: claim.leaseToken,
+          state: result.state,
+        });
+        return { state: 'rescheduled' as const, requestId: claim.request.requestId, result };
+      }
+      const terminal = terminalResultSchema.parse({
+        state:
+          typeof result === 'object' && result !== null && 'state' in result
+            ? result.state
+            : undefined,
+      });
+      await dependencies.repository.complete({
+        claimId: claim.claimId,
+        leaseToken: claim.leaseToken,
+        result: terminal,
+      });
+      return { state: 'completed' as const, requestId: claim.request.requestId, result };
+    } finally {
+      clearInterval(heartbeatTimer);
+      await heartbeatInFlight;
+    }
+  };
+  return {
+    enqueueStartupCatchUp: (now: string) => dependencies.repository.enqueueStartupCatchUp(now),
+    enqueueAdHoc: (input: {
+      readonly scopeKey: string;
+      readonly operationKey: string;
+    }) => dependencies.repository.enqueueAdHoc(input),
+    repairCurrent: (scopeKey: string, reason: string, repairOperationId: string) =>
+      dependencies.runner.repairCurrent(scopeKey, reason, repairOperationId),
+    async dispatchOne(): Promise<
+      | { readonly state: 'idle' }
+      | { readonly state: 'rescheduled'; readonly requestId: string; readonly result: unknown }
+      | { readonly state: 'completed'; readonly requestId: string; readonly result: unknown }
+    > {
+      const claim = await dependencies.repository.claim(workerId);
+      if (claim === null) return { state: 'idle' };
+      return processClaim(claim);
+    },
+    async dispatchRequest(requestId: string) {
+      const exactRequestId = idSchema.parse(requestId);
+      const claim = await dependencies.repository.claim(workerId, exactRequestId);
+      if (claim !== null) return processClaim(claim);
+      const retained = await dependencies.repository.load(exactRequestId);
+      if (retained === null) throw new TypeError('Requested valuation dispatch was not retained.');
+      return retained.status === 'completed'
+        ? { state: 'completed' as const, requestId: exactRequestId, result: retained.result }
+        : { state: 'waiting' as const, requestId: exactRequestId };
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/privateValuationScheduling.ts
+++ b/src/server/aflTradeIntelligence/valuation/privateValuationScheduling.ts
@@ -1,0 +1,90 @@
+import { formatInTimeZone, fromZonedTime } from 'date-fns-tz';
+import { z } from 'zod';
+
+import { createAflTradeContentAddress } from '../artifacts/contentAddress';
+
+export const AFL_TRADE_PRIVATE_VALUATION_TIME_ZONE = 'Australia/Melbourne' as const;
+export const AFL_TRADE_PRIVATE_VALUATION_SCHEDULE = {
+  weekday: 1,
+  hour: 19,
+  minute: 0,
+} as const;
+
+const instantSchema = z.string().datetime({ offset: true });
+const boundedIdSchema = z.string().trim().min(1).max(400);
+
+export const aflTradePrivateValuationDispatchTriggerSchema = z.enum([
+  'weekly',
+  'model_qualified',
+  'ad_hoc',
+]);
+
+export type AflTradePrivateValuationDispatchTrigger = z.infer<
+  typeof aflTradePrivateValuationDispatchTriggerSchema
+>;
+
+export const aflTradePrivateValuationDispatchRequestSchema = z
+  .object({
+    requestId: z.string().regex(/^private-valuation-dispatch:[a-f0-9]{64}$/),
+    scopeKey: boundedIdSchema,
+    trigger: aflTradePrivateValuationDispatchTriggerSchema,
+    scheduledFor: instantSchema,
+    authorityKey: boundedIdSchema,
+  })
+  .strict();
+
+function localMonday(date: Date): Date {
+  const localDate = formatInTimeZone(date, AFL_TRADE_PRIVATE_VALUATION_TIME_ZONE, 'yyyy-MM-dd');
+  const localMidnight = new Date(`${localDate}T00:00:00.000Z`);
+  const weekday = Number(
+    formatInTimeZone(date, AFL_TRADE_PRIVATE_VALUATION_TIME_ZONE, 'i')
+  );
+  localMidnight.setUTCDate(localMidnight.getUTCDate() - (weekday - 1));
+  return localMidnight;
+}
+
+export function latestDueAflTradePrivateValuationOccurrence(now: string): string {
+  const parsedNow = new Date(instantSchema.parse(now));
+  const monday = localMonday(parsedNow);
+  let occurrence = fromZonedTime(
+    `${monday.toISOString().slice(0, 10)} 19:00:00.000`,
+    AFL_TRADE_PRIVATE_VALUATION_TIME_ZONE
+  );
+  if (occurrence.getTime() > parsedNow.getTime()) {
+    monday.setUTCDate(monday.getUTCDate() - 7);
+    occurrence = fromZonedTime(
+      `${monday.toISOString().slice(0, 10)} 19:00:00.000`,
+      AFL_TRADE_PRIVATE_VALUATION_TIME_ZONE
+    );
+  }
+  return occurrence.toISOString();
+}
+
+export function planAflTradePrivateValuationStartupCatchUp(input: {
+  readonly now: string;
+  readonly lastScheduledFor: string | null;
+}): string | null {
+  const latest = latestDueAflTradePrivateValuationOccurrence(input.now);
+  if (
+    input.lastScheduledFor !== null &&
+    Date.parse(instantSchema.parse(input.lastScheduledFor)) >= Date.parse(latest)
+  ) {
+    return null;
+  }
+  return latest;
+}
+
+export function createAflTradePrivateValuationDispatchRequestId(input: {
+  readonly scopeKey: string;
+  readonly trigger: AflTradePrivateValuationDispatchTrigger;
+  readonly scheduledFor: string;
+  readonly authorityKey: string;
+}): string {
+  const parsed = {
+    scopeKey: boundedIdSchema.parse(input.scopeKey),
+    trigger: aflTradePrivateValuationDispatchTriggerSchema.parse(input.trigger),
+    scheduledFor: instantSchema.parse(input.scheduledFor),
+    authorityKey: boundedIdSchema.parse(input.authorityKey),
+  };
+  return createAflTradeContentAddress('private-valuation-dispatch', parsed);
+}

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1095,6 +1095,7 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0066_atomic_private_evaluation_batches',
       '0067_private_evaluation_cohort_runner',
       '0068_durable_private_evaluation_execution',
+      '0069_private_valuation_dispatch',
     ]);
 
     const tables = await query<{ table_name: string }>(

--- a/tests/outcomes-integration/afl-private-valuation-scheduling-postgres.test.ts
+++ b/tests/outcomes-integration/afl-private-valuation-scheduling-postgres.test.ts
@@ -1,0 +1,308 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+import { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import {
+  PostgresAflTradePrivateValuationScheduleRepository,
+  createPostgresAflTradePrivateValuationDispatcher,
+} from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationScheduling';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('AFL_OUTCOMES_TEST_DATABASE_URL must identify disposable PostgreSQL.');
+  })();
+const schemaName = `afl_valuation_schedule_${process.pid}_${Date.now()}`;
+const pool = new Pool({
+  connectionString: databaseUrl,
+  max: 4,
+  options: `-c search_path=${schemaName}`,
+});
+const repository = new PostgresAflTradePrivateValuationScheduleRepository(
+  createPgAflOutcomeSqlClient(pool)
+);
+
+beforeAll(async () => {
+  await pool.query(`DO $roles$ BEGIN
+    BEGIN CREATE ROLE afl_trade_private_evaluation_coordinator NOLOGIN;
+    EXCEPTION WHEN duplicate_object THEN NULL; END;
+    GRANT afl_trade_private_evaluation_coordinator TO CURRENT_USER;
+  END $roles$`);
+  await pool.query(`CREATE SCHEMA "${schemaName}"`);
+  const canonicalFunction = readFileSync(
+    join(
+      process.cwd(),
+      'prisma/afl-trade-outcomes/migrations/0037_valuation_publication_custody_index/migration.sql'
+    ),
+    'utf8'
+  ).match(
+    /CREATE FUNCTION "outcome_afl_trade_canonical_json"[\s\S]*?\$\$ LANGUAGE plpgsql IMMUTABLE STRICT;/
+  )?.[0];
+  if (canonicalFunction === undefined) throw new Error('Canonical JSON SQL function was not found.');
+  await pool.query(canonicalFunction);
+  await pool.query(`CREATE TABLE outcome_current_prepared_valuation_input_set (
+    scope_key text PRIMARY KEY,prepared_input_set_id text NOT NULL,revision integer NOT NULL
+  )`);
+  await pool.query(`CREATE TABLE outcome_current_governed_valuation_model_pair (
+    scope_key text PRIMARY KEY,qualification_id text NOT NULL,work_id text NOT NULL,revision integer NOT NULL
+  )`);
+  await pool.query(
+    readFileSync(
+      join(
+        process.cwd(),
+        'prisma/afl-trade-outcomes/migrations/0069_private_valuation_dispatch/migration.sql'
+      ),
+      'utf8'
+    )
+  );
+});
+
+afterAll(async () => {
+  await pool.query(`SET search_path TO public`);
+  await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  await pool.end();
+});
+
+beforeEach(async () => {
+  await pool.query(`TRUNCATE outcome_private_valuation_dispatch_request,
+    outcome_current_prepared_valuation_input_set,outcome_current_governed_valuation_model_pair`);
+  await pool.query(
+    `INSERT INTO outcome_current_prepared_valuation_input_set VALUES
+      ('afl-men:2026-trades','prepared:test',1)`
+  );
+});
+
+describe('private valuation scheduling PostgreSQL boundary', () => {
+  it('coalesces startup catch-up and retains newly-qualified immediate work after commit', async () => {
+    await expect(repository.enqueueStartupCatchUp('2026-06-03T03:00:00.000Z')).resolves.toHaveLength(
+      1
+    );
+    await expect(repository.enqueueStartupCatchUp('2026-07-22T03:00:00.000Z')).resolves.toHaveLength(
+      1
+    );
+
+    await pool.query(`BEGIN`);
+    await pool.query(
+      `INSERT INTO outcome_current_governed_valuation_model_pair VALUES
+        ('afl-men:2026-trades','qualification:test','work:test',1)`
+    );
+    await pool.query(`COMMIT`);
+
+    await expect(
+      pool.query(
+        `SELECT trigger_kind,status,result_json FROM outcome_private_valuation_dispatch_request
+          ORDER BY scheduled_for`
+      )
+    ).resolves.toMatchObject({
+      rows: [
+        {
+          trigger_kind: 'weekly',
+          status: 'completed',
+          result_json: { state: 'superseded_by_startup_catch_up' },
+        },
+        { trigger_kind: 'weekly', status: 'pending' },
+        { trigger_kind: 'model_qualified', status: 'pending' },
+      ],
+    });
+  });
+
+  it('converges overlapping weekly, model, and ad-hoc triggers on current authority', async () => {
+    const requestedAt = '2026-07-22T03:00:00.000Z';
+    await repository.enqueueStartupCatchUp(requestedAt);
+    await pool.query(
+      `INSERT INTO outcome_current_governed_valuation_model_pair VALUES
+        ('afl-men:2026-trades','qualification:test','work:test',1)`
+    );
+    const first = await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'manual-check-1',
+    });
+    await expect(
+      repository.enqueueAdHoc({
+        scopeKey: 'afl-men:2026-trades',
+        operationKey: 'manual-check-1',
+      })
+    ).resolves.toBe(first);
+
+    let current = false;
+    const runCurrent = vi.fn(async () => {
+      if (current) return { state: 'already_current' as const };
+      current = true;
+      return { state: 'activated' as const, batchId: 'batch:test' };
+    });
+    const dispatcher = createPostgresAflTradePrivateValuationDispatcher({
+      repository,
+      runner: { runCurrent, repairCurrent: vi.fn() },
+    });
+    const dispatched = await Promise.all([
+      dispatcher.dispatchOne(),
+      dispatcher.dispatchOne(),
+      dispatcher.dispatchOne(),
+    ]);
+    expect(dispatched.every(({ state }) => state === 'completed')).toBe(true);
+    expect(runCurrent).toHaveBeenCalledTimes(3);
+    await expect(dispatcher.dispatchOne()).resolves.toEqual({ state: 'idle' });
+    const retained = await pool.query<{ result_json: { state: string } }>(
+      `SELECT result_json FROM outcome_private_valuation_dispatch_request
+        WHERE status='completed' ORDER BY request_id`
+    );
+    expect(retained.rows.map(({ result_json }) => result_json.state).sort()).toEqual([
+      'activated',
+      'already_current',
+      'already_current',
+    ]);
+    expect(first).toMatch(/^private-valuation-dispatch:/);
+  });
+
+  it('renews a slow dispatch lease so another worker cannot reclaim it', async () => {
+    const requestId = await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'slow-run',
+    });
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const runCurrent = vi.fn(async () => {
+      await blocked;
+      return { state: 'already_current' as const };
+    });
+    const dispatcher = createPostgresAflTradePrivateValuationDispatcher({
+      repository,
+      runner: { runCurrent, repairCurrent: vi.fn() },
+      heartbeatMilliseconds: 5,
+    });
+    const running = dispatcher.dispatchOne();
+    await vi.waitFor(() => expect(runCurrent).toHaveBeenCalledOnce());
+    await pool.query(
+      `UPDATE outcome_private_valuation_dispatch_request
+          SET lease_expires_at=transaction_timestamp()+interval '10 milliseconds'
+        WHERE status='claimed'`
+    );
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await expect(repository.claim('second-worker')).resolves.toBeNull();
+    await expect(dispatcher.dispatchRequest(requestId)).resolves.toEqual({
+      state: 'waiting',
+      requestId,
+    });
+    release();
+    await expect(running).resolves.toMatchObject({ state: 'completed' });
+    await expect(dispatcher.dispatchRequest(requestId)).resolves.toMatchObject({
+      state: 'completed',
+      requestId,
+      result: { state: 'already_current' },
+    });
+    expect(runCurrent).toHaveBeenCalledOnce();
+  });
+
+  it('keeps one durable dispatch pending until trade retries reach a terminal result', async () => {
+    const requestId = await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'retry-to-success',
+    });
+    const runCurrent = vi
+      .fn()
+      .mockResolvedValueOnce({ state: 'retry_pending', pendingTradeIds: ['trade-a'] })
+      .mockResolvedValueOnce({ state: 'already_current' });
+    const dispatcher = createPostgresAflTradePrivateValuationDispatcher({
+      repository,
+      runner: { runCurrent, repairCurrent: vi.fn() },
+    });
+    await expect(dispatcher.dispatchRequest(requestId)).resolves.toMatchObject({
+      state: 'rescheduled',
+      requestId,
+    });
+    await pool.query(
+      `UPDATE outcome_private_valuation_dispatch_request
+          SET available_at=transaction_timestamp()-interval '1 second'
+        WHERE request_id=$1`,
+      [requestId]
+    );
+    await expect(dispatcher.dispatchRequest(requestId)).resolves.toMatchObject({
+      state: 'completed',
+      result: { state: 'already_current' },
+    });
+    expect(runCurrent).toHaveBeenCalledTimes(2);
+    await expect(
+      pool.query(`SELECT count(*)::int AS count FROM outcome_private_valuation_dispatch_request`)
+    ).resolves.toMatchObject({ rows: [{ count: 1 }] });
+  });
+
+  it('uses the same backend dispatcher for auditable repair', async () => {
+    const repairCurrent = vi.fn(async () => ({ cycleId: 'repair-cycle' }));
+    const dispatcher = createPostgresAflTradePrivateValuationDispatcher({
+      repository,
+      runner: { runCurrent: vi.fn(), repairCurrent },
+    });
+    await expect(
+      dispatcher.repairCurrent(
+        'afl-men:2026-trades',
+        'Corrected retained source outage.',
+        `cohort-execution-repair:${'a'.repeat(64)}`
+      )
+    ).resolves.toEqual({ cycleId: 'repair-cycle' });
+    expect(repairCurrent).toHaveBeenCalledOnce();
+  });
+
+  it('rejects forged trigger kinds, future weekly work, and fabricated completion JSON', async () => {
+    const restricted = await pool.connect();
+    try {
+      await restricted.query('BEGIN');
+      await restricted.query(`SET LOCAL ROLE afl_trade_private_evaluation_coordinator`);
+      await expect(
+        restricted.query(
+          `SELECT enqueue_outcome_private_valuation_dispatch(
+            'afl-men:2026-trades','model_qualified',transaction_timestamp(),'forged-work')`
+        )
+      ).rejects.toThrow('permission denied');
+      await restricted.query('ROLLBACK');
+
+      await restricted.query('BEGIN');
+      await restricted.query(`SET LOCAL ROLE afl_trade_private_evaluation_coordinator`);
+      await expect(
+        restricted.query(
+          `SELECT coalesce_outcome_private_valuation_weekly_dispatch(
+            'afl-men:2026-trades','2026-08-17T09:01:00.000Z'::timestamptz)`
+        )
+      ).rejects.toThrow('not exact current schedule');
+      await restricted.query('ROLLBACK');
+    } finally {
+      restricted.release();
+    }
+
+    await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'forged-result',
+    });
+    const claim = await repository.claim('test-worker');
+    expect(claim).not.toBeNull();
+    await expect(
+      pool.query(`SELECT complete_outcome_private_valuation_dispatch($1,$2,$3::jsonb)`, [
+        claim!.claimId,
+        createHash('sha256').update(claim!.leaseToken).digest('hex'),
+        JSON.stringify({ state: 'already_current', publicationEligible: true }),
+      ])
+    ).rejects.toThrow('result is invalid');
+  });
+
+  it('serializes concurrent first use of one ad-hoc operation key', async () => {
+    const requests = await Promise.all([
+      repository.enqueueAdHoc({
+        scopeKey: 'afl-men:2026-trades',
+        operationKey: 'concurrent-manual-operation',
+      }),
+      repository.enqueueAdHoc({
+        scopeKey: 'afl-men:2026-trades',
+        operationKey: 'concurrent-manual-operation',
+      }),
+    ]);
+    expect(requests[0]).toBe(requests[1]);
+    await expect(
+      pool.query(`SELECT count(*)::int AS count FROM outcome_private_valuation_dispatch_request`)
+    ).resolves.toMatchObject({ rows: [{ count: 1 }] });
+  });
+});

--- a/tests/unit/afl-trade-intelligence-private-valuation-scheduling.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-scheduling.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createAflTradePrivateValuationDispatchRequestId,
+  latestDueAflTradePrivateValuationOccurrence,
+  planAflTradePrivateValuationStartupCatchUp,
+} from '@/server/aflTradeIntelligence/valuation/privateValuationScheduling';
+
+describe('private valuation scheduling', () => {
+  it.each([
+    ['2026-01-05T08:00:00.000Z', '2026-01-05T08:00:00.000Z'],
+    ['2026-07-06T09:00:00.000Z', '2026-07-06T09:00:00.000Z'],
+    ['2026-07-06T08:59:59.999Z', '2026-06-29T09:00:00.000Z'],
+  ])('keeps Monday 19:00 on the Melbourne wall clock at %s', (now, expected) => {
+    expect(latestDueAflTradePrivateValuationOccurrence(now)).toBe(expected);
+  });
+
+  it('coalesces missed weeks to the latest due occurrence and exactly replays it', () => {
+    const occurrence = '2026-07-06T09:00:00.000Z';
+    expect(
+      planAflTradePrivateValuationStartupCatchUp({
+        now: '2026-07-22T03:00:00.000Z',
+        lastScheduledFor: '2026-06-01T09:00:00.000Z',
+      })
+    ).toBe('2026-07-20T09:00:00.000Z');
+    expect(
+      planAflTradePrivateValuationStartupCatchUp({
+        now: occurrence,
+        lastScheduledFor: occurrence,
+      })
+    ).toBeNull();
+  });
+
+  it('gives overlapping triggers a stable content-addressed request identity', () => {
+    const request = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'weekly' as const,
+      scheduledFor: '2026-07-06T09:00:00.000Z',
+      authorityKey: 'scheduled',
+    };
+    expect(createAflTradePrivateValuationDispatchRequestId(request)).toBe(
+      createAflTradePrivateValuationDispatchRequestId(request)
+    );
+    expect(createAflTradePrivateValuationDispatchRequestId(request)).toMatch(
+      /^private-valuation-dispatch:[a-f0-9]{64}$/
+    );
+  });
+});

--- a/tests/unit/afl-trade-intelligence-private-valuation-worker.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-worker.test.ts
@@ -1,0 +1,50 @@
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import { runLocalAflPrivateValuationWorker } from '../../Scripts/dev/run-local-afl-private-valuation-worker';
+
+describe('local private valuation worker', () => {
+  it('runs startup catch-up, finishes in-flight dispatch, then closes on shutdown', async () => {
+    const controller = new AbortController();
+    const end = vi.fn(async () => undefined);
+    const enqueueStartupCatchUp = vi.fn(async () => ['request:weekly']);
+    let release!: () => void;
+    const inFlight = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const dispatchOne = vi.fn(async () => {
+      await inFlight;
+      return { state: 'idle' as const };
+    });
+    const runtime = {
+      enqueueStartupCatchUp,
+      enqueueAdHoc: vi.fn(),
+      repairCurrent: vi.fn(),
+      dispatchOne,
+      dispatchRequest: vi.fn(),
+    };
+
+    const running = runLocalAflPrivateValuationWorker({
+      env: {
+        AFL_OUTCOMES_DATABASE_URL:
+          'postgresql://local:local@127.0.0.1:55432/statly_outcomes_test',
+        STATLY_LOCAL_OUTCOMES_RUNTIME_NONCE: 'a'.repeat(64),
+        AFL_TRADE_LOCAL_ARTIFACT_ROOT: '/tmp/statly-worker-test-artifacts',
+      },
+      signal: controller.signal,
+      now: () => '2026-07-22T03:00:00.000Z',
+      createPool: () => ({ end } as unknown as Pool),
+      authenticateRuntime: vi.fn(async () => undefined),
+      createRuntime: () => runtime,
+    });
+
+    await vi.waitFor(() => expect(dispatchOne).toHaveBeenCalledOnce());
+    controller.abort();
+    expect(end).not.toHaveBeenCalled();
+    release();
+    await running;
+
+    expect(enqueueStartupCatchUp).toHaveBeenCalledWith('2026-07-22T03:00:00.000Z');
+    expect(end).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/localFullStackArchitecture.test.ts
+++ b/tests/unit/localFullStackArchitecture.test.ts
@@ -76,6 +76,8 @@ describe('local full stack development architecture', () => {
     expect(source).toContain('npm:dev');
     expect(source).toContain('npm:socket');
     expect(source).toContain('npm:draft-worker:dev');
+    expect(source).toContain('npm:outcomes:valuation:worker-local');
+    expect(source).not.toContain('launchctl');
     expect(source).toContain('export SOCKET_PORT="3002"');
     expect(source).toContain('export SOCKETIO_PORT="3002"');
     expect(source).toContain('export SOCKET_IO_PORT="3002"');


### PR DESCRIPTION
Closes #539

## Summary
- calculate Monday 7:00 pm in Australia/Melbourne wall-clock time across DST and coalesce missed weeks to the latest due occurrence
- durably enqueue newly qualified model pairs in the committing PostgreSQL transaction
- run weekly and immediate work through the same fenced cohort coordinator with heartbeat renewal and durable retry rescheduling
- expose exact-request ad-hoc and repair execution with stable crash-replay operation keys
- start the local valuation worker inside the existing Statly stack with no machine-level service
- restrict scheduling mutation functions to the coordinator role and retain exact terminal dispatch summaries

## Verification
- 19 focused unit tests
- 35 focused disposable PostgreSQL integration tests
- npm run typecheck -- --pretty false
- npm run lint:ci -- --quiet
- npm run outcomes:prisma:validate
- git diff --check
- independent spec review: PASS
- independent standards/security review: PASS

## Summary by Sourcery

Enable durable weekly, immediate, ad-hoc, and repair private valuation execution through a shared PostgreSQL-backed coordinator.

New Features:
- Add weekly, model-qualification, and ad-hoc private valuation dispatch with Melbourne wall-clock scheduling and missed-week coalescing.
- Provide stable operation-keyed ad-hoc execution and auditable repair commands.
- Run the local valuation worker within the existing development stack.

Enhancements:
- Use durable PostgreSQL dispatch records with transactional enqueueing, fenced claims, lease heartbeats, retries, and terminal result retention.
- Restrict scheduling mutations through the coordinator database role and enforce dispatch request and result integrity.
- Standardize local development valuation execution on the disposable outcomes database.

Tests:
- Add unit and PostgreSQL integration coverage for scheduling, deduplication, retries, lease renewal, authorization, and local worker lifecycle.