### PR TITLE
Automate private factual preparation

### DIFF
--- a/prisma/afl-trade-outcomes/migrations/0072_private_valuation_factual_output/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0072_private_valuation_factual_output/migration.sql
@@ -1,0 +1,350 @@
+-- Retain one exact private factual-preparation result under the dispatch that produced it.
+-- This is non-authoritative custody. It does not register, activate, publish, or admit the release.
+
+DO $roles$ BEGIN
+  EXECUTE format(
+    'GRANT afl_trade_private_valuation_scheduler_owner TO %I',
+    session_user
+  );
+END $roles$;
+
+GRANT SELECT ON
+  "outcome_private_valuation_dispatch_request",
+  "outcome_private_valuation_dispatch_attempt",
+  "outcome_private_valuation_capture_binding",
+  "outcome_provider_fact_batch",
+  "outcome_factual_reconciliation_run",
+  "outcome_factual_reconciliation_metric_input",
+  "outcome_acquisition_spell_metric_batch",
+  "outcome_acquisition_spell_metric_version",
+  "outcome_acquisition_spell_metric_version_member",
+  "outcome_factual_release_candidate",
+  "outcome_release_factual_run_member",
+  "outcome_release_spell_metric_member",
+  "outcome_release_source_capture",
+  "outcome_release_manifest",
+  "outcome_registry_event"
+TO afl_trade_private_valuation_scheduler_owner;
+GRANT REFERENCES ON
+  "outcome_private_valuation_dispatch_request",
+  "outcome_private_valuation_capture_binding",
+  "outcome_provider_fact_batch",
+  "outcome_factual_reconciliation_run",
+  "outcome_acquisition_spell_metric_batch",
+  "outcome_factual_release_candidate",
+  "outcome_release_manifest"
+TO afl_trade_private_valuation_scheduler_owner;
+
+SET ROLE afl_trade_private_valuation_scheduler_owner;
+
+CREATE TABLE "outcome_private_valuation_factual_output" (
+  "output_id" TEXT PRIMARY KEY,
+  "request_id" TEXT NOT NULL UNIQUE
+    REFERENCES "outcome_private_valuation_dispatch_request"("request_id") ON DELETE RESTRICT,
+  "capture_binding_id" TEXT NOT NULL UNIQUE
+    REFERENCES "outcome_private_valuation_capture_binding"("binding_id") ON DELETE RESTRICT,
+  "normalization_run_id" TEXT NOT NULL,
+  "fact_batch_id" TEXT NOT NULL
+    REFERENCES "outcome_provider_fact_batch"("fact_batch_id") ON DELETE RESTRICT,
+  "factual_run_id" TEXT NOT NULL
+    REFERENCES "outcome_factual_reconciliation_run"("factual_run_id") ON DELETE RESTRICT,
+  "candidate_id" TEXT NOT NULL UNIQUE
+    REFERENCES "outcome_factual_release_candidate"("candidate_id") ON DELETE RESTRICT,
+  "factual_release_id" TEXT NOT NULL UNIQUE
+    REFERENCES "outcome_release_manifest"("release_id") ON DELETE RESTRICT,
+  "prepared_at" TIMESTAMPTZ(3) NOT NULL,
+  "output_json" JSONB NOT NULL,
+  CONSTRAINT "outcome_private_valuation_factual_output_id_check" CHECK (
+    "output_id" ~ '^private-valuation-factual-output:[a-f0-9]{64}$'
+  ),
+  CONSTRAINT "outcome_private_valuation_factual_output_parent_ids_check" CHECK (
+    "normalization_run_id" ~ '^provider-normalization-run:[a-f0-9]{64}$'
+    AND "fact_batch_id" ~ '^source-fact-batch:[a-f0-9]{64}$'
+    AND "factual_run_id" ~ '^factual-reconciliation-run:[a-f0-9]{64}$'
+    AND "candidate_id" ~ '^factual-release-candidate:[a-f0-9]{64}$'
+    AND "factual_release_id" ~ '^outcome-release:[a-f0-9]{64}$'
+  ),
+  CONSTRAINT "outcome_private_valuation_factual_output_json_check" CHECK (
+    jsonb_typeof("output_json")='object'
+  )
+);
+
+CREATE TABLE "outcome_private_valuation_factual_output_spell_batch" (
+  "output_id" TEXT NOT NULL
+    REFERENCES "outcome_private_valuation_factual_output"("output_id") ON DELETE RESTRICT,
+  "batch_id" TEXT NOT NULL
+    REFERENCES "outcome_acquisition_spell_metric_batch"("batch_id") ON DELETE RESTRICT,
+  "ordinal" INTEGER NOT NULL CHECK ("ordinal">0),
+  PRIMARY KEY ("output_id","batch_id"),
+  CONSTRAINT "outcome_private_factual_output_spell_ordinal_key"
+    UNIQUE ("output_id","ordinal")
+);
+
+CREATE OR REPLACE FUNCTION "reject_outcome_private_valuation_factual_output_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Private valuation factual outputs are immutable';
+END $$;
+
+CREATE TRIGGER "outcome_private_valuation_factual_output_no_update_delete"
+BEFORE UPDATE OR DELETE ON "outcome_private_valuation_factual_output"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_valuation_factual_output_mutation"();
+CREATE TRIGGER "outcome_private_valuation_factual_output_spell_batch_no_update_delete"
+BEFORE UPDATE OR DELETE ON "outcome_private_valuation_factual_output_spell_batch"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_valuation_factual_output_mutation"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_valuation_factual_output"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  parent RECORD;
+  actual_batches JSONB;
+  expected_output_id TEXT;
+BEGIN
+  SELECT
+    request."scope_key",binding."normalization_run_id" AS "bound_normalization_run_id",
+    binding."source_capture_id",fact_batch."normalization_run_id" AS "batch_normalization_run_id",
+    fact_batch."capture_id" AS "batch_capture_id",fact_batch."fact_batch_sha256",
+    fact_batch."status" AS "fact_batch_status",fact_batch."finalized_at" AS "fact_batch_finalized_at",
+    factual_run."run_sha256",factual_run."output_set_sha256",
+    factual_run."status" AS "factual_run_status",factual_run."finalized_at" AS "factual_run_finalized_at",
+    candidate."candidate_sha256",candidate."member_set_sha256",
+    candidate."target_release_id",candidate."scope_key" AS "candidate_scope_key",
+    candidate."environment"::TEXT AS "candidate_environment",
+    candidate."status" AS "candidate_status",candidate."finalized_at" AS "candidate_finalized_at",
+    release."scope_key" AS "release_scope_key",release."environment" AS "release_environment"
+  INTO parent
+  FROM "outcome_private_valuation_dispatch_request" request
+  JOIN "outcome_private_valuation_capture_binding" binding
+    ON binding."request_id"=request."request_id"
+  JOIN "outcome_provider_fact_batch" fact_batch
+    ON fact_batch."fact_batch_id"=NEW."fact_batch_id"
+  JOIN "outcome_factual_reconciliation_run" factual_run
+    ON factual_run."factual_run_id"=NEW."factual_run_id"
+  JOIN "outcome_factual_release_candidate" candidate
+    ON candidate."candidate_id"=NEW."candidate_id"
+  JOIN "outcome_release_manifest" release
+    ON release."release_id"=NEW."factual_release_id"
+  WHERE request."request_id"=NEW."request_id"
+    AND binding."binding_id"=NEW."capture_binding_id";
+
+  IF NOT FOUND
+    OR parent."bound_normalization_run_id" IS DISTINCT FROM NEW."normalization_run_id"
+    OR parent."batch_normalization_run_id" IS DISTINCT FROM NEW."normalization_run_id"
+    OR parent."batch_capture_id" IS DISTINCT FROM parent."source_capture_id"
+    OR parent."fact_batch_status" IS DISTINCT FROM 'approved'
+    OR parent."fact_batch_finalized_at" IS NULL
+    OR parent."factual_run_status" IS DISTINCT FROM 'approved'
+    OR parent."factual_run_finalized_at" IS NULL
+    OR parent."candidate_status" IS DISTINCT FROM 'approved'
+    OR parent."candidate_finalized_at" IS NULL
+    OR parent."target_release_id" IS DISTINCT FROM NEW."factual_release_id"
+    OR parent."scope_key" IS DISTINCT FROM parent."candidate_scope_key"
+    OR parent."scope_key" IS DISTINCT FROM parent."release_scope_key"
+    OR parent."candidate_environment" IS DISTINCT FROM 'non_production'
+    OR parent."release_environment" IS DISTINCT FROM 'non_production'
+    OR EXISTS (
+      SELECT 1 FROM "outcome_registry_event" event
+       WHERE event."release_id"=NEW."factual_release_id")
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_release_source_capture" member
+       WHERE member."release_id"=NEW."factual_release_id"
+         AND member."capture_id"=parent."source_capture_id")
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_release_factual_run_member" member
+       WHERE member."candidate_id"=NEW."candidate_id"
+         AND member."factual_run_id"=NEW."factual_run_id")
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_factual_reconciliation_metric_input" input
+      JOIN "outcome_provider_numeric_metric_fact" fact
+        ON fact."metric_fact_id"=input."metric_fact_id"
+       WHERE input."factual_run_id"=NEW."factual_run_id"
+         AND fact."fact_batch_id"=NEW."fact_batch_id")
+  THEN
+    RAISE EXCEPTION 'Private valuation factual output parent custody is invalid';
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object('batchId',batch."batch_id",'batchSha256',batch."batch_sha256")
+    ORDER BY batch."batch_id"),'[]'::jsonb)
+  INTO actual_batches
+  FROM (
+    SELECT DISTINCT metric_batch."batch_id",metric_batch."batch_sha256"
+      FROM "outcome_release_spell_metric_member" member
+      JOIN "outcome_acquisition_spell_metric_version" metric_version
+        ON metric_version."spell_metric_version_id"=member."spell_metric_version_id"
+      JOIN "outcome_acquisition_spell_metric_batch" metric_batch
+        ON metric_batch."batch_id"=metric_version."batch_id"
+     WHERE member."candidate_id"=NEW."candidate_id"
+       AND metric_batch."status"='approved'
+       AND metric_batch."finalized_at" IS NOT NULL
+       AND EXISTS (
+         SELECT 1 FROM "outcome_acquisition_spell_metric_version_member" metric_member
+          WHERE metric_member."spell_metric_version_id"=metric_version."spell_metric_version_id"
+            AND metric_member."factual_run_id"=NEW."factual_run_id")
+  ) batch;
+
+  IF jsonb_array_length(actual_batches)=0
+    OR NEW."prepared_at"<parent."factual_run_finalized_at"
+    OR jsonb_object_length(NEW."output_json")<>2
+    OR jsonb_object_length(NEW."output_json"->'content')<>15
+    OR NEW."output_json"->>'outputId' IS DISTINCT FROM NEW."output_id"
+    OR NEW."output_json"->'content'->>'schemaVersion'
+      IS DISTINCT FROM 'afl-trade-private-valuation-factual-output/v1'
+    OR NEW."output_json"->'content'->>'requestId' IS DISTINCT FROM NEW."request_id"
+    OR NEW."output_json"->'content'->>'valuationScopeKey' IS DISTINCT FROM parent."scope_key"
+    OR NEW."output_json"->'content'->>'captureBindingId' IS DISTINCT FROM NEW."capture_binding_id"
+    OR NEW."output_json"->'content'->>'normalizationRunId' IS DISTINCT FROM NEW."normalization_run_id"
+    OR NEW."output_json"->'content'->'factBatch' IS DISTINCT FROM jsonb_build_object(
+      'batchId',NEW."fact_batch_id",'batchSha256',parent."fact_batch_sha256")
+    OR NEW."output_json"->'content'->'reconciliation' IS DISTINCT FROM jsonb_build_object(
+      'factualRunId',NEW."factual_run_id",'runSha256',parent."run_sha256",
+      'outputSetSha256',parent."output_set_sha256",
+      'finalizedAt',to_char(parent."factual_run_finalized_at" AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'))
+    OR NEW."output_json"->'content'->'spellMetricBatches' IS DISTINCT FROM actual_batches
+    OR NEW."output_json"->'content'->'candidate' IS DISTINCT FROM jsonb_build_object(
+      'candidateId',NEW."candidate_id",'candidateSha256',parent."candidate_sha256",
+      'memberSetSha256',parent."member_set_sha256")
+    OR NEW."output_json"->'content'->'factualRelease' IS DISTINCT FROM jsonb_build_object(
+      'releaseId',NEW."factual_release_id",
+      'releaseSha256',substring(NEW."factual_release_id" from length('outcome-release:')+1))
+    OR NEW."output_json"->'content'->>'preparedAt' IS DISTINCT FROM
+      to_char(NEW."prepared_at" AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    OR NEW."output_json"->'content'->>'environment' IS DISTINCT FROM 'non_production'
+    OR jsonb_typeof(NEW."output_json"->'content'->'publicationEligible') IS DISTINCT FROM 'boolean'
+    OR NEW."output_json"->'content'->'publicationEligible' IS DISTINCT FROM 'false'::jsonb
+    OR jsonb_typeof(NEW."output_json"->'content'->'publicationProhibited') IS DISTINCT FROM 'boolean'
+    OR NEW."output_json"->'content'->'publicationProhibited' IS DISTINCT FROM 'true'::jsonb
+    OR NEW."output_json"->'content'->>'limitation' IS DISTINCT FROM
+      'Retained non-production factual preparation custody only; it grants no model-training, private-evaluation, publication, or production authority.'
+  THEN
+    RAISE EXCEPTION 'Private valuation factual output content is invalid';
+  END IF;
+
+  expected_output_id:='private-valuation-factual-output:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(NEW."output_json"->'content'),'UTF8')),'hex');
+  IF NEW."output_id" IS DISTINCT FROM expected_output_id THEN
+    RAISE EXCEPTION 'Private valuation factual output content address is invalid';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "validate_outcome_private_valuation_factual_output_trigger"
+BEFORE INSERT ON "outcome_private_valuation_factual_output"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_valuation_factual_output"();
+
+CREATE OR REPLACE FUNCTION "retain_outcome_private_valuation_factual_output"(
+  target_request_id TEXT,
+  target_claim_id TEXT,
+  target_lease_token_sha256 TEXT,
+  target_output JSONB
+) RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  dispatch_authority RECORD;
+  retained RECORD;
+  trusted_at TIMESTAMPTZ(3);
+  output_content JSONB;
+  batch JSONB;
+  batch_ordinal INTEGER:=0;
+BEGIN
+  IF target_request_id !~ '^private-valuation-dispatch:[a-f0-9]{64}$'
+    OR target_claim_id !~ '^private-valuation-dispatch-claim:[a-f0-9]{64}$'
+    OR target_lease_token_sha256 !~ '^[a-f0-9]{64}$'
+    OR jsonb_typeof(target_output) IS DISTINCT FROM 'object'
+  THEN
+    RAISE EXCEPTION 'Private valuation factual output retention is malformed';
+  END IF;
+
+  SELECT request."request_id",request."claim_id",request."claim_sequence",
+         request."lease_token_sha256",request."lease_expires_at",
+         attempt."attempt_sequence",attempt."lease_token_sha256" AS "attempt_token",
+         attempt."lease_expires_at" AS "attempt_expiry",attempt."finished_at"
+    INTO dispatch_authority
+    FROM "outcome_private_valuation_dispatch_request" request
+    JOIN "outcome_private_valuation_dispatch_attempt" attempt
+      ON attempt."request_id"=request."request_id"
+     AND attempt."claim_id"=target_claim_id
+   WHERE request."request_id"=target_request_id
+     AND request."claim_id"=target_claim_id
+   FOR UPDATE OF request,attempt;
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF NOT FOUND
+    OR dispatch_authority."claim_sequence" IS DISTINCT FROM dispatch_authority."attempt_sequence"
+    OR dispatch_authority."lease_token_sha256" IS DISTINCT FROM target_lease_token_sha256
+    OR dispatch_authority."attempt_token" IS DISTINCT FROM target_lease_token_sha256
+    OR dispatch_authority."lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_expiry"<trusted_at
+    OR dispatch_authority."finished_at" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation factual output lost its live dispatch claim fence';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    'outcome-private-valuation-factual-output:'||target_request_id,0));
+  SELECT * INTO retained FROM "outcome_private_valuation_factual_output"
+   WHERE "request_id"=target_request_id FOR SHARE;
+  IF FOUND THEN
+    IF retained."output_json" IS DISTINCT FROM target_output THEN
+      RAISE EXCEPTION 'Private valuation dispatch already retained different factual output';
+    END IF;
+    RETURN retained."output_json";
+  END IF;
+
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF dispatch_authority."lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_expiry"<trusted_at
+    OR dispatch_authority."finished_at" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation factual output lost its live dispatch claim fence';
+  END IF;
+  output_content:=target_output->'content';
+  IF output_content->>'requestId' IS DISTINCT FROM target_request_id
+    OR (output_content->>'preparedAt')::timestamptz>trusted_at
+  THEN
+    RAISE EXCEPTION 'Private valuation factual output does not match its dispatch or trusted chronology';
+  END IF;
+
+  INSERT INTO "outcome_private_valuation_factual_output"(
+    "output_id","request_id","capture_binding_id","normalization_run_id",
+    "fact_batch_id","factual_run_id","candidate_id","factual_release_id",
+    "prepared_at","output_json"
+  ) VALUES (
+    target_output->>'outputId',target_request_id,output_content->>'captureBindingId',
+    output_content->>'normalizationRunId',output_content->'factBatch'->>'batchId',
+    output_content->'reconciliation'->>'factualRunId',output_content->'candidate'->>'candidateId',
+    output_content->'factualRelease'->>'releaseId',
+    (output_content->>'preparedAt')::timestamptz,target_output
+  );
+  FOR batch IN SELECT value FROM jsonb_array_elements(output_content->'spellMetricBatches') LOOP
+    batch_ordinal:=batch_ordinal+1;
+    INSERT INTO "outcome_private_valuation_factual_output_spell_batch"(
+      "output_id","batch_id","ordinal")
+    VALUES (target_output->>'outputId',batch->>'batchId',batch_ordinal);
+  END LOOP;
+  RETURN target_output;
+END $$;
+
+DO $paths$ BEGIN
+  EXECUTE format(
+    'ALTER FUNCTION %I.retain_outcome_private_valuation_factual_output(TEXT,TEXT,TEXT,JSONB) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+END $paths$;
+
+REVOKE ALL ON "outcome_private_valuation_factual_output",
+  "outcome_private_valuation_factual_output_spell_batch"
+FROM PUBLIC,afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_private_valuation_factual_output",
+  "outcome_private_valuation_factual_output_spell_batch"
+TO afl_trade_private_evaluation_coordinator;
+REVOKE ALL ON FUNCTION "retain_outcome_private_valuation_factual_output"(TEXT,TEXT,TEXT,JSONB)
+FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "retain_outcome_private_valuation_factual_output"(TEXT,TEXT,TEXT,JSONB)
+TO afl_trade_private_evaluation_coordinator;
+
+RESET ROLE;
+
+DO $membership$ BEGIN
+  EXECUTE format(
+    'REVOKE afl_trade_private_valuation_scheduler_owner FROM %I',
+    session_user
+  );
+END $membership$;

--- a/prisma/afl-trade-outcomes/migrations/0073_automated_nonproduction_source_admission/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0073_automated_nonproduction_source_admission/migration.sql
@@ -1,0 +1,390 @@
+-- Admit one exact accepted fitzRoy source chain for non-production private calculation.
+-- This is not public factual-release approval and never touches the public registry.
+
+DO $roles$ BEGIN
+  EXECUTE format('GRANT afl_trade_private_valuation_scheduler_owner TO %I', session_user);
+END $roles$;
+
+GRANT SELECT ON
+  "outcome_private_valuation_dispatch_request",
+  "outcome_private_valuation_dispatch_attempt",
+  "outcome_private_valuation_capture_binding",
+  "outcome_provider_fact_batch",
+  "outcome_provider_numeric_metric_fact",
+  "outcome_provider_player_appearance_fact",
+  "outcome_provider_match_universe_fact",
+  "outcome_factual_reconciliation_run",
+  "outcome_factual_reconciliation_metric_input",
+  "outcome_factual_reconciliation_appearance_input",
+  "outcome_factual_reconciliation_match_input"
+TO afl_trade_private_valuation_scheduler_owner;
+GRANT UPDATE ("status") ON "outcome_source_capture"
+TO afl_trade_private_valuation_scheduler_owner;
+GRANT REFERENCES ON
+  "outcome_provider_fact_batch",
+  "outcome_factual_reconciliation_run"
+TO afl_trade_private_valuation_scheduler_owner;
+
+SET ROLE afl_trade_private_valuation_scheduler_owner;
+
+CREATE UNIQUE INDEX "outcome_private_valuation_capture_binding_id_run_key"
+  ON "outcome_private_valuation_capture_binding"("binding_id","normalization_run_id");
+
+CREATE TABLE "outcome_private_valuation_source_admission" (
+  "admission_id" TEXT PRIMARY KEY,
+  "request_id" TEXT NOT NULL UNIQUE
+    REFERENCES "outcome_private_valuation_dispatch_request"("request_id") ON DELETE RESTRICT,
+  "capture_binding_id" TEXT NOT NULL UNIQUE
+    REFERENCES "outcome_private_valuation_capture_binding"("binding_id") ON DELETE RESTRICT,
+  "source_capture_id" TEXT NOT NULL UNIQUE
+    REFERENCES "outcome_source_capture"("capture_id") ON DELETE RESTRICT,
+  "normalization_run_id" TEXT NOT NULL,
+  "fact_batch_id" TEXT NOT NULL
+    REFERENCES "outcome_provider_fact_batch"("fact_batch_id") ON DELETE RESTRICT,
+  "factual_run_id" TEXT NOT NULL
+    REFERENCES "outcome_factual_reconciliation_run"("factual_run_id") ON DELETE RESTRICT,
+  "admitted_at" TIMESTAMPTZ(3) NOT NULL,
+  "admission_json" JSONB NOT NULL,
+  CONSTRAINT "outcome_private_valuation_source_admission_binding_run_fkey"
+    FOREIGN KEY ("capture_binding_id","normalization_run_id")
+    REFERENCES "outcome_private_valuation_capture_binding"("binding_id","normalization_run_id")
+    ON DELETE RESTRICT,
+  CONSTRAINT "outcome_private_valuation_source_admission_fact_run_fkey"
+    FOREIGN KEY ("fact_batch_id","normalization_run_id")
+    REFERENCES "outcome_provider_fact_batch"("fact_batch_id","normalization_run_id")
+    ON DELETE RESTRICT,
+  CONSTRAINT "outcome_private_valuation_source_admission_id_check" CHECK (
+    "admission_id" ~ '^private-valuation-source-admission:[a-f0-9]{64}$'
+  ),
+  CONSTRAINT "outcome_private_valuation_source_admission_json_check" CHECK (
+    jsonb_typeof("admission_json")='object'
+  )
+);
+
+CREATE UNIQUE INDEX "outcome_private_valuation_source_admission_binding_run_key"
+  ON "outcome_private_valuation_source_admission"("capture_binding_id","normalization_run_id");
+
+CREATE OR REPLACE FUNCTION "create_outcome_private_valuation_source_admission_id"(
+  target_content JSONB
+) RETURNS TEXT LANGUAGE SQL IMMUTABLE STRICT AS $$
+  SELECT 'private-valuation-source-admission:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(target_content),'UTF8')),'hex')
+$$;
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_valuation_source_admission"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE expected_content JSONB;
+BEGIN
+  expected_content:=NEW."admission_json"->'content';
+  IF (SELECT count(*) FROM jsonb_object_keys(NEW."admission_json"))<>2
+    OR (SELECT count(*) FROM jsonb_object_keys(expected_content))<>13
+    OR NEW."admission_json"->>'admissionId' IS DISTINCT FROM NEW."admission_id"
+    OR NEW."admission_id" IS DISTINCT FROM
+       "create_outcome_private_valuation_source_admission_id"(expected_content)
+    OR expected_content->>'schemaVersion' IS DISTINCT FROM
+       'afl-trade-private-valuation-source-admission/v1'
+    OR expected_content->>'requestId' IS DISTINCT FROM NEW."request_id"
+    OR expected_content->>'captureBindingId' IS DISTINCT FROM NEW."capture_binding_id"
+    OR expected_content->>'sourceCaptureId' IS DISTINCT FROM NEW."source_capture_id"
+    OR expected_content->>'normalizationRunId' IS DISTINCT FROM NEW."normalization_run_id"
+    OR expected_content->>'factBatchId' IS DISTINCT FROM NEW."fact_batch_id"
+    OR expected_content->>'factualRunId' IS DISTINCT FROM NEW."factual_run_id"
+    OR jsonb_typeof(expected_content->'publicationEligible') IS DISTINCT FROM 'boolean'
+    OR (expected_content->'publicationEligible')::boolean IS DISTINCT FROM false
+    OR jsonb_typeof(expected_content->'publicationProhibited') IS DISTINCT FROM 'boolean'
+    OR (expected_content->'publicationProhibited')::boolean IS DISTINCT FROM true
+    OR expected_content->>'principalId' IS DISTINCT FROM 'system:weekly-valuation-coordinator'
+    OR expected_content->>'environment' IS DISTINCT FROM 'non_production'
+    OR expected_content->>'limitation' IS DISTINCT FROM
+       'Non-production private-calculation source admission only; it grants no model, public-display, redistribution, publication, or production authority.'
+    OR (expected_content->>'admittedAt')::timestamptz IS DISTINCT FROM NEW."admitted_at"
+  THEN
+    RAISE EXCEPTION 'Private valuation source admission custody is invalid';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_private_valuation_source_admission_validate"
+BEFORE INSERT ON "outcome_private_valuation_source_admission"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_valuation_source_admission"();
+
+CREATE OR REPLACE FUNCTION "reject_outcome_private_valuation_source_admission_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Private valuation source admissions are immutable';
+END $$;
+
+CREATE TRIGGER "outcome_private_valuation_source_admission_no_update_delete"
+BEFORE UPDATE OR DELETE ON "outcome_private_valuation_source_admission"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_valuation_source_admission_mutation"();
+
+RESET ROLE;
+
+CREATE OR REPLACE FUNCTION "guard_outcome_private_valuation_source_admission_status"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP='DELETE' THEN
+    RAISE EXCEPTION 'Outcome analytical evidence is append-only';
+  END IF;
+  IF (to_jsonb(NEW)-'status') IS DISTINCT FROM (to_jsonb(OLD)-'status')
+    OR OLD."status" IS DISTINCT FROM 'staged'::"OutcomeRecordStatus"
+    OR NEW."status" IS DISTINCT FROM 'approved'::"OutcomeRecordStatus"
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_private_valuation_source_admission" admission
+       WHERE admission."source_capture_id"=NEW."capture_id"
+    )
+  THEN
+    RAISE EXCEPTION 'Source capture status requires exact automated non-production admission';
+  END IF;
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER "outcome_source_capture_append_only" ON "outcome_source_capture";
+CREATE TRIGGER "outcome_source_capture_private_admission_status_guard"
+BEFORE UPDATE OR DELETE ON "outcome_source_capture"
+FOR EACH ROW EXECUTE FUNCTION "guard_outcome_private_valuation_source_admission_status"();
+
+ALTER FUNCTION "guard_outcome_private_valuation_source_admission_status"()
+  OWNER TO afl_trade_private_valuation_scheduler_owner;
+
+SET ROLE afl_trade_private_valuation_scheduler_owner;
+
+CREATE OR REPLACE FUNCTION "admit_outcome_private_valuation_dispatch_source"(
+  target_request_id TEXT,
+  target_claim_id TEXT,
+  target_lease_token_sha256 TEXT
+) RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  trusted_at TIMESTAMPTZ(3);
+  dispatch_authority RECORD;
+  binding RECORD;
+  fact_batch RECORD;
+  factual_run RECORD;
+  retained RECORD;
+  fact_batch_count INTEGER;
+  factual_run_count INTEGER;
+  invalid_input_count INTEGER;
+  expected_competition TEXT;
+  expected_season INTEGER;
+  admission_content JSONB;
+  target_admission_id TEXT;
+  target_admission_json JSONB;
+BEGIN
+  IF target_request_id !~ '^private-valuation-dispatch:[a-f0-9]{64}$'
+    OR target_claim_id !~ '^private-valuation-dispatch-claim:[a-f0-9]{64}$'
+    OR target_lease_token_sha256 !~ '^[a-f0-9]{64}$'
+  THEN
+    RAISE EXCEPTION 'Private valuation source admission request is malformed';
+  END IF;
+
+  SELECT request."request_id",request."scope_key",request."request_json",
+         request."claim_id" AS "current_claim_id",
+         request."claim_sequence" AS "current_claim_sequence",
+         request."lease_token_sha256" AS "current_lease_token_sha256",
+         request."lease_expires_at" AS "current_lease_expires_at",
+         attempt."attempt_sequence",attempt."lease_token_sha256" AS "attempt_lease_token_sha256",
+         attempt."lease_expires_at" AS "attempt_lease_expires_at",
+         attempt."finished_at" AS "attempt_finished_at"
+    INTO dispatch_authority
+    FROM "outcome_private_valuation_dispatch_request" request
+    JOIN "outcome_private_valuation_dispatch_attempt" attempt
+      ON attempt."request_id"=request."request_id"
+     AND attempt."claim_id"=target_claim_id
+   WHERE request."request_id"=target_request_id
+     AND request."claim_id"=target_claim_id
+   FOR UPDATE OF request,attempt;
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF NOT FOUND
+    OR dispatch_authority."current_claim_id" IS DISTINCT FROM target_claim_id
+    OR dispatch_authority."current_claim_sequence" IS DISTINCT FROM dispatch_authority."attempt_sequence"
+    OR dispatch_authority."current_lease_token_sha256" IS DISTINCT FROM target_lease_token_sha256
+    OR dispatch_authority."attempt_lease_token_sha256" IS DISTINCT FROM target_lease_token_sha256
+    OR dispatch_authority."current_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_finished_at" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation source admission lost its live dispatch claim fence';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    'outcome-private-valuation-source-admission:'||target_request_id,0));
+  SELECT * INTO retained FROM "outcome_private_valuation_source_admission"
+   WHERE "request_id"=target_request_id FOR SHARE;
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF dispatch_authority."current_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_lease_expires_at"<trusted_at
+  THEN
+    RAISE EXCEPTION 'Private valuation source admission lost its live dispatch claim fence';
+  END IF;
+  IF FOUND THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM "outcome_source_capture" capture
+       WHERE capture."capture_id"=retained."source_capture_id"
+         AND capture."status"='approved'
+    ) THEN
+      RAISE EXCEPTION 'Retained private valuation source admission is not effective';
+    END IF;
+    RETURN jsonb_build_object(
+      'state','already_admitted','admission',retained."admission_json");
+  END IF;
+
+  IF dispatch_authority."scope_key" !~ '^afl-(men|women):[0-9]{4}-trades$' THEN
+    RAISE EXCEPTION 'Private valuation source admission scope is unsupported';
+  END IF;
+  expected_competition:=CASE
+    WHEN dispatch_authority."scope_key" LIKE 'afl-men:%' THEN 'AFLM'
+    ELSE 'AFLW'
+  END;
+  expected_season:=substring(dispatch_authority."scope_key" FROM ':([0-9]{4})-')::integer;
+
+  SELECT capture_binding."binding_id",capture_binding."source_capture_id",
+         capture_binding."normalization_run_id",capture_binding."binding_json",
+         capture."status" AS "capture_status"
+    INTO binding
+    FROM "outcome_private_valuation_capture_binding" capture_binding
+    JOIN "outcome_source_capture" capture
+      ON capture."capture_id"=capture_binding."source_capture_id"
+   WHERE capture_binding."request_id"=target_request_id
+   FOR UPDATE OF capture;
+  IF NOT FOUND
+    OR binding."binding_json"->'content'->'request' IS DISTINCT FROM dispatch_authority."request_json"
+    OR binding."binding_json"->'content'->'sourcePlan'->>'competition' IS DISTINCT FROM expected_competition
+    OR (binding."binding_json"->'content'->'sourcePlan'->>'seasonYear')::integer
+       IS DISTINCT FROM expected_season
+    OR binding."capture_status" IS DISTINCT FROM 'staged'::"OutcomeRecordStatus"
+  THEN
+    RAISE EXCEPTION 'Private valuation source admission capture ancestry is invalid';
+  END IF;
+
+  SELECT count(*) INTO fact_batch_count
+    FROM "outcome_provider_fact_batch" batch
+   WHERE batch."normalization_run_id"=binding."normalization_run_id"
+     AND batch."capture_id"=binding."source_capture_id"
+     AND batch."environment"='non_production'
+     AND batch."status"='approved' AND batch."finalized_at" IS NOT NULL
+     AND batch."issue_count"=0 AND batch."non_normalized_row_count"=0
+     AND batch."source_row_count"=batch."normalized_row_count";
+  IF fact_batch_count<>1 THEN
+    RAISE EXCEPTION 'Private valuation source admission requires one exact clean factual batch';
+  END IF;
+  SELECT * INTO fact_batch FROM "outcome_provider_fact_batch" batch
+   WHERE batch."normalization_run_id"=binding."normalization_run_id"
+     AND batch."capture_id"=binding."source_capture_id"
+     AND batch."environment"='non_production'
+     AND batch."status"='approved' AND batch."finalized_at" IS NOT NULL
+     AND batch."issue_count"=0 AND batch."non_normalized_row_count"=0
+     AND batch."source_row_count"=batch."normalized_row_count";
+  IF fact_batch."competition" IS DISTINCT FROM expected_competition
+    OR fact_batch."season_year" IS DISTINCT FROM expected_season
+    OR fact_batch."provider" IS DISTINCT FROM binding."binding_json"->'content'->'sourcePlan'->>'provider'
+    OR fact_batch."capability_id" IS DISTINCT FROM binding."binding_json"->'content'->'sourcePlan'->>'capabilityId'
+    OR fact_batch."finalized_at">trusted_at
+  THEN
+    RAISE EXCEPTION 'Private valuation source admission factual batch is outside scope';
+  END IF;
+
+  SELECT count(DISTINCT run."factual_run_id") INTO factual_run_count
+    FROM "outcome_factual_reconciliation_run" run
+   WHERE run."environment"='non_production'
+     AND run."competition"=expected_competition AND run."season_year"=expected_season
+     AND run."status"='approved' AND run."finalized_at" IS NOT NULL
+     AND run."conflict_count"=0
+     AND EXISTS (
+       SELECT 1 FROM "outcome_factual_reconciliation_metric_input" input
+       JOIN "outcome_provider_numeric_metric_fact" fact
+         ON fact."metric_fact_id"=input."metric_fact_id"
+      WHERE input."factual_run_id"=run."factual_run_id"
+        AND fact."fact_batch_id"=fact_batch."fact_batch_id"
+     );
+  IF factual_run_count<>1 THEN
+    RAISE EXCEPTION 'Private valuation source admission requires one exact clean reconciliation';
+  END IF;
+  SELECT run.* INTO factual_run
+    FROM "outcome_factual_reconciliation_run" run
+   WHERE run."environment"='non_production'
+     AND run."competition"=expected_competition AND run."season_year"=expected_season
+     AND run."status"='approved' AND run."finalized_at" IS NOT NULL
+     AND run."conflict_count"=0
+     AND EXISTS (
+       SELECT 1 FROM "outcome_factual_reconciliation_metric_input" input
+       JOIN "outcome_provider_numeric_metric_fact" fact
+         ON fact."metric_fact_id"=input."metric_fact_id"
+      WHERE input."factual_run_id"=run."factual_run_id"
+        AND fact."fact_batch_id"=fact_batch."fact_batch_id"
+     );
+  SELECT count(*) INTO invalid_input_count FROM (
+    SELECT fact."fact_batch_id" FROM "outcome_factual_reconciliation_metric_input" input
+    JOIN "outcome_provider_numeric_metric_fact" fact ON fact."metric_fact_id"=input."metric_fact_id"
+    WHERE input."factual_run_id"=factual_run."factual_run_id"
+    UNION ALL
+    SELECT fact."fact_batch_id" FROM "outcome_factual_reconciliation_appearance_input" input
+    JOIN "outcome_provider_player_appearance_fact" fact ON fact."appearance_fact_id"=input."appearance_fact_id"
+    WHERE input."factual_run_id"=factual_run."factual_run_id"
+    UNION ALL
+    SELECT fact."fact_batch_id" FROM "outcome_factual_reconciliation_match_input" input
+    JOIN "outcome_provider_match_universe_fact" fact ON fact."match_fact_id"=input."match_fact_id"
+    WHERE input."factual_run_id"=factual_run."factual_run_id"
+  ) inputs WHERE inputs."fact_batch_id" IS DISTINCT FROM fact_batch."fact_batch_id";
+  IF invalid_input_count<>0
+    OR factual_run."source_fact_count" IS DISTINCT FROM
+       (fact_batch."metric_fact_count"+fact_batch."appearance_fact_count"+fact_batch."match_fact_count")
+    OR factual_run."finalized_at">trusted_at
+  THEN
+    RAISE EXCEPTION 'Private valuation source admission reconciliation ancestry is invalid';
+  END IF;
+
+  admission_content:=jsonb_build_object(
+    'schemaVersion','afl-trade-private-valuation-source-admission/v1',
+    'requestId',target_request_id,
+    'captureBindingId',binding."binding_id",
+    'sourceCaptureId',binding."source_capture_id",
+    'normalizationRunId',binding."normalization_run_id",
+    'factBatchId',fact_batch."fact_batch_id",
+    'factualRunId',factual_run."factual_run_id",
+    'admittedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'principalId','system:weekly-valuation-coordinator',
+    'environment','non_production',
+    'publicationEligible',false,
+    'publicationProhibited',true,
+    'limitation','Non-production private-calculation source admission only; it grants no model, public-display, redistribution, publication, or production authority.'
+  );
+  target_admission_id:="create_outcome_private_valuation_source_admission_id"(admission_content);
+  target_admission_json:=jsonb_build_object(
+    'admissionId',target_admission_id,'content',admission_content);
+  INSERT INTO "outcome_private_valuation_source_admission"(
+    "admission_id","request_id","capture_binding_id","source_capture_id",
+    "normalization_run_id","fact_batch_id","factual_run_id","admitted_at","admission_json"
+  ) VALUES (
+    target_admission_id,target_request_id,binding."binding_id",binding."source_capture_id",
+    binding."normalization_run_id",fact_batch."fact_batch_id",factual_run."factual_run_id",
+    trusted_at,target_admission_json
+  );
+  UPDATE "outcome_source_capture" SET "status"='approved'
+   WHERE "capture_id"=binding."source_capture_id" AND "status"='staged';
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Private valuation source admission did not advance exact staged custody';
+  END IF;
+  RETURN jsonb_build_object(
+    'state','admitted','admission',target_admission_json);
+END $$;
+
+DO $paths$ BEGIN
+  EXECUTE format(
+    'ALTER FUNCTION %I.admit_outcome_private_valuation_dispatch_source(TEXT,TEXT,TEXT) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+END $paths$;
+
+REVOKE ALL ON "outcome_private_valuation_source_admission"
+  FROM PUBLIC,afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_private_valuation_source_admission"
+  TO afl_trade_private_evaluation_coordinator;
+REVOKE ALL ON FUNCTION "admit_outcome_private_valuation_dispatch_source"(TEXT,TEXT,TEXT)
+  FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "admit_outcome_private_valuation_dispatch_source"(TEXT,TEXT,TEXT)
+  TO afl_trade_private_evaluation_coordinator;
+
+RESET ROLE;
+
+DO $membership$ BEGIN
+  EXECUTE format('REVOKE afl_trade_private_valuation_scheduler_owner FROM %I', session_user);
+END $membership$;

--- a/prisma/afl-trade-outcomes/migrations/0074_bind_factual_output_to_source_admission/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0074_bind_factual_output_to_source_admission/migration.sql
@@ -1,0 +1,270 @@
+-- Bind every retained factual output to the exact automated source admission that enabled it.
+
+DO $roles$ BEGIN
+  EXECUTE format('GRANT afl_trade_private_valuation_scheduler_owner TO %I', session_user);
+END $roles$;
+
+SET ROLE afl_trade_private_valuation_scheduler_owner;
+
+ALTER TABLE "outcome_private_valuation_factual_output"
+  ADD COLUMN "source_admission_id" TEXT NOT NULL UNIQUE
+    REFERENCES "outcome_private_valuation_source_admission"("admission_id") ON DELETE RESTRICT;
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_valuation_factual_output"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  parent RECORD;
+  actual_batches JSONB;
+  expected_output_id TEXT;
+BEGIN
+  SELECT
+    request."scope_key",binding."normalization_run_id" AS "bound_normalization_run_id",
+    binding."source_capture_id",admission."admission_id",
+    admission."normalization_run_id" AS "admitted_normalization_run_id",
+    admission."fact_batch_id" AS "admitted_fact_batch_id",
+    admission."factual_run_id" AS "admitted_factual_run_id",
+    fact_batch."normalization_run_id" AS "batch_normalization_run_id",
+    fact_batch."capture_id" AS "batch_capture_id",fact_batch."fact_batch_sha256",
+    fact_batch."status" AS "fact_batch_status",fact_batch."finalized_at" AS "fact_batch_finalized_at",
+    factual_run."run_sha256",factual_run."output_set_sha256",
+    factual_run."status" AS "factual_run_status",factual_run."finalized_at" AS "factual_run_finalized_at",
+    candidate."candidate_sha256",candidate."member_set_sha256",
+    candidate."target_release_id",candidate."scope_key" AS "candidate_scope_key",
+    candidate."environment"::TEXT AS "candidate_environment",
+    candidate."status" AS "candidate_status",candidate."finalized_at" AS "candidate_finalized_at",
+    release."scope_key" AS "release_scope_key",release."environment" AS "release_environment"
+  INTO parent
+  FROM "outcome_private_valuation_dispatch_request" request
+  JOIN "outcome_private_valuation_capture_binding" binding
+    ON binding."request_id"=request."request_id"
+  JOIN "outcome_private_valuation_source_admission" admission
+    ON admission."request_id"=request."request_id"
+   AND admission."capture_binding_id"=binding."binding_id"
+   AND admission."source_capture_id"=binding."source_capture_id"
+  JOIN "outcome_provider_fact_batch" fact_batch
+    ON fact_batch."fact_batch_id"=admission."fact_batch_id"
+  JOIN "outcome_factual_reconciliation_run" factual_run
+    ON factual_run."factual_run_id"=admission."factual_run_id"
+  JOIN "outcome_factual_release_candidate" candidate
+    ON candidate."candidate_id"=NEW."candidate_id"
+  JOIN "outcome_release_manifest" release
+    ON release."release_id"=NEW."factual_release_id"
+  WHERE request."request_id"=NEW."request_id"
+    AND binding."binding_id"=NEW."capture_binding_id"
+    AND admission."admission_id"=NEW."source_admission_id";
+
+  IF NOT FOUND
+    OR parent."bound_normalization_run_id" IS DISTINCT FROM NEW."normalization_run_id"
+    OR parent."admitted_normalization_run_id" IS DISTINCT FROM NEW."normalization_run_id"
+    OR parent."admitted_fact_batch_id" IS DISTINCT FROM NEW."fact_batch_id"
+    OR parent."admitted_factual_run_id" IS DISTINCT FROM NEW."factual_run_id"
+    OR parent."batch_normalization_run_id" IS DISTINCT FROM NEW."normalization_run_id"
+    OR parent."batch_capture_id" IS DISTINCT FROM parent."source_capture_id"
+    OR parent."fact_batch_status" IS DISTINCT FROM 'approved'
+    OR parent."fact_batch_finalized_at" IS NULL
+    OR parent."factual_run_status" IS DISTINCT FROM 'approved'
+    OR parent."factual_run_finalized_at" IS NULL
+    OR parent."candidate_status" IS DISTINCT FROM 'approved'
+    OR parent."candidate_finalized_at" IS NULL
+    OR parent."target_release_id" IS DISTINCT FROM NEW."factual_release_id"
+    OR parent."scope_key" IS DISTINCT FROM parent."candidate_scope_key"
+    OR parent."scope_key" IS DISTINCT FROM parent."release_scope_key"
+    OR parent."candidate_environment" IS DISTINCT FROM 'non_production'
+    OR parent."release_environment" IS DISTINCT FROM 'non_production'
+    OR EXISTS (
+      SELECT 1 FROM "outcome_registry_event" event
+       WHERE event."release_id"=NEW."factual_release_id")
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_release_source_capture" member
+       WHERE member."release_id"=NEW."factual_release_id"
+         AND member."capture_id"=parent."source_capture_id")
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_release_factual_run_member" member
+       WHERE member."candidate_id"=NEW."candidate_id"
+         AND member."factual_run_id"=NEW."factual_run_id")
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_factual_reconciliation_metric_input" input
+      JOIN "outcome_provider_numeric_metric_fact" fact
+        ON fact."metric_fact_id"=input."metric_fact_id"
+       WHERE input."factual_run_id"=NEW."factual_run_id"
+         AND fact."fact_batch_id"=NEW."fact_batch_id")
+  THEN
+    RAISE EXCEPTION 'Private valuation factual output parent custody is invalid';
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object('batchId',batch."batch_id",'batchSha256',batch."batch_sha256")
+    ORDER BY batch."batch_id"),'[]'::jsonb)
+  INTO actual_batches
+  FROM (
+    SELECT DISTINCT metric_batch."batch_id",metric_batch."batch_sha256"
+      FROM "outcome_release_spell_metric_member" member
+      JOIN "outcome_acquisition_spell_metric_version" metric_version
+        ON metric_version."spell_metric_version_id"=member."spell_metric_version_id"
+      JOIN "outcome_acquisition_spell_metric_batch" metric_batch
+        ON metric_batch."batch_id"=metric_version."batch_id"
+     WHERE member."candidate_id"=NEW."candidate_id"
+       AND metric_batch."status"='approved'
+       AND metric_batch."finalized_at" IS NOT NULL
+       AND EXISTS (
+         SELECT 1 FROM "outcome_acquisition_spell_metric_version_member" metric_member
+          WHERE metric_member."spell_metric_version_id"=metric_version."spell_metric_version_id"
+            AND metric_member."factual_run_id"=NEW."factual_run_id")
+       AND NOT EXISTS (
+         SELECT 1
+           FROM "outcome_release_spell_metric_member" sibling_member
+           JOIN "outcome_acquisition_spell_metric_version" sibling_version
+             ON sibling_version."spell_metric_version_id"=sibling_member."spell_metric_version_id"
+          WHERE sibling_member."candidate_id"=member."candidate_id"
+            AND sibling_version."batch_id"=metric_batch."batch_id"
+            AND EXISTS (
+              SELECT 1
+                FROM "outcome_acquisition_spell_metric_version_member" foreign_member
+               WHERE foreign_member."spell_metric_version_id"=sibling_version."spell_metric_version_id"
+                 AND foreign_member."factual_run_id"<>NEW."factual_run_id"))
+  ) batch;
+
+  IF jsonb_array_length(actual_batches)=0
+    OR NEW."prepared_at"<parent."factual_run_finalized_at"
+    OR (SELECT count(*) FROM jsonb_object_keys(NEW."output_json"))<>2
+    OR (SELECT count(*) FROM jsonb_object_keys(NEW."output_json"->'content'))<>16
+    OR NEW."output_json"->>'outputId' IS DISTINCT FROM NEW."output_id"
+    OR NEW."output_json"->'content'->>'schemaVersion'
+      IS DISTINCT FROM 'afl-trade-private-valuation-factual-output/v1'
+    OR NEW."output_json"->'content'->>'requestId' IS DISTINCT FROM NEW."request_id"
+    OR NEW."output_json"->'content'->>'valuationScopeKey' IS DISTINCT FROM parent."scope_key"
+    OR NEW."output_json"->'content'->>'captureBindingId' IS DISTINCT FROM NEW."capture_binding_id"
+    OR NEW."output_json"->'content'->>'sourceAdmissionId' IS DISTINCT FROM NEW."source_admission_id"
+    OR NEW."output_json"->'content'->>'normalizationRunId' IS DISTINCT FROM NEW."normalization_run_id"
+    OR NEW."output_json"->'content'->'factBatch' IS DISTINCT FROM jsonb_build_object(
+      'batchId',NEW."fact_batch_id",'batchSha256',parent."fact_batch_sha256")
+    OR NEW."output_json"->'content'->'reconciliation' IS DISTINCT FROM jsonb_build_object(
+      'factualRunId',NEW."factual_run_id",'runSha256',parent."run_sha256",
+      'outputSetSha256',parent."output_set_sha256",
+      'finalizedAt',to_char(parent."factual_run_finalized_at" AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'))
+    OR NEW."output_json"->'content'->'spellMetricBatches' IS DISTINCT FROM actual_batches
+    OR NEW."output_json"->'content'->'candidate' IS DISTINCT FROM jsonb_build_object(
+      'candidateId',NEW."candidate_id",'candidateSha256',parent."candidate_sha256",
+      'memberSetSha256',parent."member_set_sha256")
+    OR NEW."output_json"->'content'->'factualRelease' IS DISTINCT FROM jsonb_build_object(
+      'releaseId',NEW."factual_release_id",
+      'releaseSha256',substring(NEW."factual_release_id" from length('outcome-release:')+1))
+    OR NEW."output_json"->'content'->>'preparedAt' IS DISTINCT FROM
+      to_char(NEW."prepared_at" AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    OR NEW."output_json"->'content'->>'environment' IS DISTINCT FROM 'non_production'
+    OR jsonb_typeof(NEW."output_json"->'content'->'publicationEligible') IS DISTINCT FROM 'boolean'
+    OR NEW."output_json"->'content'->'publicationEligible' IS DISTINCT FROM 'false'::jsonb
+    OR jsonb_typeof(NEW."output_json"->'content'->'publicationProhibited') IS DISTINCT FROM 'boolean'
+    OR NEW."output_json"->'content'->'publicationProhibited' IS DISTINCT FROM 'true'::jsonb
+    OR NEW."output_json"->'content'->>'limitation' IS DISTINCT FROM
+      'Retained non-production factual preparation custody only; it grants no model-training, private-evaluation, publication, or production authority.'
+  THEN
+    RAISE EXCEPTION 'Private valuation factual output content is invalid';
+  END IF;
+
+  expected_output_id:='private-valuation-factual-output:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(NEW."output_json"->'content'),'UTF8')),'hex');
+  IF NEW."output_id" IS DISTINCT FROM expected_output_id THEN
+    RAISE EXCEPTION 'Private valuation factual output content address is invalid';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE OR REPLACE FUNCTION "retain_outcome_private_valuation_factual_output"(
+  target_request_id TEXT,
+  target_claim_id TEXT,
+  target_lease_token_sha256 TEXT,
+  target_output JSONB
+) RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  dispatch_authority RECORD;
+  retained RECORD;
+  trusted_at TIMESTAMPTZ(3);
+  output_content JSONB;
+  batch JSONB;
+  batch_ordinal INTEGER:=0;
+BEGIN
+  IF target_request_id !~ '^private-valuation-dispatch:[a-f0-9]{64}$'
+    OR target_claim_id !~ '^private-valuation-dispatch-claim:[a-f0-9]{64}$'
+    OR target_lease_token_sha256 !~ '^[a-f0-9]{64}$'
+    OR jsonb_typeof(target_output) IS DISTINCT FROM 'object'
+  THEN
+    RAISE EXCEPTION 'Private valuation factual output retention is malformed';
+  END IF;
+  SELECT request."request_id",request."claim_id",request."claim_sequence",
+         request."lease_token_sha256",request."lease_expires_at",
+         attempt."attempt_sequence",attempt."lease_token_sha256" AS "attempt_token",
+         attempt."lease_expires_at" AS "attempt_expiry",attempt."finished_at"
+    INTO dispatch_authority
+    FROM "outcome_private_valuation_dispatch_request" request
+    JOIN "outcome_private_valuation_dispatch_attempt" attempt
+      ON attempt."request_id"=request."request_id" AND attempt."claim_id"=target_claim_id
+   WHERE request."request_id"=target_request_id AND request."claim_id"=target_claim_id
+   FOR UPDATE OF request,attempt;
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF NOT FOUND
+    OR dispatch_authority."claim_sequence" IS DISTINCT FROM dispatch_authority."attempt_sequence"
+    OR dispatch_authority."lease_token_sha256" IS DISTINCT FROM target_lease_token_sha256
+    OR dispatch_authority."attempt_token" IS DISTINCT FROM target_lease_token_sha256
+    OR dispatch_authority."lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_expiry"<trusted_at
+    OR dispatch_authority."finished_at" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation factual output lost its live dispatch claim fence';
+  END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    'outcome-private-valuation-factual-output:'||target_request_id,0));
+  SELECT * INTO retained FROM "outcome_private_valuation_factual_output"
+   WHERE "request_id"=target_request_id FOR SHARE;
+  IF FOUND THEN
+    IF retained."output_json" IS DISTINCT FROM target_output THEN
+      RAISE EXCEPTION 'Private valuation dispatch already retained different factual output';
+    END IF;
+    RETURN retained."output_json";
+  END IF;
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF dispatch_authority."lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_expiry"<trusted_at
+    OR dispatch_authority."finished_at" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation factual output lost its live dispatch claim fence';
+  END IF;
+  output_content:=target_output->'content';
+  IF output_content->>'requestId' IS DISTINCT FROM target_request_id
+    OR (output_content->>'preparedAt')::timestamptz>trusted_at
+  THEN
+    RAISE EXCEPTION 'Private valuation factual output does not match its dispatch or trusted chronology';
+  END IF;
+  INSERT INTO "outcome_private_valuation_factual_output"(
+    "output_id","request_id","capture_binding_id","source_admission_id",
+    "normalization_run_id","fact_batch_id","factual_run_id","candidate_id",
+    "factual_release_id","prepared_at","output_json"
+  ) VALUES (
+    target_output->>'outputId',target_request_id,output_content->>'captureBindingId',
+    output_content->>'sourceAdmissionId',output_content->>'normalizationRunId',
+    output_content->'factBatch'->>'batchId',
+    output_content->'reconciliation'->>'factualRunId',
+    output_content->'candidate'->>'candidateId',
+    output_content->'factualRelease'->>'releaseId',
+    (output_content->>'preparedAt')::timestamptz,target_output
+  );
+  FOR batch IN SELECT value FROM jsonb_array_elements(output_content->'spellMetricBatches') LOOP
+    batch_ordinal:=batch_ordinal+1;
+    INSERT INTO "outcome_private_valuation_factual_output_spell_batch"(
+      "output_id","batch_id","ordinal")
+    VALUES (target_output->>'outputId',batch->>'batchId',batch_ordinal);
+  END LOOP;
+  RETURN target_output;
+END $$;
+
+DO $paths$ BEGIN
+  EXECUTE format(
+    'ALTER FUNCTION %I.retain_outcome_private_valuation_factual_output(TEXT,TEXT,TEXT,JSONB) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+END $paths$;
+
+RESET ROLE;
+
+DO $membership$ BEGIN
+  EXECUTE format('REVOKE afl_trade_private_valuation_scheduler_owner FROM %I', session_user);
+END $membership$;

--- a/prisma/afl-trade-outcomes/migrations/0075_versioned_release_acquisition_spell_eligibility/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0075_versioned_release_acquisition_spell_eligibility/migration.sql
@@ -1,0 +1,224 @@
+-- Release membership originally predated versioned acquisition-spell metrics and therefore
+-- accepted only the legacy compatibility table. Preserve that path while allowing factual-v3
+-- candidates to prove the same eligibility from their exact finalized versioned metric members.
+
+DROP TRIGGER IF EXISTS "outcome_release_acquisition_spell_eligibility"
+  ON "outcome_release_acquisition_spell";
+
+CREATE OR REPLACE FUNCTION "validate_outcome_release_acquisition_spell_v2"()
+RETURNS TRIGGER AS $$
+DECLARE
+  release_row RECORD;
+  spell_row RECORD;
+  candidate_row RECORD;
+  candidate_uses_versioned_metrics BOOLEAN := FALSE;
+  legacy_metric_count INTEGER;
+  versioned_metric_count INTEGER;
+  invalid_metric_count INTEGER;
+BEGIN
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('outcome-release-parent:' || NEW."spell_version_id", 0)
+  );
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('outcome-release-membership:' || NEW."release_id", 0)
+  );
+
+  SELECT manifest."effective_through", manifest."environment"::"OutcomeEnvironment"
+    INTO release_row
+    FROM "outcome_release_manifest" manifest
+   WHERE manifest."release_id" = NEW."release_id"
+   FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Release acquisition-spell membership requires one existing release cutoff';
+  END IF;
+
+  SELECT spell."status", spell."recorded_at", spell."start_date",
+         spell."end_date", spell."spell_id", spell."player_id", spell."club_id",
+         spell."start_event_version_id",
+         spell."start_asset_version_id", spell."rule_id"
+    INTO spell_row
+    FROM "outcome_acquisition_spell_version" spell
+   WHERE spell."spell_version_id" = NEW."spell_version_id"
+   FOR KEY SHARE;
+  IF NOT FOUND OR
+     spell_row."status" IS DISTINCT FROM 'approved'::"OutcomeRecordStatus" OR
+     spell_row."recorded_at" IS NULL OR
+     spell_row."recorded_at" > release_row."effective_through" OR
+     spell_row."start_date"::timestamp AT TIME ZONE 'UTC' > release_row."effective_through" THEN
+    RAISE EXCEPTION 'Release acquisition-spell membership requires approved evidence within the release cutoff';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM "outcome_release_event_version" event_member
+      JOIN "outcome_event_asset" asset
+        ON asset."event_version_id" = spell_row."start_event_version_id"
+       AND asset."asset_version_id" = spell_row."start_asset_version_id"
+      JOIN "outcome_acquisition_spell_rule" rule
+        ON rule."rule_id" = spell_row."rule_id"
+     WHERE event_member."release_id" = NEW."release_id"
+       AND event_member."event_version_id" = spell_row."start_event_version_id"
+       AND asset."kind" = 'player'
+       AND asset."player_id" = spell_row."player_id"
+       AND asset."to_club_id" = spell_row."club_id"
+       AND asset."status" = 'approved'::"OutcomeRecordStatus"
+       AND rule."status" = 'approved'::"OutcomeRecordStatus"
+  ) THEN
+    RAISE EXCEPTION 'Released spells require their exact released event asset and approved rule';
+  END IF;
+
+  SELECT candidate."candidate_id", candidate."candidate_json", candidate."competition",
+         candidate."environment", candidate."created_at", candidate."effective_through",
+         candidate."status", candidate."finalized_at"
+    INTO candidate_row
+    FROM "outcome_factual_release_candidate" candidate
+   WHERE candidate."target_release_id" = NEW."release_id"
+   FOR KEY SHARE;
+  IF FOUND THEN
+    candidate_uses_versioned_metrics :=
+      jsonb_typeof(candidate_row."candidate_json"->'members'->'spellMetrics') = 'array' AND
+      jsonb_array_length(candidate_row."candidate_json"->'members'->'spellMetrics') > 0;
+    IF candidate_row."status" IS DISTINCT FROM 'approved'::"OutcomeRecordStatus" OR
+       candidate_row."finalized_at" IS NULL OR
+       candidate_row."environment" IS DISTINCT FROM release_row."environment" OR
+       candidate_row."effective_through" IS DISTINCT FROM release_row."effective_through" OR
+       NOT EXISTS (
+         SELECT 1
+           FROM jsonb_array_elements(
+             candidate_row."candidate_json"->'members'->'acquisitionSpells'
+           ) planned(member_json)
+          WHERE planned.member_json = NEW."membership_json"
+            AND planned.member_json->>'spellVersionId' = NEW."spell_version_id"
+            AND (planned.member_json->>'ordinal')::INTEGER = NEW."ordinal"
+            AND planned.member_json->>'recordSha256' = NEW."record_sha256"
+            AND (
+              NOT (planned.member_json ? 'spellId')
+              OR planned.member_json->>'spellId' = spell_row."spell_id")
+            AND planned.member_json->>'playerId' = spell_row."player_id"
+            AND planned.member_json->>'clubId' = spell_row."club_id"
+            AND planned.member_json->>'startDate' = spell_row."start_date"::TEXT
+            AND planned.member_json->>'endDate' IS NOT DISTINCT FROM spell_row."end_date"::TEXT)
+    THEN
+      RAISE EXCEPTION 'Released spell membership must equal the factual candidate declaration';
+    END IF;
+  END IF;
+
+  SELECT count(*) INTO legacy_metric_count
+    FROM "outcome_acquisition_spell_metric" metric
+   WHERE metric."spell_version_id" = NEW."spell_version_id";
+
+  IF NOT candidate_uses_versioned_metrics AND legacy_metric_count > 0 THEN
+    IF EXISTS (
+      SELECT 1
+        FROM "outcome_acquisition_spell_metric" metric
+        JOIN "outcome_metric_definition" definition
+          ON definition."metric_code" = metric."metric_code"
+         AND definition."definition_version" = metric."metric_definition_version"
+       WHERE metric."spell_version_id" = NEW."spell_version_id"
+         AND definition."status" <> 'approved'::"OutcomeRecordStatus"
+    ) OR EXISTS (
+      SELECT 1
+        FROM "outcome_acquisition_spell_metric" metric
+       WHERE metric."spell_version_id" = NEW."spell_version_id"
+         AND metric."effective_through"::timestamp AT TIME ZONE 'UTC' >
+             release_row."effective_through"
+    ) THEN
+      RAISE EXCEPTION 'Released spells require approved legacy metrics and no post-cutoff evidence';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF candidate_row."candidate_id" IS NULL THEN
+    RAISE EXCEPTION 'Versioned release spell metrics require the exact finalized factual candidate';
+  END IF;
+
+  SELECT count(*) INTO versioned_metric_count
+    FROM "outcome_release_spell_metric_member" member
+    JOIN "outcome_acquisition_spell_metric_version" version
+      ON version."spell_metric_version_id" = member."spell_metric_version_id"
+   WHERE member."candidate_id" = candidate_row."candidate_id"
+     AND version."spell_version_id" = NEW."spell_version_id";
+
+  SELECT count(*) INTO invalid_metric_count
+    FROM "outcome_release_spell_metric_member" member
+    JOIN "outcome_acquisition_spell_metric_version" version
+      ON version."spell_metric_version_id" = member."spell_metric_version_id"
+    LEFT JOIN "outcome_acquisition_spell_metric_batch" batch
+      ON batch."batch_id" = version."batch_id"
+    LEFT JOIN "outcome_acquisition_spell_metric_policy" policy
+      ON policy."policy_id" = batch."policy_id"
+    LEFT JOIN "outcome_review_decision" approval
+      ON approval."decision_id" = policy."approval_decision_id"
+    LEFT JOIN "outcome_metric_definition" definition
+      ON definition."metric_code" = version."metric_code"
+     AND definition."definition_version" = version."definition_version"
+    LEFT JOIN "outcome_acquisition_spell_metric_head" head
+      ON head."subject_key" = member."membership_json"->>'subjectKey'
+   WHERE member."candidate_id" = candidate_row."candidate_id"
+     AND version."spell_version_id" = NEW."spell_version_id"
+     AND (
+       member."record_sha256" IS DISTINCT FROM version."fact_sha256" OR
+       head."spell_metric_version_id" IS DISTINCT FROM version."spell_metric_version_id" OR
+       head."revision" IS DISTINCT FROM member."head_revision" OR
+       batch."spell_version_id" IS DISTINCT FROM NEW."spell_version_id" OR
+       batch."environment" IS DISTINCT FROM release_row."environment" OR
+       batch."competition" IS DISTINCT FROM candidate_row."competition" OR
+       batch."status" IS DISTINCT FROM 'approved'::"OutcomeRecordStatus" OR
+       batch."finalized_at" IS NULL OR
+       batch."finalized_at" > candidate_row."created_at" OR
+       policy."environment" IS DISTINCT FROM release_row."environment" OR
+       policy."competition" IS DISTINCT FROM candidate_row."competition" OR
+       policy."status" IS DISTINCT FROM 'approved'::"OutcomeRecordStatus" OR
+       policy."created_at" > candidate_row."created_at" OR
+       approval."decision" IS DISTINCT FROM 'approved' OR
+       approval."decided_at" > candidate_row."created_at" OR
+       EXISTS (
+         SELECT 1 FROM "outcome_review_decision" successor
+          WHERE successor."supersedes_decision_id" = approval."decision_id"
+       ) OR
+       definition."status" IS DISTINCT FROM 'approved'::"OutcomeRecordStatus" OR
+       version."recorded_at" > candidate_row."created_at" OR
+       version."effective_through"::timestamp AT TIME ZONE 'UTC' >
+         release_row."effective_through" OR
+       member."membership_json"->>'spellMetricVersionId' IS DISTINCT FROM
+         version."spell_metric_version_id" OR
+       member."membership_json"->>'spellVersionId' IS DISTINCT FROM
+         version."spell_version_id" OR
+       member."membership_json"->>'policyId' IS DISTINCT FROM policy."policy_id" OR
+       member."membership_json"->>'playerId' IS DISTINCT FROM spell_row."player_id" OR
+       member."membership_json"->>'clubId' IS DISTINCT FROM spell_row."club_id" OR
+       member."membership_json"->>'metricCode' IS DISTINCT FROM version."metric_code" OR
+       member."membership_json"->>'state' IS DISTINCT FROM version."state" OR
+       member."membership_json"->>'effectiveThrough' IS DISTINCT FROM
+         version."effective_through"::TEXT OR
+       member."membership_json"->>'recordSha256' IS DISTINCT FROM member."record_sha256" OR
+       (member."membership_json"->>'ordinal')::INTEGER IS DISTINCT FROM member."ordinal" OR
+       NOT EXISTS (
+         SELECT 1
+           FROM jsonb_array_elements(
+             candidate_row."candidate_json"->'members'->'spellMetrics'
+           ) planned(member_json)
+          WHERE planned.member_json = member."membership_json"
+       ) OR
+       (
+         SELECT count(*)
+           FROM "outcome_release_spell_metric_member" batch_member
+           JOIN "outcome_acquisition_spell_metric_version" batch_version
+             ON batch_version."spell_metric_version_id" = batch_member."spell_metric_version_id"
+          WHERE batch_member."candidate_id" = candidate_row."candidate_id"
+            AND batch_version."batch_id" = batch."batch_id"
+       ) IS DISTINCT FROM batch."metric_count"
+     );
+
+  IF versioned_metric_count = 0 OR invalid_metric_count <> 0 THEN
+    RAISE EXCEPTION 'Released spells require exact approved versioned metrics and no post-cutoff evidence';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER "outcome_release_acquisition_spell_eligibility"
+AFTER INSERT ON "outcome_release_acquisition_spell"
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_release_acquisition_spell_v2"();

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -151,6 +151,7 @@ model OutcomeReleaseManifest {
   privateValuationEvaluationDecisions OutcomePrivateValuationEvaluationDecision[]
   privateValuationEvaluationHeads     OutcomePrivateValuationEvaluationHead[]
   currentValuationCohortOperations    OutcomeCurrentValuationCohortOperation[]
+  privateValuationFactualOutput       OutcomePrivateValuationFactualOutput?
 
   @@index([scopeKey, createdAt])
   @@map("outcome_release_manifest")
@@ -392,6 +393,7 @@ model OutcomeSourceCapture {
   valuationDatasetAdmissions  OutcomeValuationDatasetAdmissionSource[]
   valuationDatasetFieldSets   OutcomeValuationDatasetConsumedFieldSet[]
   privateValuationCaptureBindings OutcomePrivateValuationCaptureBinding[] @relation("PrivateValuationCaptureSource")
+  privateValuationSourceAdmission OutcomePrivateValuationSourceAdmission?
 
   @@unique([captureId, attemptId, sourceSnapshotId], map: "outcome_source_capture_exact_ancestry_key")
   @@index([provider, dataset, capturedAt], map: "outcome_source_capture_provider_captured_idx")
@@ -2425,6 +2427,8 @@ model OutcomeProviderFactBatch {
   completedAt                     DateTime?           @map("completed_at") @outcomes.Timestamptz(3)
   finalizedAt                     DateTime?           @map("finalized_at") @outcomes.Timestamptz(3)
   receiptJson                     Json                @map("receipt_json")
+  privateValuationFactualOutputs  OutcomePrivateValuationFactualOutput[]
+  privateValuationSourceAdmissions OutcomePrivateValuationSourceAdmission[]
 
   @@unique([normalizationRunId, extractorVersion, factBatchSha256], map: "outcome_provider_fact_batch_idempotency_key")
   @@unique([factBatchId, normalizationRunId], map: "outcome_provider_fact_batch_run_key")
@@ -2670,6 +2674,8 @@ model OutcomeFactualReconciliationRun {
   reconciledFacts     OutcomeReconciledFactualMetric[]
   spellMetricMembers  OutcomeAcquisitionSpellMetricVersionMember[]
   hpnPavInputSets     OutcomeHpnPavInputSet[]
+  privateValuationFactualOutputs OutcomePrivateValuationFactualOutput[]
+  privateValuationSourceAdmissions OutcomePrivateValuationSourceAdmission[]
 
   @@unique([policyId, competition, seasonYear, algorithmVersion, inputSetSha256], map: "outcome_factual_run_idempotency_key")
   @@index([environment, competition, seasonYear, status], map: "outcome_factual_run_scope_idx")
@@ -2961,6 +2967,7 @@ model OutcomeFactualReleaseCandidate {
   publicFactualArchive            OutcomePublicFactualArchive?
   valuationDatasets               OutcomeValuationDatasetCandidate[]
   valuationDatasetAuthorities     OutcomeValuationDatasetOperationAuthority[]
+  privateValuationFactualOutput    OutcomePrivateValuationFactualOutput?
 
   @@index([environment, scopeKey, status], map: "outcome_factual_release_candidate_scope_idx")
   @@index([promotionBackedCorpusId, status], map: "outcome_factual_candidate_promotion_corpus_idx")
@@ -3539,6 +3546,7 @@ model OutcomeAcquisitionSpellMetricBatch {
   policy         OutcomeAcquisitionSpellMetricPolicy    @relation(fields: [policyId], references: [policyId], onDelete: Restrict)
   spellVersion   OutcomeAcquisitionSpellVersion         @relation(fields: [spellVersionId], references: [spellVersionId], onDelete: Restrict)
   metrics        OutcomeAcquisitionSpellMetricVersion[]
+  privateValuationFactualOutputs OutcomePrivateValuationFactualOutputSpellBatch[]
 
   @@unique([policyId, spellVersionId, batchSha256], map: "outcome_spell_metric_batch_idempotency_key")
   @@map("outcome_acquisition_spell_metric_batch")
@@ -5395,6 +5403,8 @@ model OutcomePrivateValuationDispatchRequest {
   transientFailureCount Int       @default(0) @map("transient_failure_count")
   attempts              OutcomePrivateValuationDispatchAttempt[]
   captureBinding        OutcomePrivateValuationCaptureBinding?
+  sourceAdmission       OutcomePrivateValuationSourceAdmission?
+  factualOutput         OutcomePrivateValuationFactualOutput?
 
   @@index([status, availableAt, scopeKey], map: "outcome_private_valuation_dispatch_due_idx")
   @@map("outcome_private_valuation_dispatch_request")
@@ -5439,9 +5449,69 @@ model OutcomePrivateValuationCaptureBinding {
   dispatchAttempt       OutcomePrivateValuationDispatchAttempt     @relation("PrivateValuationCaptureDispatchAttempt", fields: [requestId, attemptSequence, dispatchClaimId], references: [requestId, attemptSequence, claimId], onDelete: Restrict)
   sourceCapture         OutcomeSourceCapture                       @relation("PrivateValuationCaptureSource", fields: [sourceCaptureId, sourceCaptureAttemptId, sourceSnapshotId], references: [captureId, attemptId, sourceSnapshotId], onDelete: Restrict)
   normalizationRun      OutcomeProviderNormalizationRun            @relation("PrivateValuationCaptureNormalization", fields: [normalizationRunId, sourceCaptureId], references: [normalizationRunId, captureId], onDelete: Restrict)
+  sourceAdmission       OutcomePrivateValuationSourceAdmission?
+  factualOutput         OutcomePrivateValuationFactualOutput?
 
+  @@unique([bindingId, normalizationRunId], map: "outcome_private_valuation_capture_binding_id_run_key")
   @@index([normalizationRunId, sourceCaptureId], map: "outcome_private_valuation_capture_binding_source_idx")
   @@map("outcome_private_valuation_capture_binding")
+}
+
+model OutcomePrivateValuationSourceAdmission {
+  admissionId       String                                   @id @map("admission_id") @outcomes.Text
+  requestId         String                                   @unique @map("request_id") @outcomes.Text
+  captureBindingId  String                                   @unique @map("capture_binding_id") @outcomes.Text
+  sourceCaptureId   String                                   @unique @map("source_capture_id") @outcomes.Text
+  normalizationRunId String                                  @map("normalization_run_id") @outcomes.Text
+  factBatchId       String                                   @map("fact_batch_id") @outcomes.Text
+  factualRunId      String                                   @map("factual_run_id") @outcomes.Text
+  admittedAt        DateTime                                 @map("admitted_at") @outcomes.Timestamptz(3)
+  admissionJson     Json                                     @map("admission_json")
+  request           OutcomePrivateValuationDispatchRequest   @relation(fields: [requestId], references: [requestId], onDelete: Restrict)
+  captureBinding    OutcomePrivateValuationCaptureBinding    @relation(fields: [captureBindingId, normalizationRunId], references: [bindingId, normalizationRunId], onDelete: Restrict)
+  sourceCapture     OutcomeSourceCapture                     @relation(fields: [sourceCaptureId], references: [captureId], onDelete: Restrict)
+  factBatch         OutcomeProviderFactBatch                  @relation(fields: [factBatchId, normalizationRunId], references: [factBatchId, normalizationRunId], onDelete: Restrict)
+  factualRun        OutcomeFactualReconciliationRun           @relation(fields: [factualRunId], references: [factualRunId], onDelete: Restrict)
+  factualOutput     OutcomePrivateValuationFactualOutput?
+
+  @@unique([captureBindingId, normalizationRunId], map: "outcome_private_valuation_source_admission_binding_run_key")
+  @@map("outcome_private_valuation_source_admission")
+}
+
+model OutcomePrivateValuationFactualOutput {
+  outputId            String                                              @id @map("output_id") @outcomes.Text
+  requestId           String                                              @unique @map("request_id") @outcomes.Text
+  captureBindingId    String                                              @unique @map("capture_binding_id") @outcomes.Text
+  sourceAdmissionId   String                                              @unique @map("source_admission_id") @outcomes.Text
+  normalizationRunId  String                                              @map("normalization_run_id") @outcomes.Text
+  factBatchId         String                                              @map("fact_batch_id") @outcomes.Text
+  factualRunId        String                                              @map("factual_run_id") @outcomes.Text
+  candidateId         String                                              @unique @map("candidate_id") @outcomes.Text
+  factualReleaseId    String                                              @unique @map("factual_release_id") @outcomes.Text
+  preparedAt          DateTime                                            @map("prepared_at") @outcomes.Timestamptz(3)
+  outputJson          Json                                                @map("output_json")
+  request             OutcomePrivateValuationDispatchRequest             @relation(fields: [requestId], references: [requestId], onDelete: Restrict)
+  captureBinding      OutcomePrivateValuationCaptureBinding               @relation(fields: [captureBindingId], references: [bindingId], onDelete: Restrict)
+  sourceAdmission     OutcomePrivateValuationSourceAdmission              @relation(fields: [sourceAdmissionId], references: [admissionId], onDelete: Restrict)
+  factBatch           OutcomeProviderFactBatch                            @relation(fields: [factBatchId], references: [factBatchId], onDelete: Restrict)
+  factualRun          OutcomeFactualReconciliationRun                     @relation(fields: [factualRunId], references: [factualRunId], onDelete: Restrict)
+  candidate           OutcomeFactualReleaseCandidate                      @relation(fields: [candidateId], references: [candidateId], onDelete: Restrict)
+  factualRelease      OutcomeReleaseManifest                              @relation(fields: [factualReleaseId], references: [releaseId], onDelete: Restrict)
+  spellMetricBatches  OutcomePrivateValuationFactualOutputSpellBatch[]
+
+  @@map("outcome_private_valuation_factual_output")
+}
+
+model OutcomePrivateValuationFactualOutputSpellBatch {
+  outputId String                                       @map("output_id") @outcomes.Text
+  batchId  String                                       @map("batch_id") @outcomes.Text
+  ordinal  Int
+  output   OutcomePrivateValuationFactualOutput          @relation(fields: [outputId], references: [outputId], onDelete: Restrict)
+  batch    OutcomeAcquisitionSpellMetricBatch            @relation(fields: [batchId], references: [batchId], onDelete: Restrict)
+
+  @@id([outputId, batchId])
+  @@unique([outputId, ordinal], map: "outcome_private_factual_output_spell_ordinal_key")
+  @@map("outcome_private_valuation_factual_output_spell_batch")
 }
 
 model OutcomePrivateEvaluationTransitionReceipt {

--- a/src/server/aflTradeIntelligence/outcomes/postgresAcquisitionSpellMetricRepository.ts
+++ b/src/server/aflTradeIntelligence/outcomes/postgresAcquisitionSpellMetricRepository.ts
@@ -238,7 +238,12 @@ async function requireExactPolicy(
 
 function canonicalDate(value: string | Date | null): string | null {
   if (value === null) return null;
-  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  if (value instanceof Date) {
+    const year = value.getFullYear();
+    const month = String(value.getMonth() + 1).padStart(2, '0');
+    const day = String(value.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
   return value.slice(0, 10);
 }
 

--- a/src/server/aflTradeIntelligence/valuation/internal/privateValuationFactualOutputMaterializer.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/privateValuationFactualOutputMaterializer.ts
@@ -84,6 +84,16 @@ export async function materializeAflTradePrivateValuationFactualOutput(
         AND request.scope_key=candidate.scope_key
         AND candidate.environment='non_production'
         AND NOT EXISTS (
+          SELECT 1
+            FROM outcome_release_source_capture candidate_source
+           WHERE candidate_source.release_id=candidate.target_release_id
+             AND candidate_source.capture_id<>binding.source_capture_id)
+        AND NOT EXISTS (
+          SELECT 1
+            FROM outcome_release_factual_run_member candidate_run
+           WHERE candidate_run.candidate_id=candidate.candidate_id
+             AND candidate_run.factual_run_id<>factual_run.factual_run_id)
+        AND NOT EXISTS (
           SELECT 1 FROM outcome_registry_event event
            WHERE event.release_id=candidate.target_release_id)
       GROUP BY request.scope_key,binding.binding_id,admission.admission_id,

--- a/src/server/aflTradeIntelligence/valuation/internal/privateValuationFactualOutputMaterializer.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/privateValuationFactualOutputMaterializer.ts
@@ -1,0 +1,166 @@
+import type { AflOutcomeSqlClient } from '../../outcomes/postgresOutcomeReleaseRepository';
+import {
+  createAflTradePrivateValuationFactualOutput,
+  type AflTradePrivateValuationFactualOutput,
+} from '../privateValuationFactualOutput';
+
+interface ParentRow {
+  scope_key: string;
+  binding_id: string;
+  source_admission_id: string;
+  normalization_run_id: string;
+  fact_batch_id: string;
+  fact_batch_sha256: string;
+  factual_run_id: string;
+  run_sha256: string;
+  output_set_sha256: string;
+  factual_run_finalized_at: Date | string;
+  candidate_id: string;
+  candidate_sha256: string;
+  member_set_sha256: string;
+  target_release_id: string;
+  candidate_finalized_at: Date | string;
+}
+
+interface SpellBatchRow {
+  batch_id: string;
+  batch_sha256: string;
+}
+
+function asIso(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+export class AflTradePrivateValuationFactualOutputUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AflTradePrivateValuationFactualOutputUnavailableError';
+  }
+}
+
+export async function materializeAflTradePrivateValuationFactualOutput(
+  client: AflOutcomeSqlClient,
+  input: { requestId: string; candidateId: string }
+): Promise<AflTradePrivateValuationFactualOutput> {
+  const parents = await client.query<ParentRow>(
+    `SELECT request.scope_key,binding.binding_id,admission.admission_id AS source_admission_id,
+            binding.normalization_run_id,
+            fact_batch.fact_batch_id,fact_batch.fact_batch_sha256,
+            factual_run.factual_run_id,factual_run.run_sha256,factual_run.output_set_sha256,
+            factual_run.finalized_at AS factual_run_finalized_at,
+            candidate.candidate_id,candidate.candidate_sha256,candidate.member_set_sha256,
+            candidate.target_release_id,candidate.finalized_at AS candidate_finalized_at
+       FROM outcome_private_valuation_dispatch_request request
+       JOIN outcome_private_valuation_capture_binding binding
+         ON binding.request_id=request.request_id
+       JOIN outcome_private_valuation_source_admission admission
+         ON admission.request_id=request.request_id
+        AND admission.capture_binding_id=binding.binding_id
+        AND admission.source_capture_id=binding.source_capture_id
+        AND admission.normalization_run_id=binding.normalization_run_id
+       JOIN outcome_provider_fact_batch fact_batch
+         ON fact_batch.fact_batch_id=admission.fact_batch_id
+        AND fact_batch.normalization_run_id=binding.normalization_run_id
+        AND fact_batch.capture_id=binding.source_capture_id
+        AND fact_batch.status='approved' AND fact_batch.finalized_at IS NOT NULL
+       JOIN outcome_provider_numeric_metric_fact metric_fact
+         ON metric_fact.fact_batch_id=fact_batch.fact_batch_id
+       JOIN outcome_factual_reconciliation_metric_input metric_input
+         ON metric_input.metric_fact_id=metric_fact.metric_fact_id
+       JOIN outcome_factual_reconciliation_run factual_run
+         ON factual_run.factual_run_id=admission.factual_run_id
+        AND factual_run.factual_run_id=metric_input.factual_run_id
+        AND factual_run.status='approved' AND factual_run.finalized_at IS NOT NULL
+       JOIN outcome_release_factual_run_member factual_member
+         ON factual_member.factual_run_id=factual_run.factual_run_id
+       JOIN outcome_factual_release_candidate candidate
+         ON candidate.candidate_id=factual_member.candidate_id
+        AND candidate.status='approved' AND candidate.finalized_at IS NOT NULL
+       JOIN outcome_release_source_capture source_member
+         ON source_member.release_id=candidate.target_release_id
+        AND source_member.capture_id=binding.source_capture_id
+      WHERE request.request_id=$1
+        AND candidate.candidate_id=$2
+        AND request.scope_key=candidate.scope_key
+        AND candidate.environment='non_production'
+        AND NOT EXISTS (
+          SELECT 1 FROM outcome_registry_event event
+           WHERE event.release_id=candidate.target_release_id)
+      GROUP BY request.scope_key,binding.binding_id,admission.admission_id,
+               binding.normalization_run_id,
+               fact_batch.fact_batch_id,fact_batch.fact_batch_sha256,
+               factual_run.factual_run_id,factual_run.run_sha256,factual_run.output_set_sha256,
+               factual_run.finalized_at,candidate.candidate_id,candidate.candidate_sha256,
+               candidate.member_set_sha256,candidate.target_release_id,candidate.finalized_at`,
+    [input.requestId, input.candidateId]
+  );
+  if (parents.rows.length !== 1) {
+    throw new AflTradePrivateValuationFactualOutputUnavailableError(
+      'Private factual preparation requires one exact finalized fact, reconciliation, and candidate chain.'
+    );
+  }
+  const parent = parents.rows[0];
+  const batches = await client.query<SpellBatchRow>(
+    `SELECT DISTINCT batch.batch_id,batch.batch_sha256
+       FROM outcome_release_spell_metric_member candidate_member
+       JOIN outcome_acquisition_spell_metric_version metric_version
+         ON metric_version.spell_metric_version_id=candidate_member.spell_metric_version_id
+       JOIN outcome_acquisition_spell_metric_batch batch
+         ON batch.batch_id=metric_version.batch_id
+        AND batch.status='approved' AND batch.finalized_at IS NOT NULL
+      JOIN outcome_acquisition_spell_metric_version_member factual_member
+         ON factual_member.spell_metric_version_id=metric_version.spell_metric_version_id
+        AND factual_member.factual_run_id=$2
+      WHERE candidate_member.candidate_id=$1
+        AND NOT EXISTS (
+          SELECT 1
+            FROM outcome_release_spell_metric_member sibling_member
+            JOIN outcome_acquisition_spell_metric_version sibling_version
+              ON sibling_version.spell_metric_version_id=sibling_member.spell_metric_version_id
+           WHERE sibling_member.candidate_id=candidate_member.candidate_id
+             AND sibling_version.batch_id=batch.batch_id
+             AND EXISTS (
+               SELECT 1
+                 FROM outcome_acquisition_spell_metric_version_member foreign_member
+                WHERE foreign_member.spell_metric_version_id=sibling_version.spell_metric_version_id
+                  AND foreign_member.factual_run_id<>$2))
+      ORDER BY batch.batch_id`,
+    [parent.candidate_id, parent.factual_run_id]
+  );
+  if (batches.rows.length === 0) {
+    throw new AflTradePrivateValuationFactualOutputUnavailableError(
+      'Private factual preparation requires finalized acquisition-spell metrics from the exact factual run.'
+    );
+  }
+  return createAflTradePrivateValuationFactualOutput({
+    requestId: input.requestId,
+    valuationScopeKey: parent.scope_key,
+    captureBindingId: parent.binding_id,
+    sourceAdmissionId: parent.source_admission_id,
+    normalizationRunId: parent.normalization_run_id,
+    factBatch: {
+      batchId: parent.fact_batch_id,
+      batchSha256: parent.fact_batch_sha256,
+    },
+    reconciliation: {
+      factualRunId: parent.factual_run_id,
+      runSha256: parent.run_sha256,
+      outputSetSha256: parent.output_set_sha256,
+      finalizedAt: asIso(parent.factual_run_finalized_at),
+    },
+    spellMetricBatches: batches.rows.map((batch) => ({
+      batchId: batch.batch_id,
+      batchSha256: batch.batch_sha256,
+    })),
+    candidate: {
+      candidateId: parent.candidate_id,
+      candidateSha256: parent.candidate_sha256,
+      memberSetSha256: parent.member_set_sha256,
+    },
+    factualRelease: {
+      releaseId: parent.target_release_id,
+      releaseSha256: parent.target_release_id.slice('outcome-release:'.length),
+    },
+    preparedAt: asIso(parent.candidate_finalized_at),
+  });
+}

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationFactualPreparation.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationFactualPreparation.ts
@@ -1,0 +1,152 @@
+import { createHash } from 'node:crypto';
+
+import { z } from 'zod';
+
+import { canonicalizeAflTradeJson } from '../artifacts/contentAddress';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../outcomes/postgresOutcomeReleaseRepository';
+import { materializeAflTradePrivateValuationFactualOutput } from './internal/privateValuationFactualOutputMaterializer';
+import {
+  parseAflTradePrivateValuationFactualOutput,
+  type AflTradePrivateValuationFactualOutput,
+} from './privateValuationFactualOutput';
+import { PostgresAflTradePrivateValuationSourceAdmission } from './postgresPrivateValuationSourceAdmission';
+import type { AflTradePrivateValuationSourceAdmission } from './privateValuationSourceAdmission';
+
+const EXECUTION_DATABASE_ROLE = 'afl_trade_private_evaluation_coordinator';
+const requestIdSchema = z.string().regex(/^private-valuation-dispatch:[a-f0-9]{64}$/);
+const claimIdSchema = z.string().regex(/^private-valuation-dispatch-claim:[a-f0-9]{64}$/);
+const leaseTokenSchema = z.string().regex(/^[a-f0-9]{64}$/);
+const candidateIdSchema = z.string().regex(/^factual-release-candidate:[a-f0-9]{64}$/);
+
+export type AflTradePrivateValuationFactualPreparationResult =
+  | { readonly state: 'prepared'; readonly output: AflTradePrivateValuationFactualOutput }
+  | { readonly state: 'already_prepared'; readonly output: AflTradePrivateValuationFactualOutput };
+
+export interface AflTradePrivateValuationFactualPreparationDependencies {
+  readonly prepareSourceEvidence: (input: {
+    readonly requestId: string;
+    readonly claim: { readonly claimId: string; readonly leaseToken: string };
+  }) => Promise<void>;
+  readonly prepareCandidate: (input: {
+    readonly requestId: string;
+    readonly admission: AflTradePrivateValuationSourceAdmission;
+  }) => Promise<{ readonly candidateId: string }>;
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function requireExactOutput(
+  expected: AflTradePrivateValuationFactualOutput,
+  actual: AflTradePrivateValuationFactualOutput
+): AflTradePrivateValuationFactualOutput {
+  if (canonicalizeAflTradeJson(expected) !== canonicalizeAflTradeJson(actual)) {
+    throw new TypeError('Retained factual output conflicts with its materialized parent chain.');
+  }
+  return actual;
+}
+
+export class PostgresAflTradePrivateFactualPreparation {
+  constructor(
+    private readonly client: AflOutcomeSqlClient,
+    private readonly dependencies: AflTradePrivateValuationFactualPreparationDependencies
+  ) {}
+
+  private async load(
+    transaction: AflOutcomeSqlTransaction,
+    requestId: string
+  ): Promise<AflTradePrivateValuationFactualOutput | null> {
+    const retained = await transaction.query<{ output_json: unknown }>(
+      `SELECT output_json FROM outcome_private_valuation_factual_output WHERE request_id=$1`,
+      [requestId]
+    );
+    if (retained.rows.length === 0) return null;
+    if (retained.rows.length !== 1) {
+      throw new TypeError('Dispatch has more than one retained factual output.');
+    }
+    return parseAflTradePrivateValuationFactualOutput(retained.rows[0].output_json);
+  }
+
+  private async retain(
+    transaction: AflOutcomeSqlTransaction,
+    input: {
+      readonly requestId: string;
+      readonly claimId: string;
+      readonly leaseToken: string;
+      readonly output: AflTradePrivateValuationFactualOutput;
+    }
+  ): Promise<AflTradePrivateValuationFactualOutput> {
+    const retained = await transaction.query<{ output_json: unknown }>(
+      `SELECT retain_outcome_private_valuation_factual_output($1,$2,$3,$4::jsonb)
+              AS output_json`,
+      [
+        input.requestId,
+        input.claimId,
+        sha256(input.leaseToken),
+        canonicalizeAflTradeJson(input.output),
+      ]
+    );
+    if (retained.rows.length !== 1) {
+      throw new TypeError('Factual preparation did not retain exactly one result.');
+    }
+    return requireExactOutput(
+      input.output,
+      parseAflTradePrivateValuationFactualOutput(retained.rows[0].output_json)
+    );
+  }
+
+  async prepare(input: {
+    readonly requestId: string;
+    readonly claim: { readonly claimId: string; readonly leaseToken: string };
+  }): Promise<AflTradePrivateValuationFactualPreparationResult> {
+    const requestId = requestIdSchema.parse(input.requestId);
+    const claimId = claimIdSchema.parse(input.claim.claimId);
+    const leaseToken = leaseTokenSchema.parse(input.claim.leaseToken);
+    return this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      await transaction.query(`SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, [
+        `outcome-private-valuation-factual-preparation:${requestId}`,
+      ]);
+      const replay = await this.load(transaction, requestId);
+      if (replay) {
+        return {
+          state: 'already_prepared' as const,
+          output: await this.retain(transaction, {
+            requestId,
+            claimId,
+            leaseToken,
+            output: replay,
+          }),
+        };
+      }
+
+      const claim = { claimId, leaseToken };
+      await this.dependencies.prepareSourceEvidence({ requestId, claim });
+      const admission = await new PostgresAflTradePrivateValuationSourceAdmission(
+        this.client
+      ).admit({ requestId, claim });
+      const candidate = await this.dependencies.prepareCandidate({
+        requestId,
+        admission: admission.admission,
+      });
+      const candidateId = candidateIdSchema.parse(candidate.candidateId);
+      const materialized = await materializeAflTradePrivateValuationFactualOutput(this.client, {
+        requestId,
+        candidateId,
+      });
+      return {
+        state: 'prepared' as const,
+        output: await this.retain(transaction, {
+          requestId,
+          claimId,
+          leaseToken,
+          output: materialized,
+        }),
+      };
+    });
+  }
+}

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationSourceAdmission.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationSourceAdmission.ts
@@ -1,0 +1,60 @@
+import { createHash } from 'node:crypto';
+
+import { z } from 'zod';
+
+import type { AflOutcomeSqlClient } from '../outcomes/postgresOutcomeReleaseRepository';
+import {
+  parseAflTradePrivateValuationSourceAdmission,
+  type AflTradePrivateValuationSourceAdmission,
+} from './privateValuationSourceAdmission';
+
+const EXECUTION_DATABASE_ROLE = 'afl_trade_private_evaluation_coordinator';
+const requestIdSchema = z.string().regex(/^private-valuation-dispatch:[a-f0-9]{64}$/);
+const claimIdSchema = z.string().regex(/^private-valuation-dispatch-claim:[a-f0-9]{64}$/);
+const leaseTokenSchema = z.string().regex(/^[a-f0-9]{64}$/);
+const admissionResultSchema = z
+  .object({
+    state: z.enum(['admitted', 'already_admitted']),
+    admission: z.unknown(),
+  })
+  .strict();
+
+export type AflTradePrivateValuationSourceAdmissionResult =
+  | { readonly state: 'admitted'; readonly admission: AflTradePrivateValuationSourceAdmission }
+  | {
+      readonly state: 'already_admitted';
+      readonly admission: AflTradePrivateValuationSourceAdmission;
+    };
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+export class PostgresAflTradePrivateValuationSourceAdmission {
+  constructor(private readonly client: AflOutcomeSqlClient) {}
+
+  async admit(input: {
+    readonly requestId: string;
+    readonly claim: { readonly claimId: string; readonly leaseToken: string };
+  }): Promise<AflTradePrivateValuationSourceAdmissionResult> {
+    const requestId = requestIdSchema.parse(input.requestId);
+    const claimId = claimIdSchema.parse(input.claim.claimId);
+    const leaseToken = leaseTokenSchema.parse(input.claim.leaseToken);
+    const retained = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<{ admission_result: unknown }>(
+        `SELECT admit_outcome_private_valuation_dispatch_source($1,$2,$3)
+                AS admission_result`,
+        [requestId, claimId, sha256(leaseToken)]
+      );
+    });
+    if (retained.rows.length !== 1) {
+      throw new TypeError('Source admission did not retain exactly one result.');
+    }
+    const result = admissionResultSchema.parse(retained.rows[0]?.admission_result);
+    return {
+      state: result.state,
+      admission: parseAflTradePrivateValuationSourceAdmission(result.admission),
+    };
+  }
+}

--- a/src/server/aflTradeIntelligence/valuation/privateValuationFactualOutput.ts
+++ b/src/server/aflTradeIntelligence/valuation/privateValuationFactualOutput.ts
@@ -1,0 +1,175 @@
+import { z } from 'zod';
+
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  aflTradeSha256Schema,
+  createAflTradeContentAddress,
+} from '../artifacts/contentAddress';
+
+export const AFL_TRADE_PRIVATE_VALUATION_FACTUAL_OUTPUT_SCHEMA_VERSION =
+  'afl-trade-private-valuation-factual-output/v1' as const;
+export const AFL_TRADE_PRIVATE_VALUATION_FACTUAL_OUTPUT_LIMITATION =
+  'Retained non-production factual preparation custody only; it grants no model-training, private-evaluation, publication, or production authority.' as const;
+
+const boundedPublicIdSchema = z.string().trim().min(1).max(300);
+const utcInstantSchema = z
+  .string()
+  .datetime({ offset: true, precision: 3 })
+  .regex(/Z$/, 'Factual-output instants must use canonical UTC Z notation.');
+
+function immutableReferenceSchema(prefix: string, idKey: string, shaKey: string) {
+  return z
+    .object({
+      [idKey]: aflTradeContentAddressedIdSchema(prefix),
+      [shaKey]: aflTradeSha256Schema,
+    })
+    .strict()
+    .superRefine((reference, context) => {
+      if (reference[idKey] !== `${prefix}:${reference[shaKey]}`) {
+        context.addIssue({
+          code: 'custom',
+          path: [shaKey],
+          message: `${prefix} digest must equal its content-address suffix.`,
+        });
+      }
+    });
+}
+
+const factBatchSchema = immutableReferenceSchema('source-fact-batch', 'batchId', 'batchSha256');
+const spellMetricBatchSchema = immutableReferenceSchema(
+  'acquisition-spell-metric-batch',
+  'batchId',
+  'batchSha256'
+);
+const candidateSchema = immutableReferenceSchema(
+  'factual-release-candidate',
+  'candidateId',
+  'candidateSha256'
+).extend({ memberSetSha256: aflTradeSha256Schema });
+const factualReleaseSchema = immutableReferenceSchema(
+  'outcome-release',
+  'releaseId',
+  'releaseSha256'
+);
+
+export const aflTradePrivateValuationFactualOutputContentSchema = z
+  .object({
+    schemaVersion: z.literal(AFL_TRADE_PRIVATE_VALUATION_FACTUAL_OUTPUT_SCHEMA_VERSION),
+    requestId: aflTradeContentAddressedIdSchema('private-valuation-dispatch'),
+    valuationScopeKey: boundedPublicIdSchema,
+    captureBindingId: aflTradeContentAddressedIdSchema('private-valuation-capture-binding'),
+    sourceAdmissionId: aflTradeContentAddressedIdSchema(
+      'private-valuation-source-admission'
+    ),
+    normalizationRunId: aflTradeContentAddressedIdSchema('provider-normalization-run'),
+    factBatch: factBatchSchema,
+    reconciliation: z
+      .object({
+        factualRunId: aflTradeContentAddressedIdSchema('factual-reconciliation-run'),
+        runSha256: aflTradeSha256Schema,
+        outputSetSha256: aflTradeSha256Schema,
+        finalizedAt: utcInstantSchema,
+      })
+      .strict()
+      .superRefine((reconciliation, context) => {
+        if (
+          reconciliation.factualRunId !==
+          `factual-reconciliation-run:${reconciliation.runSha256}`
+        ) {
+          context.addIssue({
+            code: 'custom',
+            path: ['runSha256'],
+            message: 'Factual-reconciliation-run digest must equal its content-address suffix.',
+          });
+        }
+      }),
+    spellMetricBatches: z.array(spellMetricBatchSchema).min(1).max(100_000),
+    candidate: candidateSchema,
+    factualRelease: factualReleaseSchema,
+    preparedAt: utcInstantSchema,
+    environment: z.literal('non_production'),
+    publicationEligible: z.literal(false),
+    publicationProhibited: z.literal(true),
+    limitation: z.literal(AFL_TRADE_PRIVATE_VALUATION_FACTUAL_OUTPUT_LIMITATION),
+  })
+  .strict()
+  .superRefine((content, context) => {
+    const batchIds = content.spellMetricBatches.map(({ batchId }) => batchId);
+    if (new Set(batchIds).size !== batchIds.length) {
+      context.addIssue({
+        code: 'custom',
+        path: ['spellMetricBatches'],
+        message: 'Spell-metric batch references must be unique.',
+      });
+    }
+    if (batchIds.some((batchId, index) => index > 0 && batchIds[index - 1]! > batchId)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['spellMetricBatches'],
+        message: 'Spell-metric batch references must use canonical order.',
+      });
+    }
+    if (Date.parse(content.preparedAt) < Date.parse(content.reconciliation.finalizedAt)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['preparedAt'],
+        message: 'Factual output cannot predate reconciliation finalization.',
+      });
+    }
+  });
+
+export const aflTradePrivateValuationFactualOutputSchema = z
+  .object({
+    outputId: aflTradeContentAddressedIdSchema('private-valuation-factual-output'),
+    content: aflTradePrivateValuationFactualOutputContentSchema,
+  })
+  .strict()
+  .superRefine((output, context) => {
+    addAflTradeContentAddressIssue(
+      'private-valuation-factual-output',
+      output.outputId,
+      output.content,
+      context,
+      ['outputId']
+    );
+  });
+
+export type AflTradePrivateValuationFactualOutput = z.infer<
+  typeof aflTradePrivateValuationFactualOutputSchema
+>;
+
+export type CreateAflTradePrivateValuationFactualOutputInput = Omit<
+  z.input<typeof aflTradePrivateValuationFactualOutputContentSchema>,
+  'schemaVersion' | 'environment' | 'publicationEligible' | 'publicationProhibited' | 'limitation'
+>;
+
+export function createAflTradePrivateValuationFactualOutput(
+  input: CreateAflTradePrivateValuationFactualOutputInput
+): AflTradePrivateValuationFactualOutput {
+  const spellMetricBatches = [...input.spellMetricBatches].sort((left, right) =>
+    left.batchId.localeCompare(right.batchId)
+  );
+  if (new Set(spellMetricBatches.map(({ batchId }) => batchId)).size !== spellMetricBatches.length) {
+    throw new TypeError('Spell-metric batch references must be unique.');
+  }
+  const content = aflTradePrivateValuationFactualOutputContentSchema.parse({
+    ...input,
+    schemaVersion: AFL_TRADE_PRIVATE_VALUATION_FACTUAL_OUTPUT_SCHEMA_VERSION,
+    spellMetricBatches,
+    environment: 'non_production',
+    publicationEligible: false,
+    publicationProhibited: true,
+    limitation: AFL_TRADE_PRIVATE_VALUATION_FACTUAL_OUTPUT_LIMITATION,
+  });
+  return aflTradePrivateValuationFactualOutputSchema.parse({
+    outputId: createAflTradeContentAddress('private-valuation-factual-output', content),
+    content,
+  });
+}
+
+export function parseAflTradePrivateValuationFactualOutput(
+  value: unknown
+): AflTradePrivateValuationFactualOutput {
+  return aflTradePrivateValuationFactualOutputSchema.parse(value);
+}

--- a/src/server/aflTradeIntelligence/valuation/privateValuationSourceAdmission.ts
+++ b/src/server/aflTradeIntelligence/valuation/privateValuationSourceAdmission.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  createAflTradeContentAddress,
+} from '../artifacts/contentAddress';
+import { AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID } from './automatedPrivateEvaluationPolicy';
+
+export const AFL_TRADE_PRIVATE_VALUATION_SOURCE_ADMISSION_SCHEMA_VERSION =
+  'afl-trade-private-valuation-source-admission/v1' as const;
+export const AFL_TRADE_PRIVATE_VALUATION_SOURCE_ADMISSION_LIMITATION =
+  'Non-production private-calculation source admission only; it grants no model, public-display, redistribution, publication, or production authority.' as const;
+
+const instantSchema = z.string().datetime({ offset: true });
+
+export const aflTradePrivateValuationSourceAdmissionContentSchema = z
+  .object({
+    schemaVersion: z.literal(AFL_TRADE_PRIVATE_VALUATION_SOURCE_ADMISSION_SCHEMA_VERSION),
+    requestId: aflTradeContentAddressedIdSchema('private-valuation-dispatch'),
+    captureBindingId: aflTradeContentAddressedIdSchema('private-valuation-capture-binding'),
+    sourceCaptureId: aflTradeContentAddressedIdSchema('source-capture'),
+    normalizationRunId: aflTradeContentAddressedIdSchema('provider-normalization-run'),
+    factBatchId: aflTradeContentAddressedIdSchema('source-fact-batch'),
+    factualRunId: aflTradeContentAddressedIdSchema('factual-reconciliation-run'),
+    admittedAt: instantSchema,
+    principalId: z.literal(AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID),
+    environment: z.literal('non_production'),
+    publicationEligible: z.literal(false),
+    publicationProhibited: z.literal(true),
+    limitation: z.literal(AFL_TRADE_PRIVATE_VALUATION_SOURCE_ADMISSION_LIMITATION),
+  })
+  .strict();
+
+export const aflTradePrivateValuationSourceAdmissionSchema = z
+  .object({
+    admissionId: aflTradeContentAddressedIdSchema('private-valuation-source-admission'),
+    content: aflTradePrivateValuationSourceAdmissionContentSchema,
+  })
+  .strict()
+  .superRefine((admission, context) => {
+    addAflTradeContentAddressIssue(
+      'private-valuation-source-admission',
+      admission.admissionId,
+      admission.content,
+      context,
+      ['admissionId']
+    );
+  });
+
+export type AflTradePrivateValuationSourceAdmission = z.infer<
+  typeof aflTradePrivateValuationSourceAdmissionSchema
+>;
+
+export function createAflTradePrivateValuationSourceAdmission(
+  input: Omit<
+    z.input<typeof aflTradePrivateValuationSourceAdmissionContentSchema>,
+    | 'schemaVersion'
+    | 'principalId'
+    | 'environment'
+    | 'publicationEligible'
+    | 'publicationProhibited'
+    | 'limitation'
+  >
+): AflTradePrivateValuationSourceAdmission {
+  const content = aflTradePrivateValuationSourceAdmissionContentSchema.parse({
+    schemaVersion: AFL_TRADE_PRIVATE_VALUATION_SOURCE_ADMISSION_SCHEMA_VERSION,
+    ...input,
+    principalId: AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID,
+    environment: 'non_production',
+    publicationEligible: false,
+    publicationProhibited: true,
+    limitation: AFL_TRADE_PRIVATE_VALUATION_SOURCE_ADMISSION_LIMITATION,
+  });
+  return aflTradePrivateValuationSourceAdmissionSchema.parse({
+    admissionId: createAflTradeContentAddress('private-valuation-source-admission', content),
+    content,
+  });
+}
+
+export function parseAflTradePrivateValuationSourceAdmission(
+  value: unknown
+): AflTradePrivateValuationSourceAdmission {
+  return aflTradePrivateValuationSourceAdmissionSchema.parse(value);
+}

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1098,6 +1098,10 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0069_private_valuation_dispatch',
       '0070_private_valuation_dispatch_custody',
       '0071_private_valuation_capture_binding',
+      '0072_private_valuation_factual_output',
+      '0073_automated_nonproduction_source_admission',
+      '0074_bind_factual_output_to_source_admission',
+      '0075_versioned_release_acquisition_spell_eligibility',
     ]);
 
     const tables = await query<{ table_name: string }>(

--- a/tests/outcomes-integration/afl-private-valuation-factual-preparation-postgres.test.ts
+++ b/tests/outcomes-integration/afl-private-valuation-factual-preparation-postgres.test.ts
@@ -225,6 +225,53 @@ describe.sequential('private valuation factual preparation in PostgreSQL', () =>
       ).rejects.toThrow(/finalized acquisition-spell metrics from the exact factual run/);
       await transaction.query('ROLLBACK TO SAVEPOINT mixed_run_attack');
     });
+    await client.transaction(async (transaction) => {
+      await transaction.query('SAVEPOINT extra_source_attack');
+      await transaction.query(`SET LOCAL session_replication_role='replica'`);
+      await transaction.query(
+        `INSERT INTO outcome_release_source_capture
+          (release_id,capture_id,ordinal,record_sha256,membership_json)
+         SELECT $1,$2,COALESCE(MAX(ordinal),0)+1,$3,'{}'::jsonb
+           FROM outcome_release_source_capture
+          WHERE release_id=$1`,
+        [
+          result.output.content.factualRelease.releaseId,
+          `source-capture:${'e'.repeat(64)}`,
+          'e'.repeat(64),
+        ]
+      );
+      await transaction.query(`SET LOCAL session_replication_role='origin'`);
+      await expect(
+        materializeAflTradePrivateValuationFactualOutput(transaction, {
+          requestId: staged.requestId,
+          candidateId: result.output.content.candidate.candidateId,
+        })
+      ).rejects.toThrow(/exact finalized fact, reconciliation, and candidate chain/);
+      await transaction.query('ROLLBACK TO SAVEPOINT extra_source_attack');
+
+      await transaction.query('SAVEPOINT extra_run_attack');
+      await transaction.query(`SET LOCAL session_replication_role='replica'`);
+      await transaction.query(
+        `INSERT INTO outcome_release_factual_run_member
+          (candidate_id,factual_run_id,ordinal,record_sha256,membership_json)
+         SELECT $1,$2,COALESCE(MAX(ordinal),0)+1,$3,'{}'::jsonb
+           FROM outcome_release_factual_run_member
+          WHERE candidate_id=$1`,
+        [
+          result.output.content.candidate.candidateId,
+          `factual-reconciliation-run:${'d'.repeat(64)}`,
+          'd'.repeat(64),
+        ]
+      );
+      await transaction.query(`SET LOCAL session_replication_role='origin'`);
+      await expect(
+        materializeAflTradePrivateValuationFactualOutput(transaction, {
+          requestId: staged.requestId,
+          candidateId: result.output.content.candidate.candidateId,
+        })
+      ).rejects.toThrow(/exact finalized fact, reconciliation, and candidate chain/);
+      await transaction.query('ROLLBACK TO SAVEPOINT extra_run_attack');
+    });
     await expect(
       outcomesPool.query(
         `SELECT

--- a/tests/outcomes-integration/afl-private-valuation-factual-preparation-postgres.test.ts
+++ b/tests/outcomes-integration/afl-private-valuation-factual-preparation-postgres.test.ts
@@ -1,0 +1,325 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { prepareLocalAflTradeFitzRoyFactualReleaseCandidate } from '@/server/aflTradeIntelligence/development/localFitzRoyFactualRehearsal';
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import { materializeAflTradePrivateValuationFactualOutput } from '@/server/aflTradeIntelligence/valuation/internal/privateValuationFactualOutputMaterializer';
+import { PostgresAflTradePrivateFactualPreparation } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationFactualPreparation';
+import {
+  persistPrivateValuationFactualCandidateFixture,
+  seedPrivateValuationAcquisitionSpellFixture,
+  stageAcceptedPrivateValuationCaptureFixture,
+} from '../testUtils/privateValuationFactualPreparationFixture';
+import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('A disposable AFL_OUTCOMES_TEST_DATABASE_URL is required.');
+  })();
+const schemaName = `afl_fitzroy_factual_rehearsal_${process.pid}_${Date.now()}`;
+const adminPool = new Pool({ connectionString: databaseUrl });
+const outcomesPool = new Pool({
+  connectionString: databaseUrl,
+  options: `-c search_path=${schemaName}`,
+  max: 4,
+});
+
+function scopedDatabaseUrl(): string {
+  const scoped = new URL(databaseUrl);
+  scoped.searchParams.set('schema', schemaName);
+  return scoped.toString();
+}
+
+beforeAll(async () => {
+  await adminPool.query(`DO $role$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='afl_trade_nonproduction_spell_metric_policy_reviewer') THEN
+      CREATE ROLE afl_trade_nonproduction_spell_metric_policy_reviewer NOLOGIN;
+    END IF;
+  END $role$`);
+  await adminPool.query(
+    'GRANT afl_trade_nonproduction_spell_metric_policy_reviewer TO statly_test'
+  );
+  await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
+  runOutcomesPrismaTestCommand(['migrate', 'deploy'], { databaseUrl: scopedDatabaseUrl() });
+  await adminPool.query(
+    `GRANT USAGE ON SCHEMA "${schemaName}" TO afl_trade_nonproduction_spell_metric_policy_reviewer`
+  );
+  await adminPool.query(
+    `GRANT SELECT,INSERT ON "${schemaName}".outcome_review_decision TO afl_trade_nonproduction_spell_metric_policy_reviewer`
+  );
+});
+
+afterAll(async () => {
+  const failures: unknown[] = [];
+  try {
+    await outcomesPool.end();
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await adminPool.end();
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Private factual-preparation PostgreSQL cleanup failed.');
+  }
+});
+
+describe.sequential('private valuation factual preparation in PostgreSQL', () => {
+  it('prepares and exactly replays one accepted capture without changing public authority', async () => {
+    const client = createPgAflOutcomeSqlClient(outcomesPool);
+    const staged = await stageAcceptedPrivateValuationCaptureFixture(
+      client,
+      'private-factual-preparation-tracer'
+    );
+    const before = await outcomesPool.query<{
+      revision: number;
+      events: string;
+      active_releases: string;
+      projections: string;
+    }>(
+      `SELECT
+        (SELECT revision FROM outcome_registry_head WHERE singleton_id=1) AS revision,
+        (SELECT count(*)::text FROM outcome_registry_event) AS events,
+        (SELECT count(*)::text FROM outcome_active_release) AS active_releases,
+        (SELECT count(*)::text FROM outcome_projection_manifest) AS projections`
+    );
+
+    let factual: Awaited<ReturnType<typeof prepareLocalAflTradeFitzRoyFactualReleaseCandidate>>;
+    let sourcePreparationCalls = 0;
+    let candidatePreparationCalls = 0;
+    const preparation = new PostgresAflTradePrivateFactualPreparation(client, {
+      prepareSourceEvidence: async () => {
+        sourcePreparationCalls += 1;
+        factual = await prepareLocalAflTradeFitzRoyFactualReleaseCandidate(client);
+      },
+      prepareCandidate: async ({ admission }) => {
+        candidatePreparationCalls += 1;
+        expect(admission.content).toMatchObject({
+          requestId: staged.requestId,
+          captureBindingId: staged.binding.bindingId,
+          sourceCaptureId: staged.binding.content.sourceCaptureId,
+        });
+        const spell = await seedPrivateValuationAcquisitionSpellFixture(
+          client,
+          staged.binding.content.sourceCaptureId,
+          factual.candidate
+        );
+        const candidate = await persistPrivateValuationFactualCandidateFixture(
+          client,
+          factual.candidate,
+          spell,
+          staged.claim.request.scopeKey
+        );
+        return { candidateId: candidate.candidateId };
+      },
+    });
+    const preparationInput = {
+      requestId: staged.requestId,
+      claim: { claimId: staged.claim.claimId, leaseToken: staged.claim.leaseToken },
+    };
+    const concurrent = await Promise.all([
+      preparation.prepare(preparationInput),
+      preparation.prepare(preparationInput),
+    ]);
+    expect(concurrent.map(({ state }) => state).sort()).toEqual([
+      'already_prepared',
+      'prepared',
+    ]);
+    expect(sourcePreparationCalls).toBe(1);
+    expect(candidatePreparationCalls).toBe(1);
+    const result = concurrent.find(({ state }) => state === 'prepared');
+    if (!result) throw new TypeError('Concurrent preparation did not retain one created result.');
+    expect(concurrent[0]?.output).toEqual(concurrent[1]?.output);
+    await expect(
+      materializeAflTradePrivateValuationFactualOutput(client, {
+        requestId: staged.requestId,
+        candidateId: `factual-release-candidate:${'0'.repeat(64)}`,
+      })
+    ).rejects.toThrow(/exact finalized fact, reconciliation, and candidate chain/);
+
+    expect(result).toMatchObject({
+      state: 'prepared',
+      output: {
+        content: {
+          requestId: staged.requestId,
+          captureBindingId: staged.binding.bindingId,
+          sourceAdmissionId: expect.stringMatching(/^private-valuation-source-admission:/),
+          normalizationRunId: staged.binding.content.normalizationRunId,
+          factBatch: { batchId: expect.stringMatching(/^source-fact-batch:/) },
+          reconciliation: { factualRunId: expect.stringMatching(/^factual-reconciliation-run:/) },
+          spellMetricBatches: [
+            { batchId: expect.stringMatching(/^acquisition-spell-metric-batch:/) },
+          ],
+          candidate: { candidateId: expect.stringMatching(/^factual-release-candidate:/) },
+          factualRelease: { releaseId: expect.stringMatching(/^outcome-release:/) },
+          publicationEligible: false,
+          publicationProhibited: true,
+        },
+      },
+    });
+
+    const restarted = await new PostgresAflTradePrivateFactualPreparation(client, {
+      prepareSourceEvidence: async () => {
+        throw new Error('Restart replay must not rebuild factual evidence.');
+      },
+      prepareCandidate: async () => {
+        throw new Error('Restart replay must not rebuild the factual candidate.');
+      },
+    }).prepare({
+      requestId: staged.requestId,
+      claim: { claimId: staged.claim.claimId, leaseToken: staged.claim.leaseToken },
+    });
+    expect(restarted).toEqual({
+      state: 'already_prepared',
+      output: result.output,
+    });
+    const wrongLeaseToken = `${staged.claim.leaseToken[0] === 'f' ? 'e' : 'f'}${staged.claim.leaseToken.slice(1)}`;
+    await expect(
+      new PostgresAflTradePrivateFactualPreparation(client, {
+        prepareSourceEvidence: async () => {
+          throw new Error('Invalid replay authority must fail before source preparation.');
+        },
+        prepareCandidate: async () => {
+          throw new Error('Invalid replay authority must fail before candidate preparation.');
+        },
+      }).prepare({
+        requestId: staged.requestId,
+        claim: { claimId: staged.claim.claimId, leaseToken: wrongLeaseToken },
+      })
+    ).rejects.toThrow(/lost its live dispatch claim fence/);
+
+    await client.transaction(async (transaction) => {
+      await transaction.query('SAVEPOINT mixed_run_attack');
+      await transaction.query(`SET LOCAL session_replication_role='replica'`);
+      const mutated = await transaction.query(
+        `UPDATE outcome_acquisition_spell_metric_version_member
+            SET factual_run_id=$2
+          WHERE (spell_metric_version_id,reconciled_fact_id)=(
+            SELECT metric_member.spell_metric_version_id,metric_member.reconciled_fact_id
+              FROM outcome_release_spell_metric_member release_member
+              JOIN outcome_acquisition_spell_metric_version_member metric_member
+                ON metric_member.spell_metric_version_id=release_member.spell_metric_version_id
+             WHERE release_member.candidate_id=$1
+             ORDER BY metric_member.reconciled_fact_id
+             LIMIT 1)`,
+        [
+          result.output.content.candidate.candidateId,
+          `factual-reconciliation-run:${'f'.repeat(64)}`,
+        ]
+      );
+      expect(mutated.rowCount).toBe(1);
+      await transaction.query(`SET LOCAL session_replication_role='origin'`);
+      await expect(
+        materializeAflTradePrivateValuationFactualOutput(transaction, {
+          requestId: staged.requestId,
+          candidateId: result.output.content.candidate.candidateId,
+        })
+      ).rejects.toThrow(/finalized acquisition-spell metrics from the exact factual run/);
+      await transaction.query('ROLLBACK TO SAVEPOINT mixed_run_attack');
+    });
+    await expect(
+      outcomesPool.query(
+        `SELECT
+          (SELECT revision FROM outcome_registry_head WHERE singleton_id=1) AS revision,
+          (SELECT count(*)::text FROM outcome_registry_event) AS events,
+          (SELECT count(*)::text FROM outcome_active_release) AS active_releases,
+          (SELECT count(*)::text FROM outcome_projection_manifest) AS projections`
+      )
+    ).resolves.toMatchObject({ rows: before.rows });
+    await expect(
+      outcomesPool.query<{ outputs: string; admissions: string; candidates: string }>(
+        `SELECT
+          (SELECT count(*)::text FROM outcome_private_valuation_factual_output
+            WHERE request_id=$1) AS outputs,
+          (SELECT count(*)::text FROM outcome_private_valuation_source_admission
+            WHERE request_id=$1) AS admissions,
+          (SELECT count(*)::text FROM outcome_factual_release_candidate) AS candidates`,
+        [staged.requestId]
+      )
+    ).resolves.toMatchObject({
+      rows: [{ outputs: '1', admissions: '1', candidates: '1' }],
+    });
+    await expect(
+      outcomesPool.query<{ legacy_metrics: string; versioned_members: string }>(
+        `SELECT
+          (SELECT count(*)::text FROM outcome_acquisition_spell_metric) AS legacy_metrics,
+          (SELECT count(*)::text FROM outcome_release_spell_metric_member) AS versioned_members`
+      )
+    ).resolves.toMatchObject({
+      rows: [{ legacy_metrics: '0', versioned_members: '2' }],
+    });
+  });
+
+  it('rejects substituted spell ancestry and prevents legacy rows bypassing versioned checks', async () => {
+    const client = createPgAflOutcomeSqlClient(outcomesPool);
+    const factual = await prepareLocalAflTradeFitzRoyFactualReleaseCandidate(client);
+    const captureId = factual.candidate.content.members.sourceCaptures[0]?.captureId;
+    if (!captureId) throw new TypeError('The adversarial fixture requires one source capture.');
+
+    const substitutedSpell = await seedPrivateValuationAcquisitionSpellFixture(
+      client,
+      captureId,
+      factual.candidate,
+      'substituted-spell'
+    );
+    await expect(
+      persistPrivateValuationFactualCandidateFixture(
+        client,
+        factual.candidate,
+        substitutedSpell,
+        'afl-men:2026-trades',
+        { playerId: 'fixture-substituted-player' }
+      )
+    ).rejects.toThrow(/must equal the factual candidate declaration/);
+
+    const legacyBypassSpell = await seedPrivateValuationAcquisitionSpellFixture(
+      client,
+      captureId,
+      factual.candidate,
+      'legacy-bypass'
+    );
+    await client.query(
+      `INSERT INTO outcome_acquisition_spell_metric
+        (spell_version_id,metric_code,metric_definition_version,numeric_value,numerator,
+         denominator,coverage_state,observation_count,effective_through,evidence_json)
+       VALUES ($1,'games','games/v1',0,0,1,'complete',1,'2026-08-12','{}'::jsonb)`,
+      [legacyBypassSpell.spellVersionId]
+    );
+    await client.transaction(async (transaction) => {
+      await transaction.query(
+        'SET LOCAL ROLE afl_trade_nonproduction_spell_metric_policy_reviewer'
+      );
+      await transaction.query(
+        `INSERT INTO outcome_review_decision
+          (decision_id,subject_type,subject_id,decision,supersedes_decision_id,
+           rationale,evidence_json,decided_by,decided_at)
+         VALUES ($1,'acquisition_spell_metric_policy',$2,'withdrawn',$3,$4,$5::jsonb,$6,$7)`,
+        [
+          `spell-metric-policy-withdrawal:${legacyBypassSpell.policy.policyId}`,
+          legacyBypassSpell.policy.policyId,
+          legacyBypassSpell.policy.content.approval.id,
+          'Withdraw the disposable policy to prove legacy evidence cannot bypass versioned checks.',
+          JSON.stringify({ environment: 'non_production' }),
+          'private-valuation-fixture-reviewer',
+          '2026-08-12T00:05:00.000Z',
+        ]
+      );
+    });
+    await expect(
+      persistPrivateValuationFactualCandidateFixture(
+        client,
+        factual.candidate,
+        legacyBypassSpell,
+        'afl-men:2026-trades'
+      )
+    ).rejects.toThrow(/exact approved versioned metrics/);
+  });
+});

--- a/tests/outcomes-integration/afl-private-valuation-source-admission-postgres.test.ts
+++ b/tests/outcomes-integration/afl-private-valuation-source-admission-postgres.test.ts
@@ -1,0 +1,154 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { prepareLocalAflTradeFitzRoyFactualReleaseCandidate } from '@/server/aflTradeIntelligence/development/localFitzRoyFactualRehearsal';
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import { PostgresAflTradePrivateValuationSourceAdmission } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationSourceAdmission';
+import { stageAcceptedPrivateValuationCaptureFixture } from '../testUtils/privateValuationFactualPreparationFixture';
+import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('A disposable AFL_OUTCOMES_TEST_DATABASE_URL is required.');
+  })();
+const schemaName = `afl_fitzroy_factual_rehearsal_${process.pid}_${Date.now()}`;
+const adminPool = new Pool({ connectionString: databaseUrl });
+const outcomesPool = new Pool({
+  connectionString: databaseUrl,
+  options: `-c search_path=${schemaName}`,
+  max: 4,
+});
+
+function scopedDatabaseUrl(): string {
+  const scoped = new URL(databaseUrl);
+  scoped.searchParams.set('schema', schemaName);
+  return scoped.toString();
+}
+
+beforeAll(async () => {
+  await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
+  runOutcomesPrismaTestCommand(['migrate', 'deploy'], { databaseUrl: scopedDatabaseUrl() });
+});
+
+afterAll(async () => {
+  const failures: unknown[] = [];
+  try {
+    await outcomesPool.end();
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await adminPool.end();
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Private source-admission PostgreSQL cleanup failed.');
+  }
+});
+
+describe.sequential('private valuation source admission in PostgreSQL', () => {
+  it('admits and exactly replays one clean accepted capture without changing public authority', async () => {
+    const client = createPgAflOutcomeSqlClient(outcomesPool);
+    const staged = await stageAcceptedPrivateValuationCaptureFixture(
+      client,
+      'private-source-admission-tracer'
+    );
+    await prepareLocalAflTradeFitzRoyFactualReleaseCandidate(client);
+    const before = await outcomesPool.query<{
+      revision: number;
+      events: string;
+      active_releases: string;
+      projections: string;
+    }>(
+      `SELECT
+        (SELECT revision FROM outcome_registry_head WHERE singleton_id=1) AS revision,
+        (SELECT count(*)::text FROM outcome_registry_event) AS events,
+        (SELECT count(*)::text FROM outcome_active_release) AS active_releases,
+        (SELECT count(*)::text FROM outcome_projection_manifest) AS projections`
+    );
+
+    const admissionInput = {
+      requestId: staged.requestId,
+      claim: { claimId: staged.claim.claimId, leaseToken: staged.claim.leaseToken },
+    };
+    const concurrent = await Promise.all([
+      new PostgresAflTradePrivateValuationSourceAdmission(client).admit(admissionInput),
+      new PostgresAflTradePrivateValuationSourceAdmission(client).admit(admissionInput),
+    ]);
+    expect(concurrent.map(({ state }) => state).sort()).toEqual([
+      'admitted',
+      'already_admitted',
+    ]);
+    const result = concurrent.find(({ state }) => state === 'admitted');
+    if (!result) throw new TypeError('Concurrent admission did not retain one created result.');
+
+    expect(result).toMatchObject({
+      state: 'admitted',
+      admission: {
+        content: {
+          requestId: staged.requestId,
+          captureBindingId: staged.binding.bindingId,
+          sourceCaptureId: staged.binding.content.sourceCaptureId,
+          normalizationRunId: staged.binding.content.normalizationRunId,
+          factBatchId: expect.stringMatching(/^source-fact-batch:/),
+          factualRunId: expect.stringMatching(/^factual-reconciliation-run:/),
+          principalId: 'system:weekly-valuation-coordinator',
+          environment: 'non_production',
+          publicationEligible: false,
+          publicationProhibited: true,
+        },
+      },
+    });
+    await expect(
+      outcomesPool.query<{ status: string }>(
+        `SELECT status::text FROM outcome_source_capture WHERE capture_id=$1`,
+        [staged.binding.content.sourceCaptureId]
+      )
+    ).resolves.toMatchObject({ rows: [{ status: 'approved' }] });
+
+    const restarted = await new PostgresAflTradePrivateValuationSourceAdmission(client).admit({
+      requestId: staged.requestId,
+      claim: { claimId: staged.claim.claimId, leaseToken: staged.claim.leaseToken },
+    });
+    expect(restarted).toEqual({ state: 'already_admitted', admission: result.admission });
+    await expect(
+      outcomesPool.query(
+        `SELECT
+          (SELECT revision FROM outcome_registry_head WHERE singleton_id=1) AS revision,
+          (SELECT count(*)::text FROM outcome_registry_event) AS events,
+          (SELECT count(*)::text FROM outcome_active_release) AS active_releases,
+          (SELECT count(*)::text FROM outcome_projection_manifest) AS projections`
+      )
+    ).resolves.toMatchObject({ rows: before.rows });
+    await expect(
+      outcomesPool.query<{ admissions: string }>(
+        `SELECT count(*)::text AS admissions
+           FROM outcome_private_valuation_source_admission
+          WHERE request_id=$1`,
+        [staged.requestId]
+      )
+    ).resolves.toMatchObject({ rows: [{ admissions: '1' }] });
+    await expect(
+      outcomesPool.query(
+        `UPDATE outcome_source_capture SET status='staged' WHERE capture_id=$1`,
+        [staged.binding.content.sourceCaptureId]
+      )
+    ).rejects.toThrow(/requires exact automated non-production admission/);
+    await expect(
+      client.transaction(async (transaction) => {
+        await transaction.query('SET LOCAL ROLE afl_trade_private_evaluation_coordinator');
+        await transaction.query(
+          `UPDATE outcome_source_capture SET status='staged' WHERE capture_id=$1`,
+          [staged.binding.content.sourceCaptureId]
+        );
+      })
+    ).rejects.toThrow(/permission denied/);
+  });
+});

--- a/tests/testUtils/privateValuationFactualPreparationFixture.ts
+++ b/tests/testUtils/privateValuationFactualPreparationFixture.ts
@@ -1,0 +1,473 @@
+import {
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+  sha256AflTradeCanonicalJson,
+} from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import {
+  AFL_TRADE_ACQUISITION_SPELL_METRIC_AUTHORITY_BOUNDARY,
+  AFL_TRADE_ACQUISITION_SPELL_METRIC_POLICY_SCHEMA_VERSION,
+  createAflTradeAcquisitionSpellMetricPolicy,
+} from '@/server/aflTradeIntelligence/outcomes/acquisitionSpellMetricContracts';
+import { calculateAflTradeAcquisitionSpellMetrics } from '@/server/aflTradeIntelligence/outcomes/acquisitionSpellMetricService';
+import {
+  createAflTradeFactualReleaseCandidate,
+  type AflTradeFactualReleaseCandidate,
+} from '@/server/aflTradeIntelligence/outcomes/factualReleaseCandidateContracts';
+import {
+  createAflDraftTradeOutcomeFactualReleaseManifest,
+  type AflDraftTradeOutcomeFactualReleaseManifest,
+} from '@/server/aflTradeIntelligence/outcomes/outcomeReleaseContracts';
+import { PostgresAflTradeAcquisitionSpellMetricRepository } from '@/server/aflTradeIntelligence/outcomes/postgresAcquisitionSpellMetricRepository';
+import { PostgresAflTradeFactualReleaseCandidateWriter } from '@/server/aflTradeIntelligence/outcomes/postgresFactualReleaseCandidateRepository';
+import type { AflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { AFL_DRAFT_TRADE_OUTCOME_METRIC_DEFINITIONS } from '@/server/aflTradeIntelligence/outcomes/outcomeReadService';
+import { PostgresAflTradePrivateValuationCaptureBindingRepository } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationCaptureBindingRepository';
+import { PostgresAflTradePrivateValuationScheduleRepository } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationScheduling';
+
+import { stageLocalAflTradeFitzRoyFixture } from './localFitzRoyStagingFixture';
+import { AFL_DRAFT_TRADE_OUTCOME_PUBLIC_ASSET_BOUNDARY } from '@/types/aflDraftTradeOutcomes';
+
+const SCOPE_KEY = 'afl-men:2026-trades';
+const SCHEDULED_FOR = '2026-08-12T00:00:05.000Z';
+
+export async function stageAcceptedPrivateValuationCaptureFixture(
+  client: AflOutcomeSqlClient,
+  operationKey: string
+) {
+  const ingestion = await stageLocalAflTradeFitzRoyFixture(client);
+  const requestId = await client.transaction(async (transaction) => {
+    await transaction.query('SET LOCAL ROLE afl_trade_private_valuation_scheduler_owner');
+    const enqueued = await transaction.query<{ request_id: string }>(
+      `SELECT enqueue_outcome_private_valuation_dispatch($1,'ad_hoc',$2::timestamptz,$3)
+              AS request_id`,
+      [SCOPE_KEY, SCHEDULED_FOR, operationKey]
+    );
+    const retainedRequestId = enqueued.rows[0]?.request_id;
+    if (!retainedRequestId || enqueued.rows.length !== 1) {
+      throw new TypeError('The factual-preparation fixture did not enqueue exactly one request.');
+    }
+    return retainedRequestId;
+  });
+  const schedule = new PostgresAflTradePrivateValuationScheduleRepository(client);
+  const claim = await schedule.claim('system:weekly-valuation-coordinator', requestId);
+  if (claim === null) {
+    throw new TypeError('The factual-preparation fixture did not claim its due request.');
+  }
+  const binding = await new PostgresAflTradePrivateValuationCaptureBindingRepository(client).accept({
+    request: claim.request,
+    claim: { claimId: claim.claimId, leaseToken: claim.leaseToken },
+    normalizationRunId: ingestion.staging.normalization.normalizationRunId,
+  });
+  return { ingestion, requestId, claim, binding };
+}
+
+function immutableReference(prefix: string, content: unknown) {
+  const id = createAflTradeContentAddress(prefix, content);
+  return { id, sha256: id.slice(id.indexOf(':') + 1) };
+}
+
+function calendarDate(value: Date | string): string {
+  if (typeof value === 'string') return value.slice(0, 10);
+  return [
+    value.getFullYear(),
+    String(value.getMonth() + 1).padStart(2, '0'),
+    String(value.getDate()).padStart(2, '0'),
+  ].join('-');
+}
+
+export async function seedPrivateValuationAcquisitionSpellFixture(
+  client: AflOutcomeSqlClient,
+  captureId: string,
+  baseCandidate: AflTradeFactualReleaseCandidate,
+  fixtureKey = 'default'
+) {
+  const player = await client.query<{ player_id: string; player_identity_id: string }>(
+    `SELECT player_id,player_identity_id
+       FROM outcome_provider_player_resolution
+      WHERE outcome='approved' AND player_id IS NOT NULL AND player_identity_id IS NOT NULL
+      ORDER BY revision DESC LIMIT 1`
+  );
+  const club = await client.query<{ club_id: string }>(
+    `SELECT club_id
+       FROM outcome_provider_club_resolution
+      WHERE outcome='approved' AND club_id IS NOT NULL
+      ORDER BY revision DESC LIMIT 1`
+  );
+  const playerRow = player.rows[0];
+  const clubRow = club.rows[0];
+  if (!playerRow || !clubRow) {
+    throw new TypeError('The spell fixture requires existing reviewed player and club identities.');
+  }
+  const currentSpell = await client.query<{
+    spell_id: string;
+    spell_version_id: string;
+    version: number;
+  }>(
+    `SELECT spell.spell_id,spell.spell_version_id,spell.version
+       FROM outcome_acquisition_spell_version spell
+      WHERE spell.player_id=$1 AND spell.club_id=$2
+        AND NOT EXISTS (
+          SELECT 1 FROM outcome_acquisition_spell_version successor
+           WHERE successor.supersedes_spell_version_id=spell.spell_version_id)
+      ORDER BY spell.version DESC LIMIT 1`,
+    [playerRow.player_id, clubRow.club_id]
+  );
+  const predecessor = currentSpell.rows[0] ?? null;
+
+  const recordedAt = '2026-08-12T00:04:30.000Z';
+  const policyVersion = `private-valuation-fixture/${fixtureKey}`;
+  const importRunId = createAflTradeContentAddress('import-run', { captureId, fixtureKey });
+  const importRowId = createAflTradeContentAddress('import-row', { importRunId });
+  const importPartitionId = createAflTradeContentAddress('import-partition', { importRunId });
+  const eventId = createAflTradeContentAddress('outcome-event', { captureId, fixtureKey });
+  const eventVersionId = createAflTradeContentAddress('outcome-event-version', { eventId });
+  const assetVersionId = createAflTradeContentAddress('outcome-asset-version', { eventVersionId });
+  const rule = immutableReference('acquisition-spell-rule', { policyVersion });
+  const spellId =
+    predecessor?.spell_id ??
+    createAflTradeContentAddress('acquisition-spell', {
+      playerId: playerRow.player_id,
+      clubId: clubRow.club_id,
+      fixtureKey,
+    });
+  const spellVersion = (predecessor?.version ?? 0) + 1;
+  const spellVersionId = createAflTradeContentAddress('acquisition-spell-version', {
+    spellId,
+    eventVersionId,
+    spellVersion,
+  });
+  await client.transaction(async (transaction) => {
+    await transaction.query(
+      `INSERT INTO outcome_import_run
+        (import_run_id,capture_id,import_kind,parser_version,started_at,completed_at,status,manifest_json)
+       VALUES ($1,$2,'private_valuation_fixture',$3,$4,$4,'approved',$5::jsonb)`,
+      [importRunId, captureId, policyVersion, recordedAt, canonicalizeAflTradeJson({ captureId, fixtureKey })]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_import_row
+        (import_row_id,import_run_id,source_locator,source_ordinal,record_kind,row_sha256,
+         parse_status,raw_payload,recorded_at)
+       VALUES ($1,$2,$3,1,'event',$4,'approved',$5::jsonb,$6)`,
+      [
+        importRowId,
+        importRunId,
+        `fixture://private-valuation/${fixtureKey}`,
+        immutableReference('fixture-row', { importRowId }).sha256,
+        canonicalizeAflTradeJson({ eventId }),
+        recordedAt,
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_import_partition
+        (import_partition_id,import_run_id,partition_key,partition_kind,competition,
+         season_year,row_count,rows_sha256,partition_json)
+       VALUES ($1,$2,'AFLM:2026','season','AFLM',2026,1,$3,$4::jsonb)`,
+      [
+        importPartitionId,
+        importRunId,
+        immutableReference('fixture-partition', { importRowId }).sha256,
+        canonicalizeAflTradeJson({ competition: 'AFLM', seasonYear: 2026 }),
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_import_partition_row
+        (import_partition_id,import_row_id,import_run_id,ordinal) VALUES ($1,$2,$3,1)`,
+      [importPartitionId, importRowId, importRunId]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_event (event_id,competition,season_year,stable_key)
+       VALUES ($1,'AFLM',2026,$2)`,
+      [eventId, `private-valuation-fixture:${captureId}:${fixtureKey}`]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_event_version
+        (event_version_id,event_id,version,kind,acquisition_mechanism,event_date,
+         official_name,status,source_import_row_id,recorded_at)
+       VALUES ($1,$2,1,'other_acquisition','pre_draft','2026-01-01',
+               'Private valuation fixture','approved',$3,$4)`,
+      [eventVersionId, eventId, importRowId, recordedAt]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_event_party
+        (event_version_id,club_id,source_import_row_id,role,ordinal)
+       VALUES ($1,$2,$3,'receiving_club',1)`,
+      [eventVersionId, clubRow.club_id, importRowId]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_event_asset
+        (asset_version_id,event_version_id,asset_key,kind,player_id,player_identity_id,
+         from_club_id,to_club_id,source_import_row_id,raw_description,status)
+       VALUES ($1,$2,'fixture-player','player',$3,$4,NULL,$5,$6,'Fixture player','approved')`,
+      [
+        assetVersionId,
+        eventVersionId,
+        playerRow.player_id,
+        playerRow.player_identity_id,
+        clubRow.club_id,
+        importRowId,
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_acquisition_spell_rule
+        (rule_id,rule_version,definition_json,status,created_at)
+       VALUES ($1,$2,$3::jsonb,'approved',$4)`,
+      [rule.id, policyVersion, canonicalizeAflTradeJson({ fixtureKey }), recordedAt]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_acquisition_spell_version
+        (spell_version_id,spell_id,version,player_id,club_id,start_event_version_id,
+         start_asset_version_id,start_date,end_date,end_reason,rule_id,status,
+         supersedes_spell_version_id,recorded_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,'2026-01-01',NULL,NULL,$8,'approved',$9,$10)`,
+      [
+        spellVersionId,
+        spellId,
+        spellVersion,
+        playerRow.player_id,
+        clubRow.club_id,
+        eventVersionId,
+        assetVersionId,
+        rule.id,
+        predecessor?.spell_version_id ?? null,
+        recordedAt,
+      ]
+    );
+  });
+
+  const metricDefinitions = Object.fromEntries(
+    AFL_DRAFT_TRADE_OUTCOME_METRIC_DEFINITIONS.filter(({ metric }) =>
+      ['games', 'goals'].includes(metric)
+    ).map(({ metric, metricDefinitionId }) => [
+      metric,
+      { id: metricDefinitionId, sha256: metricDefinitionId.slice(metricDefinitionId.indexOf(':') + 1) },
+    ])
+  ) as Record<'games' | 'goals', { id: string; sha256: string }>;
+  const approval = immutableReference('acquisition-spell-metric-policy-approval', {
+    policyVersion,
+  });
+  const policy = createAflTradeAcquisitionSpellMetricPolicy({
+    schemaVersion: AFL_TRADE_ACQUISITION_SPELL_METRIC_POLICY_SCHEMA_VERSION,
+    publicAssetBoundary: AFL_DRAFT_TRADE_OUTCOME_PUBLIC_ASSET_BOUNDARY,
+    authorityBoundary: AFL_TRADE_ACQUISITION_SPELL_METRIC_AUTHORITY_BOUNDARY,
+    publicationEligible: false,
+    environment: 'non_production',
+    competition: 'AFLM',
+    validFromSeason: 2026,
+    validThroughSeason: 2026,
+    policyVersion,
+    approval,
+    rules: (['games', 'goals'] as const).map((metricCode) => ({
+      metricCode,
+      definitionVersion: `${metricCode}/v1`,
+      definition: metricDefinitions[metricCode],
+      unit: metricCode,
+      sourceGrain: 'match' as const,
+      aggregation: 'sum_non_negative_integer' as const,
+      attribution: 'exact_player_real_club_and_effective_date_inside_spell' as const,
+      noEvidenceSemantics: 'unavailable_never_zero' as const,
+      conflictSemantics: 'preserve_conflict_and_withhold_numeric_total' as const,
+    })),
+    createdAt: recordedAt,
+  });
+  await client.transaction(async (transaction) => {
+    await transaction.query(
+      'SET LOCAL ROLE afl_trade_nonproduction_spell_metric_policy_reviewer'
+    );
+    await transaction.query(
+      `INSERT INTO outcome_review_decision
+        (decision_id,subject_type,subject_id,decision,rationale,evidence_json,decided_by,decided_at)
+       VALUES ($1,'acquisition_spell_metric_policy',$2,'approved',$3,$4::jsonb,$5,$6)`,
+      [
+        approval.id,
+        policy.policyId,
+        'Approve the exact disposable spell-metric fixture policy.',
+        canonicalizeAflTradeJson({ environment: 'non_production' }),
+        'private-valuation-fixture-reviewer',
+        recordedAt,
+      ]
+    );
+  });
+  const repository = new PostgresAflTradeAcquisitionSpellMetricRepository(client);
+  await repository.persistPolicy(policy, { environment: 'non_production' });
+  const factualRun = baseCandidate.content.members.factualRuns[0];
+  if (!factualRun) throw new TypeError('The spell fixture requires one finalized factual run.');
+  const storedSpell = await client.query<{
+    spell_version_id: string;
+    spell_id: string;
+    version: number;
+    player_id: string;
+    club_id: string;
+    start_event_version_id: string;
+    start_asset_version_id: string;
+    start_date: Date | string;
+    end_date: Date | string | null;
+    recorded_at: Date | string;
+  }>(
+    `SELECT spell_version_id,spell_id,version,player_id,club_id,start_event_version_id,
+            start_asset_version_id,start_date,end_date,recorded_at
+       FROM outcome_acquisition_spell_version WHERE spell_version_id=$1`,
+    [spellVersionId]
+  );
+  const retainedSpell = storedSpell.rows[0];
+  if (!retainedSpell) throw new TypeError('The spell fixture did not retain its exact spell.');
+  const reconciled = await client.query<{
+    fact_json: unknown;
+    reconciled_fact_id: string;
+    fact_sha256: string;
+    subject_key: string;
+    revision: number;
+    finalized_at: Date | string;
+  }>(
+    `SELECT fact.fact_json,fact.reconciled_fact_id,fact.fact_sha256,
+            head.subject_key,head.revision,run.finalized_at
+       FROM outcome_reconciled_factual_metric fact
+       JOIN outcome_reconciled_factual_metric_head head
+         ON head.reconciled_fact_id=fact.reconciled_fact_id
+       JOIN outcome_factual_reconciliation_run run
+         ON run.factual_run_id=fact.factual_run_id
+      WHERE fact.factual_run_id=$1 ORDER BY fact.reconciled_fact_id`,
+    [factualRun.factualRunId]
+  );
+  const spell = {
+    spellVersionId: retainedSpell.spell_version_id,
+    spellId: retainedSpell.spell_id,
+    version: retainedSpell.version,
+    playerId: retainedSpell.player_id,
+    clubId: retainedSpell.club_id,
+    startEventVersionId: retainedSpell.start_event_version_id,
+    startAssetVersionId: retainedSpell.start_asset_version_id,
+    startDate:
+      calendarDate(retainedSpell.start_date),
+    endDate:
+      retainedSpell.end_date === null
+        ? null
+        : calendarDate(retainedSpell.end_date),
+    rule,
+    status: 'approved' as const,
+    recordedAt:
+      retainedSpell.recorded_at instanceof Date
+        ? retainedSpell.recorded_at.toISOString()
+        : retainedSpell.recorded_at,
+  };
+  const batch = calculateAflTradeAcquisitionSpellMetrics({
+    policy,
+    spell,
+    currentMembers: reconciled.rows.map((row) => ({
+      factualRunId: factualRun.factualRunId,
+      factualRunSha256: factualRun.factualRunId.slice(
+        'factual-reconciliation-run:'.length
+      ),
+      environment: 'non_production' as const,
+      finalization: factualRun.finalization,
+      finalizedAt:
+        row.finalized_at instanceof Date ? row.finalized_at.toISOString() : row.finalized_at,
+      subjectKey: row.subject_key,
+      headRevision: row.revision,
+      result: {
+        reconciledFactId: row.reconciled_fact_id,
+        factSha256: row.fact_sha256,
+        content: row.fact_json,
+      },
+    })),
+    currentHeadRevisions: [],
+    recordedAt: '2026-08-12T00:04:45.000Z',
+  });
+  await repository.persistBatch(batch, { environment: 'non_production' });
+  return { policy, spell, batch, spellVersionId, spellId, eventId, eventVersionId, rule };
+}
+
+export async function persistPrivateValuationFactualCandidateFixture(
+  client: AflOutcomeSqlClient,
+  baseCandidate: AflTradeFactualReleaseCandidate,
+  spellFixture: Awaited<ReturnType<typeof seedPrivateValuationAcquisitionSpellFixture>>,
+  scopeKey: string,
+  spellMemberOverrides: Readonly<{ playerId?: string; clubId?: string }> = {}
+) {
+  const recordedAt = '2026-08-12T00:06:00.000Z';
+  const members = {
+    ...baseCandidate.content.members,
+    eventVersions: [
+      {
+        ordinal: 1,
+        recordSha256: sha256AflTradeCanonicalJson({
+          eventVersionId: spellFixture.eventVersionId,
+        }),
+        recordedAt,
+        eventVersionId: spellFixture.eventVersionId,
+        eventId: spellFixture.eventId,
+      },
+    ],
+    acquisitionSpells: [
+      {
+        ordinal: 1,
+        recordSha256: sha256AflTradeCanonicalJson({
+          spellVersionId: spellFixture.spellVersionId,
+        }),
+        recordedAt,
+        spellVersionId: spellFixture.spellVersionId,
+        spellId: spellFixture.spellId,
+        playerId: spellMemberOverrides.playerId ?? spellFixture.spell.playerId,
+        clubId: spellMemberOverrides.clubId ?? spellFixture.spell.clubId,
+        startDate: spellFixture.spell.startDate,
+        endDate: spellFixture.spell.endDate,
+      },
+    ],
+    spellMetrics: [...spellFixture.batch.content.metrics]
+      .sort((left, right) => left.spellMetricVersionId.localeCompare(right.spellMetricVersionId))
+      .map((metric, index) => {
+        const head = spellFixture.batch.content.headAdvances.find(
+          ({ spellMetricVersionId }) => spellMetricVersionId === metric.spellMetricVersionId
+        );
+        if (!head) throw new TypeError('The spell fixture metric is missing its head advance.');
+        return {
+          ordinal: index + 1,
+          recordSha256: metric.factSha256,
+          recordedAt,
+          spellMetricVersionId: metric.spellMetricVersionId,
+          subjectKey: head.subjectKey,
+          headRevision: head.nextRevision,
+          spellVersionId: spellFixture.spellVersionId,
+          policyId: spellFixture.policy.policyId,
+          playerId: spellMemberOverrides.playerId ?? spellFixture.spell.playerId,
+          clubId: spellMemberOverrides.clubId ?? spellFixture.spell.clubId,
+          metricCode: metric.content.rule.metricCode,
+          definition: metric.content.rule.definition,
+          state: metric.content.availability.state,
+          effectiveThrough: metric.content.effectiveThrough,
+        };
+      }),
+  };
+  const memberSetSha256 = sha256AflTradeCanonicalJson(members);
+  const release = createAflDraftTradeOutcomeFactualReleaseManifest({
+    ...baseCandidate.content.targetReleaseManifest.content,
+    scopeKey,
+    createdAt: recordedAt,
+    effectiveThrough: recordedAt,
+    acquisitionSpellRuleId: spellFixture.rule.id,
+    outcomeRecordCount:
+      members.reconciledMetrics.length +
+      members.reconciledAchievements.length +
+      members.spellMetrics.length,
+    sourceMemberSetSha256: memberSetSha256,
+  }) as AflDraftTradeOutcomeFactualReleaseManifest;
+  const counts = Object.fromEntries(
+    Object.entries(members).map(([kind, values]) => [kind, values.length])
+  ) as AflTradeFactualReleaseCandidate['content']['counts'];
+  const candidate = createAflTradeFactualReleaseCandidate({
+    ...baseCandidate.content,
+    scopeKey,
+    createdAt: recordedAt,
+    effectiveThrough: recordedAt,
+    targetRelease: {
+      id: release.releaseId,
+      sha256: release.releaseId.slice('outcome-release:'.length),
+    },
+    targetReleaseManifest: release,
+    acquisitionSpellRule: spellFixture.rule,
+    members,
+    memberSetSha256,
+    counts,
+  });
+  await new PostgresAflTradeFactualReleaseCandidateWriter(client).persistCandidate(candidate);
+  return candidate;
+}

--- a/tests/unit/afl-trade-intelligence-private-valuation-factual-output.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-factual-output.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AFL_TRADE_PRIVATE_VALUATION_FACTUAL_OUTPUT_LIMITATION,
+  createAflTradePrivateValuationFactualOutput,
+  parseAflTradePrivateValuationFactualOutput,
+} from '@/server/aflTradeIntelligence/valuation/privateValuationFactualOutput';
+
+const sha = (character: string) => character.repeat(64);
+
+function createFixture() {
+  return createAflTradePrivateValuationFactualOutput({
+    requestId: `private-valuation-dispatch:${sha('1')}`,
+    valuationScopeKey: 'afl-men:2026-trades',
+    captureBindingId: `private-valuation-capture-binding:${sha('2')}`,
+    sourceAdmissionId: `private-valuation-source-admission:${sha('c')}`,
+    normalizationRunId: `provider-normalization-run:${sha('3')}`,
+    factBatch: {
+      batchId: `source-fact-batch:${sha('4')}`,
+      batchSha256: sha('4'),
+    },
+    reconciliation: {
+      factualRunId: `factual-reconciliation-run:${sha('5')}`,
+      runSha256: sha('5'),
+      outputSetSha256: sha('6'),
+      finalizedAt: '2026-08-24T09:04:00.000Z',
+    },
+    spellMetricBatches: [
+      {
+        batchId: `acquisition-spell-metric-batch:${sha('8')}`,
+        batchSha256: sha('8'),
+      },
+      {
+        batchId: `acquisition-spell-metric-batch:${sha('7')}`,
+        batchSha256: sha('7'),
+      },
+    ],
+    candidate: {
+      candidateId: `factual-release-candidate:${sha('9')}`,
+      candidateSha256: sha('9'),
+      memberSetSha256: sha('a'),
+    },
+    factualRelease: {
+      releaseId: `outcome-release:${sha('b')}`,
+      releaseSha256: sha('b'),
+    },
+    preparedAt: '2026-08-24T09:05:00.000Z',
+  });
+}
+
+describe('private valuation factual output', () => {
+  it('content-addresses one exact non-production factual result for a dispatch', () => {
+    const output = createFixture();
+
+    expect(output.outputId).toMatch(/^private-valuation-factual-output:[a-f0-9]{64}$/);
+    expect(parseAflTradePrivateValuationFactualOutput(output)).toEqual(output);
+    expect(createFixture()).toEqual(output);
+    expect(output.content).toMatchObject({
+      valuationScopeKey: 'afl-men:2026-trades',
+      sourceAdmissionId: `private-valuation-source-admission:${sha('c')}`,
+      spellMetricBatches: [
+        { batchId: `acquisition-spell-metric-batch:${sha('7')}` },
+        { batchId: `acquisition-spell-metric-batch:${sha('8')}` },
+      ],
+      environment: 'non_production',
+      publicationEligible: false,
+      publicationProhibited: true,
+      limitation: AFL_TRADE_PRIVATE_VALUATION_FACTUAL_OUTPUT_LIMITATION,
+    });
+  });
+
+  it('rejects a recomputed output that claims another identifier', () => {
+    const output = createFixture();
+
+    expect(() =>
+      parseAflTradePrivateValuationFactualOutput({
+        ...output,
+        outputId: `private-valuation-factual-output:${sha('c')}`,
+      })
+    ).toThrow('content address');
+  });
+
+  it('rejects duplicate spell-metric batch custody', () => {
+    const output = createFixture();
+
+    expect(() =>
+      createAflTradePrivateValuationFactualOutput({
+        ...output.content,
+        spellMetricBatches: [output.content.spellMetricBatches[0]!, output.content.spellMetricBatches[0]!],
+      })
+    ).toThrow('unique');
+  });
+});


### PR DESCRIPTION
## Summary

- retain one immutable factual-output receipt for an accepted raw-data capture
- reuse the existing factual observation, reconciliation, acquisition-spell metric, and release-candidate owners
- authorize the exact non-production source lineage without changing the public release registry or active release pointer
- add forward-only migrations 0072 through 0075 and migrated PostgreSQL replay/tamper coverage

## Stack position

This is Stage 2 of the raw-data-to-recalculation delivery and is based on merged PR #558. It remains local, non-production, and publication-prohibited. HPN preparation will be restacked and proposed only after this stage lands.

## Verification

- migrated PostgreSQL migration-history assertion
- migrated PostgreSQL factual preparation and source admission: 3/3
- focused factual-output unit tests: 3/3
- full TypeScript check
- git diff --check

The happy path uses the existing repositories and authority tables; this PR adds no scheduler, queue, public release pointer, or parallel factual ledger.

## Summary by Sourcery

Automate immutable non-production factual preparation while preserving publication and production authority boundaries.

New Features:
- Automate non-production source admission and factual-output preparation for accepted valuation captures.
- Retain immutable, content-addressed factual preparation outputs linked to their exact source, reconciliation, candidate, and metric ancestry.

Bug Fixes:
- Prevent versioned acquisition-spell metric eligibility from being bypassed through legacy metric records or substituted ancestry.

Enhancements:
- Enforce publication-prohibited custody, dispatch claim fencing, replay safety, and exact parent-chain validation for private factual preparation.

Tests:
- Add migrated PostgreSQL coverage for source admission, factual preparation, concurrent replay, public-authority invariants, and ancestry tampering.
- Add unit coverage for factual-output content addressing, canonical ordering, and validation.