### PR TITLE
Retain raw valuation dispatch custody

### DIFF
--- a/prisma/afl-trade-outcomes/migrations/0070_private_valuation_dispatch_custody/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0070_private_valuation_dispatch_custody/migration.sql
@@ -1,0 +1,508 @@
+-- Durable dispatch attempt custody and a bounded outer technical-failure budget.
+-- Cohort retry_pending work remains owned and bounded by migration 0068.
+
+DO $roles$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM "outcome_private_valuation_dispatch_request" WHERE "status"='claimed'
+  ) THEN
+    RAISE EXCEPTION 'Private valuation dispatch migration cannot authenticate an active legacy claim';
+  END IF;
+  EXECUTE format(
+    'GRANT afl_trade_private_valuation_scheduler_owner TO %I',
+    session_user
+  );
+END $roles$;
+
+SET ROLE afl_trade_private_valuation_scheduler_owner;
+
+ALTER TABLE "outcome_private_valuation_dispatch_request"
+  ADD COLUMN "claim_sequence" INTEGER NOT NULL DEFAULT 0 CHECK ("claim_sequence">=0),
+  ADD COLUMN "transient_failure_count" INTEGER NOT NULL DEFAULT 0
+    CHECK ("transient_failure_count" BETWEEN 0 AND 3),
+  ADD CONSTRAINT "outcome_private_valuation_dispatch_exhaustion_shape" CHECK (
+    "transient_failure_count"<3 OR "status"='completed'
+  );
+
+CREATE TABLE "outcome_private_valuation_dispatch_attempt" (
+  "claim_id" TEXT PRIMARY KEY,
+  "request_id" TEXT NOT NULL
+    REFERENCES "outcome_private_valuation_dispatch_request"("request_id") ON DELETE RESTRICT,
+  "attempt_sequence" INTEGER NOT NULL CHECK ("attempt_sequence">0),
+  "attempt_number" INTEGER NOT NULL CHECK ("attempt_number" BETWEEN 1 AND 3),
+  "worker_id" TEXT NOT NULL,
+  "lease_token_sha256" CHAR(64) NOT NULL
+    CHECK ("lease_token_sha256" ~ '^[a-f0-9]{64}$'),
+  "claimed_at" TIMESTAMPTZ(3) NOT NULL,
+  "lease_expires_at" TIMESTAMPTZ(3) NOT NULL,
+  "heartbeat_at" TIMESTAMPTZ(3) NOT NULL,
+  "finished_at" TIMESTAMPTZ(3),
+  "outcome" TEXT CHECK (
+    "outcome" IN (
+      'completed','retry_pending','stale_authority','transient_failure',
+      'lease_expired','superseded'
+    )
+  ),
+  "result_json" JSONB,
+  CONSTRAINT "outcome_private_valuation_dispatch_attempt_sequence"
+    UNIQUE ("request_id","attempt_sequence"),
+  CONSTRAINT "outcome_private_valuation_dispatch_attempt_fence"
+    UNIQUE ("request_id","attempt_sequence","claim_id"),
+  CONSTRAINT "outcome_private_valuation_dispatch_attempt_chronology" CHECK (
+    "lease_expires_at">"claimed_at" AND "heartbeat_at">="claimed_at"
+      AND ("finished_at" IS NULL OR "finished_at">="claimed_at")
+  ),
+  CONSTRAINT "outcome_private_valuation_dispatch_attempt_result_shape" CHECK (
+    ("finished_at" IS NULL)=("outcome" IS NULL AND "result_json" IS NULL)
+  )
+);
+
+CREATE INDEX "outcome_private_valuation_dispatch_attempt_request_idx"
+  ON "outcome_private_valuation_dispatch_attempt"("request_id","attempt_sequence");
+
+CREATE OR REPLACE FUNCTION "create_outcome_private_valuation_dispatch_claim_id"(
+  target_request_id TEXT,
+  target_attempt_sequence INTEGER,
+  target_worker_id TEXT,
+  target_lease_token_sha256 TEXT
+) RETURNS TEXT LANGUAGE SQL IMMUTABLE STRICT AS $$
+  SELECT 'private-valuation-dispatch-claim:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(jsonb_build_object(
+      'requestId',target_request_id,
+      'attemptSequence',target_attempt_sequence,
+      'workerId',target_worker_id,
+      'leaseTokenSha256',target_lease_token_sha256
+    )), 'UTF8')), 'hex')
+$$;
+
+DROP TRIGGER "outcome_private_valuation_dispatch_request_validate"
+  ON "outcome_private_valuation_dispatch_request";
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_valuation_dispatch_request_v2"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE expected_id TEXT;
+BEGIN
+  expected_id:="create_outcome_private_valuation_dispatch_id"(
+    NEW."scope_key",NEW."trigger_kind",NEW."scheduled_for",NEW."authority_key");
+  IF NEW."request_id" IS DISTINCT FROM expected_id
+    OR NEW."request_json" IS DISTINCT FROM jsonb_build_object(
+      'requestId',expected_id,'scopeKey',NEW."scope_key",'trigger',NEW."trigger_kind",
+      'scheduledFor',to_char(NEW."scheduled_for" AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+      'authorityKey',NEW."authority_key")
+    OR NEW."available_at" IS DISTINCT FROM NEW."scheduled_for"
+    OR NEW."status"<>'pending'
+    OR NEW."claim_sequence"<>0 OR NEW."transient_failure_count"<>0
+    OR NEW."claim_id" IS NOT NULL OR NEW."lease_token_sha256" IS NOT NULL
+    OR NEW."lease_expires_at" IS NOT NULL OR NEW."claimed_at" IS NOT NULL
+    OR NEW."completed_at" IS NOT NULL OR NEW."result_json" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation dispatch request custody is invalid';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_private_valuation_dispatch_request_validate_v2"
+BEFORE INSERT ON "outcome_private_valuation_dispatch_request"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_valuation_dispatch_request_v2"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_valuation_dispatch_attempt_insert"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE request RECORD; expected_claim_id TEXT;
+BEGIN
+  SELECT * INTO request
+    FROM "outcome_private_valuation_dispatch_request"
+   WHERE "request_id"=NEW."request_id" FOR KEY SHARE;
+  expected_claim_id:="create_outcome_private_valuation_dispatch_claim_id"(
+    NEW."request_id",NEW."attempt_sequence",NEW."worker_id",NEW."lease_token_sha256");
+  IF current_user IS DISTINCT FROM 'afl_trade_private_valuation_scheduler_owner'
+    OR NOT FOUND OR request."status"<>'pending'
+    OR NEW."claim_id" IS DISTINCT FROM expected_claim_id
+    OR NEW."attempt_sequence"<>request."claim_sequence"+1
+    OR NEW."attempt_number"<>request."transient_failure_count"+1
+    OR btrim(NEW."worker_id")='' OR length(NEW."worker_id")>240
+    OR NEW."claimed_at">date_trunc('milliseconds',clock_timestamp())
+    OR NEW."claimed_at"<date_trunc('milliseconds',clock_timestamp())-interval '1 second'
+    OR NEW."heartbeat_at" IS DISTINCT FROM NEW."claimed_at"
+    OR NEW."lease_expires_at"<=NEW."claimed_at"
+    OR NEW."finished_at" IS NOT NULL OR NEW."outcome" IS NOT NULL
+    OR NEW."result_json" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation dispatch attempt lacks exact claim custody';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_private_valuation_dispatch_attempt_validate_insert"
+BEFORE INSERT ON "outcome_private_valuation_dispatch_attempt"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_valuation_dispatch_attempt_insert"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_valuation_dispatch_attempt_update"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF current_user IS DISTINCT FROM 'afl_trade_private_valuation_scheduler_owner'
+    OR NEW."claim_id" IS DISTINCT FROM OLD."claim_id"
+    OR NEW."request_id" IS DISTINCT FROM OLD."request_id"
+    OR NEW."attempt_sequence" IS DISTINCT FROM OLD."attempt_sequence"
+    OR NEW."attempt_number" IS DISTINCT FROM OLD."attempt_number"
+    OR NEW."worker_id" IS DISTINCT FROM OLD."worker_id"
+    OR NEW."lease_token_sha256" IS DISTINCT FROM OLD."lease_token_sha256"
+    OR NEW."claimed_at" IS DISTINCT FROM OLD."claimed_at"
+    OR OLD."finished_at" IS NOT NULL
+    OR NEW."heartbeat_at"<OLD."heartbeat_at"
+    OR NEW."lease_expires_at"<OLD."lease_expires_at"
+    OR NEW."heartbeat_at">date_trunc('milliseconds',clock_timestamp())
+    OR NEW."finished_at">date_trunc('milliseconds',clock_timestamp())
+    OR (NEW."finished_at" IS NULL AND (
+      NEW."outcome" IS NOT NULL OR NEW."result_json" IS NOT NULL))
+    OR (NEW."finished_at" IS NOT NULL AND (
+      NEW."outcome" IS NULL OR jsonb_typeof(NEW."result_json") IS DISTINCT FROM 'object'))
+    OR (NEW."outcome"='completed' AND (
+      NEW."result_json"->>'state' NOT IN ('activated','already_current','exhausted','unexpected_failure')
+      OR NEW."result_json" IS DISTINCT FROM jsonb_build_object('state',NEW."result_json"->>'state')))
+    OR (NEW."outcome"='retry_pending'
+      AND NEW."result_json" IS DISTINCT FROM jsonb_build_object('state','retry_pending'))
+    OR (NEW."outcome"='stale_authority'
+      AND NEW."result_json" IS DISTINCT FROM jsonb_build_object('state','stale_authority'))
+    OR (NEW."outcome"='transient_failure'
+      AND NEW."result_json" IS DISTINCT FROM jsonb_build_object('state','transient_failure'))
+    OR (NEW."outcome"='lease_expired'
+      AND NEW."result_json" IS DISTINCT FROM jsonb_build_object('state','lease_expired'))
+    OR (NEW."outcome"='superseded' AND (
+      NEW."result_json"->>'state' IS DISTINCT FROM 'superseded_by_startup_catch_up'
+      OR NEW."result_json"->>'latestRequestId' !~ '^private-valuation-dispatch:[a-f0-9]{64}$'
+      OR NEW."result_json" IS DISTINCT FROM jsonb_build_object(
+        'state','superseded_by_startup_catch_up',
+        'latestRequestId',NEW."result_json"->>'latestRequestId')))
+  THEN
+    RAISE EXCEPTION 'Private valuation dispatch attempt transition is invalid';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_private_valuation_dispatch_attempt_validate_update"
+BEFORE UPDATE ON "outcome_private_valuation_dispatch_attempt"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_valuation_dispatch_attempt_update"();
+
+CREATE TRIGGER "outcome_private_valuation_dispatch_attempt_no_delete"
+BEFORE DELETE ON "outcome_private_valuation_dispatch_attempt"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_valuation_dispatch_delete"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_valuation_dispatch_request_update"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF current_user IS DISTINCT FROM 'afl_trade_private_valuation_scheduler_owner'
+    OR OLD."status"='completed'
+    OR NEW."request_id" IS DISTINCT FROM OLD."request_id"
+    OR NEW."scope_key" IS DISTINCT FROM OLD."scope_key"
+    OR NEW."trigger_kind" IS DISTINCT FROM OLD."trigger_kind"
+    OR NEW."scheduled_for" IS DISTINCT FROM OLD."scheduled_for"
+    OR NEW."authority_key" IS DISTINCT FROM OLD."authority_key"
+    OR NEW."request_json" IS DISTINCT FROM OLD."request_json"
+    OR NEW."claim_sequence"<OLD."claim_sequence"
+    OR NEW."claim_sequence">OLD."claim_sequence"+1
+    OR NEW."transient_failure_count"<OLD."transient_failure_count"
+    OR NEW."transient_failure_count">OLD."transient_failure_count"+1
+    OR (OLD."status"='pending' AND NEW."status" NOT IN ('pending','claimed','completed'))
+    OR (OLD."status"='claimed' AND NEW."status" NOT IN ('claimed','pending','completed'))
+    OR (NEW."status"='claimed' AND OLD."status"<>'claimed'
+      AND NEW."claim_sequence"<>OLD."claim_sequence"+1)
+    OR (NEW."status"='claimed' AND OLD."status"='claimed'
+      AND NEW."claim_sequence"<>OLD."claim_sequence")
+    OR (NEW."status"<>'claimed' AND NEW."claim_sequence"<>OLD."claim_sequence")
+    OR (NEW."transient_failure_count">OLD."transient_failure_count" AND NOT EXISTS (
+      SELECT 1 FROM "outcome_private_valuation_dispatch_attempt" attempt
+       WHERE attempt."claim_id"=OLD."claim_id" AND attempt."request_id"=OLD."request_id"
+         AND attempt."finished_at" IS NOT NULL
+         AND attempt."outcome" IN ('transient_failure','lease_expired')))
+    OR (NEW."status"='claimed' AND NOT EXISTS (
+      SELECT 1 FROM "outcome_private_valuation_dispatch_attempt" attempt
+       WHERE attempt."claim_id"=NEW."claim_id" AND attempt."request_id"=NEW."request_id"
+         AND attempt."attempt_sequence"=NEW."claim_sequence"
+         AND attempt."attempt_number"=NEW."transient_failure_count"+1
+         AND attempt."lease_token_sha256"=NEW."lease_token_sha256"
+         AND attempt."claimed_at"=NEW."claimed_at"
+         AND attempt."lease_expires_at"=NEW."lease_expires_at"
+         AND attempt."finished_at" IS NULL))
+    OR (OLD."status"='claimed' AND NEW."status"<>'claimed' AND NOT EXISTS (
+      SELECT 1 FROM "outcome_private_valuation_dispatch_attempt" attempt
+       WHERE attempt."claim_id"=OLD."claim_id" AND attempt."request_id"=OLD."request_id"
+         AND attempt."finished_at" IS NOT NULL))
+  THEN
+    RAISE EXCEPTION 'Private valuation dispatch request transition is invalid';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_private_valuation_dispatch_request_validate_update"
+BEFORE UPDATE ON "outcome_private_valuation_dispatch_request"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_valuation_dispatch_request_update"();
+
+CREATE OR REPLACE FUNCTION "claim_outcome_private_valuation_dispatch"(
+  target_worker_id TEXT,target_lease_token_sha256 TEXT,target_lease_seconds INTEGER,
+  target_request_id TEXT DEFAULT NULL
+) RETURNS TABLE(request_id TEXT,request_json JSONB,claim_id TEXT,lease_expires_at TIMESTAMPTZ)
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  candidate "outcome_private_valuation_dispatch_request"%ROWTYPE;
+  trusted_at TIMESTAMPTZ(3):=date_trunc('milliseconds',clock_timestamp());
+  next_sequence INTEGER;
+  next_attempt INTEGER;
+  new_claim_id TEXT;
+  new_lease_expires_at TIMESTAMPTZ(3);
+BEGIN
+  IF target_worker_id IS NULL OR btrim(target_worker_id)='' OR length(target_worker_id)>240
+    OR target_lease_token_sha256 !~ '^[a-f0-9]{64}$'
+    OR target_lease_seconds NOT BETWEEN 5 AND 3600
+  THEN RAISE EXCEPTION 'Private valuation dispatch claim is malformed'; END IF;
+
+  LOOP
+    SELECT * INTO candidate FROM "outcome_private_valuation_dispatch_request" request
+     WHERE request."available_at"<=trusted_at
+       AND (request."status"='pending'
+         OR (request."status"='claimed' AND request."lease_expires_at"<trusted_at))
+       AND (target_request_id IS NULL OR request."request_id"=target_request_id)
+     ORDER BY request."scheduled_for",request."request_id"
+     FOR UPDATE SKIP LOCKED LIMIT 1;
+    IF NOT FOUND THEN RETURN; END IF;
+
+    -- The row lock is the authority boundary. Take trusted time only after it is held.
+    trusted_at:=date_trunc('milliseconds',clock_timestamp());
+
+    IF candidate."status"='claimed' THEN
+      UPDATE "outcome_private_valuation_dispatch_attempt" expired_attempt SET
+        "finished_at"=trusted_at,"outcome"='lease_expired',
+        "result_json"=jsonb_build_object('state','lease_expired')
+       WHERE expired_attempt."claim_id"=candidate."claim_id"
+         AND expired_attempt."finished_at" IS NULL;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'Private valuation dispatch expired claim lacks attempt custody';
+      END IF;
+      IF candidate."transient_failure_count"+1>=3 THEN
+        UPDATE "outcome_private_valuation_dispatch_request" exhausted_request SET
+          "status"='completed',"completed_at"=trusted_at,
+          "result_json"=jsonb_build_object('state','exhausted'),
+          "transient_failure_count"="transient_failure_count"+1,
+          "claim_id"=NULL,"lease_token_sha256"=NULL,
+          "lease_expires_at"=NULL,"claimed_at"=NULL
+         WHERE exhausted_request."request_id"=candidate."request_id";
+        IF target_request_id IS NULL THEN CONTINUE; END IF;
+        RETURN;
+      END IF;
+      UPDATE "outcome_private_valuation_dispatch_request" retry_request SET
+        "status"='pending',"available_at"=trusted_at,
+        "transient_failure_count"="transient_failure_count"+1,
+        "claim_id"=NULL,"lease_token_sha256"=NULL,
+        "lease_expires_at"=NULL,"claimed_at"=NULL
+       WHERE retry_request."request_id"=candidate."request_id";
+      candidate."transient_failure_count":=candidate."transient_failure_count"+1;
+    END IF;
+    EXIT;
+  END LOOP;
+
+  next_sequence:=candidate."claim_sequence"+1;
+  next_attempt:=candidate."transient_failure_count"+1;
+  new_claim_id:="create_outcome_private_valuation_dispatch_claim_id"(
+    candidate."request_id",next_sequence,target_worker_id,target_lease_token_sha256);
+  new_lease_expires_at:=trusted_at+make_interval(secs=>target_lease_seconds);
+  INSERT INTO "outcome_private_valuation_dispatch_attempt"(
+    "claim_id","request_id","attempt_sequence","attempt_number","worker_id",
+    "lease_token_sha256","claimed_at","lease_expires_at","heartbeat_at"
+  ) VALUES (
+    new_claim_id,candidate."request_id",next_sequence,next_attempt,target_worker_id,
+    target_lease_token_sha256,trusted_at,new_lease_expires_at,trusted_at
+  );
+  UPDATE "outcome_private_valuation_dispatch_request" SET
+    "status"='claimed',"claim_sequence"=next_sequence,"claim_id"=new_claim_id,
+    "lease_token_sha256"=target_lease_token_sha256,"claimed_at"=trusted_at,
+    "lease_expires_at"=new_lease_expires_at,"completed_at"=NULL,"result_json"=NULL
+   WHERE "outcome_private_valuation_dispatch_request"."request_id"=candidate."request_id";
+  request_id:=candidate."request_id";
+  request_json:=candidate."request_json";
+  claim_id:=new_claim_id;
+  lease_expires_at:=new_lease_expires_at;
+  RETURN NEXT;
+END $$;
+
+CREATE OR REPLACE FUNCTION "complete_outcome_private_valuation_dispatch"(
+  target_claim_id TEXT,target_lease_token_sha256 TEXT,target_result JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  trusted_at TIMESTAMPTZ(3);
+  request RECORD;
+BEGIN
+  IF jsonb_typeof(target_result) IS DISTINCT FROM 'object'
+    OR target_result->>'state' NOT IN ('activated','already_current','exhausted','unexpected_failure')
+    OR target_result IS DISTINCT FROM jsonb_build_object('state',target_result->>'state')
+  THEN RAISE EXCEPTION 'Private valuation dispatch result is invalid'; END IF;
+  SELECT * INTO request FROM "outcome_private_valuation_dispatch_request"
+   WHERE "claim_id"=target_claim_id FOR UPDATE;
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF NOT FOUND OR request."status"<>'claimed'
+    OR request."lease_token_sha256" IS DISTINCT FROM target_lease_token_sha256
+    OR request."lease_expires_at"<trusted_at
+  THEN RAISE EXCEPTION 'Private valuation dispatch claim was lost'; END IF;
+  UPDATE "outcome_private_valuation_dispatch_attempt" SET
+    "finished_at"=trusted_at,"outcome"='completed',"result_json"=target_result
+   WHERE "claim_id"=target_claim_id AND "finished_at" IS NULL;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Private valuation dispatch claim was lost'; END IF;
+  UPDATE "outcome_private_valuation_dispatch_request" SET
+    "status"='completed',"completed_at"=trusted_at,"result_json"=target_result,
+    "claim_id"=NULL,"lease_token_sha256"=NULL,"lease_expires_at"=NULL,"claimed_at"=NULL
+   WHERE "request_id"=request."request_id";
+END $$;
+
+CREATE OR REPLACE FUNCTION "reschedule_outcome_private_valuation_dispatch"(
+  target_claim_id TEXT,target_lease_token_sha256 TEXT,target_state TEXT
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  trusted_at TIMESTAMPTZ(3);
+  request RECORD;
+  attempt_outcome TEXT;
+  attempt_result JSONB;
+  next_failure_count INTEGER;
+BEGIN
+  IF target_state NOT IN ('retry_pending','stale_authority','transient_failure')
+  THEN RAISE EXCEPTION 'Private valuation dispatch reschedule state is invalid'; END IF;
+  SELECT * INTO request FROM "outcome_private_valuation_dispatch_request"
+   WHERE "claim_id"=target_claim_id FOR UPDATE;
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF NOT FOUND OR request."status"<>'claimed'
+    OR request."lease_token_sha256" IS DISTINCT FROM target_lease_token_sha256
+    OR request."lease_expires_at"<trusted_at
+  THEN RAISE EXCEPTION 'Private valuation dispatch claim was lost'; END IF;
+  attempt_outcome:=target_state;
+  attempt_result:=jsonb_build_object('state',target_state);
+  UPDATE "outcome_private_valuation_dispatch_attempt" SET
+    "finished_at"=trusted_at,"outcome"=attempt_outcome,"result_json"=attempt_result
+   WHERE "claim_id"=target_claim_id AND "finished_at" IS NULL;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Private valuation dispatch claim was lost'; END IF;
+
+  next_failure_count:=request."transient_failure_count"
+    +CASE WHEN target_state='transient_failure' THEN 1 ELSE 0 END;
+  IF next_failure_count>=3 THEN
+    UPDATE "outcome_private_valuation_dispatch_request" SET
+      "status"='completed',"completed_at"=trusted_at,
+      "result_json"=jsonb_build_object('state','exhausted'),
+      "transient_failure_count"=next_failure_count,
+      "claim_id"=NULL,"lease_token_sha256"=NULL,
+      "lease_expires_at"=NULL,"claimed_at"=NULL
+     WHERE "request_id"=request."request_id";
+    RETURN;
+  END IF;
+  UPDATE "outcome_private_valuation_dispatch_request" SET
+    "status"='pending',
+    "available_at"=trusted_at+CASE target_state
+      WHEN 'retry_pending' THEN interval '5 seconds'
+      WHEN 'stale_authority' THEN interval '30 seconds'
+      ELSE make_interval(secs=>LEAST(60,5*(2^request."transient_failure_count"))) END,
+    "transient_failure_count"=next_failure_count,
+    "claim_id"=NULL,"lease_token_sha256"=NULL,
+    "lease_expires_at"=NULL,"claimed_at"=NULL
+   WHERE "request_id"=request."request_id";
+END $$;
+
+CREATE OR REPLACE FUNCTION "heartbeat_outcome_private_valuation_dispatch"(
+  target_claim_id TEXT,target_lease_token_sha256 TEXT
+) RETURNS TIMESTAMPTZ LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  trusted_at TIMESTAMPTZ(3);
+  renewed_until TIMESTAMPTZ(3);
+  request RECORD;
+BEGIN
+  SELECT * INTO request FROM "outcome_private_valuation_dispatch_request"
+   WHERE "claim_id"=target_claim_id FOR UPDATE;
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF NOT FOUND OR request."status"<>'claimed'
+    OR request."lease_token_sha256" IS DISTINCT FROM target_lease_token_sha256
+    OR request."lease_expires_at"<trusted_at
+  THEN RAISE EXCEPTION 'Private valuation dispatch claim was lost'; END IF;
+  renewed_until:=GREATEST(request."lease_expires_at",trusted_at+interval '120 seconds');
+  UPDATE "outcome_private_valuation_dispatch_attempt" SET
+    "heartbeat_at"=trusted_at,"lease_expires_at"=renewed_until
+   WHERE "claim_id"=target_claim_id AND "finished_at" IS NULL;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Private valuation dispatch claim was lost'; END IF;
+  UPDATE "outcome_private_valuation_dispatch_request" SET
+    "lease_expires_at"=renewed_until
+   WHERE "request_id"=request."request_id";
+  RETURN renewed_until;
+END $$;
+
+CREATE OR REPLACE FUNCTION "coalesce_outcome_private_valuation_weekly_dispatch"(
+  target_scope_key TEXT,target_scheduled_for TIMESTAMPTZ
+) RETURNS TEXT LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  target_id TEXT;
+  trusted_at TIMESTAMPTZ(3):=date_trunc('milliseconds',transaction_timestamp());
+  prior RECORD;
+  superseded_result JSONB;
+BEGIN
+  IF target_scheduled_for>trusted_at
+    OR extract(isodow FROM target_scheduled_for AT TIME ZONE 'Australia/Melbourne')<>1
+    OR extract(hour FROM target_scheduled_for AT TIME ZONE 'Australia/Melbourne')<>19
+    OR extract(minute FROM target_scheduled_for AT TIME ZONE 'Australia/Melbourne')<>0
+    OR date_trunc('minute',target_scheduled_for) IS DISTINCT FROM target_scheduled_for
+    OR NOT EXISTS (SELECT 1 FROM "outcome_current_prepared_valuation_input_set"
+                    WHERE scope_key=target_scope_key)
+  THEN RAISE EXCEPTION 'Weekly private valuation occurrence is not exact current schedule'; END IF;
+  target_id:="enqueue_outcome_private_valuation_dispatch"(
+    target_scope_key,'weekly',target_scheduled_for,'scheduled');
+  superseded_result:=jsonb_build_object(
+    'state','superseded_by_startup_catch_up','latestRequestId',target_id);
+  FOR prior IN
+    SELECT * FROM "outcome_private_valuation_dispatch_request"
+     WHERE "scope_key"=target_scope_key AND "trigger_kind"='weekly'
+       AND "scheduled_for"<target_scheduled_for
+       AND ("status"='pending' OR ("status"='claimed' AND "lease_expires_at"<trusted_at))
+     FOR UPDATE
+  LOOP
+    IF prior."status"='claimed' THEN
+      UPDATE "outcome_private_valuation_dispatch_attempt" SET
+        "finished_at"=trusted_at,"outcome"='superseded',"result_json"=superseded_result
+       WHERE "claim_id"=prior."claim_id" AND "finished_at" IS NULL;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'Private valuation dispatch supersession lacks attempt custody';
+      END IF;
+    END IF;
+    UPDATE "outcome_private_valuation_dispatch_request" SET
+      "status"='completed',"completed_at"=trusted_at,"result_json"=superseded_result,
+      "claim_id"=NULL,"lease_token_sha256"=NULL,
+      "lease_expires_at"=NULL,"claimed_at"=NULL
+     WHERE "request_id"=prior."request_id";
+  END LOOP;
+  RETURN target_id;
+END $$;
+
+DO $paths$ BEGIN
+  EXECUTE format(
+    'ALTER FUNCTION %I.claim_outcome_private_valuation_dispatch(TEXT,TEXT,INTEGER,TEXT) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+  EXECUTE format(
+    'ALTER FUNCTION %I.complete_outcome_private_valuation_dispatch(TEXT,TEXT,JSONB) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+  EXECUTE format(
+    'ALTER FUNCTION %I.reschedule_outcome_private_valuation_dispatch(TEXT,TEXT,TEXT) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+  EXECUTE format(
+    'ALTER FUNCTION %I.heartbeat_outcome_private_valuation_dispatch(TEXT,TEXT) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+  EXECUTE format(
+    'ALTER FUNCTION %I.coalesce_outcome_private_valuation_weekly_dispatch(TEXT,TIMESTAMPTZ) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+END $paths$;
+
+REVOKE ALL ON "outcome_private_valuation_dispatch_attempt"
+  FROM PUBLIC,afl_trade_private_evaluation_coordinator;
+REVOKE SELECT ON "outcome_private_valuation_dispatch_request"
+  FROM afl_trade_private_evaluation_coordinator;
+GRANT SELECT (
+  "request_id","scope_key","trigger_kind","scheduled_for","status","result_json"
+) ON "outcome_private_valuation_dispatch_request"
+  TO afl_trade_private_evaluation_coordinator;
+
+RESET ROLE;
+
+DO $membership$ BEGIN
+  EXECUTE format(
+    'REVOKE afl_trade_private_valuation_scheduler_owner FROM %I',
+    session_user
+  );
+END $membership$;

--- a/prisma/afl-trade-outcomes/migrations/0071_private_valuation_capture_binding/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0071_private_valuation_capture_binding/migration.sql
@@ -1,0 +1,420 @@
+-- Accept one exact non-production fitzRoy capture/normalization result under a live dispatch fence.
+-- This is source custody only. It grants no factual, model, evaluation, or publication authority.
+-- Its source plan records the selected actual lineage; factual admission must still match scope.
+
+DO $roles$ BEGIN
+  EXECUTE format(
+    'GRANT afl_trade_private_valuation_scheduler_owner TO %I',
+    session_user
+  );
+END $roles$;
+
+GRANT SELECT ON
+  "outcome_private_valuation_dispatch_request",
+  "outcome_private_valuation_dispatch_attempt",
+  "outcome_source_capture_attempt",
+  "outcome_source_capture",
+  "outcome_review_decision",
+  "outcome_provider_field_map",
+  "outcome_provider_normalization_run"
+TO afl_trade_private_valuation_scheduler_owner;
+GRANT REFERENCES ON
+  "outcome_source_capture",
+  "outcome_provider_normalization_run"
+TO afl_trade_private_valuation_scheduler_owner;
+
+CREATE UNIQUE INDEX "outcome_source_capture_exact_ancestry_key"
+  ON "outcome_source_capture"("capture_id","attempt_id","source_snapshot_id");
+
+SET ROLE afl_trade_private_valuation_scheduler_owner;
+
+CREATE TABLE "outcome_private_valuation_capture_binding" (
+  "binding_id" TEXT PRIMARY KEY,
+  "request_id" TEXT NOT NULL UNIQUE
+    REFERENCES "outcome_private_valuation_dispatch_request"("request_id") ON DELETE RESTRICT,
+  "dispatch_claim_id" TEXT NOT NULL,
+  "attempt_sequence" INTEGER NOT NULL CHECK ("attempt_sequence">0),
+  "attempt_number" INTEGER NOT NULL CHECK ("attempt_number" BETWEEN 1 AND 3),
+  "source_capture_id" TEXT NOT NULL,
+  "source_capture_attempt_id" TEXT NOT NULL,
+  "source_snapshot_id" TEXT NOT NULL,
+  "capture_receipt_id" TEXT NOT NULL,
+  "normalization_run_id" TEXT NOT NULL,
+  "accepted_at" TIMESTAMPTZ(3) NOT NULL,
+  "binding_json" JSONB NOT NULL,
+  CONSTRAINT "outcome_private_valuation_capture_binding_attempt_fkey"
+    FOREIGN KEY ("request_id","attempt_sequence","dispatch_claim_id")
+    REFERENCES "outcome_private_valuation_dispatch_attempt"
+      ("request_id","attempt_sequence","claim_id") ON DELETE RESTRICT,
+  CONSTRAINT "outcome_private_valuation_capture_binding_source_fkey"
+    FOREIGN KEY ("source_capture_id","source_capture_attempt_id","source_snapshot_id")
+    REFERENCES "outcome_source_capture"("capture_id","attempt_id","source_snapshot_id")
+    ON DELETE RESTRICT,
+  CONSTRAINT "outcome_private_valuation_capture_binding_normalization_fkey"
+    FOREIGN KEY ("normalization_run_id","source_capture_id")
+    REFERENCES "outcome_provider_normalization_run"("normalization_run_id","capture_id")
+    ON DELETE RESTRICT,
+  CONSTRAINT "outcome_private_valuation_capture_binding_id_check" CHECK (
+    "binding_id" ~ '^private-valuation-capture-binding:[a-f0-9]{64}$'
+  ),
+  CONSTRAINT "outcome_private_valuation_capture_binding_source_id_check" CHECK (
+    "source_capture_id" ~ '^source-capture:[a-f0-9]{64}$'
+    AND "source_capture_attempt_id" ~ '^source-capture-attempt:[a-f0-9]{64}$'
+    AND "source_snapshot_id" ~ '^source-snapshot:[a-f0-9]{64}$'
+    AND "capture_receipt_id" ~ '^fitzroy-capture:[a-f0-9]{64}$'
+    AND "normalization_run_id" ~ '^provider-normalization-run:[a-f0-9]{64}$'
+  ),
+  CONSTRAINT "outcome_private_valuation_capture_binding_json_check" CHECK (
+    jsonb_typeof("binding_json")='object'
+  )
+);
+
+CREATE INDEX "outcome_private_valuation_capture_binding_source_idx"
+  ON "outcome_private_valuation_capture_binding"("normalization_run_id","source_capture_id");
+
+CREATE OR REPLACE FUNCTION "create_outcome_private_valuation_capture_binding_id"(
+  target_content JSONB
+) RETURNS TEXT LANGUAGE SQL IMMUTABLE STRICT AS $$
+  SELECT 'private-valuation-capture-binding:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(target_content),'UTF8')),'hex')
+$$;
+
+CREATE OR REPLACE FUNCTION "reject_outcome_private_valuation_capture_binding_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Private valuation capture bindings are immutable';
+END $$;
+
+CREATE TRIGGER "outcome_private_valuation_capture_binding_no_update_delete"
+BEFORE UPDATE OR DELETE ON "outcome_private_valuation_capture_binding"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_valuation_capture_binding_mutation"();
+
+CREATE OR REPLACE FUNCTION "accept_outcome_private_valuation_dispatch_capture"(
+  target_request_id TEXT,
+  target_claim_id TEXT,
+  target_lease_token_sha256 TEXT,
+  target_normalization_run_id TEXT
+) RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  trusted_at TIMESTAMPTZ(3);
+  dispatch_authority RECORD;
+  authority RECORD;
+  retained RECORD;
+  expected_source_attempt_id TEXT;
+  expected_snapshot_id TEXT;
+  expected_capture_receipt_id TEXT;
+  expected_gate_receipt_id TEXT;
+  expected_capture_id TEXT;
+  expected_normalization_run_id TEXT;
+  expected_field_map_sha256 TEXT;
+  source_plan JSONB;
+  binding_content JSONB;
+  target_binding_id TEXT;
+  target_binding_json JSONB;
+BEGIN
+  IF target_request_id !~ '^private-valuation-dispatch:[a-f0-9]{64}$'
+    OR target_claim_id !~ '^private-valuation-dispatch-claim:[a-f0-9]{64}$'
+    OR target_lease_token_sha256 !~ '^[a-f0-9]{64}$'
+    OR target_normalization_run_id !~ '^provider-normalization-run:[a-f0-9]{64}$'
+  THEN
+    RAISE EXCEPTION 'Private valuation capture acceptance is malformed';
+  END IF;
+
+  SELECT
+    request."request_id",request."request_json",request."scheduled_for",
+    request."claim_id" AS "current_claim_id",
+    request."claim_sequence" AS "current_claim_sequence",
+    request."lease_token_sha256" AS "current_lease_token_sha256",
+    request."lease_expires_at" AS "current_lease_expires_at",
+    dispatch_attempt."attempt_sequence",dispatch_attempt."attempt_number",
+    dispatch_attempt."lease_token_sha256" AS "attempt_lease_token_sha256",
+    dispatch_attempt."lease_expires_at" AS "attempt_lease_expires_at",
+    dispatch_attempt."finished_at" AS "attempt_finished_at"
+  INTO dispatch_authority
+  FROM "outcome_private_valuation_dispatch_request" request
+  JOIN "outcome_private_valuation_dispatch_attempt" dispatch_attempt
+    ON dispatch_attempt."request_id"=request."request_id"
+   AND dispatch_attempt."claim_id"=target_claim_id
+  WHERE request."request_id"=target_request_id
+    AND request."claim_id"=target_claim_id
+  FOR UPDATE OF request,dispatch_attempt;
+
+  -- The dispatch and attempt locks fence acceptance. Judge expiry after they are held.
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+
+  IF NOT FOUND
+    OR dispatch_authority."request_id" IS DISTINCT FROM target_request_id
+    OR dispatch_authority."current_claim_id" IS DISTINCT FROM target_claim_id
+    OR dispatch_authority."current_claim_sequence"
+      IS DISTINCT FROM dispatch_authority."attempt_sequence"
+    OR dispatch_authority."current_lease_token_sha256"
+      IS DISTINCT FROM target_lease_token_sha256
+    OR dispatch_authority."attempt_lease_token_sha256"
+      IS DISTINCT FROM target_lease_token_sha256
+    OR dispatch_authority."current_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_finished_at" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation capture acceptance lost its live dispatch claim fence or requested dispatch';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    'outcome-private-valuation-capture-binding:'||dispatch_authority."request_id",0));
+  SELECT * INTO retained
+    FROM "outcome_private_valuation_capture_binding"
+   WHERE "request_id"=dispatch_authority."request_id" FOR SHARE;
+  -- Binding-lock waits consume lease time; recheck before exact replay or fresh acceptance.
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF dispatch_authority."current_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_finished_at" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation capture acceptance lost its live dispatch claim fence or requested dispatch';
+  END IF;
+  IF FOUND THEN
+    IF retained."dispatch_claim_id" IS DISTINCT FROM target_claim_id
+      OR retained."normalization_run_id" IS DISTINCT FROM target_normalization_run_id
+    THEN
+      RAISE EXCEPTION 'Private valuation dispatch already accepted different source custody';
+    END IF;
+    RETURN retained."binding_json";
+  END IF;
+
+  SELECT
+    normalization."normalization_run_id",normalization."capture_id",
+    normalization."field_map_id",normalization."decoder_version",
+    normalization."normalizer_version",normalization."decoded_sha256",
+    normalization."receipt_sha256",normalization."staging_sha256",
+    normalization."status" AS "normalization_status",
+    normalization."completed_at" AS "normalization_completed_at",
+    normalization."finalized_at" AS "normalization_finalized_at",
+    capture."attempt_id" AS "source_capture_attempt_id",
+    capture."source_snapshot_id",capture."source_artifact_id",
+    capture."environment" AS "capture_environment",
+    capture."provider",capture."dataset",capture."capability_id",
+    capture."competition",capture."anchor_season_year",
+    capture."captured_at",capture."status" AS "capture_status",
+    capture."manifest_json",
+    source_attempt."environment" AS "source_attempt_environment",
+    source_attempt."provider" AS "source_attempt_provider",
+    source_attempt."dataset" AS "source_attempt_dataset",
+    source_attempt."capability_id" AS "source_attempt_capability_id",
+    source_attempt."status" AS "source_attempt_status",
+    source_attempt."started_at" AS "source_attempt_started_at",
+    source_attempt."completed_at" AS "source_attempt_completed_at",
+    source_attempt."attempt_json",
+    field_map."capability_id" AS "field_map_capability_id",
+    field_map."approval_decision_id" AS "field_map_approval_decision_id",
+    field_map."field_map_sha256",field_map."approved_at" AS "field_map_approved_at",
+    field_map."map_json"
+  INTO authority
+  FROM "outcome_provider_normalization_run" normalization
+  JOIN "outcome_source_capture" capture
+    ON capture."capture_id"=normalization."capture_id"
+  JOIN "outcome_source_capture_attempt" source_attempt
+    ON source_attempt."attempt_id"=capture."attempt_id"
+  JOIN "outcome_provider_field_map" field_map
+    ON field_map."field_map_id"=normalization."field_map_id"
+  WHERE normalization."normalization_run_id"=target_normalization_run_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Private valuation capture normalization is absent from source custody';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    'outcome-review-subject:provider_field_map:'||authority."field_map_id",0));
+  IF NOT EXISTS (
+    SELECT 1
+      FROM "outcome_review_decision" approval
+     WHERE approval."decision_id"=authority."field_map_approval_decision_id"
+       AND approval."subject_type"='provider_field_map'
+       AND approval."subject_id"=authority."field_map_id"
+       AND approval."decision"='approved'
+       AND approval."decided_at"=authority."field_map_approved_at"
+       AND approval."evidence_json"->>'fieldMapSha256'=authority."field_map_sha256"
+       AND NOT EXISTS (
+         SELECT 1 FROM "outcome_review_decision" successor
+          WHERE successor."supersedes_decision_id"=approval."decision_id")
+  ) THEN
+    RAISE EXCEPTION 'Private valuation capture field map is no longer currently approved';
+  END IF;
+
+  -- Review-lock waits also consume lease time; recheck immediately before fresh acceptance.
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF dispatch_authority."current_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_finished_at" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation capture acceptance lost its live dispatch claim fence or requested dispatch';
+  END IF;
+
+  expected_source_attempt_id:='source-capture-attempt:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(authority."attempt_json"),'UTF8')),'hex');
+  expected_snapshot_id:='source-snapshot:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(authority."manifest_json"),'UTF8')),'hex');
+  expected_capture_receipt_id:='fitzroy-capture:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(
+      authority."manifest_json"->'fitzRoyCaptureReceipt'->'content'),'UTF8')),'hex');
+  expected_gate_receipt_id:='gate0a-evaluation:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(
+      authority."manifest_json"->'gate0aReceipt'->'content'),'UTF8')),'hex');
+  expected_capture_id:='source-capture:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(jsonb_build_object(
+      'sourceSnapshotId',authority."source_snapshot_id",
+      'attemptId',authority."source_capture_attempt_id",
+      'sourceArtifactId',authority."source_artifact_id")),'UTF8')),'hex');
+  expected_normalization_run_id:='provider-normalization-run:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(jsonb_build_object(
+      'captureId',authority."capture_id",
+      'fieldMapId',authority."field_map_id",
+      'decoderVersion',authority."decoder_version",
+      'normalizerVersion',authority."normalizer_version",
+      'decodedSha256',authority."decoded_sha256",
+      'receiptSha256',authority."receipt_sha256",
+      'stagingSha256',authority."staging_sha256")),'UTF8')),'hex');
+  expected_field_map_sha256:=encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(authority."map_json"),'UTF8')),'hex');
+
+  IF authority."capture_environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR authority."source_attempt_environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR authority."source_attempt_status" IS DISTINCT FROM 'captured'
+    OR authority."capture_status" IN ('rejected','superseded')
+    OR authority."normalization_finalized_at" IS NULL
+    OR authority."normalization_finalized_at" IS DISTINCT FROM authority."normalization_completed_at"
+    OR dispatch_authority."scheduled_for">trusted_at
+    OR authority."source_attempt_started_at"<dispatch_authority."scheduled_for"
+    OR authority."source_attempt_completed_at">trusted_at
+    OR authority."captured_at">trusted_at
+    OR authority."normalization_completed_at">trusted_at
+    OR authority."field_map_approved_at">trusted_at
+    OR authority."source_capture_attempt_id" IS DISTINCT FROM expected_source_attempt_id
+    OR authority."source_snapshot_id" IS DISTINCT FROM expected_snapshot_id
+    OR authority."manifest_json"->'fitzRoyCaptureReceipt'->>'captureReceiptId'
+      IS DISTINCT FROM expected_capture_receipt_id
+    OR authority."attempt_json"->>'captureReceiptId'
+      IS DISTINCT FROM expected_capture_receipt_id
+    OR authority."manifest_json"->'gate0aReceipt'->>'receiptId'
+      IS DISTINCT FROM expected_gate_receipt_id
+    OR authority."attempt_json"->>'authorizationReceiptId'
+      IS DISTINCT FROM expected_gate_receipt_id
+    OR authority."capture_id" IS DISTINCT FROM expected_capture_id
+    OR authority."normalization_run_id" IS DISTINCT FROM expected_normalization_run_id
+    OR authority."field_map_sha256" IS DISTINCT FROM expected_field_map_sha256
+    OR authority."attempt_json"->>'schemaVersion'
+      IS DISTINCT FROM 'afl-trade-source-capture-attempt/v1'
+    OR authority."attempt_json"->>'sourceSnapshotId'
+      IS DISTINCT FROM authority."source_snapshot_id"
+    OR authority."attempt_json"->>'status' IS DISTINCT FROM 'captured'
+    OR (authority."attempt_json"->>'completedAt')::timestamptz
+      IS DISTINCT FROM authority."source_attempt_completed_at"
+    OR authority."manifest_json"->>'schemaVersion'
+      IS DISTINCT FROM 'afl-trade-source-snapshot/v3'
+    OR authority."manifest_json"->'capture'->>'kind' IS DISTINCT FROM 'fitzroy'
+    OR authority."manifest_json"->'capture'->>'upstreamProvider'
+      IS DISTINCT FROM authority."provider"
+    OR authority."manifest_json"->'capture'->>'upstreamDataset'
+      IS DISTINCT FROM authority."dataset"
+    OR authority."manifest_json"->'capture'->>'capabilityId'
+      IS DISTINCT FROM authority."capability_id"
+    OR authority."manifest_json"->'sourceArtifact'->>'artifactId'
+      IS DISTINCT FROM authority."source_artifact_id"
+    OR authority."manifest_json"->'gate0aReceipt'->'content'->'request'->>'environment'
+      IS DISTINCT FROM 'non_production'
+    OR authority."manifest_json"->'gate0aReceipt'->'content'->'request'->>'competition'
+      IS DISTINCT FROM authority."competition"
+    OR (authority."manifest_json"->'gate0aReceipt'->'content'->'request'->>'season')::integer
+      IS DISTINCT FROM authority."anchor_season_year"
+    OR authority."manifest_json"->'gate0aReceipt'->'content'->'request'->>'capabilityId'
+      IS DISTINCT FROM authority."capability_id"
+    OR authority."manifest_json"->'gate0aReceipt'->'content'->'result'->>'status'
+      IS DISTINCT FROM 'mechanically_eligible'
+    OR authority."manifest_json"->'gate0aReceipt'->'content'->'result'->>'decisionId' IS NULL
+    OR authority."manifest_json"->'fitzRoyCaptureReceipt'->'content'->'authorizationReceipt'->>'receiptId'
+      IS DISTINCT FROM expected_gate_receipt_id
+    OR authority."manifest_json"->'fitzRoyCaptureReceipt'->'content'->'invocation'->>'provider'
+      IS DISTINCT FROM authority."provider"
+    OR authority."manifest_json"->'fitzRoyCaptureReceipt'->'content'->'invocation'->>'capabilityId'
+      IS DISTINCT FROM authority."capability_id"
+    OR (authority."manifest_json"->'fitzRoyCaptureReceipt'->'content'->'invocation'->>'authorizationSeason')::integer
+      IS DISTINCT FROM authority."anchor_season_year"
+    OR authority."source_attempt_provider" IS DISTINCT FROM authority."provider"
+    OR authority."source_attempt_dataset" IS DISTINCT FROM authority."dataset"
+    OR authority."source_attempt_capability_id" IS DISTINCT FROM authority."capability_id"
+    OR authority."field_map_capability_id" IS DISTINCT FROM authority."capability_id"
+    OR authority."map_json"->>'mapId' IS DISTINCT FROM authority."field_map_id"
+    OR authority."map_json"->>'capabilityId' IS DISTINCT FROM authority."capability_id"
+    OR authority."map_json"->>'competition' IS DISTINCT FROM authority."competition"
+    OR (authority."map_json"->>'validFromSeason')::integer>authority."anchor_season_year"
+    OR (authority."map_json"->>'validThroughSeason')::integer<authority."anchor_season_year"
+  THEN
+    RAISE EXCEPTION 'Private valuation capture source custody is invalid';
+  END IF;
+
+  source_plan:=jsonb_build_object(
+    'provider',authority."provider",
+    'dataset',authority."dataset",
+    'capabilityId',authority."capability_id",
+    'competition',authority."competition",
+    'seasonYear',authority."anchor_season_year",
+    'fieldMapId',authority."field_map_id",
+    'gate0AReceiptId',expected_gate_receipt_id
+  );
+  binding_content:=jsonb_build_object(
+    'schemaVersion','afl-trade-private-valuation-capture-binding/v1',
+    'request',dispatch_authority."request_json",
+    'dispatchClaimId',target_claim_id,
+    'attemptSequence',dispatch_authority."attempt_sequence",
+    'attemptNumber',dispatch_authority."attempt_number",
+    'sourcePlan',source_plan,
+    'sourceCaptureAttemptId',authority."source_capture_attempt_id",
+    'captureReceiptId',expected_capture_receipt_id,
+    'snapshotId',authority."source_snapshot_id",
+    'sourceCaptureId',authority."capture_id",
+    'normalizationRunId',authority."normalization_run_id",
+    'acceptedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'environment','non_production',
+    'publicationEligible',false,
+    'limitation','Accepted non-production source custody only; it grants no factual, model, private-evaluation, or publication authority.'
+  );
+  target_binding_id:="create_outcome_private_valuation_capture_binding_id"(binding_content);
+  target_binding_json:=jsonb_build_object(
+    'bindingId',target_binding_id,
+    'content',binding_content
+  );
+
+  INSERT INTO "outcome_private_valuation_capture_binding"(
+    "binding_id","request_id","dispatch_claim_id","attempt_sequence","attempt_number",
+    "source_capture_id","source_capture_attempt_id","source_snapshot_id",
+    "capture_receipt_id","normalization_run_id","accepted_at","binding_json"
+  ) VALUES (
+    target_binding_id,dispatch_authority."request_id",target_claim_id,
+    dispatch_authority."attempt_sequence",dispatch_authority."attempt_number",
+    authority."capture_id",authority."source_capture_attempt_id",authority."source_snapshot_id",
+    expected_capture_receipt_id,authority."normalization_run_id",trusted_at,target_binding_json
+  );
+  RETURN target_binding_json;
+END $$;
+
+DO $paths$ BEGIN
+  EXECUTE format(
+    'ALTER FUNCTION %I.accept_outcome_private_valuation_dispatch_capture(TEXT,TEXT,TEXT,TEXT) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+END $paths$;
+
+REVOKE ALL ON "outcome_private_valuation_capture_binding"
+  FROM PUBLIC,afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_private_valuation_capture_binding"
+  TO afl_trade_private_evaluation_coordinator;
+REVOKE ALL ON FUNCTION "accept_outcome_private_valuation_dispatch_capture"(TEXT,TEXT,TEXT,TEXT)
+  FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "accept_outcome_private_valuation_dispatch_capture"(TEXT,TEXT,TEXT,TEXT)
+  TO afl_trade_private_evaluation_coordinator;
+
+RESET ROLE;
+
+DO $membership$ BEGIN
+  EXECUTE format(
+    'REVOKE afl_trade_private_valuation_scheduler_owner FROM %I',
+    session_user
+  );
+END $membership$;

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -391,7 +391,9 @@ model OutcomeSourceCapture {
   canonicalPromotionRuns      OutcomeExternalCanonicalPromotionImportRun[]
   valuationDatasetAdmissions  OutcomeValuationDatasetAdmissionSource[]
   valuationDatasetFieldSets   OutcomeValuationDatasetConsumedFieldSet[]
+  privateValuationCaptureBindings OutcomePrivateValuationCaptureBinding[] @relation("PrivateValuationCaptureSource")
 
+  @@unique([captureId, attemptId, sourceSnapshotId], map: "outcome_source_capture_exact_ancestry_key")
   @@index([provider, dataset, capturedAt], map: "outcome_source_capture_provider_captured_idx")
   @@index([sourceArtifactId], map: "outcome_source_capture_artifact_idx")
   @@map("outcome_source_capture")
@@ -1210,6 +1212,7 @@ model OutcomeProviderNormalizationRun {
   resolutionProposals       OutcomeProviderResolutionProposal[]
   hpnPavInputRuns           OutcomeHpnPavInputRun[]
   hpnReviewedSeasons        OutcomeHpnReviewedSeasonUniverse[]
+  privateValuationCaptureBindings OutcomePrivateValuationCaptureBinding[] @relation("PrivateValuationCaptureNormalization")
 
   @@unique([captureId, fieldMapId, decoderVersion, normalizerVersion], map: "outcome_provider_normalization_idempotency_key")
   @@unique([normalizationRunId, captureId], map: "outcome_provider_normalization_run_capture_key")
@@ -5388,9 +5391,57 @@ model OutcomePrivateValuationDispatchRequest {
   completedAt      DateTime? @map("completed_at") @outcomes.Timestamptz(3)
   resultJson       Json?     @map("result_json")
   requestJson      Json      @map("request_json")
+  claimSequence         Int       @default(0) @map("claim_sequence")
+  transientFailureCount Int       @default(0) @map("transient_failure_count")
+  attempts              OutcomePrivateValuationDispatchAttempt[]
+  captureBinding        OutcomePrivateValuationCaptureBinding?
 
   @@index([status, availableAt, scopeKey], map: "outcome_private_valuation_dispatch_due_idx")
   @@map("outcome_private_valuation_dispatch_request")
+}
+
+model OutcomePrivateValuationDispatchAttempt {
+  claimId          String                                 @id @map("claim_id") @outcomes.Text
+  requestId        String                                 @map("request_id") @outcomes.Text
+  attemptSequence  Int                                    @map("attempt_sequence")
+  attemptNumber    Int                                    @map("attempt_number")
+  workerId         String                                 @map("worker_id") @outcomes.Text
+  leaseTokenSha256 String                                 @map("lease_token_sha256") @outcomes.Char(64)
+  claimedAt        DateTime                               @map("claimed_at") @outcomes.Timestamptz(3)
+  leaseExpiresAt   DateTime                               @map("lease_expires_at") @outcomes.Timestamptz(3)
+  heartbeatAt      DateTime                               @map("heartbeat_at") @outcomes.Timestamptz(3)
+  finishedAt       DateTime?                              @map("finished_at") @outcomes.Timestamptz(3)
+  outcome          String?                                @outcomes.Text
+  resultJson       Json?                                  @map("result_json")
+  request          OutcomePrivateValuationDispatchRequest @relation(fields: [requestId], references: [requestId], onDelete: Restrict)
+  captureBindings  OutcomePrivateValuationCaptureBinding[] @relation("PrivateValuationCaptureDispatchAttempt")
+
+  @@unique([requestId, attemptSequence], map: "outcome_private_valuation_dispatch_attempt_sequence")
+  @@unique([requestId, attemptSequence, claimId], map: "outcome_private_valuation_dispatch_attempt_fence")
+  @@index([requestId, attemptSequence], map: "outcome_private_valuation_dispatch_attempt_request_idx")
+  @@map("outcome_private_valuation_dispatch_attempt")
+}
+
+model OutcomePrivateValuationCaptureBinding {
+  bindingId             String                                    @id @map("binding_id") @outcomes.Text
+  requestId             String                                    @unique @map("request_id") @outcomes.Text
+  dispatchClaimId       String                                    @map("dispatch_claim_id") @outcomes.Text
+  attemptSequence       Int                                       @map("attempt_sequence")
+  attemptNumber         Int                                       @map("attempt_number")
+  sourceCaptureId       String                                    @map("source_capture_id")
+  sourceCaptureAttemptId String                                   @map("source_capture_attempt_id")
+  sourceSnapshotId      String                                    @map("source_snapshot_id")
+  captureReceiptId      String                                    @map("capture_receipt_id")
+  normalizationRunId    String                                    @map("normalization_run_id")
+  acceptedAt            DateTime                                  @map("accepted_at") @outcomes.Timestamptz(3)
+  bindingJson           Json                                      @map("binding_json")
+  request               OutcomePrivateValuationDispatchRequest    @relation(fields: [requestId], references: [requestId], onDelete: Restrict)
+  dispatchAttempt       OutcomePrivateValuationDispatchAttempt     @relation("PrivateValuationCaptureDispatchAttempt", fields: [requestId, attemptSequence, dispatchClaimId], references: [requestId, attemptSequence, claimId], onDelete: Restrict)
+  sourceCapture         OutcomeSourceCapture                       @relation("PrivateValuationCaptureSource", fields: [sourceCaptureId, sourceCaptureAttemptId, sourceSnapshotId], references: [captureId, attemptId, sourceSnapshotId], onDelete: Restrict)
+  normalizationRun      OutcomeProviderNormalizationRun            @relation("PrivateValuationCaptureNormalization", fields: [normalizationRunId, sourceCaptureId], references: [normalizationRunId, captureId], onDelete: Restrict)
+
+  @@index([normalizationRunId, sourceCaptureId], map: "outcome_private_valuation_capture_binding_source_idx")
+  @@map("outcome_private_valuation_capture_binding")
 }
 
 model OutcomePrivateEvaluationTransitionReceipt {

--- a/src/server/aflTradeIntelligence/development/localPrivateValuationRuntime.ts
+++ b/src/server/aflTradeIntelligence/development/localPrivateValuationRuntime.ts
@@ -42,7 +42,13 @@ export function createLocalAflTradePrivateValuationRuntime(input: {
   });
   return createPostgresAflTradePrivateValuationDispatcher({
     repository: new PostgresAflTradePrivateValuationScheduleRepository(client),
-    runner,
+    runner: {
+      // Keep the established prepared-v3 path until factual admission can consume accepted capture
+      // custody. Running capture here and then runCurrent would calculate the old prepared head.
+      run: ({ request }) => runner.runCurrent(request.scopeKey),
+      repairCurrent: (scopeKey, reason, repairOperationId) =>
+        runner.repairCurrent(scopeKey, reason, repairOperationId),
+    },
     workerId: input.workerId,
   });
 }

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationCaptureBindingRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationCaptureBindingRepository.ts
@@ -1,0 +1,91 @@
+import { createHash } from 'node:crypto';
+
+import { z } from 'zod';
+
+import { canonicalizeAflTradeJson } from '../artifacts/contentAddress';
+import type { AflOutcomeSqlClient } from '../outcomes/postgresOutcomeReleaseRepository';
+import {
+  parseAflTradePrivateValuationCaptureBinding,
+  type AflTradePrivateValuationCaptureBinding,
+} from './privateValuationCaptureBinding';
+import type { AflTradePrivateValuationCaptureBindingRepository } from './privateValuationRawDataCoordinator';
+import { aflTradePrivateValuationDispatchRequestSchema } from './privateValuationScheduling';
+
+const EXECUTION_DATABASE_ROLE = 'afl_trade_private_evaluation_coordinator';
+const claimIdSchema = z.string().regex(/^private-valuation-dispatch-claim:[a-f0-9]{64}$/);
+const leaseTokenSchema = z.string().regex(/^[a-f0-9]{64}$/);
+const normalizationRunIdSchema = z
+  .string()
+  .regex(/^provider-normalization-run:[a-f0-9]{64}$/);
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function requireExactRequest(
+  binding: AflTradePrivateValuationCaptureBinding,
+  request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>
+): AflTradePrivateValuationCaptureBinding {
+  if (canonicalizeAflTradeJson(binding.content.request) !== canonicalizeAflTradeJson(request)) {
+    throw new TypeError('Retained capture binding conflicts with the requested dispatch.');
+  }
+  return binding;
+}
+
+export class PostgresAflTradePrivateValuationCaptureBindingRepository
+  implements AflTradePrivateValuationCaptureBindingRepository
+{
+  constructor(private readonly client: AflOutcomeSqlClient) {}
+
+  async load(
+    unparsedRequest: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>
+  ): Promise<AflTradePrivateValuationCaptureBinding | null> {
+    const request = aflTradePrivateValuationDispatchRequestSchema.parse(unparsedRequest);
+    const result = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<{ readonly binding_json: unknown }>(
+        `SELECT binding_json
+           FROM outcome_private_valuation_capture_binding
+          WHERE request_id=$1`,
+        [request.requestId]
+      );
+    });
+    const row = result.rows[0];
+    if (row === undefined) return null;
+    if (result.rows.length !== 1) {
+      throw new TypeError('Dispatch has more than one accepted capture binding.');
+    }
+    return requireExactRequest(parseAflTradePrivateValuationCaptureBinding(row.binding_json), request);
+  }
+
+  async accept(input: {
+    readonly request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>;
+    readonly claim: { readonly claimId: string; readonly leaseToken: string };
+    readonly normalizationRunId: string;
+  }): Promise<AflTradePrivateValuationCaptureBinding> {
+    const request = aflTradePrivateValuationDispatchRequestSchema.parse(input.request);
+    const claimId = claimIdSchema.parse(input.claim.claimId);
+    const leaseToken = leaseTokenSchema.parse(input.claim.leaseToken);
+    const normalizationRunId = normalizationRunIdSchema.parse(input.normalizationRunId);
+    const result = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<{ readonly binding_json: unknown }>(
+        `SELECT accept_outcome_private_valuation_dispatch_capture($1,$2,$3,$4)
+                AS binding_json`,
+        [request.requestId, claimId, sha256(leaseToken), normalizationRunId]
+      );
+    });
+    const binding = requireExactRequest(
+      parseAflTradePrivateValuationCaptureBinding(result.rows[0]?.binding_json),
+      request
+    );
+    if (
+      result.rows.length !== 1 ||
+      binding.content.dispatchClaimId !== claimId ||
+      binding.content.normalizationRunId !== normalizationRunId
+    ) {
+      throw new TypeError('Accepted capture binding disagrees with its dispatch claim or source.');
+    }
+    return binding;
+  }
+}

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationScheduling.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationScheduling.ts
@@ -26,7 +26,13 @@ interface ClaimRow {
 }
 
 export interface AflTradePrivateValuationDispatchRunner {
-  runCurrent(scopeKey: string): Promise<unknown>;
+  run(input: {
+    readonly request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>;
+    readonly claim: {
+      readonly claimId: string;
+      readonly leaseToken: string;
+    };
+  }): Promise<unknown>;
   repairCurrent(scopeKey: string, reason: string, repairOperationId: string): Promise<unknown>;
 }
 
@@ -177,7 +183,7 @@ export class PostgresAflTradePrivateValuationScheduleRepository {
   async reschedule(input: {
     readonly claimId: string;
     readonly leaseToken: string;
-    readonly state: 'retry_pending' | 'stale_authority';
+    readonly state: 'retry_pending' | 'stale_authority' | 'transient_failure';
   }): Promise<void> {
     await this.client.transaction(async (transaction) => {
       await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
@@ -219,19 +225,35 @@ export function createPostgresAflTradePrivateValuationDispatcher(dependencies: {
       if (heartbeatFailure !== null) throw heartbeatFailure;
     };
     try {
-      const result = await dependencies.runner.runCurrent(claim.request.scopeKey);
+      const result = await dependencies.runner.run({
+        request: claim.request,
+        claim: {
+          claimId: claim.claimId,
+          leaseToken: claim.leaseToken,
+        },
+      });
       await stopHeartbeat();
       if (
         typeof result === 'object' &&
         result !== null &&
         'state' in result &&
-        (result.state === 'retry_pending' || result.state === 'stale_authority')
+        (result.state === 'retry_pending' ||
+          result.state === 'stale_authority' ||
+          result.state === 'transient_failure')
       ) {
         await dependencies.repository.reschedule({
           claimId: claim.claimId,
           leaseToken: claim.leaseToken,
           state: result.state,
         });
+        const retained = await dependencies.repository.load(claim.request.requestId);
+        if (retained?.status === 'completed') {
+          return {
+            state: 'completed' as const,
+            requestId: claim.request.requestId,
+            result: retained.result,
+          };
+        }
         return { state: 'rescheduled' as const, requestId: claim.request.requestId, result };
       }
       const terminal = terminalResultSchema.parse({

--- a/src/server/aflTradeIntelligence/valuation/privateValuationCaptureBinding.ts
+++ b/src/server/aflTradeIntelligence/valuation/privateValuationCaptureBinding.ts
@@ -1,0 +1,111 @@
+import { z } from 'zod';
+
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  createAflTradeContentAddress,
+} from '../artifacts/contentAddress';
+import { aflTradePrivateValuationDispatchRequestSchema } from './privateValuationScheduling';
+
+export const AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_SCHEMA_VERSION =
+  'afl-trade-private-valuation-capture-binding/v1' as const;
+export const AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_LIMITATION =
+  'Accepted non-production source custody only; it grants no factual, model, private-evaluation, or publication authority.' as const;
+
+const instantSchema = z.string().datetime({ offset: true });
+const boundedSourceIdSchema = z.string().trim().min(1).max(300);
+
+// This is the exact selected source lineage retained as Stage-1 output custody. Stage 2 must
+// compare it with its intended factual scope before it can grant any downstream authority.
+export const aflTradePrivateValuationCaptureSourcePlanSchema = z
+  .object({
+    provider: boundedSourceIdSchema,
+    dataset: boundedSourceIdSchema,
+    capabilityId: boundedSourceIdSchema,
+    competition: z.enum(['AFLM', 'AFLW']),
+    seasonYear: z.number().int().min(1897).max(2200),
+    fieldMapId: boundedSourceIdSchema,
+    gate0AReceiptId: aflTradeContentAddressedIdSchema('gate0a-evaluation'),
+  })
+  .strict();
+
+export const aflTradePrivateValuationCaptureBindingContentSchema = z
+  .object({
+    schemaVersion: z.literal(AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_SCHEMA_VERSION),
+    request: aflTradePrivateValuationDispatchRequestSchema,
+    dispatchClaimId: z.string().regex(/^private-valuation-dispatch-claim:[a-f0-9]{64}$/),
+    attemptSequence: z.number().int().positive(),
+    attemptNumber: z.number().int().min(1).max(3),
+    sourcePlan: aflTradePrivateValuationCaptureSourcePlanSchema,
+    sourceCaptureAttemptId: aflTradeContentAddressedIdSchema('source-capture-attempt'),
+    captureReceiptId: aflTradeContentAddressedIdSchema('fitzroy-capture'),
+    snapshotId: aflTradeContentAddressedIdSchema('source-snapshot'),
+    sourceCaptureId: aflTradeContentAddressedIdSchema('source-capture'),
+    normalizationRunId: aflTradeContentAddressedIdSchema('provider-normalization-run'),
+    acceptedAt: instantSchema,
+    environment: z.literal('non_production'),
+    publicationEligible: z.literal(false),
+    limitation: z.literal(AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_LIMITATION),
+  })
+  .strict()
+  .superRefine((content, context) => {
+    if (content.attemptNumber > content.attemptSequence) {
+      context.addIssue({
+        code: 'custom',
+        path: ['attemptNumber'],
+        message: 'The technical attempt number cannot exceed its dispatch claim sequence.',
+      });
+    }
+    if (Date.parse(content.acceptedAt) < Date.parse(content.request.scheduledFor)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['acceptedAt'],
+        message: 'A capture cannot be accepted before its dispatch was scheduled.',
+      });
+    }
+  });
+
+export const aflTradePrivateValuationCaptureBindingSchema = z
+  .object({
+    bindingId: aflTradeContentAddressedIdSchema('private-valuation-capture-binding'),
+    content: aflTradePrivateValuationCaptureBindingContentSchema,
+  })
+  .strict()
+  .superRefine((binding, context) => {
+    addAflTradeContentAddressIssue(
+      'private-valuation-capture-binding',
+      binding.bindingId,
+      binding.content,
+      context,
+      ['bindingId']
+    );
+  });
+
+export type AflTradePrivateValuationCaptureBinding = z.infer<
+  typeof aflTradePrivateValuationCaptureBindingSchema
+>;
+
+export function createAflTradePrivateValuationCaptureBinding(
+  input: Omit<
+    z.input<typeof aflTradePrivateValuationCaptureBindingContentSchema>,
+    'schemaVersion' | 'environment' | 'publicationEligible' | 'limitation'
+  >
+): AflTradePrivateValuationCaptureBinding {
+  const content = aflTradePrivateValuationCaptureBindingContentSchema.parse({
+    schemaVersion: AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_SCHEMA_VERSION,
+    ...input,
+    environment: 'non_production',
+    publicationEligible: false,
+    limitation: AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_LIMITATION,
+  });
+  return aflTradePrivateValuationCaptureBindingSchema.parse({
+    bindingId: createAflTradeContentAddress('private-valuation-capture-binding', content),
+    content,
+  });
+}
+
+export function parseAflTradePrivateValuationCaptureBinding(
+  value: unknown
+): AflTradePrivateValuationCaptureBinding {
+  return aflTradePrivateValuationCaptureBindingSchema.parse(value);
+}

--- a/src/server/aflTradeIntelligence/valuation/privateValuationRawDataCoordinator.ts
+++ b/src/server/aflTradeIntelligence/valuation/privateValuationRawDataCoordinator.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+
+import { canonicalizeAflTradeJson } from '../artifacts/contentAddress';
+import {
+  parseAflTradePrivateValuationCaptureBinding,
+  type AflTradePrivateValuationCaptureBinding,
+} from './privateValuationCaptureBinding';
+import { aflTradePrivateValuationDispatchRequestSchema } from './privateValuationScheduling';
+
+const claimSchema = z
+  .object({
+    claimId: z.string().regex(/^private-valuation-dispatch-claim:[a-f0-9]{64}$/),
+    leaseToken: z.string().regex(/^[a-f0-9]{64}$/),
+  })
+  .strict();
+const capturedNormalizationSchema = z
+  .object({
+    normalizationRunId: z.string().regex(/^provider-normalization-run:[a-f0-9]{64}$/),
+  })
+  .strict();
+
+export interface AflTradePrivateValuationCaptureBindingRepository {
+  load(
+    request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>
+  ): Promise<AflTradePrivateValuationCaptureBinding | null>;
+  accept(input: {
+    readonly request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>;
+    readonly claim: z.infer<typeof claimSchema>;
+    readonly normalizationRunId: string;
+  }): Promise<AflTradePrivateValuationCaptureBinding>;
+}
+
+function requireBindingForRequest(
+  binding: AflTradePrivateValuationCaptureBinding,
+  request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>
+): AflTradePrivateValuationCaptureBinding {
+  const parsed = parseAflTradePrivateValuationCaptureBinding(binding);
+  if (canonicalizeAflTradeJson(parsed.content.request) !== canonicalizeAflTradeJson(request)) {
+    throw new TypeError('Accepted capture binding conflicts with the requested dispatch.');
+  }
+  return parsed;
+}
+
+export function createAflTradePrivateValuationRawDataCoordinator(dependencies: {
+  readonly captureBindings: AflTradePrivateValuationCaptureBindingRepository;
+  readonly capture: (input: {
+    readonly request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>;
+    readonly claim: z.infer<typeof claimSchema>;
+  }) => Promise<z.infer<typeof capturedNormalizationSchema>>;
+}) {
+  return {
+    async run(input: {
+      readonly request: z.input<typeof aflTradePrivateValuationDispatchRequestSchema>;
+      readonly claim: z.input<typeof claimSchema>;
+    }) {
+      const request = aflTradePrivateValuationDispatchRequestSchema.parse(input.request);
+      const claim = claimSchema.parse(input.claim);
+      const retained = await dependencies.captureBindings.load(request);
+      if (retained !== null) {
+        const binding = requireBindingForRequest(retained, request);
+        return {
+          state: 'capture_accepted' as const,
+          requestId: request.requestId,
+          binding,
+          idempotentReplay: true,
+        };
+      }
+
+      const captured = capturedNormalizationSchema.parse(
+        await dependencies.capture({ request, claim })
+      );
+      const binding = requireBindingForRequest(
+        await dependencies.captureBindings.accept({
+          request,
+          claim,
+          normalizationRunId: captured.normalizationRunId,
+        }),
+        request
+      );
+      if (binding.content.dispatchClaimId !== claim.claimId) {
+        throw new TypeError('Accepted capture binding disagrees with the live dispatch claim.');
+      }
+      if (binding.content.normalizationRunId !== captured.normalizationRunId) {
+        throw new TypeError('Accepted capture binding disagrees with the captured normalization.');
+      }
+      return {
+        state: 'capture_accepted' as const,
+        requestId: request.requestId,
+        binding,
+        idempotentReplay: false,
+      };
+    },
+  };
+}

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1096,6 +1096,8 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0067_private_evaluation_cohort_runner',
       '0068_durable_private_evaluation_execution',
       '0069_private_valuation_dispatch',
+      '0070_private_valuation_dispatch_custody',
+      '0071_private_valuation_capture_binding',
     ]);
 
     const tables = await query<{ table_name: string }>(

--- a/tests/outcomes-integration/afl-private-valuation-capture-binding-postgres.test.ts
+++ b/tests/outcomes-integration/afl-private-valuation-capture-binding-postgres.test.ts
@@ -1,0 +1,440 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import { PostgresAflTradePrivateValuationCaptureBindingRepository } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationCaptureBindingRepository';
+import { PostgresAflTradePrivateValuationScheduleRepository } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationScheduling';
+import { createAflTradePrivateValuationRawDataCoordinator } from '@/server/aflTradeIntelligence/valuation/privateValuationRawDataCoordinator';
+import { createAflTradePrivateValuationDispatchRequestId } from '@/server/aflTradeIntelligence/valuation/privateValuationScheduling';
+import { stageLocalAflTradeFitzRoyFixture } from '../testUtils/localFitzRoyStagingFixture';
+import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('A disposable AFL_OUTCOMES_TEST_DATABASE_URL is required.');
+  })();
+const schemaName = `afl_private_capture_binding_${process.pid}_${Date.now()}`;
+const dispatchScheduledFor = '2026-08-12T00:00:05.000Z';
+const adminPool = new Pool({ connectionString: databaseUrl });
+const outcomesPool = new Pool({
+  connectionString: databaseUrl,
+  options: `-c search_path=${schemaName}`,
+  max: 4,
+});
+
+function scopedDatabaseUrl(): string {
+  const scoped = new URL(databaseUrl);
+  scoped.searchParams.set('schema', schemaName);
+  return scoped.toString();
+}
+
+async function enqueueDispatch(
+  operationKey: string,
+  scheduledFor = dispatchScheduledFor
+): Promise<string> {
+  const connection = await outcomesPool.connect();
+  try {
+    await connection.query('BEGIN');
+    await connection.query('SET LOCAL ROLE afl_trade_private_valuation_scheduler_owner');
+    const result = await connection.query<{ request_id: string }>(
+      `SELECT enqueue_outcome_private_valuation_dispatch(
+         'afl-men:2026-trades','ad_hoc',
+         $2::timestamptz,$1
+       ) AS request_id`,
+      [operationKey, scheduledFor]
+    );
+    await connection.query('COMMIT');
+    return result.rows[0]!.request_id;
+  } catch (error) {
+    await connection.query('ROLLBACK').catch(() => undefined);
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
+async function currentNormalizationRunId(): Promise<string> {
+  const result = await outcomesPool.query<{ normalization_run_id: string }>(
+    `SELECT normalization_run_id
+       FROM outcome_provider_normalization_run
+      WHERE finalized_at IS NOT NULL
+      ORDER BY completed_at DESC,normalization_run_id DESC
+      LIMIT 1`
+  );
+  return result.rows[0]!.normalization_run_id;
+}
+
+async function makeDispatchDue(requestId: string): Promise<void> {
+  const connection = await outcomesPool.connect();
+  try {
+    await connection.query('BEGIN');
+    await connection.query('SET LOCAL ROLE afl_trade_private_valuation_scheduler_owner');
+    await connection.query(
+      `UPDATE outcome_private_valuation_dispatch_request
+          SET available_at=statement_timestamp()-interval '1 second'
+        WHERE request_id=$1 AND status='pending'`,
+      [requestId]
+    );
+    await connection.query('COMMIT');
+  } catch (error) {
+    await connection.query('ROLLBACK').catch(() => undefined);
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
+beforeAll(async () => {
+  await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
+  runOutcomesPrismaTestCommand(['migrate', 'deploy'], { databaseUrl: scopedDatabaseUrl() });
+  await stageLocalAflTradeFitzRoyFixture(createPgAflOutcomeSqlClient(outcomesPool));
+});
+
+afterAll(async () => {
+  const failures: unknown[] = [];
+  try {
+    await outcomesPool.end();
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await adminPool.end();
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Capture-binding PostgreSQL cleanup failed.');
+  }
+});
+
+describe.sequential('private valuation capture binding in PostgreSQL', () => {
+  it('accepts database-derived source custody and exactly replays it after restart', async () => {
+    const sql = createPgAflOutcomeSqlClient(outcomesPool);
+    const schedule = new PostgresAflTradePrivateValuationScheduleRepository(sql);
+    const requestId = await enqueueDispatch('capture-binding-restart');
+    const claim = await schedule.claim('system:weekly-valuation-coordinator', requestId);
+    const normalizationRunId = await currentNormalizationRunId();
+    expect(claim).not.toBeNull();
+
+    const binding = await new PostgresAflTradePrivateValuationCaptureBindingRepository(sql).accept({
+      request: claim!.request,
+      claim: { claimId: claim!.claimId, leaseToken: claim!.leaseToken },
+      normalizationRunId,
+    });
+
+    expect(binding.content).toMatchObject({
+      request: claim!.request,
+      dispatchClaimId: claim!.claimId,
+      attemptSequence: 1,
+      attemptNumber: 1,
+      normalizationRunId,
+      sourcePlan: {
+        provider: 'footywire',
+        dataset: 'Footywire historical player match statistics',
+        capabilityId: 'footywire-player-stats',
+        competition: 'AFLM',
+        seasonYear: 2026,
+        fieldMapId: 'footywire-player-stats-local-rehearsal-v1',
+        gate0AReceiptId: expect.stringMatching(/^gate0a-evaluation:[a-f0-9]{64}$/),
+      },
+      environment: 'non_production',
+      publicationEligible: false,
+    });
+
+    await schedule.reschedule({
+      claimId: claim!.claimId,
+      leaseToken: claim!.leaseToken,
+      state: 'transient_failure',
+    });
+    await makeDispatchDue(requestId);
+    const restartedSchedule = new PostgresAflTradePrivateValuationScheduleRepository(sql);
+    const restartedClaim = await restartedSchedule.claim(
+      'system:weekly-valuation-coordinator',
+      requestId
+    );
+    expect(restartedClaim).not.toBeNull();
+    expect(restartedClaim!.claimId).not.toBe(claim!.claimId);
+    const restarted = new PostgresAflTradePrivateValuationCaptureBindingRepository(sql);
+    await expect(restarted.load(restartedClaim!.request)).resolves.toEqual(binding);
+    const capture = vi.fn();
+    const coordinator = createAflTradePrivateValuationRawDataCoordinator({
+      captureBindings: restarted,
+      capture,
+    });
+    await expect(
+      coordinator.run({
+        request: restartedClaim!.request,
+        claim: {
+          claimId: restartedClaim!.claimId,
+          leaseToken: restartedClaim!.leaseToken,
+        },
+      })
+    ).resolves.toMatchObject({
+      state: 'capture_accepted',
+      binding,
+      idempotentReplay: true,
+    });
+    expect(capture).not.toHaveBeenCalled();
+
+    const stored = await outcomesPool.query<{ count: string }>(
+      `SELECT count(*)::text AS count
+         FROM outcome_private_valuation_capture_binding
+        WHERE request_id=$1`,
+      [requestId]
+    );
+    expect(stored.rows[0]?.count).toBe('1');
+  });
+
+  it('rejects a lost claim or a normalization outside retained source custody', async () => {
+    const sql = createPgAflOutcomeSqlClient(outcomesPool);
+    const schedule = new PostgresAflTradePrivateValuationScheduleRepository(sql);
+    const repository = new PostgresAflTradePrivateValuationCaptureBindingRepository(sql);
+    const requestId = await enqueueDispatch('capture-binding-fence');
+    const claim = await schedule.claim('system:weekly-valuation-coordinator', requestId);
+    const normalizationRunId = await currentNormalizationRunId();
+    expect(claim).not.toBeNull();
+
+    await expect(
+      repository.accept({
+        request: claim!.request,
+        claim: { claimId: claim!.claimId, leaseToken: '0'.repeat(64) },
+        normalizationRunId,
+      })
+    ).rejects.toThrow(/claim|fence|lease/i);
+    await expect(
+      repository.accept({
+        request: claim!.request,
+        claim: { claimId: claim!.claimId, leaseToken: claim!.leaseToken },
+        normalizationRunId: `provider-normalization-run:${'f'.repeat(64)}`,
+      })
+    ).rejects.toThrow(/normalization|source custody/i);
+  });
+
+  it('rejects a caller-request mismatch before retaining a binding', async () => {
+    const sql = createPgAflOutcomeSqlClient(outcomesPool);
+    const schedule = new PostgresAflTradePrivateValuationScheduleRepository(sql);
+    const repository = new PostgresAflTradePrivateValuationCaptureBindingRepository(sql);
+    const requestId = await enqueueDispatch('capture-binding-request-mismatch');
+    const claim = await schedule.claim('system:weekly-valuation-coordinator', requestId);
+    const normalizationRunId = await currentNormalizationRunId();
+    expect(claim).not.toBeNull();
+    const authorityKey = 'another-dispatch';
+    const conflictingRequest = {
+      ...claim!.request,
+      requestId: createAflTradePrivateValuationDispatchRequestId({
+        scopeKey: claim!.request.scopeKey,
+        trigger: claim!.request.trigger,
+        scheduledFor: claim!.request.scheduledFor,
+        authorityKey,
+      }),
+      authorityKey,
+    };
+
+    await expect(
+      repository.accept({
+        request: conflictingRequest,
+        claim: { claimId: claim!.claimId, leaseToken: claim!.leaseToken },
+        normalizationRunId,
+      })
+    ).rejects.toThrow(/requested dispatch|request/i);
+    const stored = await outcomesPool.query<{ count: string }>(
+      `SELECT count(*)::text AS count
+         FROM outcome_private_valuation_capture_binding
+        WHERE request_id=$1`,
+      [requestId]
+    );
+    expect(stored.rows[0]?.count).toBe('0');
+  });
+
+  it('rejects source custody created before the dispatch was scheduled', async () => {
+    const sql = createPgAflOutcomeSqlClient(outcomesPool);
+    const schedule = new PostgresAflTradePrivateValuationScheduleRepository(sql);
+    const repository = new PostgresAflTradePrivateValuationCaptureBindingRepository(sql);
+    const requestId = await enqueueDispatch(
+      'capture-binding-old-source',
+      new Date(Date.now() - 1_000).toISOString()
+    );
+    const claim = await schedule.claim('system:weekly-valuation-coordinator', requestId);
+    expect(claim).not.toBeNull();
+
+    await expect(
+      repository.accept({
+        request: claim!.request,
+        claim: { claimId: claim!.claimId, leaseToken: claim!.leaseToken },
+        normalizationRunId: await currentNormalizationRunId(),
+      })
+    ).rejects.toThrow(/source custody/i);
+    const stored = await outcomesPool.query<{ count: string }>(
+      `SELECT count(*)::text AS count
+         FROM outcome_private_valuation_capture_binding
+        WHERE request_id=$1`,
+      [requestId]
+    );
+    expect(stored.rows[0]?.count).toBe('0');
+  });
+
+  it('judges capture acceptance expiry after acquiring its dispatch locks', async () => {
+    const requestId = await enqueueDispatch('capture-binding-blocked-expiry');
+    const leaseTokenSha256 = '4'.repeat(64);
+    const claimed = await outcomesPool.query<{ claim_id: string }>(
+      `SELECT claim_id
+         FROM claim_outcome_private_valuation_dispatch($1,$2,5,$3)`,
+      ['blocked-capture-worker', leaseTokenSha256, requestId]
+    );
+    const normalizationRunId = await currentNormalizationRunId();
+    const blocker = await outcomesPool.connect();
+    try {
+      await blocker.query('BEGIN');
+      await blocker.query(
+        `SELECT request_id
+           FROM outcome_private_valuation_dispatch_request
+          WHERE request_id=$1
+          FOR UPDATE`,
+        [requestId]
+      );
+      const guardedAcceptance = outcomesPool
+        .query(
+          `SELECT accept_outcome_private_valuation_dispatch_capture($1,$2,$3,$4)`,
+          [
+            requestId,
+            claimed.rows[0]!.claim_id,
+            leaseTokenSha256,
+            normalizationRunId,
+          ]
+        )
+        .then(
+          () => ({ state: 'fulfilled' as const, error: null }),
+          (error: unknown) => ({ state: 'rejected' as const, error })
+        );
+
+      await new Promise((resolve) => setTimeout(resolve, 5_300));
+      await blocker.query('COMMIT');
+      const outcome = await guardedAcceptance;
+      expect(outcome.state).toBe('rejected');
+      expect(String(outcome.error)).toMatch(/lost its live dispatch claim fence/i);
+    } catch (error) {
+      await blocker.query('ROLLBACK').catch(() => undefined);
+      throw error;
+    } finally {
+      blocker.release();
+    }
+
+    await expect(
+      outcomesPool.query<{ count: string }>(
+        `SELECT count(*)::text AS count
+           FROM outcome_private_valuation_capture_binding
+          WHERE request_id=$1`,
+        [requestId]
+      )
+    ).resolves.toMatchObject({ rows: [{ count: '0' }] });
+  }, 15_000);
+
+  it('serializes field-map supersession while preserving exact accepted replay', async () => {
+    const normalizationRunId = await currentNormalizationRunId();
+    const sql = createPgAflOutcomeSqlClient(outcomesPool);
+    const schedule = new PostgresAflTradePrivateValuationScheduleRepository(sql);
+    const repository = new PostgresAflTradePrivateValuationCaptureBindingRepository(sql);
+    const acceptedRequestId = await enqueueDispatch('capture-binding-before-field-map-change');
+    const acceptedClaim = await schedule.claim(
+      'system:weekly-valuation-coordinator',
+      acceptedRequestId
+    );
+    expect(acceptedClaim).not.toBeNull();
+    const acceptedBinding = await repository.accept({
+      request: acceptedClaim!.request,
+      claim: { claimId: acceptedClaim!.claimId, leaseToken: acceptedClaim!.leaseToken },
+      normalizationRunId,
+    });
+
+    const rejectedRequestId = await enqueueDispatch('capture-binding-during-field-map-change');
+    const rejectedClaim = await schedule.claim(
+      'system:weekly-valuation-coordinator',
+      rejectedRequestId
+    );
+    expect(rejectedClaim).not.toBeNull();
+
+    const reviewer = await outcomesPool.connect();
+    try {
+      await reviewer.query('BEGIN');
+      await reviewer.query(
+        `INSERT INTO outcome_review_decision
+          (decision_id,subject_type,subject_id,decision,supersedes_decision_id,
+           rationale,evidence_json,decided_by,decided_at)
+         SELECT $1,'provider_field_map',field_map_id,'rejected',approval_decision_id,
+                'Superseded for capture-binding current-authority regression.',
+                jsonb_build_object('fieldMapSha256',field_map_sha256),
+                'capture-binding-regression-reviewer',statement_timestamp()
+           FROM outcome_provider_field_map
+          WHERE field_map_id='footywire-player-stats-local-rehearsal-v1'`,
+        [`review-decision:${'8'.repeat(64)}`]
+      );
+
+      const guardedAcceptance = repository
+        .accept({
+          request: rejectedClaim!.request,
+          claim: { claimId: rejectedClaim!.claimId, leaseToken: rejectedClaim!.leaseToken },
+          normalizationRunId,
+        })
+        .then(
+          (binding) => ({ state: 'fulfilled' as const, binding, error: null }),
+          (error: unknown) => ({ state: 'rejected' as const, binding: null, error })
+        );
+
+      await expect(
+        repository.accept({
+          request: acceptedClaim!.request,
+          claim: { claimId: acceptedClaim!.claimId, leaseToken: acceptedClaim!.leaseToken },
+          normalizationRunId,
+        })
+      ).resolves.toEqual(acceptedBinding);
+      await expect(
+        Promise.race([
+          guardedAcceptance.then(() => 'settled' as const),
+          new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 100)),
+        ])
+      ).resolves.toBe('pending');
+
+      await reviewer.query('COMMIT');
+      const rejected = await guardedAcceptance;
+      expect(rejected.state).toBe('rejected');
+      expect(String(rejected.error)).toMatch(/field map is no longer currently approved/i);
+    } catch (error) {
+      await reviewer.query('ROLLBACK').catch(() => undefined);
+      throw error;
+    } finally {
+      reviewer.release();
+    }
+
+    await expect(
+      outcomesPool.query<{ count: string }>(
+        `SELECT count(*)::text AS count
+           FROM outcome_private_valuation_capture_binding
+          WHERE request_id=ANY($1::text[])`,
+        [[acceptedRequestId, rejectedRequestId]]
+      )
+    ).resolves.toMatchObject({ rows: [{ count: '1' }] });
+  }, 10_000);
+
+  it('denies direct capture-binding writes to the coordinator runtime role', async () => {
+    const connection = await outcomesPool.connect();
+    try {
+      await connection.query('BEGIN');
+      await connection.query('SET LOCAL ROLE afl_trade_private_evaluation_coordinator');
+      await expect(
+        connection.query(
+          `INSERT INTO outcome_private_valuation_capture_binding (binding_id)
+           VALUES ('private-valuation-capture-binding:${'0'.repeat(64)}')`
+        )
+      ).rejects.toMatchObject({ code: '42501' });
+    } finally {
+      await connection.query('ROLLBACK').catch(() => undefined);
+      connection.release();
+    }
+  });
+});

--- a/tests/outcomes-integration/afl-private-valuation-scheduling-postgres.test.ts
+++ b/tests/outcomes-integration/afl-private-valuation-scheduling-postgres.test.ts
@@ -26,6 +26,26 @@ const repository = new PostgresAflTradePrivateValuationScheduleRepository(
   createPgAflOutcomeSqlClient(pool)
 );
 
+async function makeDispatchDue(requestId: string): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('SET LOCAL ROLE afl_trade_private_valuation_scheduler_owner');
+    await client.query(
+      `UPDATE outcome_private_valuation_dispatch_request
+          SET available_at=transaction_timestamp()-interval '1 second'
+        WHERE request_id=$1 AND status='pending'`,
+      [requestId]
+    );
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
 beforeAll(async () => {
   await pool.query(`DO $roles$ BEGIN
     BEGIN CREATE ROLE afl_trade_private_evaluation_coordinator NOLOGIN;
@@ -59,6 +79,15 @@ beforeAll(async () => {
       'utf8'
     )
   );
+  await pool.query(
+    readFileSync(
+      join(
+        process.cwd(),
+        'prisma/afl-trade-outcomes/migrations/0070_private_valuation_dispatch_custody/migration.sql'
+      ),
+      'utf8'
+    )
+  );
 });
 
 afterAll(async () => {
@@ -68,7 +97,8 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-  await pool.query(`TRUNCATE outcome_private_valuation_dispatch_request,
+  await pool.query(`TRUNCATE outcome_private_valuation_dispatch_attempt,
+    outcome_private_valuation_dispatch_request,
     outcome_current_prepared_valuation_input_set,outcome_current_governed_valuation_model_pair`);
   await pool.query(
     `INSERT INTO outcome_current_prepared_valuation_input_set VALUES
@@ -129,14 +159,14 @@ describe('private valuation scheduling PostgreSQL boundary', () => {
     ).resolves.toBe(first);
 
     let current = false;
-    const runCurrent = vi.fn(async () => {
+    const run = vi.fn(async () => {
       if (current) return { state: 'already_current' as const };
       current = true;
       return { state: 'activated' as const, batchId: 'batch:test' };
     });
     const dispatcher = createPostgresAflTradePrivateValuationDispatcher({
       repository,
-      runner: { runCurrent, repairCurrent: vi.fn() },
+      runner: { run, repairCurrent: vi.fn() },
     });
     const dispatched = await Promise.all([
       dispatcher.dispatchOne(),
@@ -144,7 +174,7 @@ describe('private valuation scheduling PostgreSQL boundary', () => {
       dispatcher.dispatchOne(),
     ]);
     expect(dispatched.every(({ state }) => state === 'completed')).toBe(true);
-    expect(runCurrent).toHaveBeenCalledTimes(3);
+    expect(run).toHaveBeenCalledTimes(3);
     await expect(dispatcher.dispatchOne()).resolves.toEqual({ state: 'idle' });
     const retained = await pool.query<{ result_json: { state: string } }>(
       `SELECT result_json FROM outcome_private_valuation_dispatch_request
@@ -158,6 +188,39 @@ describe('private valuation scheduling PostgreSQL boundary', () => {
     expect(first).toMatch(/^private-valuation-dispatch:/);
   });
 
+  it('passes the exact retained request and live claim fence to the coordinator', async () => {
+    const requestId = await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'exact-claimed-request',
+    });
+    const run = vi.fn(async () => ({ state: 'already_current' as const }));
+    const dispatcher = createPostgresAflTradePrivateValuationDispatcher({
+      repository,
+      runner: { run, repairCurrent: vi.fn() },
+      workerId: 'system:weekly-valuation-coordinator',
+    });
+
+    await expect(dispatcher.dispatchRequest(requestId)).resolves.toMatchObject({
+      state: 'completed',
+      requestId,
+    });
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledWith({
+      request: {
+        requestId,
+        scopeKey: 'afl-men:2026-trades',
+        trigger: 'ad_hoc',
+        scheduledFor: expect.any(String),
+        authorityKey: 'exact-claimed-request',
+      },
+      claim: {
+        claimId: expect.stringMatching(/^private-valuation-dispatch-claim:/),
+        leaseToken: expect.stringMatching(/^[a-f0-9]{64}$/),
+      },
+    });
+  });
+
   it('renews a slow dispatch lease so another worker cannot reclaim it', async () => {
     const requestId = await repository.enqueueAdHoc({
       scopeKey: 'afl-men:2026-trades',
@@ -167,40 +230,35 @@ describe('private valuation scheduling PostgreSQL boundary', () => {
     const blocked = new Promise<void>((resolve) => {
       release = resolve;
     });
-    const runCurrent = vi.fn(async () => {
+    const run = vi.fn(async () => {
       await blocked;
       return { state: 'already_current' as const };
     });
     const dispatcher = createPostgresAflTradePrivateValuationDispatcher({
       repository,
-      runner: { runCurrent, repairCurrent: vi.fn() },
+      runner: { run, repairCurrent: vi.fn() },
       heartbeatMilliseconds: 5,
     });
     const running = dispatcher.dispatchOne();
-    await vi.waitFor(() => expect(runCurrent).toHaveBeenCalledOnce());
-    const shortenedLease = await pool.query<{ lease_expires_at: Date }>(
-      `UPDATE outcome_private_valuation_dispatch_request
-          SET lease_expires_at=transaction_timestamp()+interval '250 milliseconds'
-        WHERE status='claimed'
-        RETURNING lease_expires_at`
+    await vi.waitFor(() => expect(run).toHaveBeenCalledOnce());
+    const originalLease = await pool.query<{ lease_expires_at: Date }>(
+      `SELECT lease_expires_at
+         FROM outcome_private_valuation_dispatch_request
+        WHERE status='claimed'`
     );
-    const shortenedLeaseExpiresAt = shortenedLease.rows[0]?.lease_expires_at;
-    expect(shortenedLeaseExpiresAt).toBeInstanceOf(Date);
+    const originalLeaseExpiresAt = originalLease.rows[0]?.lease_expires_at;
+    expect(originalLeaseExpiresAt).toBeInstanceOf(Date);
     await vi.waitFor(async () => {
-      const renewal = await pool.query<{ renewed: boolean }>(
-        `SELECT lease_expires_at>$1::timestamptz+interval '60 seconds' AS renewed
-           FROM outcome_private_valuation_dispatch_request
-          WHERE status='claimed'`,
-        [shortenedLeaseExpiresAt]
+      const renewal = await pool.query<{ request_renewed: boolean; attempt_renewed: boolean }>(
+        `SELECT request.lease_expires_at>$1::timestamptz AS request_renewed,
+                attempt.lease_expires_at>$1::timestamptz AS attempt_renewed
+           FROM outcome_private_valuation_dispatch_request request
+           JOIN outcome_private_valuation_dispatch_attempt attempt
+             ON attempt.claim_id=request.claim_id
+          WHERE request.status='claimed'`,
+        [originalLeaseExpiresAt]
       );
-      expect(renewal.rows[0]?.renewed).toBe(true);
-    });
-    await vi.waitFor(async () => {
-      const clock = await pool.query<{ original_lease_expired: boolean }>(
-        `SELECT transaction_timestamp()>$1::timestamptz AS original_lease_expired`,
-        [shortenedLeaseExpiresAt]
-      );
-      expect(clock.rows[0]?.original_lease_expired).toBe(true);
+      expect(renewal.rows[0]).toEqual({ request_renewed: true, attempt_renewed: true });
     });
     await expect(repository.claim('second-worker')).resolves.toBeNull();
     await expect(dispatcher.dispatchRequest(requestId)).resolves.toEqual({
@@ -214,7 +272,42 @@ describe('private valuation scheduling PostgreSQL boundary', () => {
       requestId,
       result: { state: 'already_current' },
     });
-    expect(runCurrent).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it('never shortens a caller-selected long lease when heartbeating', async () => {
+    const requestId = await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'long-lease-heartbeat',
+    });
+    const tokenSha256 = 'a'.repeat(64);
+    const claimed = await pool.query<{ claim_id: string; lease_expires_at: Date }>(
+      `SELECT claim_id,lease_expires_at
+         FROM claim_outcome_private_valuation_dispatch($1,$2,3600,$3)`,
+      ['long-lease-worker', tokenSha256, requestId]
+    );
+    const originalExpiry = claimed.rows[0]!.lease_expires_at;
+    const renewed = await pool.query<{ renewed_until: Date }>(
+      `SELECT heartbeat_outcome_private_valuation_dispatch($1,$2) AS renewed_until`,
+      [claimed.rows[0]!.claim_id, tokenSha256]
+    );
+
+    expect(renewed.rows[0]!.renewed_until.getTime()).toBeGreaterThanOrEqual(
+      originalExpiry.getTime()
+    );
+    await expect(
+      pool.query<{ request_lease: Date; attempt_lease: Date }>(
+        `SELECT request.lease_expires_at AS request_lease,
+                attempt.lease_expires_at AS attempt_lease
+           FROM outcome_private_valuation_dispatch_request request
+           JOIN outcome_private_valuation_dispatch_attempt attempt
+             ON attempt.claim_id=request.claim_id
+          WHERE request.request_id=$1`,
+        [requestId]
+      )
+    ).resolves.toMatchObject({
+      rows: [{ request_lease: originalExpiry, attempt_lease: originalExpiry }],
+    });
   });
 
   it('keeps one durable dispatch pending until trade retries reach a terminal result', async () => {
@@ -222,39 +315,434 @@ describe('private valuation scheduling PostgreSQL boundary', () => {
       scopeKey: 'afl-men:2026-trades',
       operationKey: 'retry-to-success',
     });
-    const runCurrent = vi
+    const run = vi
       .fn()
       .mockResolvedValueOnce({ state: 'retry_pending', pendingTradeIds: ['trade-a'] })
       .mockResolvedValueOnce({ state: 'already_current' });
     const dispatcher = createPostgresAflTradePrivateValuationDispatcher({
       repository,
-      runner: { runCurrent, repairCurrent: vi.fn() },
+      runner: { run, repairCurrent: vi.fn() },
     });
     await expect(dispatcher.dispatchRequest(requestId)).resolves.toMatchObject({
       state: 'rescheduled',
       requestId,
     });
-    await pool.query(
-      `UPDATE outcome_private_valuation_dispatch_request
-          SET available_at=transaction_timestamp()-interval '1 second'
-        WHERE request_id=$1`,
-      [requestId]
-    );
+    await makeDispatchDue(requestId);
     await expect(dispatcher.dispatchRequest(requestId)).resolves.toMatchObject({
       state: 'completed',
       result: { state: 'already_current' },
     });
-    expect(runCurrent).toHaveBeenCalledTimes(2);
+    expect(run).toHaveBeenCalledTimes(2);
     await expect(
       pool.query(`SELECT count(*)::int AS count FROM outcome_private_valuation_dispatch_request`)
     ).resolves.toMatchObject({ rows: [{ count: 1 }] });
+  });
+
+  it('exhausts three durable transient failures without charging stale or cohort polling', async () => {
+    const requestId = await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'bounded-dispatch-retries',
+    });
+    const reschedule = async (
+      state: 'retry_pending' | 'stale_authority' | 'transient_failure',
+      scheduleRepository = repository
+    ) => {
+      const claim = await scheduleRepository.claim('bounded-retry-worker', requestId);
+      expect(claim).not.toBeNull();
+      await scheduleRepository.reschedule({
+        claimId: claim!.claimId,
+        leaseToken: claim!.leaseToken,
+        state,
+      });
+      await makeDispatchDue(requestId);
+    };
+
+    await reschedule('stale_authority');
+    await reschedule('retry_pending');
+    await reschedule('transient_failure');
+    const restartedRepository = new PostgresAflTradePrivateValuationScheduleRepository(
+      createPgAflOutcomeSqlClient(pool)
+    );
+    await reschedule('transient_failure', restartedRepository);
+    await reschedule('transient_failure', restartedRepository);
+
+    await expect(repository.claim('restart-worker', requestId)).resolves.toBeNull();
+    await expect(
+      pool.query<{
+        status: string;
+        claim_sequence: number;
+        transient_failure_count: number;
+        result_json: unknown;
+      }>(
+        `SELECT status,claim_sequence,transient_failure_count,result_json
+           FROM outcome_private_valuation_dispatch_request WHERE request_id=$1`,
+        [requestId]
+      )
+    ).resolves.toMatchObject({
+      rows: [
+        {
+          status: 'completed',
+          claim_sequence: 5,
+          transient_failure_count: 3,
+          result_json: { state: 'exhausted' },
+        },
+      ],
+    });
+    await expect(
+      pool.query<{ attempt_sequence: number; attempt_number: number; outcome: string }>(
+        `SELECT attempt_sequence,attempt_number,outcome
+           FROM outcome_private_valuation_dispatch_attempt
+          WHERE request_id=$1 ORDER BY attempt_sequence`,
+        [requestId]
+      )
+    ).resolves.toMatchObject({
+      rows: [
+        { attempt_sequence: 1, attempt_number: 1, outcome: 'stale_authority' },
+        { attempt_sequence: 2, attempt_number: 1, outcome: 'retry_pending' },
+        { attempt_sequence: 3, attempt_number: 1, outcome: 'transient_failure' },
+        { attempt_sequence: 4, attempt_number: 2, outcome: 'transient_failure' },
+        { attempt_sequence: 5, attempt_number: 3, outcome: 'transient_failure' },
+      ],
+    });
+  });
+
+  it('charges expired leases to the same durable three-attempt budget', async () => {
+    const requestId = await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'expired-lease-budget',
+    });
+    const tokenSha256 = 'b'.repeat(64);
+    const claim = async () =>
+      pool.query<{ claim_id: string }>(
+        `SELECT claim_id FROM claim_outcome_private_valuation_dispatch($1,$2,5,$3)`,
+        ['expiry-worker', tokenSha256, requestId]
+      );
+
+    expect((await claim()).rows).toHaveLength(1);
+    await pool.query(`SELECT pg_sleep(5.05)`);
+    expect((await claim()).rows).toHaveLength(1);
+    await pool.query(`SELECT pg_sleep(5.05)`);
+    expect((await claim()).rows).toHaveLength(1);
+    await pool.query(`SELECT pg_sleep(5.05)`);
+    expect((await claim()).rows).toHaveLength(0);
+
+    await expect(
+      pool.query(
+        `SELECT status,transient_failure_count,result_json
+           FROM outcome_private_valuation_dispatch_request WHERE request_id=$1`,
+        [requestId]
+      )
+    ).resolves.toMatchObject({
+      rows: [
+        {
+          status: 'completed',
+          transient_failure_count: 3,
+          result_json: { state: 'exhausted' },
+        },
+      ],
+    });
+    await expect(
+      pool.query(
+        `SELECT attempt_sequence,attempt_number,outcome
+           FROM outcome_private_valuation_dispatch_attempt
+          WHERE request_id=$1 ORDER BY attempt_sequence`,
+        [requestId]
+      )
+    ).resolves.toMatchObject({
+      rows: [
+        { attempt_sequence: 1, attempt_number: 1, outcome: 'lease_expired' },
+        { attempt_sequence: 2, attempt_number: 2, outcome: 'lease_expired' },
+        { attempt_sequence: 3, attempt_number: 3, outcome: 'lease_expired' },
+      ],
+    });
+  }, 25_000);
+
+  it('continues to the next due dispatch after an expired request exhausts', async () => {
+    const exhaustedRequestId = await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'expired-head-does-not-mask-next',
+    });
+    for (let attempt = 1; attempt < 3; attempt += 1) {
+      const claim = await repository.claim('expiry-budget-worker', exhaustedRequestId);
+      expect(claim).not.toBeNull();
+      await repository.reschedule({
+        claimId: claim!.claimId,
+        leaseToken: claim!.leaseToken,
+        state: 'transient_failure',
+      });
+      await makeDispatchDue(exhaustedRequestId);
+    }
+
+    const expiringClaim = await pool.query<{ claim_id: string }>(
+      `SELECT claim_id FROM claim_outcome_private_valuation_dispatch($1,$2,5,$3)`,
+      ['expiry-budget-worker', 'c'.repeat(64), exhaustedRequestId]
+    );
+    expect(expiringClaim.rows).toHaveLength(1);
+    const nextRequestId = await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'due-after-expired-head',
+    });
+
+    await pool.query(`SELECT pg_sleep(5.05)`);
+    const nextClaim = await repository.claim('next-due-worker');
+
+    expect(nextClaim?.request.requestId).toBe(nextRequestId);
+    await expect(
+      pool.query(
+        `SELECT status,transient_failure_count,result_json
+           FROM outcome_private_valuation_dispatch_request WHERE request_id=$1`,
+        [exhaustedRequestId]
+      )
+    ).resolves.toMatchObject({
+      rows: [
+        {
+          status: 'completed',
+          transient_failure_count: 3,
+          result_json: { state: 'exhausted' },
+        },
+      ],
+    });
+  }, 10_000);
+
+  it('keeps another coordinator from reading or using a live worker fence', async () => {
+    const requestId = await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'worker-fence-is-private',
+    });
+    const claim = await repository.claim('owning-worker', requestId);
+    expect(claim).not.toBeNull();
+
+    const restricted = await pool.connect();
+    try {
+      await restricted.query('BEGIN');
+      await restricted.query(`SET LOCAL ROLE afl_trade_private_evaluation_coordinator`);
+      await expect(
+        restricted.query(
+          `SELECT lease_token_sha256 FROM outcome_private_valuation_dispatch_request
+            WHERE request_id=$1`,
+          [requestId]
+        )
+      ).rejects.toThrow('permission denied');
+      await restricted.query('ROLLBACK');
+
+      await restricted.query('BEGIN');
+      await restricted.query(`SET LOCAL ROLE afl_trade_private_evaluation_coordinator`);
+      await expect(
+        restricted.query(`SELECT * FROM outcome_private_valuation_dispatch_attempt`)
+      ).rejects.toThrow('permission denied');
+      await restricted.query('ROLLBACK');
+
+      await restricted.query('BEGIN');
+      await restricted.query(`SET LOCAL ROLE afl_trade_private_evaluation_coordinator`);
+      await expect(
+        restricted.query(
+          `SELECT complete_outcome_private_valuation_dispatch($1,$2,$3::jsonb)`,
+          [claim!.claimId, 'd'.repeat(64), JSON.stringify({ state: 'already_current' })]
+        )
+      ).rejects.toThrow('claim was lost');
+      await restricted.query('ROLLBACK');
+    } finally {
+      restricted.release();
+    }
+
+    await expect(repository.load(requestId)).resolves.toEqual({ status: 'claimed', result: null });
+    await repository.complete({
+      claimId: claim!.claimId,
+      leaseToken: claim!.leaseToken,
+      result: { state: 'already_current' },
+    });
+  });
+
+  it('fences an expired claimant after another worker reclaims the request', async () => {
+    const requestId = await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'expired-worker-is-fenced',
+    });
+    const firstTokenSha256 = 'e'.repeat(64);
+    const first = await pool.query<{ claim_id: string }>(
+      `SELECT claim_id FROM claim_outcome_private_valuation_dispatch($1,$2,5,$3)`,
+      ['first-worker', firstTokenSha256, requestId]
+    );
+    await pool.query(`SELECT pg_sleep(5.05)`);
+    const secondTokenSha256 = 'f'.repeat(64);
+    const second = await pool.query<{ claim_id: string }>(
+      `SELECT claim_id FROM claim_outcome_private_valuation_dispatch($1,$2,120,$3)`,
+      ['second-worker', secondTokenSha256, requestId]
+    );
+
+    await expect(
+      pool.query(`SELECT heartbeat_outcome_private_valuation_dispatch($1,$2)`, [
+        first.rows[0]!.claim_id,
+        firstTokenSha256,
+      ])
+    ).rejects.toThrow('claim was lost');
+    await expect(
+      pool.query(`SELECT reschedule_outcome_private_valuation_dispatch($1,$2,$3)`, [
+        first.rows[0]!.claim_id,
+        firstTokenSha256,
+        'retry_pending',
+      ])
+    ).rejects.toThrow('claim was lost');
+    await expect(
+      pool.query(`SELECT complete_outcome_private_valuation_dispatch($1,$2,$3::jsonb)`, [
+        first.rows[0]!.claim_id,
+        firstTokenSha256,
+        JSON.stringify({ state: 'already_current' }),
+      ])
+    ).rejects.toThrow('claim was lost');
+    await expect(
+      pool.query(
+        `SELECT status,claim_id,transient_failure_count
+           FROM outcome_private_valuation_dispatch_request WHERE request_id=$1`,
+        [requestId]
+      )
+    ).resolves.toMatchObject({
+      rows: [
+        {
+          status: 'claimed',
+          claim_id: second.rows[0]!.claim_id,
+          transient_failure_count: 1,
+        },
+      ],
+    });
+  }, 10_000);
+
+  it('judges completion, reschedule, and heartbeat expiry after their row locks are acquired', async () => {
+    const requestIds = await Promise.all(
+      ['blocked-completion', 'blocked-reschedule', 'blocked-heartbeat'].map((operationKey) =>
+        repository.enqueueAdHoc({ scopeKey: 'afl-men:2026-trades', operationKey })
+      )
+    );
+    const tokenSha256s = ['1'.repeat(64), '2'.repeat(64), '3'.repeat(64)];
+    const claims = await Promise.all(
+      requestIds.map((requestId, index) =>
+        pool.query<{ claim_id: string }>(
+          `SELECT claim_id
+             FROM claim_outcome_private_valuation_dispatch($1,$2,5,$3)`,
+          [`blocked-worker-${index}`, tokenSha256s[index], requestId]
+        )
+      )
+    );
+
+    const blocker = await pool.connect();
+    try {
+      await blocker.query('BEGIN');
+      await blocker.query(
+        `SELECT request_id
+           FROM outcome_private_valuation_dispatch_request
+          WHERE request_id=ANY($1::text[])
+          ORDER BY request_id
+          FOR UPDATE`,
+        [requestIds]
+      );
+
+      const guardedCalls = [
+        pool.query(`SELECT complete_outcome_private_valuation_dispatch($1,$2,$3::jsonb)`, [
+          claims[0]!.rows[0]!.claim_id,
+          tokenSha256s[0],
+          JSON.stringify({ state: 'already_current' }),
+        ]),
+        pool.query(`SELECT reschedule_outcome_private_valuation_dispatch($1,$2,$3)`, [
+          claims[1]!.rows[0]!.claim_id,
+          tokenSha256s[1],
+          'retry_pending',
+        ]),
+        pool.query(`SELECT heartbeat_outcome_private_valuation_dispatch($1,$2)`, [
+          claims[2]!.rows[0]!.claim_id,
+          tokenSha256s[2],
+        ]),
+      ].map((operation) =>
+        operation.then(
+          () => ({ state: 'fulfilled' as const, error: null }),
+          (error: unknown) => ({ state: 'rejected' as const, error })
+        )
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 5_300));
+      await blocker.query('COMMIT');
+      const outcomes = await Promise.all(guardedCalls);
+      for (const outcome of outcomes) {
+        expect(outcome.state).toBe('rejected');
+        expect(String(outcome.error)).toMatch(/claim was lost/i);
+      }
+    } catch (error) {
+      await blocker.query('ROLLBACK').catch(() => undefined);
+      throw error;
+    } finally {
+      blocker.release();
+    }
+
+    await expect(
+      pool.query(
+        `SELECT status,result_json
+           FROM outcome_private_valuation_dispatch_request
+          WHERE request_id=ANY($1::text[])
+          ORDER BY request_id`,
+        [requestIds]
+      )
+    ).resolves.toMatchObject({
+      rows: [
+        { status: 'claimed', result_json: null },
+        { status: 'claimed', result_json: null },
+        { status: 'claimed', result_json: null },
+      ],
+    });
+  }, 15_000);
+
+  it('replays exhausted dispatch custody after restart without rerunning work', async () => {
+    const operationKey = 'restart-safe-exhaustion';
+    const requestId = await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey,
+    });
+    const run = vi.fn(async () => ({ state: 'transient_failure' as const }));
+    const dispatcher = createPostgresAflTradePrivateValuationDispatcher({
+      repository,
+      runner: { run, repairCurrent: vi.fn() },
+    });
+
+    await expect(dispatcher.dispatchRequest(requestId)).resolves.toMatchObject({
+      state: 'rescheduled',
+    });
+    await makeDispatchDue(requestId);
+    await expect(dispatcher.dispatchRequest(requestId)).resolves.toMatchObject({
+      state: 'rescheduled',
+    });
+    await makeDispatchDue(requestId);
+    await expect(dispatcher.dispatchRequest(requestId)).resolves.toEqual({
+      state: 'completed',
+      requestId,
+      result: { state: 'exhausted' },
+    });
+    expect(run).toHaveBeenCalledTimes(3);
+
+    const restartedRepository = new PostgresAflTradePrivateValuationScheduleRepository(
+      createPgAflOutcomeSqlClient(pool)
+    );
+    const restartedRun = vi.fn();
+    const restarted = createPostgresAflTradePrivateValuationDispatcher({
+      repository: restartedRepository,
+      runner: { run: restartedRun, repairCurrent: vi.fn() },
+    });
+    await expect(
+      restartedRepository.enqueueAdHoc({
+        scopeKey: 'afl-men:2026-trades',
+        operationKey,
+      })
+    ).resolves.toBe(requestId);
+    await expect(restarted.dispatchRequest(requestId)).resolves.toEqual({
+      state: 'completed',
+      requestId,
+      result: { state: 'exhausted' },
+    });
+    expect(restartedRun).not.toHaveBeenCalled();
   });
 
   it('uses the same backend dispatcher for auditable repair', async () => {
     const repairCurrent = vi.fn(async () => ({ cycleId: 'repair-cycle' }));
     const dispatcher = createPostgresAflTradePrivateValuationDispatcher({
       repository,
-      runner: { runCurrent: vi.fn(), repairCurrent },
+      runner: { run: vi.fn(), repairCurrent },
     });
     await expect(
       dispatcher.repairCurrent(

--- a/tests/testUtils/localFitzRoyStagingFixture.ts
+++ b/tests/testUtils/localFitzRoyStagingFixture.ts
@@ -1,0 +1,83 @@
+import { canonicalizeAflTradeJson } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import {
+  LOCAL_FITZROY_REHEARSAL_INSTANTS,
+  LOCAL_FITZROY_REHEARSAL_RUNTIME,
+  createLocalAflTradeFitzRoyFactualRehearsalFixture,
+} from '@/server/aflTradeIntelligence/development/localFitzRoyFactualRehearsalFixture';
+import type { AflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { createAflTradeFitzRoyFieldMapSha256 } from '@/server/aflTradeIntelligence/source/fitzRoyObservationContracts';
+import { ingestAuthorizedAflTradeFitzRoyProviderSeason } from '@/server/aflTradeIntelligence/source/fitzRoyProviderIngestion';
+import { PostgresAflTradeProviderObservationRepository } from '@/server/aflTradeIntelligence/source/postgresProviderObservationRepository';
+import { PostgresAflTradeSourceCaptureRepository } from '@/server/aflTradeIntelligence/source/postgresSourceCaptureRepository';
+
+export async function stageLocalAflTradeFitzRoyFixture(client: AflOutcomeSqlClient) {
+  const fixture = createLocalAflTradeFitzRoyFactualRehearsalFixture();
+  const fieldMap = fixture.command.fieldMap;
+  const fieldMapSha256 = createAflTradeFitzRoyFieldMapSha256(fieldMap);
+  await client.query(
+    `INSERT INTO outcome_competition_season (competition,season_year)
+     VALUES ('AFLM',2026) ON CONFLICT DO NOTHING`
+  );
+  await client.query(
+    `INSERT INTO outcome_review_decision
+      (decision_id,subject_type,subject_id,decision,rationale,evidence_json,decided_by,decided_at)
+     VALUES ($1,'provider_field_map',$2,'approved',$3,
+             jsonb_build_object('fieldMapSha256',$4::text),$5,$6)
+     ON CONFLICT (decision_id) DO NOTHING`,
+    [
+      fieldMap.approvalDecisionId,
+      fieldMap.mapId,
+      'Source-independent local staging fixture field map.',
+      fieldMapSha256,
+      'local-staging-fixture-reviewer',
+      fieldMap.approvedAt,
+    ]
+  );
+  await client.query(
+    `INSERT INTO outcome_provider_field_map
+      (field_map_id,capability_id,fitzroy_version,source_schema_sha256,
+       field_map_sha256,approval_decision_id,approved_at,map_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb)
+     ON CONFLICT (field_map_id) DO NOTHING`,
+    [
+      fieldMap.mapId,
+      fieldMap.capabilityId,
+      fieldMap.fitzRoyVersion,
+      fieldMap.sourceSchemaSha256,
+      fieldMapSha256,
+      fieldMap.approvalDecisionId,
+      fieldMap.approvedAt,
+      canonicalizeAflTradeJson(fieldMap),
+    ]
+  );
+
+  const normalizationTimes = [
+    LOCAL_FITZROY_REHEARSAL_INSTANTS.normalizationStartedAt,
+    LOCAL_FITZROY_REHEARSAL_INSTANTS.normalizationCompletedAt,
+  ];
+  return ingestAuthorizedAflTradeFitzRoyProviderSeason(fixture.command, {
+    capture: fixture.captureDependencies,
+    staging: {
+      rawArtifactRepository: fixture.rawArtifactRepository,
+      sourceCaptureRepository: new PostgresAflTradeSourceCaptureRepository(client),
+      providerObservationRepository: new PostgresAflTradeProviderObservationRepository(client),
+      decoderExecutor: fixture.decoderExecutor,
+      clock: {
+        now: () =>
+          normalizationTimes.shift() ??
+          LOCAL_FITZROY_REHEARSAL_INSTANTS.normalizationCompletedAt,
+      },
+      dependencyLockSha256: LOCAL_FITZROY_REHEARSAL_RUNTIME.dependencyLockSha256,
+      imageDigest: LOCAL_FITZROY_REHEARSAL_RUNTIME.imageDigest,
+      timeoutMs: 30_000,
+      maximumSourceBytes: 1_024,
+      maximumRows: 10,
+      maximumFields: 20,
+      maximumCells: 200,
+      maximumCellBytes: 1_024,
+      maximumOutputBytes: 65_536,
+      egressExecutionVerifier: fixture.captureDependencies.egressExecutionVerifier,
+    },
+    clock: { now: () => LOCAL_FITZROY_REHEARSAL_INSTANTS.captureCompletedAt },
+  });
+}

--- a/tests/unit/afl-trade-intelligence-private-valuation-capture-binding.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-capture-binding.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_LIMITATION,
+  createAflTradePrivateValuationCaptureBinding,
+  parseAflTradePrivateValuationCaptureBinding,
+} from '@/server/aflTradeIntelligence/valuation/privateValuationCaptureBinding';
+
+const sha = (character: string) => character.repeat(64);
+
+function createFixture() {
+  return createAflTradePrivateValuationCaptureBinding({
+    request: {
+      requestId: `private-valuation-dispatch:${sha('1')}`,
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'weekly',
+      scheduledFor: '2026-08-24T09:00:00.000Z',
+      authorityKey: 'weekly:2026-08-24T09:00:00.000Z',
+    },
+    dispatchClaimId: `private-valuation-dispatch-claim:${sha('2')}`,
+    attemptSequence: 1,
+    attemptNumber: 1,
+    sourcePlan: {
+      provider: 'fitzRoy',
+      dataset: 'AFL Tables player statistics',
+      capabilityId: 'afl-tables-player-stats',
+      competition: 'AFLM',
+      seasonYear: 2026,
+      fieldMapId: 'afl-tables-player-stats-2026-v1',
+      gate0AReceiptId: `gate0a-evaluation:${sha('8')}`,
+    },
+    sourceCaptureAttemptId: `source-capture-attempt:${sha('3')}`,
+    captureReceiptId: `fitzroy-capture:${sha('4')}`,
+    snapshotId: `source-snapshot:${sha('5')}`,
+    sourceCaptureId: `source-capture:${sha('6')}`,
+    normalizationRunId: `provider-normalization-run:${sha('7')}`,
+    acceptedAt: '2026-08-24T09:01:00.000Z',
+  });
+}
+
+describe('private valuation capture binding', () => {
+  it('content-addresses one exact accepted source result for its dispatch', () => {
+    const binding = createFixture();
+
+    expect(binding.bindingId).toMatch(/^private-valuation-capture-binding:[a-f0-9]{64}$/);
+    expect(parseAflTradePrivateValuationCaptureBinding(binding)).toEqual(binding);
+    expect(createFixture()).toEqual(binding);
+    expect(binding.content).toMatchObject({
+      sourcePlan: {
+        capabilityId: 'afl-tables-player-stats',
+        competition: 'AFLM',
+        seasonYear: 2026,
+        fieldMapId: 'afl-tables-player-stats-2026-v1',
+      },
+      environment: 'non_production',
+      publicationEligible: false,
+      limitation: AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_LIMITATION,
+    });
+  });
+
+  it('rejects a recomputed binding that claims another identifier', () => {
+    const binding = createFixture();
+
+    expect(() =>
+      parseAflTradePrivateValuationCaptureBinding({
+        ...binding,
+        bindingId: `private-valuation-capture-binding:${sha('8')}`,
+      })
+    ).toThrow('content address');
+  });
+
+  it('rejects an attempt budget number beyond its dispatch claim sequence', () => {
+    expect(() =>
+      createAflTradePrivateValuationCaptureBinding({
+        ...createFixture().content,
+        attemptSequence: 1,
+        attemptNumber: 2,
+      })
+    ).toThrow('attempt number cannot exceed');
+  });
+});

--- a/tests/unit/afl-trade-intelligence-private-valuation-raw-data-coordinator.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-raw-data-coordinator.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAflTradePrivateValuationCaptureBinding } from '@/server/aflTradeIntelligence/valuation/privateValuationCaptureBinding';
+import { createAflTradePrivateValuationRawDataCoordinator } from '@/server/aflTradeIntelligence/valuation/privateValuationRawDataCoordinator';
+
+const sha = (character: string) => character.repeat(64);
+const request = {
+  requestId: `private-valuation-dispatch:${sha('1')}`,
+  scopeKey: 'afl-men:2026-trades',
+  trigger: 'weekly' as const,
+  scheduledFor: '2026-08-24T09:00:00.000Z',
+  authorityKey: 'weekly:2026-08-24T09:00:00.000Z',
+};
+const claim = {
+  claimId: `private-valuation-dispatch-claim:${sha('2')}`,
+  leaseToken: sha('3'),
+};
+
+function bindingFor(boundRequest: typeof request, normalizationCharacter = '8') {
+  return createAflTradePrivateValuationCaptureBinding({
+    request: boundRequest,
+    dispatchClaimId: claim.claimId,
+    attemptSequence: 1,
+    attemptNumber: 1,
+    sourcePlan: {
+      provider: 'fitzRoy',
+      dataset: 'AFL Tables player statistics',
+      capabilityId: 'afl-tables-player-stats',
+      competition: 'AFLM',
+      seasonYear: 2026,
+      fieldMapId: 'afl-tables-player-stats-2026-v1',
+      gate0AReceiptId: `gate0a-evaluation:${sha('a')}`,
+    },
+    sourceCaptureAttemptId: `source-capture-attempt:${sha('4')}`,
+    captureReceiptId: `fitzroy-capture:${sha('5')}`,
+    snapshotId: `source-snapshot:${sha('6')}`,
+    sourceCaptureId: `source-capture:${sha('7')}`,
+    normalizationRunId: `provider-normalization-run:${sha(normalizationCharacter)}`,
+    acceptedAt: '2026-08-24T09:01:00.000Z',
+  });
+}
+
+describe('private valuation raw-data coordinator', () => {
+  it('loads the exact accepted capture before attempting provider work', async () => {
+    const retained = bindingFor(request);
+    const load = vi.fn(async () => retained);
+    const capture = vi.fn();
+    const accept = vi.fn();
+    const coordinator = createAflTradePrivateValuationRawDataCoordinator({
+      captureBindings: { load, accept },
+      capture,
+    });
+
+    await expect(coordinator.run({ request, claim })).resolves.toEqual({
+      state: 'capture_accepted',
+      requestId: request.requestId,
+      binding: retained,
+      idempotentReplay: true,
+    });
+    expect(load).toHaveBeenCalledWith(request);
+    expect(capture).not.toHaveBeenCalled();
+    expect(accept).not.toHaveBeenCalled();
+  });
+
+  it('accepts one newly captured result through the live claim fence', async () => {
+    const candidate = bindingFor(request);
+    const load = vi.fn(async () => null);
+    const capture = vi.fn(async () => ({
+      normalizationRunId: candidate.content.normalizationRunId,
+    }));
+    const accept = vi.fn(async () => candidate);
+    const coordinator = createAflTradePrivateValuationRawDataCoordinator({
+      captureBindings: { load, accept },
+      capture,
+    });
+
+    await expect(coordinator.run({ request, claim })).resolves.toMatchObject({
+      state: 'capture_accepted',
+      requestId: request.requestId,
+      binding: candidate,
+      idempotentReplay: false,
+    });
+    expect(capture).toHaveBeenCalledWith({ request, claim });
+    expect(accept).toHaveBeenCalledWith({
+      request,
+      claim,
+      normalizationRunId: candidate.content.normalizationRunId,
+    });
+  });
+
+  it('rejects retained custody belonging to another dispatch before provider work', async () => {
+    const conflictingRequest = {
+      ...request,
+      requestId: `private-valuation-dispatch:${sha('a')}`,
+      authorityKey: 'another-operation',
+    };
+    const capture = vi.fn();
+    const coordinator = createAflTradePrivateValuationRawDataCoordinator({
+      captureBindings: {
+        load: vi.fn(async () => bindingFor(conflictingRequest)),
+        accept: vi.fn(),
+      },
+      capture,
+    });
+
+    await expect(coordinator.run({ request, claim })).rejects.toThrow(
+      'conflicts with the requested dispatch'
+    );
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('rejects accepted custody that does not descend from the captured normalization', async () => {
+    const captured = bindingFor(request, '8');
+    const conflicting = bindingFor(request, '9');
+    const coordinator = createAflTradePrivateValuationRawDataCoordinator({
+      captureBindings: {
+        load: vi.fn(async () => null),
+        accept: vi.fn(async () => conflicting),
+      },
+      capture: vi.fn(async () => ({
+        normalizationRunId: captured.content.normalizationRunId,
+      })),
+    });
+
+    await expect(coordinator.run({ request, claim })).rejects.toThrow(
+      'disagrees with the captured normalization'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add bounded, durable dispatch attempts with lease fencing and exact replay
- retain one immutable accepted fitzRoy capture and normalization binding per dispatch
- preserve the existing scheduler and provider-ingestion owners instead of adding a workflow engine or parallel queue
- keep raw capture custody additive; downstream factual and HPN preparation land in later stacked pull requests

## Owning boundary and decisions

The existing private valuation dispatch remains the orchestration root. PostgreSQL owns attempt numbering, transient-failure limits, claim fencing, immutable accepted-capture custody, and role restrictions. The coordinator loads an accepted binding before any recapture and rejects conflicting replay. No publication or production authority is granted.

## Verification

Verified locally on the complete stacked branch that contains this commit:

- npm run outcomes:prisma:validate
- npm run docs:check
- npm run typecheck
- npm run lint:ci
- npm run test:unit — 598 files / 3755 tests passed
- focused disposable PostgreSQL scheduling and capture-binding suites passed during implementation
- git diff --check

Full npm run test:int and npm run build require protected DATABASE_URL_TEST and Firebase worker configuration that are not available in this isolated worktree; CI must supply those values.

## Impact and compatibility

- database: forward migrations 0070 and 0071 only; existing migrations are unchanged
- security: coordinator table access is narrowed; live claims remain bearer-fenced and stale claimants fail closed
- data: local non-production AFL outcomes custody only
- deployment: no production publication or public reader cutover
- compatibility: the existing prepared-cohort runner remains callable until the later factual-preparation cutover lands

## Landing sequence

This is 1 of 3 and must merge first. Follow with automated private factual preparation, then governed HPN input preparation.

## Summary by Sourcery

Establish durable, fenced private valuation dispatch and immutable raw FitzRoy capture custody without changing downstream publication or preparation authority.

New Features:
- Add durable private valuation dispatch attempts with bounded retries, lease heartbeats, fencing, and restart-safe replay.
- Retain one immutable, content-addressed non-production FitzRoy capture and normalization binding for each dispatch.
- Coalesce superseded weekly dispatches while preserving the existing scheduler and provider-ingestion ownership boundaries.

Bug Fixes:
- Prevent stale or expired workers from completing, rescheduling, heartbeating, or accepting captures after losing their dispatch fence.
- Prevent recapture and conflicting replay when accepted source custody already exists.

Enhancements:
- Restrict database access so coordinator roles can consume retained results without directly reading live claim credentials or writing custody records.
- Pass the exact dispatch request and live claim fence through the valuation runner boundary.
- Keep retained capture custody explicitly non-production and ineligible for downstream factual, model, evaluation, or publication authority.

Tests:
- Add unit and PostgreSQL integration coverage for bounded dispatch attempts, lease fencing, expiry handling, exact replay, source-custody validation, and role restrictions.