### PR TITLE
Prepare governed HPN valuation inputs

### DIFF
--- a/docs/architecture/afl-trade-intelligence.md
+++ b/docs/architecture/afl-trade-intelligence.md
@@ -1918,11 +1918,22 @@ The local full-stack worker drains retained pending dispatches at startup and en
 missed Monday 19:00 `Australia/Melbourne` occurrence. A newly qualified model pair separately enqueues
 immediate work. The calendar calculation preserves local wall-clock time across daylight-saving
 changes and coalesces missed weekly occurrences. An authenticated backend-only command can enqueue the
-same coordinator ad hoc using a caller-supplied stable operation key. This is not a complete
-new-game-data pipeline:
-fitzRoy capture, canonical factual promotion, model observation/benchmark rebuild, and prepared-v3
-activation remain separately governed upstream processes. The weekly run consumes whatever exact
-prepared-v3 head is current; it never promotes source data or invents model authority.
+same coordinator ad hoc using a caller-supplied stable operation key.
+
+The upstream path now has a claim-fenced HPN preparation boundary, but it is not yet wired into the
+weekly worker. Given one exact dispatch and live claim, it reuses the retained private factual output,
+accepts one result capture plus primary and corroborating player-stat captures under distinct source
+roles, resolves one current reviewed HPN map for each exact provider/capability/schema/season lane,
+and delegates input construction and calculation to the existing content-addressed HPN repositories.
+Restart reloads accepted captures and the existing HPN input/calculation records. Missing or stale
+source custody, map approval, identity resolution, factual-universe coverage, or method authority
+fails closed before downstream authority changes. The current public release pointer and publication
+Gates remain untouched.
+
+This is still not a complete new-game-data pipeline. The deployed weekly runner continues to consume
+whatever exact prepared-v3 head is current. Model observation rebuild, bounded model execution,
+automatic qualification handoff, and prepared-v3 activation still need to be composed after HPN
+preparation before the worker can run raw data through to recalculation without manual orchestration.
 
 A structurally valid fixture report always retains `publicationReady: false` and the remaining
 external blockers: a real historical-data run, component-model calibration exit criteria, downstream

--- a/docs/runbooks/afl-trade-intelligence-operations.md
+++ b/docs/runbooks/afl-trade-intelligence-operations.md
@@ -836,6 +836,7 @@ npx vitest run --config vitest.config.unit.ts \
   tests/unit/afl-trade-intelligence-private-local-workbook-reads.test.ts \
   tests/unit/afl-trade-intelligence-current-valuation-cohort-runner.test.ts \
   tests/unit/afl-trade-intelligence-private-valuation-scheduling.test.ts \
+  tests/unit/afl-trade-intelligence-private-valuation-hpn-preparation.test.ts \
   tests/unit/local-workbook-trade-evaluation-page.test.tsx \
   tests/unit/local-private-reviewed-trade-calculation-panel.test.tsx \
   tests/unit/afl-trade-intelligence-private-governed-exact-export-route.test.ts \
@@ -845,7 +846,10 @@ AFL_OUTCOMES_TEST_DATABASE_URL='<owned-disposable-loopback-postgresql>' \
   npx vitest run --config vitest.config.outcomes-int.ts \
   tests/outcomes-integration/afl-governed-private-evaluation-lifecycle-postgres.test.ts \
   tests/outcomes-integration/afl-private-evaluation-batch-postgres.test.ts \
-  tests/outcomes-integration/afl-private-valuation-scheduling-postgres.test.ts
+  tests/outcomes-integration/afl-private-valuation-scheduling-postgres.test.ts \
+  tests/outcomes-integration/afl-private-valuation-capture-binding-postgres.test.ts \
+  tests/outcomes-integration/afl-hpn-pav-projected-input-postgres.test.ts \
+  tests/outcomes-integration/afl-private-valuation-hpn-preparation-postgres.test.ts
 ```
 
 The provisioned integration command is permitted only when the caller owns the disposable database.
@@ -864,6 +868,15 @@ occurrence rather than a 604800-second interval, so daylight-saving changes do n
 Startup coalesces missed weeks to the latest occurrence. A newly committed qualified model pair also
 enqueues immediate work. Neither trigger promotes factual data or prepares model evidence: execution
 begins only from the exact current authenticated prepared-v3 head.
+
+The repository now also contains a backend-only HPN preparation seam for the next upstream cutover.
+It accepts an exact retained dispatch plus its live claim, replays the private factual output, and
+accepts three separately authenticated source roles: AFL Tables completed results, AFL Tables primary
+player statistics, and Official AFL corroborating player statistics. It then requires one current
+reviewed HPN projection for each exact source and uses the existing HPN input/calculation repositories.
+This seam is not yet invoked by the local worker, and it must not be described as automatic weekly
+raw-data recalculation until the later model and prepared-v3 stages are composed into the same runner.
+Do not bypass missing HPN map reviews or identity resolutions; those states remain backend blockers.
 
 To request the same coordinator ad hoc, supply a stable operation key that can be reused after process
 or response loss:

--- a/prisma/afl-trade-outcomes/migrations/0076_role_aware_private_valuation_capture_binding/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0076_role_aware_private_valuation_capture_binding/migration.sql
@@ -1,0 +1,469 @@
+-- Allow one authenticated source-capture binding per dispatch source role.
+-- Existing v1 bindings remain factual_input. HPN roles are exact fixed source lanes.
+
+DO $roles$ BEGIN
+  EXECUTE format(
+    'GRANT afl_trade_private_valuation_scheduler_owner TO %I',
+    session_user
+  );
+END $roles$;
+
+SET ROLE afl_trade_private_valuation_scheduler_owner;
+
+ALTER TABLE "outcome_private_valuation_capture_binding"
+  ADD COLUMN "source_role" TEXT NOT NULL DEFAULT 'factual_input';
+
+ALTER TABLE "outcome_private_valuation_capture_binding"
+  DROP CONSTRAINT "outcome_private_valuation_capture_binding_request_id_key";
+
+ALTER TABLE "outcome_private_valuation_capture_binding"
+  ADD CONSTRAINT "outcome_private_valuation_capture_binding_source_role_check" CHECK (
+    "source_role" IN (
+      'factual_input',
+      'hpn_completed_results',
+      'hpn_primary_player_stats',
+      'hpn_corroborating_player_stats'
+    )
+  ),
+  ADD CONSTRAINT "outcome_private_valuation_capture_binding_request_role_key"
+    UNIQUE ("request_id","source_role");
+
+CREATE OR REPLACE FUNCTION "accept_outcome_private_valuation_dispatch_capture"(
+  target_request_id TEXT,
+  target_claim_id TEXT,
+  target_lease_token_sha256 TEXT,
+  target_source_role TEXT,
+  target_normalization_run_id TEXT
+) RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  trusted_at TIMESTAMPTZ(3);
+  dispatch_authority RECORD;
+  authority RECORD;
+  retained RECORD;
+  expected_source_attempt_id TEXT;
+  expected_snapshot_id TEXT;
+  expected_capture_receipt_id TEXT;
+  expected_gate_receipt_id TEXT;
+  expected_rights_artifact_id TEXT;
+  expected_capture_id TEXT;
+  expected_normalization_run_id TEXT;
+  expected_field_map_sha256 TEXT;
+  source_plan JSONB;
+  binding_content JSONB;
+  target_binding_id TEXT;
+  target_binding_json JSONB;
+BEGIN
+  IF target_request_id !~ '^private-valuation-dispatch:[a-f0-9]{64}$'
+    OR target_claim_id !~ '^private-valuation-dispatch-claim:[a-f0-9]{64}$'
+    OR target_lease_token_sha256 !~ '^[a-f0-9]{64}$'
+    OR target_source_role NOT IN (
+      'factual_input',
+      'hpn_completed_results',
+      'hpn_primary_player_stats',
+      'hpn_corroborating_player_stats'
+    )
+    OR target_normalization_run_id !~ '^provider-normalization-run:[a-f0-9]{64}$'
+  THEN
+    RAISE EXCEPTION 'Private valuation capture acceptance is malformed';
+  END IF;
+
+  SELECT
+    request."request_id",request."request_json",request."scheduled_for",
+    request."claim_id" AS "current_claim_id",
+    request."claim_sequence" AS "current_claim_sequence",
+    request."lease_token_sha256" AS "current_lease_token_sha256",
+    request."lease_expires_at" AS "current_lease_expires_at",
+    dispatch_attempt."attempt_sequence",dispatch_attempt."attempt_number",
+    dispatch_attempt."lease_token_sha256" AS "attempt_lease_token_sha256",
+    dispatch_attempt."lease_expires_at" AS "attempt_lease_expires_at",
+    dispatch_attempt."finished_at" AS "attempt_finished_at"
+  INTO dispatch_authority
+  FROM "outcome_private_valuation_dispatch_request" request
+  JOIN "outcome_private_valuation_dispatch_attempt" dispatch_attempt
+    ON dispatch_attempt."request_id"=request."request_id"
+   AND dispatch_attempt."claim_id"=target_claim_id
+  WHERE request."request_id"=target_request_id
+    AND request."claim_id"=target_claim_id
+  FOR UPDATE OF request,dispatch_attempt;
+
+  -- The dispatch and attempt locks fence acceptance. Judge expiry after they are held.
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+
+  IF NOT FOUND
+    OR dispatch_authority."request_id" IS DISTINCT FROM target_request_id
+    OR dispatch_authority."current_claim_id" IS DISTINCT FROM target_claim_id
+    OR dispatch_authority."current_claim_sequence"
+      IS DISTINCT FROM dispatch_authority."attempt_sequence"
+    OR dispatch_authority."current_lease_token_sha256"
+      IS DISTINCT FROM target_lease_token_sha256
+    OR dispatch_authority."attempt_lease_token_sha256"
+      IS DISTINCT FROM target_lease_token_sha256
+    OR dispatch_authority."current_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_finished_at" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation capture acceptance lost its live dispatch claim fence or requested dispatch';
+  END IF;
+
+  -- The factual admission owner still resolves its single v1 capture by request. Requiring that
+  -- admission before any HPN lane makes that lookup unambiguous without duplicating its function.
+  IF target_source_role<>'factual_input' AND NOT EXISTS (
+    SELECT 1 FROM "outcome_private_valuation_source_admission" admission
+     WHERE admission."request_id"=target_request_id
+  ) THEN
+    RAISE EXCEPTION 'Private valuation HPN capture requires the exact factual admission first';
+  END IF;
+  IF target_source_role<>'factual_input'
+    AND dispatch_authority."request_json"->>'scopeKey'
+      IS DISTINCT FROM 'afl-men:2026-trades'
+  THEN
+    RAISE EXCEPTION 'Private valuation HPN capture scope is unsupported';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    'outcome-private-valuation-capture-binding:'||dispatch_authority."request_id"||':'||target_source_role,0));
+  SELECT * INTO retained
+    FROM "outcome_private_valuation_capture_binding"
+   WHERE "request_id"=dispatch_authority."request_id"
+     AND "source_role"=target_source_role FOR SHARE;
+  -- Binding-lock waits consume lease time; recheck before exact replay or fresh acceptance.
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF dispatch_authority."current_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_finished_at" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation capture acceptance lost its live dispatch claim fence or requested dispatch';
+  END IF;
+  IF FOUND THEN
+    IF retained."dispatch_claim_id" IS DISTINCT FROM target_claim_id
+      OR retained."source_role" IS DISTINCT FROM target_source_role
+      OR retained."normalization_run_id" IS DISTINCT FROM target_normalization_run_id
+    THEN
+      RAISE EXCEPTION 'Private valuation dispatch already accepted different source custody';
+    END IF;
+    RETURN retained."binding_json";
+  END IF;
+
+  SELECT
+    normalization."normalization_run_id",normalization."capture_id",
+    normalization."field_map_id",normalization."decoder_version",
+    normalization."normalizer_version",normalization."decoded_sha256",
+    normalization."receipt_sha256",normalization."staging_sha256",
+    normalization."status" AS "normalization_status",
+    normalization."completed_at" AS "normalization_completed_at",
+    normalization."finalized_at" AS "normalization_finalized_at",
+    capture."attempt_id" AS "source_capture_attempt_id",
+    capture."source_snapshot_id",capture."source_artifact_id",
+    capture."environment" AS "capture_environment",
+    capture."provider",capture."dataset",capture."capability_id",
+    capture."competition",capture."anchor_season_year",
+    capture."captured_at",capture."status" AS "capture_status",
+    capture."manifest_json",
+    source_attempt."environment" AS "source_attempt_environment",
+    source_attempt."provider" AS "source_attempt_provider",
+    source_attempt."dataset" AS "source_attempt_dataset",
+    source_attempt."capability_id" AS "source_attempt_capability_id",
+    source_attempt."status" AS "source_attempt_status",
+    source_attempt."started_at" AS "source_attempt_started_at",
+    source_attempt."completed_at" AS "source_attempt_completed_at",
+    source_attempt."attempt_json",
+    field_map."capability_id" AS "field_map_capability_id",
+    field_map."approval_decision_id" AS "field_map_approval_decision_id",
+    field_map."field_map_sha256",field_map."approved_at" AS "field_map_approved_at",
+    field_map."map_json"
+  INTO authority
+  FROM "outcome_provider_normalization_run" normalization
+  JOIN "outcome_source_capture" capture
+    ON capture."capture_id"=normalization."capture_id"
+  JOIN "outcome_source_capture_attempt" source_attempt
+    ON source_attempt."attempt_id"=capture."attempt_id"
+  JOIN "outcome_provider_field_map" field_map
+    ON field_map."field_map_id"=normalization."field_map_id"
+  WHERE normalization."normalization_run_id"=target_normalization_run_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Private valuation capture normalization is absent from source custody';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    'outcome-review-subject:provider_field_map:'||authority."field_map_id",0));
+  IF NOT EXISTS (
+    SELECT 1
+      FROM "outcome_review_decision" approval
+     WHERE approval."decision_id"=authority."field_map_approval_decision_id"
+       AND approval."subject_type"='provider_field_map'
+       AND approval."subject_id"=authority."field_map_id"
+       AND approval."decision"='approved'
+       AND approval."decided_at"=authority."field_map_approved_at"
+       AND approval."evidence_json"->>'fieldMapSha256'=authority."field_map_sha256"
+       AND NOT EXISTS (
+         SELECT 1 FROM "outcome_review_decision" successor
+          WHERE successor."supersedes_decision_id"=approval."decision_id")
+  ) THEN
+    RAISE EXCEPTION 'Private valuation capture field map is no longer currently approved';
+  END IF;
+
+  -- Review-lock waits also consume lease time; recheck immediately before fresh acceptance.
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF dispatch_authority."current_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_finished_at" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation capture acceptance lost its live dispatch claim fence or requested dispatch';
+  END IF;
+
+  expected_source_attempt_id:='source-capture-attempt:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(authority."attempt_json"),'UTF8')),'hex');
+  expected_snapshot_id:='source-snapshot:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(authority."manifest_json"),'UTF8')),'hex');
+  expected_capture_receipt_id:='fitzroy-capture:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(
+      authority."manifest_json"->'fitzRoyCaptureReceipt'->'content'),'UTF8')),'hex');
+  expected_gate_receipt_id:='gate0a-evaluation:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(
+      authority."manifest_json"->'gate0aReceipt'->'content'),'UTF8')),'hex');
+  expected_rights_artifact_id:=
+    authority."manifest_json"->'sourceRightsProposal'->>'rightsArtifactId';
+  expected_capture_id:='source-capture:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(jsonb_build_object(
+      'sourceSnapshotId',authority."source_snapshot_id",
+      'attemptId',authority."source_capture_attempt_id",
+      'sourceArtifactId',authority."source_artifact_id")),'UTF8')),'hex');
+  expected_normalization_run_id:='provider-normalization-run:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(jsonb_build_object(
+      'captureId',authority."capture_id",
+      'fieldMapId',authority."field_map_id",
+      'decoderVersion',authority."decoder_version",
+      'normalizerVersion',authority."normalizer_version",
+      'decodedSha256',authority."decoded_sha256",
+      'receiptSha256',authority."receipt_sha256",
+      'stagingSha256',authority."staging_sha256")),'UTF8')),'hex');
+  expected_field_map_sha256:=encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(authority."map_json"),'UTF8')),'hex');
+
+      IF (target_source_role='hpn_completed_results' AND (
+        authority."provider" IS DISTINCT FROM 'afl_tables'
+        OR authority."dataset" IS DISTINCT FROM 'AFL Tables completed match results through fitzRoy'
+        OR authority."capability_id" IS DISTINCT FROM 'afl-tables-results'))
+    OR (target_source_role='hpn_primary_player_stats' AND (
+        authority."provider" IS DISTINCT FROM 'afl_tables'
+        OR authority."dataset" IS DISTINCT FROM 'AFL Tables historical player match statistics'
+        OR authority."capability_id" IS DISTINCT FROM 'afl-tables-player-stats'))
+    OR (target_source_role='hpn_corroborating_player_stats' AND (
+        authority."provider" IS DISTINCT FROM 'official_afl'
+        OR authority."dataset" IS DISTINCT FROM 'Official AFL 2026 player match statistics'
+        OR authority."capability_id" IS DISTINCT FROM 'official-afl-player-stats'))
+    OR authority."capture_environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR authority."source_attempt_environment" IS DISTINCT FROM 'non_production'::"OutcomeEnvironment"
+    OR authority."source_attempt_status" IS DISTINCT FROM 'captured'
+    OR authority."capture_status" IN ('rejected','superseded')
+    OR authority."normalization_finalized_at" IS NULL
+    OR authority."normalization_finalized_at" IS DISTINCT FROM authority."normalization_completed_at"
+    OR dispatch_authority."scheduled_for">trusted_at
+    OR authority."source_attempt_started_at"<dispatch_authority."scheduled_for"
+    OR authority."source_attempt_completed_at">trusted_at
+    OR authority."captured_at">trusted_at
+    OR authority."normalization_completed_at">trusted_at
+    OR authority."field_map_approved_at">trusted_at
+    OR authority."source_capture_attempt_id" IS DISTINCT FROM expected_source_attempt_id
+    OR authority."source_snapshot_id" IS DISTINCT FROM expected_snapshot_id
+    OR authority."manifest_json"->'fitzRoyCaptureReceipt'->>'captureReceiptId'
+      IS DISTINCT FROM expected_capture_receipt_id
+    OR authority."attempt_json"->>'captureReceiptId'
+      IS DISTINCT FROM expected_capture_receipt_id
+    OR authority."manifest_json"->'gate0aReceipt'->>'receiptId'
+      IS DISTINCT FROM expected_gate_receipt_id
+    OR authority."attempt_json"->>'authorizationReceiptId'
+      IS DISTINCT FROM expected_gate_receipt_id
+    OR authority."capture_id" IS DISTINCT FROM expected_capture_id
+    OR authority."normalization_run_id" IS DISTINCT FROM expected_normalization_run_id
+    OR authority."field_map_sha256" IS DISTINCT FROM expected_field_map_sha256
+    OR authority."attempt_json"->>'schemaVersion'
+      IS DISTINCT FROM 'afl-trade-source-capture-attempt/v1'
+    OR authority."attempt_json"->>'sourceSnapshotId'
+      IS DISTINCT FROM authority."source_snapshot_id"
+    OR authority."attempt_json"->>'status' IS DISTINCT FROM 'captured'
+    OR (authority."attempt_json"->>'completedAt')::timestamptz
+      IS DISTINCT FROM authority."source_attempt_completed_at"
+    OR authority."manifest_json"->>'schemaVersion'
+      IS DISTINCT FROM 'afl-trade-source-snapshot/v3'
+    OR authority."manifest_json"->'capture'->>'kind' IS DISTINCT FROM 'fitzroy'
+    OR authority."manifest_json"->'capture'->>'upstreamProvider'
+      IS DISTINCT FROM authority."provider"
+    OR authority."manifest_json"->'capture'->>'upstreamDataset'
+      IS DISTINCT FROM authority."dataset"
+    OR authority."manifest_json"->'capture'->>'capabilityId'
+      IS DISTINCT FROM authority."capability_id"
+    OR authority."manifest_json"->'sourceArtifact'->>'artifactId'
+      IS DISTINCT FROM authority."source_artifact_id"
+    OR authority."manifest_json"->'gate0aReceipt'->'content'->'request'->>'environment'
+      IS DISTINCT FROM 'non_production'
+    OR authority."manifest_json"->'gate0aReceipt'->'content'->'request'->>'competition'
+      IS DISTINCT FROM authority."competition"
+    OR (authority."manifest_json"->'gate0aReceipt'->'content'->'request'->>'season')::integer
+      IS DISTINCT FROM authority."anchor_season_year"
+    OR authority."manifest_json"->'gate0aReceipt'->'content'->'request'->>'capabilityId'
+      IS DISTINCT FROM authority."capability_id"
+    OR expected_rights_artifact_id !~ '^source-rights:[a-f0-9]{64}$'
+    OR authority."manifest_json"->'gate0aReceipt'->'content'->'request'->>'rightsArtifactId'
+      IS DISTINCT FROM expected_rights_artifact_id
+    OR authority."manifest_json"->'gate0aReceipt'->'content'->'result'->>'status'
+      IS DISTINCT FROM 'mechanically_eligible'
+    OR authority."manifest_json"->'gate0aReceipt'->'content'->'result'->>'decisionId' IS NULL
+    OR authority."manifest_json"->'fitzRoyCaptureReceipt'->'content'->'authorizationReceipt'->>'receiptId'
+      IS DISTINCT FROM expected_gate_receipt_id
+    OR authority."manifest_json"->'fitzRoyCaptureReceipt'->'content'->'invocation'->>'provider'
+      IS DISTINCT FROM authority."provider"
+    OR authority."manifest_json"->'fitzRoyCaptureReceipt'->'content'->'invocation'->>'capabilityId'
+      IS DISTINCT FROM authority."capability_id"
+    OR (authority."manifest_json"->'fitzRoyCaptureReceipt'->'content'->'invocation'->>'authorizationSeason')::integer
+      IS DISTINCT FROM authority."anchor_season_year"
+    OR authority."source_attempt_provider" IS DISTINCT FROM authority."provider"
+    OR authority."source_attempt_dataset" IS DISTINCT FROM authority."dataset"
+    OR authority."source_attempt_capability_id" IS DISTINCT FROM authority."capability_id"
+    OR authority."field_map_capability_id" IS DISTINCT FROM authority."capability_id"
+    OR authority."map_json"->>'mapId' IS DISTINCT FROM authority."field_map_id"
+    OR authority."map_json"->>'capabilityId' IS DISTINCT FROM authority."capability_id"
+    OR authority."map_json"->>'competition' IS DISTINCT FROM authority."competition"
+    OR (authority."map_json"->>'validFromSeason')::integer>authority."anchor_season_year"
+    OR (authority."map_json"->>'validThroughSeason')::integer<authority."anchor_season_year"
+  THEN
+    RAISE EXCEPTION 'Private valuation capture source custody is invalid';
+  END IF;
+
+  source_plan:=jsonb_build_object(
+    'provider',authority."provider",
+    'dataset',authority."dataset",
+    'capabilityId',authority."capability_id",
+    'competition',authority."competition",
+    'seasonYear',authority."anchor_season_year",
+    'fieldMapId',authority."field_map_id",
+    'gate0AReceiptId',expected_gate_receipt_id,
+    'rightsArtifactId',expected_rights_artifact_id
+  );
+  binding_content:=jsonb_build_object(
+    'schemaVersion','afl-trade-private-valuation-capture-binding/v2',
+    'request',dispatch_authority."request_json",
+    'sourceRole',target_source_role,
+    'dispatchClaimId',target_claim_id,
+    'attemptSequence',dispatch_authority."attempt_sequence",
+    'attemptNumber',dispatch_authority."attempt_number",
+    'sourcePlan',source_plan,
+    'sourceCaptureAttemptId',authority."source_capture_attempt_id",
+    'captureReceiptId',expected_capture_receipt_id,
+    'snapshotId',authority."source_snapshot_id",
+    'sourceCaptureId',authority."capture_id",
+    'normalizationRunId',authority."normalization_run_id",
+    'acceptedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'environment','non_production',
+    'publicationEligible',false,
+    'limitation','Accepted non-production source custody only; it grants no factual, model, private-evaluation, or publication authority.'
+  );
+  target_binding_id:="create_outcome_private_valuation_capture_binding_id"(binding_content);
+  target_binding_json:=jsonb_build_object(
+    'bindingId',target_binding_id,
+    'content',binding_content
+  );
+
+  INSERT INTO "outcome_private_valuation_capture_binding"(
+    "binding_id","request_id","source_role","dispatch_claim_id","attempt_sequence","attempt_number",
+    "source_capture_id","source_capture_attempt_id","source_snapshot_id",
+    "capture_receipt_id","normalization_run_id","accepted_at","binding_json"
+  ) VALUES (
+    target_binding_id,dispatch_authority."request_id",target_source_role,target_claim_id,
+    dispatch_authority."attempt_sequence",dispatch_authority."attempt_number",
+    authority."capture_id",authority."source_capture_attempt_id",authority."source_snapshot_id",
+    expected_capture_receipt_id,authority."normalization_run_id",trusted_at,target_binding_json
+  );
+  RETURN target_binding_json;
+END $$;
+
+
+CREATE OR REPLACE FUNCTION "accept_outcome_private_valuation_dispatch_capture"(
+  target_request_id TEXT,
+  target_claim_id TEXT,
+  target_lease_token_sha256 TEXT,
+  target_normalization_run_id TEXT
+) RETURNS JSONB LANGUAGE SQL SECURITY DEFINER AS $$
+  SELECT "accept_outcome_private_valuation_dispatch_capture"(
+    target_request_id,
+    target_claim_id,
+    target_lease_token_sha256,
+    'factual_input',
+    target_normalization_run_id
+  )
+$$;
+
+CREATE OR REPLACE FUNCTION "load_outcome_private_valuation_dispatch_request_for_claim"(
+  target_request_id TEXT,
+  target_claim_id TEXT,
+  target_lease_token_sha256 TEXT
+) RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  retained RECORD;
+  trusted_at TIMESTAMPTZ(3);
+BEGIN
+  IF target_request_id !~ '^private-valuation-dispatch:[a-f0-9]{64}$'
+    OR target_claim_id !~ '^private-valuation-dispatch-claim:[a-f0-9]{64}$'
+    OR target_lease_token_sha256 !~ '^[a-f0-9]{64}$'
+  THEN
+    RAISE EXCEPTION 'Private valuation dispatch request lookup is malformed';
+  END IF;
+
+  SELECT request."request_json",request."status",request."claim_id",
+         request."lease_token_sha256",request."lease_expires_at",
+         attempt."finished_at",attempt."lease_token_sha256" AS "attempt_lease_token_sha256",
+         attempt."lease_expires_at" AS "attempt_lease_expires_at"
+    INTO retained
+    FROM "outcome_private_valuation_dispatch_request" request
+    JOIN "outcome_private_valuation_dispatch_attempt" attempt
+      ON attempt."request_id"=request."request_id"
+     AND attempt."claim_id"=target_claim_id
+   WHERE request."request_id"=target_request_id
+     AND request."claim_id"=target_claim_id
+   FOR SHARE OF request,attempt;
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+
+  IF NOT FOUND
+    OR retained."status" IS DISTINCT FROM 'claimed'
+    OR retained."claim_id" IS DISTINCT FROM target_claim_id
+    OR retained."lease_token_sha256" IS DISTINCT FROM target_lease_token_sha256
+    OR retained."attempt_lease_token_sha256" IS DISTINCT FROM target_lease_token_sha256
+    OR retained."finished_at" IS NOT NULL
+    OR retained."lease_expires_at"<trusted_at
+    OR retained."attempt_lease_expires_at"<trusted_at
+  THEN
+    RAISE EXCEPTION 'Private valuation dispatch request lookup lost its live claim fence';
+  END IF;
+  RETURN retained."request_json";
+END $$;
+
+DO $paths$ BEGIN
+  EXECUTE format(
+    'ALTER FUNCTION %I.accept_outcome_private_valuation_dispatch_capture(TEXT,TEXT,TEXT,TEXT,TEXT) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+  EXECUTE format(
+    'ALTER FUNCTION %I.accept_outcome_private_valuation_dispatch_capture(TEXT,TEXT,TEXT,TEXT) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+  EXECUTE format(
+    'ALTER FUNCTION %I.load_outcome_private_valuation_dispatch_request_for_claim(TEXT,TEXT,TEXT) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+END $paths$;
+
+REVOKE ALL ON FUNCTION "accept_outcome_private_valuation_dispatch_capture"(TEXT,TEXT,TEXT,TEXT,TEXT)
+  FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "accept_outcome_private_valuation_dispatch_capture"(TEXT,TEXT,TEXT,TEXT,TEXT)
+  TO afl_trade_private_evaluation_coordinator;
+REVOKE ALL ON FUNCTION "load_outcome_private_valuation_dispatch_request_for_claim"(TEXT,TEXT,TEXT)
+  FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "load_outcome_private_valuation_dispatch_request_for_claim"(TEXT,TEXT,TEXT)
+  TO afl_trade_private_evaluation_coordinator;
+
+RESET ROLE;
+
+DO $membership$ BEGIN
+  EXECUTE format(
+    'REVOKE afl_trade_private_valuation_scheduler_owner FROM %I',
+    session_user
+  );
+END $membership$;

--- a/prisma/afl-trade-outcomes/migrations/0077_projected_hpn_pav_input_authority/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0077_projected_hpn_pav_input_authority/migration.sql
@@ -1,0 +1,1800 @@
+-- Projected HPN field-map custody for the existing private PAV input builder.
+-- Legacy v1 input sets retain their original columns, triggers, and validation path.
+
+ALTER TABLE "outcome_hpn_pav_input_run"
+  ALTER COLUMN "field_map_id" DROP NOT NULL,
+  ADD COLUMN "projected_field_map_id" TEXT,
+  ADD CONSTRAINT "outcome_hpn_pav_input_run_projected_map_fkey"
+    FOREIGN KEY ("projected_field_map_id")
+    REFERENCES "outcome_hpn_projected_field_map"("field_map_id") ON DELETE RESTRICT,
+  ADD CONSTRAINT "outcome_hpn_pav_input_run_exact_map_authority_check"
+    CHECK (("field_map_id" IS NOT NULL)::INTEGER+
+           ("projected_field_map_id" IS NOT NULL)::INTEGER=1);
+
+CREATE INDEX "outcome_hpn_pav_input_run_projected_map_idx"
+  ON "outcome_hpn_pav_input_run"("projected_field_map_id","input_set_id")
+  WHERE "projected_field_map_id" IS NOT NULL;
+
+-- The reviewed-evidence contract remains in the existing bundle/decision/head ledger. A successor
+-- may add only the exact AFL Tables 2026 results capture and its distinct rights document to the
+-- immutable six-capture authority that was current before this migration.
+ALTER FUNCTION "outcome_private_reviewed_evidence_bundle_is_current"(TEXT)
+  RENAME TO "outcome_private_reviewed_evidence_bundle_is_current_v1";
+
+CREATE FUNCTION "outcome_private_reviewed_evidence_results_successor_is_exact"(
+  target_evidence_bundle_id TEXT,
+  base_evidence_bundle_id TEXT
+) RETURNS BOOLEAN AS $$
+DECLARE target_bundle RECORD; base_bundle RECORD; added_capture JSONB; added_rights JSONB;
+  capture_record RECORD; custody_record RECORD; rights_record RECORD;
+  rights_canonical TEXT; rights_sha256 TEXT;
+BEGIN
+  SELECT * INTO target_bundle FROM "outcome_private_reviewed_evidence_bundle"
+   WHERE "evidence_bundle_id"=target_evidence_bundle_id;
+  SELECT * INTO base_bundle FROM "outcome_private_reviewed_evidence_bundle"
+   WHERE "evidence_bundle_id"=base_evidence_bundle_id;
+  IF target_bundle."evidence_bundle_id" IS NULL OR base_bundle."evidence_bundle_id" IS NULL
+    OR target_bundle."evidence_scope_key"<>base_bundle."evidence_scope_key"
+    OR target_bundle."evidence_scope_key"<>'afl-player-match-reviewed-2021-2026'
+    OR target_bundle."candidate_count"<>base_bundle."candidate_count"
+    OR target_bundle."decision_count"<>base_bundle."decision_count"
+    OR base_bundle."source_capture_count"<>6 OR base_bundle."source_rights_count"<>2
+    OR target_bundle."source_capture_count"<>7 OR target_bundle."source_rights_count"<>3
+    OR jsonb_typeof(base_bundle."bundle_json"->'content'->'sourceCaptures')<>'array'
+    OR jsonb_array_length(base_bundle."bundle_json"->'content'->'sourceCaptures')<>6
+    OR (SELECT count(DISTINCT item) FROM jsonb_array_elements(
+      base_bundle."bundle_json"->'content'->'sourceCaptures') item)<>6
+    OR jsonb_typeof(base_bundle."bundle_json"->'content'->'sourceRightsEvidenceRefs')<>'array'
+    OR jsonb_array_length(base_bundle."bundle_json"->'content'->'sourceRightsEvidenceRefs')<>2
+    OR (SELECT count(DISTINCT item) FROM jsonb_array_elements(
+      base_bundle."bundle_json"->'content'->'sourceRightsEvidenceRefs') item)<>2
+    OR jsonb_typeof(target_bundle."bundle_json"->'content'->'sourceCaptures')<>'array'
+    OR jsonb_array_length(target_bundle."bundle_json"->'content'->'sourceCaptures')<>7
+    OR (SELECT count(DISTINCT item) FROM jsonb_array_elements(
+      target_bundle."bundle_json"->'content'->'sourceCaptures') item)<>7
+    OR jsonb_typeof(target_bundle."bundle_json"->'content'->'sourceRightsEvidenceRefs')<>'array'
+    OR jsonb_array_length(target_bundle."bundle_json"->'content'->'sourceRightsEvidenceRefs')<>3
+    OR (SELECT count(DISTINCT item) FROM jsonb_array_elements(
+      target_bundle."bundle_json"->'content'->'sourceRightsEvidenceRefs') item)<>3
+    OR target_bundle."created_at"<=base_bundle."created_at"
+    OR target_bundle."bundle_json"->>'evidenceBundleId'<>
+      target_bundle."evidence_bundle_id"
+    OR target_bundle."bundle_json"->'content'->>'schemaVersion'<>
+      'afl-trade-private-reviewed-evidence-bundle/v1'
+    OR target_bundle."bundle_json"->'content'->>'authorityBoundary'<>
+      'exact_current_private_review_sets_and_retained_source_artifacts_for_internal_nonproduction_calculation_only'
+    OR target_bundle."bundle_json"->'content'->>'environment'<>'non_production'
+    OR target_bundle."bundle_json"->'content'->>'evidenceKind'<>'retained_private_review'
+    OR target_bundle."bundle_json"->'content'->>'evidenceScopeKey'<>
+      target_bundle."evidence_scope_key"
+    OR target_bundle."bundle_json"->'content'->'publicationEligible'<>'false'::JSONB
+    OR target_bundle."bundle_json"->'content'->'publicationProhibited'<>'true'::JSONB
+    OR target_bundle."bundle_json"->'content'->>'limitation'<>
+      'Exact retained private review evidence only; not a factual release, model-training input, public fact set, publication candidate, production authority, or live-capture authority.'
+    OR (target_bundle."bundle_json"->'content'->>'candidateCount')::INTEGER<>
+      target_bundle."candidate_count"
+    OR (target_bundle."bundle_json"->'content'->>'decisionCount')::INTEGER<>
+      target_bundle."decision_count"
+    OR (target_bundle."bundle_json"->'content'->>'createdAt')::TIMESTAMPTZ<>
+      target_bundle."created_at"
+    OR target_bundle."bundle_content_canonical_json"<>
+      "outcome_afl_trade_canonical_json"(target_bundle."bundle_json"->'content')
+    OR target_bundle."bundle_sha256"<>encode(sha256(convert_to(
+      target_bundle."bundle_content_canonical_json",'UTF8')),'hex')
+    OR target_bundle."evidence_bundle_id"<>
+      'private-reviewed-evidence-bundle:'||target_bundle."bundle_sha256"
+    OR (target_bundle."bundle_json"->'content'->'reviewSets')<>
+      (base_bundle."bundle_json"->'content'->'reviewSets')
+    OR NOT ((target_bundle."bundle_json"->'content'->'sourceCaptures') @>
+      (base_bundle."bundle_json"->'content'->'sourceCaptures'))
+    OR NOT ((target_bundle."bundle_json"->'content'->'sourceRightsEvidenceRefs') @>
+      (base_bundle."bundle_json"->'content'->'sourceRightsEvidenceRefs'))
+  THEN RETURN FALSE; END IF;
+
+  SELECT item INTO added_capture
+    FROM jsonb_array_elements(target_bundle."bundle_json"->'content'->'sourceCaptures') item
+   WHERE NOT ((base_bundle."bundle_json"->'content'->'sourceCaptures') @>
+     jsonb_build_array(item));
+  IF NOT FOUND OR added_capture IS NULL OR
+    (SELECT count(*) FROM jsonb_array_elements(
+      target_bundle."bundle_json"->'content'->'sourceCaptures') item
+      WHERE NOT ((base_bundle."bundle_json"->'content'->'sourceCaptures') @>
+        jsonb_build_array(item)))<>1
+  THEN RETURN FALSE; END IF;
+  SELECT capture.* INTO capture_record FROM "outcome_source_capture" capture
+   WHERE capture."capture_id"=added_capture->>'captureId';
+  SELECT custody.* INTO custody_record FROM "outcome_artifact_custody" custody
+   WHERE custody."artifact_id"=capture_record."source_artifact_id";
+  IF capture_record."capture_id" IS NULL OR custody_record."artifact_id" IS NULL
+    OR capture_record."environment"<>'non_production'
+    OR capture_record."status"<>'staged'
+    OR capture_record."provider"<>'afl_tables'
+    OR capture_record."capability_id"<>'afl-tables-results'
+    OR capture_record."competition"<>'AFLM'
+    OR capture_record."anchor_season_year"<>2026
+    OR custody_record."environment"<>'non_production'
+    OR custody_record."verified_at" IS NULL
+    OR added_capture->>'provider'<>capture_record."provider"
+    OR added_capture->>'capabilityId'<>capture_record."capability_id"
+    OR (added_capture->>'seasonYear')::INTEGER<>capture_record."anchor_season_year"
+    OR added_capture->'sourceArtifact'->>'artifactId'<>custody_record."artifact_id"
+    OR added_capture->'sourceArtifact'->>'contentSha256'<>custody_record."content_sha256"
+    OR added_capture->'sourceArtifact'->>'storageUri'<>custody_record."storage_uri"
+    OR added_capture->'sourceArtifact'->>'mediaType'<>custody_record."media_type"
+    OR (added_capture->'sourceArtifact'->>'byteLength')::BIGINT<>custody_record."byte_length"
+    OR (added_capture->'sourceArtifact'->>'createdAt')::TIMESTAMPTZ<>
+      custody_record."created_at"
+    OR custody_record."created_at">target_bundle."created_at"
+  THEN RETURN FALSE; END IF;
+
+  SELECT item INTO added_rights
+    FROM jsonb_array_elements(
+      target_bundle."bundle_json"->'content'->'sourceRightsEvidenceRefs') item
+   WHERE NOT ((base_bundle."bundle_json"->'content'->'sourceRightsEvidenceRefs') @>
+     jsonb_build_array(item));
+  IF NOT FOUND OR added_rights IS NULL OR
+    (SELECT count(*) FROM jsonb_array_elements(
+      target_bundle."bundle_json"->'content'->'sourceRightsEvidenceRefs') item
+      WHERE NOT ((base_bundle."bundle_json"->'content'->'sourceRightsEvidenceRefs') @>
+        jsonb_build_array(item)))<>1
+  THEN RETURN FALSE; END IF;
+  SELECT rights.* INTO rights_record FROM "outcome_source_rights_proposal" rights
+   WHERE rights."rights_artifact_id"=
+     capture_record."manifest_json"->'sourceRightsProposal'->>'rightsArtifactId';
+  IF rights_record."rights_artifact_id" IS NULL THEN RETURN FALSE; END IF;
+  rights_canonical:="outcome_afl_trade_canonical_json"(rights_record."content_json");
+  rights_sha256:=encode(sha256(convert_to(rights_canonical,'UTF8')),'hex');
+  RETURN COALESCE(
+    rights_record."rights_artifact_id"='source-rights:'||encode(sha256(convert_to(
+      "outcome_afl_trade_canonical_json"(rights_record."content_json"->'content'),'UTF8')),'hex')
+    AND rights_record."rights_artifact_id"=
+      rights_record."content_json"->>'rightsArtifactId'
+    AND added_rights->>'artifactId'='artifact:'||rights_sha256
+    AND added_rights->>'contentSha256'=rights_sha256
+    AND added_rights->>'storageUri'='artifact://sha256/'||rights_sha256
+    AND added_rights->>'mediaType'='application/json'
+    AND (added_rights->>'byteLength')::INTEGER=
+      octet_length(convert_to(rights_canonical,'UTF8'))
+    AND (added_rights->>'createdAt')::TIMESTAMPTZ=rights_record."proposed_at"
+    AND rights_record."proposed_at"<=target_bundle."created_at",
+    FALSE
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql STABLE STRICT;
+
+CREATE FUNCTION "outcome_private_reviewed_evidence_bundle_is_current"(
+  target_evidence_bundle_id TEXT
+) RETURNS BOOLEAN AS $$
+  SELECT "outcome_private_reviewed_evidence_bundle_is_current_v1"($1)
+    OR EXISTS (
+      SELECT 1
+        FROM "outcome_private_reviewed_evaluation_head" head
+        JOIN "outcome_private_reviewed_evaluation_decision" decision
+          ON decision."decision_id"=head."decision_id"
+        JOIN "outcome_private_reviewed_evaluation_decision" predecessor
+          ON predecessor."decision_id"=decision."supersedes_decision_id"
+       WHERE head."evidence_bundle_id"=$1
+         AND head."status"='authorized' AND decision."status"='authorized'
+         AND "outcome_private_reviewed_evidence_results_successor_is_exact"(
+           decision."evidence_bundle_id",predecessor."evidence_bundle_id"));
+$$ LANGUAGE sql STABLE STRICT;
+
+DROP TRIGGER "outcome_private_reviewed_evidence_bundle_insert_guard"
+  ON "outcome_private_reviewed_evidence_bundle";
+CREATE TRIGGER "outcome_private_reviewed_evidence_bundle_insert_guard"
+  BEFORE INSERT ON "outcome_private_reviewed_evidence_bundle"
+  FOR EACH ROW
+  WHEN (NEW."source_capture_count"=6 AND NEW."source_rights_count"=2)
+  EXECUTE FUNCTION "validate_outcome_private_reviewed_evidence_bundle_insert"();
+
+CREATE FUNCTION "validate_outcome_private_reviewed_evidence_results_successor_insert"()
+RETURNS TRIGGER AS $$
+DECLARE base_bundle_id TEXT;
+BEGIN
+  SELECT head."evidence_bundle_id" INTO base_bundle_id
+    FROM "outcome_private_reviewed_evaluation_head" head
+   WHERE head."valuation_scope_key"='afl-men:2026-trades'
+     AND head."evidence_scope_key"=NEW."evidence_scope_key"
+     AND head."status"='authorized';
+  IF base_bundle_id IS NULL OR NOT
+    "outcome_private_reviewed_evidence_results_successor_is_exact"(
+      NEW."evidence_bundle_id",base_bundle_id) THEN
+    RAISE EXCEPTION 'Private reviewed evidence results successor failed exact authentication';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "outcome_private_reviewed_evidence_results_successor_insert_guard"
+  AFTER INSERT ON "outcome_private_reviewed_evidence_bundle"
+  FOR EACH ROW
+  WHEN (NEW."source_capture_count"=7 AND NEW."source_rights_count"=3)
+  EXECUTE FUNCTION "validate_outcome_private_reviewed_evidence_results_successor_insert"();
+
+CREATE FUNCTION "reject_outcome_private_reviewed_evidence_unsupported_shape"()
+RETURNS TRIGGER AS $$ BEGIN
+  RAISE EXCEPTION 'Private reviewed evidence bundle shape is unsupported';
+END; $$ LANGUAGE plpgsql;
+CREATE TRIGGER "outcome_private_reviewed_evidence_unsupported_shape_guard"
+  BEFORE INSERT ON "outcome_private_reviewed_evidence_bundle"
+  FOR EACH ROW
+  WHEN (NOT ((NEW."source_capture_count"=6 AND NEW."source_rights_count"=2)
+          OR (NEW."source_capture_count"=7 AND NEW."source_rights_count"=3)))
+  EXECUTE FUNCTION "reject_outcome_private_reviewed_evidence_unsupported_shape"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_reviewed_evaluation_decision_insert"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  content JSONB; bundle RECORD; bundle_canonical TEXT; bundle_sha TEXT;
+  predecessor RECORD; current_head RECORD;
+BEGIN
+  content:=NEW."decision_json"->'content';
+  SELECT * INTO bundle FROM "outcome_private_reviewed_evidence_bundle"
+   WHERE "evidence_bundle_id"=NEW."evidence_bundle_id" FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Private reviewed-evidence evaluation decision failed exact authentication';
+  END IF;
+  bundle_canonical:="outcome_afl_trade_canonical_json"(bundle."bundle_json");
+  bundle_sha:=encode(sha256(convert_to(bundle_canonical,'UTF8')),'hex');
+  IF NEW."decision_json"->>'decisionId' IS DISTINCT FROM NEW."decision_id"
+     OR content->>'schemaVersion'<>
+       'afl-trade-private-reviewed-evidence-evaluation-decision/v1'
+     OR content->>'authorityBoundary'<>
+       'exact_current_private_review_sets_and_retained_source_artifacts_for_internal_nonproduction_calculation_only'
+     OR content->>'environment'<>'non_production'
+     OR content->>'operation'<>'private_nonproduction_derived_calculation'
+     OR content->>'evidenceKind'<>'retained_private_review'
+     OR content->>'status' IS DISTINCT FROM NEW."status"
+     OR content->>'valuationScopeKey' IS DISTINCT FROM NEW."valuation_scope_key"
+     OR content->>'evidenceBundleId' IS DISTINCT FROM NEW."evidence_bundle_id"
+     OR content->>'sourceRightsEffect'<>
+       'supplemental_evaluation_authority_does_not_amend_source_rights'
+     OR content->'permissions' IS DISTINCT FROM jsonb_build_object(
+       'derivedCalculations',true,'internalEvaluation',true,'modelTraining',false,
+       'publicDisplay',false,'redistribution',false,'productionActivation',false,
+       'liveCapture',false)
+     OR content->'publicationEligible' IS DISTINCT FROM 'false'::JSONB
+     OR content->'publicationProhibited' IS DISTINCT FROM 'true'::JSONB
+     OR content->>'limitation'<>
+       'This decision authorizes only private local non-production derived calculations from the exact retained reviewed evidence bundle for internal evaluation. It grants no model-training, public-display, redistribution, production-activation, live-capture, factual-release, or publication authority.'
+     OR jsonb_typeof(content->'revision')<>'number'
+     OR (content->>'revision')::INTEGER<>NEW."revision"
+     OR content->>'supersedesDecisionId' IS DISTINCT FROM NEW."supersedes_decision_id"
+     OR content->>'reviewerId' IS DISTINCT FROM NEW."reviewer_id"
+     OR length(btrim(content->>'rationale')) NOT BETWEEN 1 AND 2000
+     OR jsonb_typeof(content->'decidedAt')<>'string'
+     OR (content->>'decidedAt')::TIMESTAMPTZ<>NEW."decided_at"
+     OR NEW."decided_at"<>NEW."registered_at"
+     OR NEW."decision_content_canonical_json"::JSONB IS DISTINCT FROM content
+     OR encode(sha256(convert_to(NEW."decision_content_canonical_json",'UTF8')),'hex')<>
+       NEW."decision_sha256"
+     OR NEW."decision_id"<>'private-reviewed-evidence-evaluation-decision:'||
+       NEW."decision_sha256"
+     OR content->'evidenceBundleArtifact'->>'artifactId' IS DISTINCT FROM
+       'artifact:'||bundle_sha
+     OR content->'evidenceBundleArtifact'->>'contentSha256' IS DISTINCT FROM bundle_sha
+     OR content->'evidenceBundleArtifact'->>'storageUri' IS DISTINCT FROM
+       'artifact://sha256/'||bundle_sha
+     OR content->'evidenceBundleArtifact'->>'mediaType'<>'application/json'
+     OR (content->'evidenceBundleArtifact'->>'byteLength')::INTEGER<>
+       octet_length(convert_to(bundle_canonical,'UTF8'))
+     OR (content->'evidenceBundleArtifact'->>'createdAt')::TIMESTAMPTZ<>
+       bundle."created_at"
+  THEN
+    RAISE EXCEPTION 'Private reviewed-evidence evaluation decision failed exact authentication';
+  END IF;
+
+  IF NEW."supersedes_decision_id" IS NULL THEN
+    IF NEW."revision"<>1 OR NOT
+      "outcome_private_reviewed_evidence_bundle_is_current"(NEW."evidence_bundle_id") THEN
+      RAISE EXCEPTION 'Private reviewed-evidence decision has invalid chronology';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  SELECT * INTO predecessor FROM "outcome_private_reviewed_evaluation_decision"
+   WHERE "decision_id"=NEW."supersedes_decision_id" FOR KEY SHARE;
+  SELECT * INTO current_head FROM "outcome_private_reviewed_evaluation_head"
+   WHERE "valuation_scope_key"=NEW."valuation_scope_key"
+     AND "decision_id"=NEW."supersedes_decision_id" FOR UPDATE;
+  IF predecessor."decision_id" IS NULL OR current_head."decision_id" IS NULL
+     OR predecessor."valuation_scope_key"<>NEW."valuation_scope_key"
+     OR predecessor."revision"<>NEW."revision"-1
+     OR predecessor."decided_at">NEW."decided_at"
+     OR current_head."revision"<>predecessor."revision"
+     OR current_head."evidence_bundle_id"<>predecessor."evidence_bundle_id"
+     OR (
+       predecessor."evidence_bundle_id"=NEW."evidence_bundle_id"
+       AND predecessor."status"=NEW."status"
+     )
+     OR (
+       predecessor."evidence_bundle_id"<>NEW."evidence_bundle_id"
+       AND (
+         predecessor."status"<>'authorized' OR NEW."status"<>'authorized'
+         OR NOT "outcome_private_reviewed_evidence_results_successor_is_exact"(
+           NEW."evidence_bundle_id",predecessor."evidence_bundle_id")
+       )
+     )
+  THEN
+    RAISE EXCEPTION 'Private reviewed-evidence decision has invalid chronology';
+  END IF;
+  RETURN NEW;
+EXCEPTION WHEN invalid_text_representation OR datetime_field_overflow OR numeric_value_out_of_range THEN
+  RAISE EXCEPTION 'Private reviewed-evidence evaluation decision failed exact authentication';
+END $$;
+
+CREATE FUNCTION "outcome_hpn_pav_projected_reviewed_fields"(map_json JSONB)
+RETURNS JSONB AS $$
+  SELECT COALESCE(jsonb_agg(field ORDER BY field COLLATE "C"),'[]'::JSONB)
+    FROM (
+      SELECT DISTINCT CASE mapping->>'kind'
+        WHEN 'direct' THEN mapping->>'sourceField'
+        ELSE NULL END AS field
+        FROM jsonb_array_elements(map_json#>'{content,semanticBindings}') binding
+        CROSS JOIN LATERAL (SELECT binding->'mapping' AS mapping) selected
+      UNION
+      SELECT DISTINCT source_field
+        FROM jsonb_array_elements(map_json#>'{content,semanticBindings}') binding
+        CROSS JOIN LATERAL jsonb_array_elements_text(
+          CASE WHEN binding#>>'{mapping,kind}'='composite_key'
+            THEN binding#>'{mapping,sourceFields}' ELSE '[]'::JSONB END
+        ) source_field
+      UNION
+      SELECT DISTINCT binding#>>'{mapping,goals}'
+        FROM jsonb_array_elements(map_json#>'{content,semanticBindings}') binding
+       WHERE binding#>>'{mapping,kind}'='goals_plus_behinds'
+      UNION
+      SELECT DISTINCT binding#>>'{mapping,behinds}'
+        FROM jsonb_array_elements(map_json#>'{content,semanticBindings}') binding
+       WHERE binding#>>'{mapping,kind}'='goals_plus_behinds'
+      UNION
+      SELECT DISTINCT binding#>>'{mapping,matchDateField}'
+        FROM jsonb_array_elements(map_json#>'{content,semanticBindings}') binding
+       WHERE binding#>>'{mapping,kind}'='reviewed_final_scores'
+      UNION
+      SELECT DISTINCT binding#>>'{mapping,homePointsField}'
+        FROM jsonb_array_elements(map_json#>'{content,semanticBindings}') binding
+       WHERE binding#>>'{mapping,kind}'='reviewed_final_scores'
+      UNION
+      SELECT DISTINCT binding#>>'{mapping,awayPointsField}'
+        FROM jsonb_array_elements(map_json#>'{content,semanticBindings}') binding
+       WHERE binding#>>'{mapping,kind}'='reviewed_final_scores'
+    ) fields
+   WHERE field IS NOT NULL;
+$$ LANGUAGE sql IMMUTABLE STRICT;
+
+CREATE FUNCTION "outcome_hpn_json_artifact_ref_is_exact"(
+  artifact_ref JSONB,document JSONB
+) RETURNS BOOLEAN AS $$
+DECLARE canonical_document TEXT; document_sha256 TEXT;
+BEGIN
+  IF jsonb_typeof(artifact_ref)<>'object'
+    OR (SELECT count(*) FROM jsonb_object_keys(artifact_ref))<>6 THEN
+    RETURN FALSE;
+  END IF;
+  canonical_document:="outcome_afl_trade_canonical_json"(document);
+  document_sha256:=encode(sha256(convert_to(canonical_document,'UTF8')),'hex');
+  RETURN COALESCE(
+    artifact_ref->>'artifactId'='artifact:'||document_sha256
+    AND artifact_ref->>'contentSha256'=document_sha256
+    AND artifact_ref->>'storageUri'='artifact://sha256/'||document_sha256
+    AND artifact_ref->>'mediaType'='application/json'
+    AND jsonb_typeof(artifact_ref->'byteLength')='number'
+    AND (artifact_ref->>'byteLength')::INTEGER=
+      octet_length(convert_to(canonical_document,'UTF8'))
+    AND jsonb_typeof(artifact_ref->'createdAt')='string'
+    AND (artifact_ref->>'createdAt')::TIMESTAMPTZ IS NOT NULL,
+    FALSE
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
+CREATE FUNCTION "outcome_hpn_projected_candidate_is_exact"(candidate_json JSONB)
+RETURNS BOOLEAN AS $$
+DECLARE content JSONB; bindings JSONB; completion_rule JSONB;
+  expected_fields JSONB; binding JSONB; mapping JSONB; mapping_kind TEXT;
+  semantic_field TEXT; consumed_fields TEXT[]:=ARRAY[]::TEXT[];
+BEGIN
+  IF jsonb_typeof(candidate_json)<>'object'
+    OR (SELECT count(*) FROM jsonb_object_keys(candidate_json))<>2
+    OR jsonb_typeof(candidate_json->'content')<>'object'
+    OR (SELECT count(*) FROM jsonb_object_keys(candidate_json->'content'))<>19 THEN
+    RETURN FALSE;
+  END IF;
+  content:=candidate_json->'content';
+  bindings:=content->'semanticBindings';
+  completion_rule:=content->'completionRule';
+  IF content->>'schemaVersion'<>'afl-trade-hpn-field-map-candidate/v2'
+    OR content->>'environment'<>'non_production'
+    OR content->>'purpose'<>'private_confirmed_realized_hpn_pav_review'
+    OR content->>'competition'<>'AFLM'
+    OR content->>'reviewState'<>'requires_review'
+    OR content->'publicationEligible' IS DISTINCT FROM 'false'::JSONB
+    OR content->'publicationProhibited' IS DISTINCT FROM 'true'::JSONB
+    OR content->>'limitation'<>
+      'Unapproved field-map candidate for private local review only; it cannot satisfy HPN input admission until an exact current review decision creates a governed HPN field map.'
+    OR content->>'provider' !~ '^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,239}$'
+    OR content->>'capabilityId' !~ '^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,239}$'
+    OR content->>'providerDecodeMapId' !~ '^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,239}$'
+    OR content->>'sourceSchemaSha256' !~ '^[a-f0-9]{64}$'
+    OR content->>'inputKind' NOT IN ('completed_match_result','player_match_stats')
+    OR jsonb_typeof(content->'validFromSeason')<>'number'
+    OR jsonb_typeof(content->'validThroughSeason')<>'number'
+    OR (content->>'validFromSeason')::INTEGER NOT BETWEEN 1998 AND 2200
+    OR (content->>'validThroughSeason')::INTEGER NOT BETWEEN
+      (content->>'validFromSeason')::INTEGER AND 2200
+    OR jsonb_typeof(content->'createdAt')<>'string'
+    OR (content->>'createdAt')::TIMESTAMPTZ IS NULL
+    OR NOT "outcome_hpn_json_artifact_ref_is_exact"(
+      content->'providerDecodeMapArtifact',
+      (SELECT map_json FROM "outcome_provider_field_map"
+        WHERE field_map_id=content->>'providerDecodeMapId')
+    )
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_provider_field_map" decode_map
+       WHERE decode_map."field_map_id"=content->>'providerDecodeMapId'
+         AND decode_map."capability_id"=content->>'capabilityId'
+         AND decode_map."source_schema_sha256"=content->>'sourceSchemaSha256'
+    )
+    OR (content#>>'{providerDecodeMapArtifact,createdAt}')::TIMESTAMPTZ>
+      (content->>'createdAt')::TIMESTAMPTZ
+    OR jsonb_typeof(bindings)<>'array' THEN
+    RETURN FALSE;
+  END IF;
+
+  expected_fields:=CASE content->>'inputKind'
+    WHEN 'completed_match_result' THEN
+      '["awayClub","awayPoints","completionStatus","homeClub","homePoints","match"]'::JSONB
+    ELSE
+      '["clearances","club","freeKicksAgainst","freeKicksFor","goalAssists","hitOuts","inside50s","marks","marksInside50","match","onePercenters","player","rebound50s","tackles","totalPoints"]'::JSONB
+  END;
+  IF (SELECT jsonb_agg(value->'semanticField' ORDER BY ordinal)
+        FROM jsonb_array_elements(bindings) WITH ORDINALITY item(value,ordinal))
+      IS DISTINCT FROM expected_fields THEN
+    RETURN FALSE;
+  END IF;
+
+  FOR binding IN SELECT value FROM jsonb_array_elements(bindings) item(value)
+  LOOP
+    IF jsonb_typeof(binding)<>'object'
+      OR (SELECT count(*) FROM jsonb_object_keys(binding))<>2
+      OR jsonb_typeof(binding->'semanticField')<>'string'
+      OR jsonb_typeof(binding->'mapping')<>'object' THEN
+      RETURN FALSE;
+    END IF;
+    semantic_field:=binding->>'semanticField';
+    mapping:=binding->'mapping';
+    mapping_kind:=mapping->>'kind';
+    IF mapping_kind='direct' THEN
+      IF (SELECT count(*) FROM jsonb_object_keys(mapping))<>2
+        OR mapping->>'sourceField' IS NULL
+        OR length(btrim(mapping->>'sourceField')) NOT BETWEEN 1 AND 200
+        OR mapping->>'sourceField'<>btrim(mapping->>'sourceField') THEN
+        RETURN FALSE;
+      END IF;
+      consumed_fields:=array_append(consumed_fields,mapping->>'sourceField');
+    ELSIF mapping_kind='goals_plus_behinds' THEN
+      IF semantic_field<>'totalPoints'
+        OR (SELECT count(*) FROM jsonb_object_keys(mapping))<>3
+        OR length(btrim(mapping->>'goals')) NOT BETWEEN 1 AND 200
+        OR length(btrim(mapping->>'behinds')) NOT BETWEEN 1 AND 200
+        OR mapping->>'goals'<>btrim(mapping->>'goals')
+        OR mapping->>'behinds'<>btrim(mapping->>'behinds') THEN
+        RETURN FALSE;
+      END IF;
+      consumed_fields:=array_append(consumed_fields,mapping->>'goals');
+      consumed_fields:=array_append(consumed_fields,mapping->>'behinds');
+    ELSIF mapping_kind='composite_key' THEN
+      IF semantic_field<>'match'
+        OR (SELECT count(*) FROM jsonb_object_keys(mapping))<>2
+        OR jsonb_typeof(mapping->'sourceFields')<>'array'
+        OR jsonb_array_length(mapping->'sourceFields') NOT BETWEEN 2 AND 10
+        OR EXISTS (
+          SELECT 1 FROM jsonb_array_elements(mapping->'sourceFields') source(value)
+           WHERE jsonb_typeof(value)<>'string'
+             OR length(btrim(value#>>'{}')) NOT BETWEEN 1 AND 200
+             OR value#>>'{}'<>btrim(value#>>'{}'))
+        OR (SELECT count(*) FROM jsonb_array_elements_text(mapping->'sourceFields'))<>
+           (SELECT count(DISTINCT value) FROM jsonb_array_elements_text(
+             mapping->'sourceFields') source(value)) THEN
+        RETURN FALSE;
+      END IF;
+    ELSIF mapping_kind='reviewed_final_scores' THEN
+      IF semantic_field<>'completionStatus'
+        OR (SELECT count(*) FROM jsonb_object_keys(mapping))<>4
+        OR length(btrim(mapping->>'matchDateField')) NOT BETWEEN 1 AND 200
+        OR length(btrim(mapping->>'homePointsField')) NOT BETWEEN 1 AND 200
+        OR length(btrim(mapping->>'awayPointsField')) NOT BETWEEN 1 AND 200 THEN
+        RETURN FALSE;
+      END IF;
+    ELSE
+      RETURN FALSE;
+    END IF;
+    IF semantic_field='totalPoints' AND mapping_kind NOT IN ('direct','goals_plus_behinds')
+      OR semantic_field='match' AND mapping_kind NOT IN ('direct','composite_key')
+      OR semantic_field='completionStatus' AND mapping_kind NOT IN ('direct','reviewed_final_scores')
+      OR semantic_field NOT IN ('totalPoints','match','completionStatus')
+         AND mapping_kind<>'direct' THEN
+      RETURN FALSE;
+    END IF;
+  END LOOP;
+  IF cardinality(consumed_fields)<>(SELECT count(DISTINCT field)
+      FROM unnest(consumed_fields) field) THEN
+    RETURN FALSE;
+  END IF;
+
+  IF content->>'inputKind'='player_match_stats' THEN
+    RETURN completion_rule='null'::JSONB;
+  END IF;
+  IF jsonb_typeof(completion_rule)<>'object' THEN RETURN FALSE; END IF;
+  IF completion_rule->>'kind'='source_status' THEN
+    RETURN (SELECT count(*) FROM jsonb_object_keys(completion_rule))=2
+      AND jsonb_typeof(completion_rule->'completedValues')='array'
+      AND jsonb_array_length(completion_rule->'completedValues') BETWEEN 1 AND 20
+      AND NOT EXISTS (
+        SELECT 1 FROM jsonb_array_elements(completion_rule->'completedValues') item(value)
+         WHERE jsonb_typeof(value)<>'string'
+           OR length(btrim(value#>>'{}')) NOT BETWEEN 1 AND 120)
+      AND EXISTS (
+        SELECT 1 FROM jsonb_array_elements(bindings) item(value)
+         WHERE value->>'semanticField'='completionStatus'
+           AND value#>>'{mapping,kind}'='direct');
+  END IF;
+  RETURN completion_rule->>'kind'='reviewed_final_score_presence'
+    AND (SELECT count(*) FROM jsonb_object_keys(completion_rule))=2
+    AND completion_rule->'decisionRequired' IS NOT DISTINCT FROM 'true'::JSONB
+    AND EXISTS (
+      SELECT 1 FROM jsonb_array_elements(bindings) item(value)
+       WHERE value->>'semanticField'='completionStatus'
+         AND value#>>'{mapping,kind}'='reviewed_final_scores');
+EXCEPTION WHEN OTHERS THEN
+  RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql STABLE STRICT;
+
+CREATE FUNCTION "outcome_hpn_private_source_rights_permit"(
+  rights_json JSONB,
+  source_fields JSONB,
+  target_competition TEXT,
+  target_season_year INTEGER,
+  target_effective_at TIMESTAMPTZ
+) RETURNS BOOLEAN AS $$
+DECLARE rights_sha256 TEXT;
+BEGIN
+  rights_sha256:=encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(rights_json->'content'),'UTF8')),'hex');
+  RETURN COALESCE(
+    jsonb_typeof(rights_json)='object'
+    AND rights_json->>'rightsArtifactId'='source-rights:'||rights_sha256
+    AND rights_json#>>'{content,schemaVersion}'='afl-trade-source-rights/v2'
+    AND (rights_json#>'{content,scope,competitions}') ? target_competition
+    AND EXISTS (
+      SELECT 1
+        FROM jsonb_array_elements(rights_json#>'{content,scope,seasonRanges}') item(range)
+       WHERE target_season_year BETWEEN
+         (range->>'from')::INTEGER AND (range->>'to')::INTEGER)
+    AND (
+      jsonb_array_length(rights_json#>'{content,restrictions,commercial}')=0
+      OR (rights_json#>'{content,restrictions,commercial}') ? 'internal-evaluation')
+    AND (
+      jsonb_array_length(rights_json#>'{content,restrictions,audience}')=0
+      OR (rights_json#>'{content,restrictions,audience}') ? 'internal')
+    AND (rights_json#>>'{content,termsEffectiveAt}' IS NULL
+      OR target_effective_at>=(rights_json#>>'{content,termsEffectiveAt}')::TIMESTAMPTZ)
+    AND (rights_json#>>'{content,termsExpireAt}' IS NULL
+      OR target_effective_at<(rights_json#>>'{content,termsExpireAt}')::TIMESTAMPTZ)
+    AND rights_json#>>'{content,operations,derived_feature_creation}'='allowed'
+    AND rights_json#>>'{content,retention,derivedArtifacts,disposition}'<>'prohibited'
+    AND (rights_json#>'{content,retention,derivedArtifacts,deleteOnWithdrawal}')=
+      'true'::JSONB
+    AND (rights_json#>'{content,withdrawalDuties,stopNewDerivedWork}')='true'::JSONB
+    AND jsonb_typeof(source_fields)='array'
+    AND jsonb_array_length(source_fields)>0
+    AND (SELECT count(*) FROM jsonb_array_elements_text(source_fields))=
+      (SELECT count(DISTINCT field) FROM jsonb_array_elements_text(source_fields) item(field))
+    AND NOT EXISTS (
+      SELECT 1 FROM jsonb_array_elements_text(source_fields) item(field)
+       WHERE NOT EXISTS (
+         SELECT 1 FROM jsonb_array_elements(rights_json#>'{content,fields}') item(rights_field)
+          WHERE rights_field->>'sourceField'=field
+            AND rights_field#>>'{uses,derived_feature}'='allowed')),
+    FALSE
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
+CREATE FUNCTION "outcome_hpn_projected_field_map_authority_is_exact"(
+  target_field_map_id TEXT,
+  target_effective_at TIMESTAMPTZ
+) RETURNS BOOLEAN AS $$
+DECLARE candidate RECORD; decision RECORD; projected RECORD;
+  reviewed RECORD;
+  assessment JSONB; assessment_content JSONB; expected_map_content JSONB;
+  candidate_sha256 TEXT; decision_sha256 TEXT; assessment_sha256 TEXT;
+  field_map_sha256 TEXT; rights_content_sha256 TEXT;
+  assessed_fields JSONB; rights_overbroad BOOLEAN;
+BEGIN
+  SELECT * INTO projected FROM "outcome_hpn_projected_field_map"
+   WHERE "field_map_id"=target_field_map_id;
+  IF NOT FOUND THEN RETURN FALSE; END IF;
+  SELECT * INTO candidate FROM "outcome_hpn_field_map_candidate"
+   WHERE "candidate_id"=projected."candidate_id";
+  IF NOT FOUND THEN RETURN FALSE; END IF;
+  SELECT * INTO decision FROM "outcome_hpn_field_map_review_decision"
+   WHERE "decision_id"=projected."approval_decision_id";
+  IF NOT FOUND THEN RETURN FALSE; END IF;
+  assessment:=decision."source_use_assessment_json";
+  assessment_content:=assessment->'content';
+  SELECT evaluation.*,head."evidence_scope_key" AS head_evidence_scope_key,
+         head."revision" AS head_revision,head."status" AS head_status,
+         bundle."bundle_json",bundle."bundle_content_canonical_json",
+         bundle."bundle_sha256",bundle."created_at" AS bundle_created_at,
+         rights."rights_artifact_id",rights."content_json" AS rights_json,
+         rights."proposed_at" AS rights_proposed_at
+    INTO reviewed
+    FROM "outcome_private_reviewed_evaluation_decision" evaluation
+    JOIN "outcome_private_reviewed_evaluation_head" head
+      ON head."decision_id"=evaluation."decision_id"
+     AND head."valuation_scope_key"=evaluation."valuation_scope_key"
+     AND head."evidence_bundle_id"=evaluation."evidence_bundle_id"
+    JOIN "outcome_private_reviewed_evidence_bundle" bundle
+      ON bundle."evidence_bundle_id"=evaluation."evidence_bundle_id"
+     AND bundle."evidence_scope_key"=head."evidence_scope_key"
+    JOIN "outcome_source_rights_proposal" rights
+      ON rights."rights_artifact_id"=assessment_content->>'rightsArtifactId'
+   WHERE evaluation."decision_id"=assessment_content->>'evaluationDecisionId'
+     AND evaluation."evidence_bundle_id"=assessment_content->>'evidenceBundleId'
+     AND evaluation."valuation_scope_key"=assessment_content->>'valuationScopeKey';
+  IF NOT FOUND THEN RETURN FALSE; END IF;
+  rights_overbroad:=
+    reviewed."rights_json"#>>'{content,operations,model_training}'<>'blocked'
+    OR reviewed."rights_json"#>>'{content,operations,public_derived_output}'<>'blocked'
+    OR reviewed."rights_json"#>>'{content,operations,public_fact_display}'<>'blocked'
+    OR reviewed."rights_json"#>>'{content,operations,raw_field_redistribution}'<>'blocked'
+    OR reviewed."rights_json"#>'{content,redistribution,rawFieldsPermitted}'<>'false'::JSONB
+    OR reviewed."rights_json"#>'{content,redistribution,publicDerivedOutputPermitted}'<>
+      'false'::JSONB
+    OR EXISTS (
+      SELECT 1 FROM jsonb_array_elements(reviewed."rights_json"#>'{content,fields}') item(field)
+       WHERE field#>>'{uses,model_training}'<>'blocked'
+          OR field#>>'{uses,public_display}'<>'blocked');
+
+  candidate_sha256:=encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(candidate."candidate_json"->'content'),'UTF8')),'hex');
+  decision_sha256:=encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(decision."decision_json"->'content'),'UTF8')),'hex');
+  assessment_sha256:=encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(assessment_content),'UTF8')),'hex');
+  field_map_sha256:=encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(projected."map_json"->'content'),'UTF8')),'hex');
+  rights_content_sha256:=encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(reviewed."rights_json"->'content'),'UTF8')),'hex');
+  SELECT COALESCE(jsonb_agg(field->'sourceField' ORDER BY field->>'sourceField'),'[]'::JSONB)
+    INTO assessed_fields
+    FROM jsonb_array_elements(assessment_content->'fields') item(field);
+
+  expected_map_content:=jsonb_build_object(
+    'schemaVersion','afl-trade-hpn-projected-field-map/v1',
+    'environment','non_production',
+    'purpose','private_confirmed_realized_hpn_pav',
+    'competition',candidate."candidate_json"#>>'{content,competition}',
+    'provider',candidate."candidate_json"#>>'{content,provider}',
+    'capabilityId',candidate."candidate_json"#>>'{content,capabilityId}',
+    'sourceSchemaSha256',candidate."candidate_json"#>>'{content,sourceSchemaSha256}',
+    'inputKind',candidate."candidate_json"#>>'{content,inputKind}',
+    'validFromSeason',candidate."candidate_json"#>'{content,validFromSeason}',
+    'validThroughSeason',candidate."candidate_json"#>'{content,validThroughSeason}',
+    'candidateId',candidate."candidate_id",
+    'candidateArtifact',candidate."candidate_artifact_json",
+    'approvalDecisionId',decision."decision_id",
+    'approvalDecisionArtifact',decision."decision_artifact_json",
+    'semanticBindings',candidate."candidate_json"#>'{content,semanticBindings}',
+    'completionRule',candidate."candidate_json"#>'{content,completionRule}',
+    'createdAt',decision."decision_json"#>'{content,decidedAt}',
+    'publicationEligible',false,
+    'publicationProhibited',true,
+    'limitation',
+      'Private non-production projection map only; it grants no factual release, model training, publication, production, activation, or live-capture authority.'
+  );
+
+  RETURN COALESCE(
+    "outcome_hpn_projected_candidate_is_exact"(candidate."candidate_json")
+    AND candidate."candidate_id"='hpn-field-map-candidate:'||candidate_sha256
+    AND candidate."candidate_sha256"=candidate_sha256
+    AND candidate."candidate_canonical_json"=
+      "outcome_afl_trade_canonical_json"(candidate."candidate_json")
+    AND "outcome_hpn_json_artifact_ref_is_exact"(
+      candidate."candidate_artifact_json",candidate."candidate_json")
+    AND decision."decision_id"='hpn-field-map-review-decision:'||decision_sha256
+    AND decision."decision_sha256"=decision_sha256
+    AND decision."decision_canonical_json"=
+      "outcome_afl_trade_canonical_json"(decision."decision_json")
+    AND decision."decision"='approved'
+    AND decision."decision_json"#>>'{content,schemaVersion}'=
+      'afl-trade-hpn-field-map-review-decision/v2'
+    AND decision."decision_json"#>>'{content,environment}'='non_production'
+    AND decision."decision_json"#>>'{content,purpose}'=
+      'private_confirmed_realized_hpn_pav_review'
+    AND decision."decision_json"#>>'{content,candidateId}'=candidate."candidate_id"
+    AND decision."decision_json"#>'{content,candidateArtifact}'=
+      candidate."candidate_artifact_json"
+    AND decision."decision_json"#>>'{content,sourceUseAssessmentId}'=
+      decision."source_use_assessment_id"
+    AND decision."decision_json"#>'{content,sourceUseAssessmentArtifact}'=
+      decision."source_use_assessment_artifact_json"
+    AND decision."decision_json"#>'{content,publicationEligible}'='false'::JSONB
+    AND decision."decision_json"#>'{content,publicationProhibited}'='true'::JSONB
+    AND (SELECT count(*) FROM jsonb_object_keys(decision."decision_json"))=2
+    AND (SELECT count(*) FROM jsonb_object_keys(
+      decision."decision_json"->'content'))=14
+    AND "outcome_hpn_json_artifact_ref_is_exact"(
+      decision."decision_artifact_json",decision."decision_json")
+    AND decision."source_use_assessment_id"=
+      'hpn-private-source-use-assessment:'||assessment_sha256
+    AND decision."source_use_assessment_canonical_json"=
+      "outcome_afl_trade_canonical_json"(assessment)
+    AND "outcome_hpn_json_artifact_ref_is_exact"(
+      decision."source_use_assessment_artifact_json",assessment)
+    AND jsonb_typeof(assessment)='object'
+    AND (SELECT count(*) FROM jsonb_object_keys(assessment))=2
+    AND jsonb_typeof(assessment_content)='object'
+    AND (SELECT count(*) FROM jsonb_object_keys(assessment_content))=17
+    AND assessment_content->>'schemaVersion'=
+      'afl-trade-hpn-private-source-use-assessment/v1'
+    AND assessment_content->>'environment'='non_production'
+    AND assessment_content->>'purpose'='private_confirmed_realized_hpn_pav'
+    AND assessment_content->>'valuationScopeKey'='afl-men:2026-trades'
+    AND assessment_content->>'evaluationDecisionId'=reviewed."decision_id"
+    AND assessment_content->>'evidenceBundleId'=reviewed."evidence_bundle_id"
+    AND assessment_content->>'competition'=
+      candidate."candidate_json"#>>'{content,competition}'
+    AND (assessment_content->>'seasonYear')::INTEGER BETWEEN
+      candidate."valid_from_season" AND candidate."valid_through_season"
+    AND assessment_content->>'state'='permitted_private_calculation'
+    AND assessment_content->'reasons'='[]'::JSONB
+    AND assessment_content->'publicationEligible'='false'::JSONB
+    AND assessment_content->'publicationProhibited'='true'::JSONB
+    AND reviewed."status"='authorized'
+    AND reviewed."head_status"='authorized'
+    AND reviewed."revision"=reviewed."head_revision"
+    AND reviewed."head_evidence_scope_key"='afl-player-match-reviewed-2021-2026'
+    AND reviewed."decision_json"#>>'{content,schemaVersion}'=
+      'afl-trade-private-reviewed-evidence-evaluation-decision/v1'
+    AND reviewed."decision_json"#>>'{content,status}'='authorized'
+    AND reviewed."decision_json"#>>'{content,valuationScopeKey}'=
+      assessment_content->>'valuationScopeKey'
+    AND reviewed."decision_json"#>>'{content,evidenceBundleId}'=
+      assessment_content->>'evidenceBundleId'
+    AND reviewed."decision_json"#>'{content,permissions,derivedCalculations}'='true'::JSONB
+    AND reviewed."decision_json"#>'{content,permissions,internalEvaluation}'='true'::JSONB
+    AND reviewed."decision_json"#>'{content,permissions,modelTraining}'='false'::JSONB
+    AND reviewed."decision_json"#>'{content,publicationEligible}'='false'::JSONB
+    AND reviewed."decision_json"#>'{content,publicationProhibited}'='true'::JSONB
+    AND reviewed."rights_artifact_id"='source-rights:'||rights_content_sha256
+    AND reviewed."rights_json"->>'rightsArtifactId'=reviewed."rights_artifact_id"
+    AND reviewed."decision_id"='private-reviewed-evidence-evaluation-decision:'||
+      encode(sha256(convert_to("outcome_afl_trade_canonical_json"(
+        reviewed."decision_json"->'content'),'UTF8')),'hex')
+    AND reviewed."bundle_content_canonical_json"=
+      "outcome_afl_trade_canonical_json"(reviewed."bundle_json"->'content')
+    AND reviewed."bundle_sha256"=encode(sha256(convert_to(
+      reviewed."bundle_content_canonical_json",'UTF8')),'hex')
+    AND reviewed."evidence_bundle_id"='private-reviewed-evidence-bundle:'||
+      reviewed."bundle_sha256"
+    AND "outcome_hpn_json_artifact_ref_is_exact"(
+      reviewed."decision_json"#>'{content,evidenceBundleArtifact}',
+      reviewed."bundle_json")
+    AND jsonb_typeof(assessment_content->'evidenceRefs')='array'
+    AND jsonb_array_length(assessment_content->'evidenceRefs')=2
+    AND EXISTS (
+      SELECT 1 FROM jsonb_array_elements(assessment_content->'evidenceRefs') item(reference)
+       WHERE reference=reviewed."decision_json"#>'{content,evidenceBundleArtifact}')
+    AND EXISTS (
+      SELECT 1 FROM jsonb_array_elements(assessment_content->'evidenceRefs') item(reference)
+       WHERE "outcome_hpn_json_artifact_ref_is_exact"(reference,reviewed."rights_json"))
+    AND EXISTS (
+      SELECT 1
+        FROM jsonb_array_elements(
+          reviewed."bundle_json"#>'{content,sourceRightsEvidenceRefs}') item(reference)
+       WHERE "outcome_hpn_json_artifact_ref_is_exact"(reference,reviewed."rights_json"))
+    AND (assessment_content->>'evaluatedAt')::TIMESTAMPTZ>=reviewed."decided_at"
+    AND (assessment_content->>'evaluatedAt')::TIMESTAMPTZ>=reviewed."rights_proposed_at"
+    AND (reviewed."rights_json"#>>'{content,termsEffectiveAt}' IS NULL
+      OR (assessment_content->>'evaluatedAt')::TIMESTAMPTZ>=
+         (reviewed."rights_json"#>>'{content,termsEffectiveAt}')::TIMESTAMPTZ)
+    AND (reviewed."rights_json"#>>'{content,termsExpireAt}' IS NULL
+      OR (assessment_content->>'evaluatedAt')::TIMESTAMPTZ<
+         (reviewed."rights_json"#>>'{content,termsExpireAt}')::TIMESTAMPTZ)
+    AND (
+      (NOT rights_overbroad AND assessment_content->'effectiveRestriction'='null'::JSONB)
+      OR (rights_overbroad AND assessment_content->'effectiveRestriction'=
+        jsonb_build_object(
+          'mode','narrowed_private_evaluation',
+          'baseRightsArtifactId',assessment_content->>'rightsArtifactId',
+          'evaluationDecisionId',reviewed."decision_id",
+          'operation','derived_feature_creation',
+          'commercialContext','internal-evaluation','audience','internal',
+          'modelTraining','blocked','publicDerivedOutput','blocked',
+          'publicFactDisplay','blocked','rawFieldRedistribution','blocked')))
+    AND jsonb_typeof(assessment_content->'fields')='array'
+    AND NOT EXISTS (
+      SELECT 1 FROM jsonb_array_elements(assessment_content->'fields') item(field)
+       WHERE jsonb_typeof(field)<>'object'
+         OR (SELECT count(*) FROM jsonb_object_keys(field))<>3
+         OR field->>'state'<>'permitted_private_calculation'
+         OR field->'reasons'<>'[]'::JSONB)
+    AND assessed_fields="outcome_hpn_pav_projected_reviewed_fields"(
+      candidate."candidate_json")
+    AND "outcome_hpn_private_source_rights_permit"(
+      reviewed."rights_json",assessed_fields,
+      assessment_content->>'competition',(assessment_content->>'seasonYear')::INTEGER,
+      target_effective_at)
+    AND projected."field_map_id"='hpn-pav-field-map:'||field_map_sha256
+    AND projected."field_map_sha256"=field_map_sha256
+    AND projected."field_map_canonical_json"=
+      "outcome_afl_trade_canonical_json"(projected."map_json")
+    AND projected."map_json"=jsonb_build_object(
+      'fieldMapId',projected."field_map_id",'content',expected_map_content),
+    FALSE
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql STABLE STRICT;
+
+CREATE FUNCTION "outcome_hpn_pav_projected_scalar"(
+  payload JSONB,map_json JSONB,semantic_field TEXT
+) RETURNS JSONB AS $$
+DECLARE mapping JSONB; mapping_kind TEXT; observed JSONB; goals JSONB; behinds JSONB;
+BEGIN
+  SELECT binding->'mapping' INTO mapping
+    FROM jsonb_array_elements(map_json#>'{content,semanticBindings}') binding
+   WHERE binding->>'semanticField'=semantic_field;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  mapping_kind:=mapping->>'kind';
+  IF mapping_kind='direct' THEN
+    observed:="outcome_hpn_pav_scalar"(payload,mapping->>'sourceField');
+    IF observed IS NULL OR jsonb_typeof(observed)='null' THEN RETURN NULL; END IF;
+    RETURN observed;
+  ELSIF mapping_kind='goals_plus_behinds' AND semantic_field='totalPoints' THEN
+    goals:="outcome_hpn_pav_scalar"(payload,mapping->>'goals');
+    behinds:="outcome_hpn_pav_scalar"(payload,mapping->>'behinds');
+    IF goals IS NULL OR behinds IS NULL
+      OR jsonb_typeof(goals)<>'number' OR jsonb_typeof(behinds)<>'number' THEN
+      RETURN NULL;
+    END IF;
+    RETURN to_jsonb((goals#>>'{}')::NUMERIC*6+(behinds#>>'{}')::NUMERIC);
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
+CREATE FUNCTION "outcome_hpn_pav_nonnegative_integer"(observed JSONB)
+RETURNS BOOLEAN AS $$
+DECLARE numeric_value NUMERIC;
+BEGIN
+  IF observed IS NULL OR jsonb_typeof(observed)<>'number' THEN RETURN FALSE; END IF;
+  numeric_value:=(observed#>>'{}')::NUMERIC;
+  RETURN numeric_value>=0 AND numeric_value<=10000000 AND trunc(numeric_value)=numeric_value;
+EXCEPTION WHEN OTHERS THEN
+  RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
+CREATE FUNCTION "outcome_hpn_pav_iso_date"(observed JSONB)
+RETURNS BOOLEAN AS $$
+DECLARE date_value TEXT;
+BEGIN
+  IF observed IS NULL OR jsonb_typeof(observed)<>'string' THEN RETURN FALSE; END IF;
+  date_value:=observed#>>'{}';
+  RETURN date_value~'^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+    AND to_char(date_value::DATE,'YYYY-MM-DD')=date_value;
+EXCEPTION WHEN OTHERS THEN
+  RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
+CREATE FUNCTION "outcome_hpn_pav_projected_expected_player_stats"(
+  payload JSONB,map_json JSONB
+) RETURNS JSONB AS $$
+  SELECT jsonb_build_object(
+    'totalPoints',"outcome_hpn_pav_projected_scalar"(payload,map_json,'totalPoints'),
+    'hitOuts',"outcome_hpn_pav_projected_scalar"(payload,map_json,'hitOuts'),
+    'goalAssists',"outcome_hpn_pav_projected_scalar"(payload,map_json,'goalAssists'),
+    'inside50s',"outcome_hpn_pav_projected_scalar"(payload,map_json,'inside50s'),
+    'marks',"outcome_hpn_pav_projected_scalar"(payload,map_json,'marks'),
+    'marksInside50',"outcome_hpn_pav_projected_scalar"(payload,map_json,'marksInside50'),
+    'freeKicksFor',"outcome_hpn_pav_projected_scalar"(payload,map_json,'freeKicksFor'),
+    'freeKicksAgainst',"outcome_hpn_pav_projected_scalar"(payload,map_json,'freeKicksAgainst'),
+    'rebound50s',"outcome_hpn_pav_projected_scalar"(payload,map_json,'rebound50s'),
+    'onePercenters',"outcome_hpn_pav_projected_scalar"(payload,map_json,'onePercenters'),
+    'clearances',"outcome_hpn_pav_projected_scalar"(payload,map_json,'clearances'),
+    'tackles',"outcome_hpn_pav_projected_scalar"(payload,map_json,'tackles'));
+$$ LANGUAGE sql IMMUTABLE STRICT;
+
+CREATE FUNCTION "outcome_hpn_pav_projected_result_completed"(
+  payload JSONB,map_json JSONB
+) RETURNS BOOLEAN AS $$
+DECLARE completion_rule JSONB; completion_mapping JSONB; observed JSONB;
+  match_date JSONB; home_points JSONB; away_points JSONB;
+BEGIN
+  completion_rule:=map_json#>'{content,completionRule}';
+  SELECT binding->'mapping' INTO completion_mapping
+    FROM jsonb_array_elements(map_json#>'{content,semanticBindings}') binding
+   WHERE binding->>'semanticField'='completionStatus';
+  IF completion_rule->>'kind'='source_status'
+    AND completion_mapping->>'kind'='direct' THEN
+    observed:="outcome_hpn_pav_scalar"(payload,completion_mapping->>'sourceField');
+    RETURN COALESCE(
+      jsonb_typeof(observed)='string'
+      AND jsonb_typeof(completion_rule->'completedValues')='array'
+      AND completion_rule->'completedValues' ? (observed#>>'{}'),FALSE);
+  END IF;
+  IF completion_rule->>'kind'='reviewed_final_score_presence'
+    AND completion_mapping->>'kind'='reviewed_final_scores' THEN
+    match_date:="outcome_hpn_pav_scalar"(
+      payload,completion_mapping->>'matchDateField');
+    home_points:="outcome_hpn_pav_scalar"(
+      payload,completion_mapping->>'homePointsField');
+    away_points:="outcome_hpn_pav_scalar"(
+      payload,completion_mapping->>'awayPointsField');
+    RETURN COALESCE("outcome_hpn_pav_iso_date"(match_date),FALSE)
+      AND COALESCE("outcome_hpn_pav_nonnegative_integer"(home_points),FALSE)
+      AND COALESCE("outcome_hpn_pav_nonnegative_integer"(away_points),FALSE);
+  END IF;
+  RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION "validate_outcome_hpn_pav_input_set_insert"()
+RETURNS TRIGGER AS $$
+DECLARE schema_version TEXT;
+BEGIN
+  schema_version:=NEW."input_set_json"#>>'{content,schemaVersion}';
+  IF NEW."status"<>'building' OR NEW."finalized_at" IS NOT NULL
+    OR NEW."created_at"<>date_trunc('milliseconds',transaction_timestamp())
+    OR NEW."input_set_json"->>'inputSetId'<>NEW."input_set_id"
+    OR schema_version NOT IN (
+      'afl-trade-hpn-pav-input-set/v1','afl-trade-hpn-pav-input-set/v2')
+    OR (schema_version='afl-trade-hpn-pav-input-set/v2'
+      AND NEW."environment"<>'non_production')
+    OR NEW."input_set_json"#>>'{content,authorityBoundary}'<>
+      'private_exact_finalized_provider_rows_current_resolutions_no_publication_or_fantasy_ownership'
+    OR NEW."input_set_json"#>'{content,publicationEligible}' IS DISTINCT FROM 'false'::JSONB
+    OR NEW."input_set_json"#>>'{content,environment}'<>NEW."environment"::TEXT
+    OR NEW."input_set_json"#>>'{content,competition}'<>NEW."competition"
+    OR (NEW."input_set_json"#>>'{content,seasonYear}')::INTEGER<>NEW."season_year"
+    OR NEW."input_set_json"#>>'{content,methodId}'<>NEW."method_id"
+    OR NEW."input_set_json"#>>'{content,factualUniverse,factualRunId}'<>NEW."factual_run_id"
+    OR NEW."input_set_json"#>>'{content,factualUniverse,inputSetSha256}'<>
+      NEW."factual_input_set_sha256"
+    OR (NEW."input_set_json"#>>'{content,factualUniverse,finalizedAt}')::TIMESTAMPTZ<>
+      NEW."factual_finalized_at"
+    OR (NEW."input_set_json"#>>'{content,effectiveThrough}')::TIMESTAMPTZ<>
+      NEW."effective_through"
+    OR (NEW."input_set_json"#>>'{content,createdAt}')::TIMESTAMPTZ<>NEW."created_at" THEN
+    RAISE EXCEPTION 'HPN PAV input-set envelope mismatch';
+  END IF;
+  IF encode(sha256(convert_to(NEW."input_set_canonical_json",'UTF8')),'hex')<>
+      NEW."input_set_sha256"
+    OR NEW."input_set_canonical_json"::JSONB IS DISTINCT FROM
+      NEW."input_set_json"->'content' THEN
+    RAISE EXCEPTION 'HPN PAV input-set canonical bytes mismatch';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION "guard_outcome_hpn_pav_input_run_insert"() RETURNS TRIGGER AS $$
+DECLARE parent_record RECORD; projected_record RECORD;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    'outcome-hpn-pav-input:'||NEW."input_set_id",0));
+  SELECT "status","environment","competition","season_year","created_at","effective_through",
+         "input_set_json"
+    INTO parent_record
+    FROM "outcome_hpn_pav_input_set"
+   WHERE "input_set_id"=NEW."input_set_id" FOR NO KEY UPDATE;
+  IF NOT FOUND OR parent_record."status"<>'building' THEN
+    RAISE EXCEPTION 'HPN PAV input members require an open input set';
+  END IF;
+  IF parent_record."input_set_json"#>>'{content,schemaVersion}'=
+      'afl-trade-hpn-pav-input-set/v1' THEN
+    IF NEW."field_map_id" IS NULL OR NEW."projected_field_map_id" IS NOT NULL THEN
+      RAISE EXCEPTION 'Legacy HPN PAV input runs require legacy map authority';
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF parent_record."input_set_json"#>>'{content,schemaVersion}'<>
+      'afl-trade-hpn-pav-input-set/v2'
+    OR NEW."field_map_id" IS NOT NULL OR NEW."projected_field_map_id" IS NULL THEN
+    RAISE EXCEPTION 'Projected HPN PAV input runs require projected map authority';
+  END IF;
+  SELECT map.*,decision."decision",decision."source_use_assessment_json",
+         current_decision."decision_id" AS current_decision_id
+    INTO projected_record
+    FROM "outcome_hpn_projected_field_map" map
+    JOIN "outcome_hpn_field_map_review_decision" decision
+      ON decision."decision_id"=map."approval_decision_id"
+    JOIN LATERAL (
+      SELECT latest."decision_id"
+        FROM "outcome_hpn_field_map_review_decision" latest
+       WHERE latest."candidate_id"=map."candidate_id"
+       ORDER BY latest."registered_at" DESC,latest."decision_id" DESC LIMIT 1
+    ) current_decision ON TRUE
+   WHERE map."field_map_id"=NEW."projected_field_map_id" FOR SHARE OF map,decision;
+  IF NOT FOUND OR projected_record."decision"<>'approved'
+    OR NOT COALESCE(
+      "outcome_hpn_projected_field_map_authority_is_exact"(
+        NEW."projected_field_map_id",parent_record."created_at"
+      ),FALSE
+    )
+    OR projected_record."current_decision_id"<>projected_record."approval_decision_id"
+    OR projected_record."environment"<>parent_record."environment"
+    OR projected_record."competition"<>parent_record."competition"
+    OR projected_record."input_kind"<>NEW."input_kind"
+    OR parent_record."season_year" NOT BETWEEN
+      projected_record."valid_from_season" AND projected_record."valid_through_season"
+    OR projected_record."source_use_assessment_json"#>>'{content,state}'<>
+      'permitted_private_calculation'
+    OR NOT (parent_record."input_set_json"#>'{content,fieldMaps}' @>
+      jsonb_build_array(projected_record."map_json"))
+    OR NOT EXISTS (
+      SELECT 1
+        FROM "outcome_provider_normalization_run" run
+        JOIN "outcome_provider_field_map" decode_map
+          ON decode_map."field_map_id"=run."field_map_id"
+        JOIN "outcome_source_capture" capture ON capture."capture_id"=run."capture_id"
+       WHERE run."normalization_run_id"=NEW."normalization_run_id"
+         AND run."status"='staged' AND run."finalized_at" IS NOT NULL
+         AND run."source_row_count"=run."accepted_row_count"
+         AND run."quarantined_row_count"=0 AND run."issue_count"=0
+         AND capture."environment"=parent_record."environment"
+         AND capture."provider"=projected_record."provider"
+         AND capture."capability_id"=projected_record."capability_id"
+         AND decode_map."capability_id"=projected_record."capability_id"
+         AND decode_map."source_schema_sha256"=projected_record."source_schema_sha256"
+         AND run."field_map_id"=
+           (SELECT candidate."candidate_json"#>>'{content,providerDecodeMapId}'
+              FROM "outcome_hpn_field_map_candidate" candidate
+             WHERE candidate."candidate_id"=projected_record."candidate_id")
+         AND projected_record."source_use_assessment_json"#>>'{content,rightsArtifactId}'=
+           capture."manifest_json"#>>'{gate0aReceipt,content,request,rightsArtifactId}'
+         AND run."finalized_at"<=parent_record."created_at"
+         AND capture."captured_at"<=parent_record."effective_through"
+         AND EXISTS (
+           SELECT 1 FROM "outcome_source_capture_season" scope
+            WHERE scope."capture_id"=capture."capture_id"
+              AND scope."competition"=parent_record."competition"
+              AND scope."season_year"=parent_record."season_year")
+    ) THEN
+    RAISE EXCEPTION 'Projected HPN PAV input run lacks exact current source authority';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER "outcome_hpn_pav_input_run_insert_guard"
+  ON "outcome_hpn_pav_input_run";
+CREATE TRIGGER "outcome_hpn_pav_input_run_insert_guard"
+  BEFORE INSERT ON "outcome_hpn_pav_input_run"
+  FOR EACH ROW EXECUTE FUNCTION "guard_outcome_hpn_pav_input_run_insert"();
+
+CREATE FUNCTION "finalize_outcome_hpn_pav_input_set_v2"() RETURNS TRIGGER AS $$
+DECLARE actual_runs INTEGER; actual_rows INTEGER; actual_matches INTEGER;
+  actual_results INTEGER; actual_primary INTEGER; actual_corroborating INTEGER;
+  actual_factual_matches INTEGER; actual_factual_appearances INTEGER;
+  json_factual_matches INTEGER; json_factual_appearances INTEGER; eligible_spell_count INTEGER;
+  lock_subject TEXT; row_record RECORD;
+BEGIN
+  IF OLD."status"<>'building' OR NEW."status"<>'finalized' OR OLD."finalized_at" IS NOT NULL
+    OR NEW."finalized_at" IS NULL OR NEW."finalized_at"<>NEW."created_at"
+    OR (to_jsonb(NEW)-'status'-'finalized_at') IS DISTINCT FROM
+       (to_jsonb(OLD)-'status'-'finalized_at') THEN
+    RAISE EXCEPTION 'HPN PAV input sets permit only one exact finalization transition';
+  END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended('outcome-hpn-pav-input:'||NEW."input_set_id",0));
+  IF NEW."input_set_json"#>>'{content,schemaVersion}'<>'afl-trade-hpn-pav-input-set/v2'
+    OR NEW."environment"<>'non_production' THEN
+    RAISE EXCEPTION 'Projected HPN PAV finalization requires the v2 non-production contract';
+  END IF;
+  FOR lock_subject IN
+    SELECT DISTINCT map."candidate_id"
+      FROM "outcome_hpn_pav_input_run" member
+      JOIN "outcome_hpn_projected_field_map" map
+        ON map."field_map_id"=member."projected_field_map_id"
+     WHERE member."input_set_id"=NEW."input_set_id"
+     ORDER BY 1
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtextextended(
+      'hpn-field-map-candidate:'||lock_subject,0));
+  END LOOP;
+
+  FOR lock_subject IN
+    SELECT DISTINCT decision."subject_type"||':'||decision."subject_id"
+    FROM "outcome_review_decision" decision
+    WHERE decision."decision_id" IN (
+      SELECT map."approval_decision_id" FROM "outcome_hpn_pav_input_run" member
+       JOIN "outcome_hpn_projected_field_map" map ON map."field_map_id"=member."projected_field_map_id"
+       WHERE member."input_set_id"=NEW."input_set_id"
+      UNION
+      SELECT policy."approval_decision_id"
+        FROM "outcome_factual_reconciliation_run" factual_run
+        JOIN "outcome_factual_reconciliation_policy" policy
+          ON policy."policy_id"=factual_run."policy_id"
+       WHERE factual_run."factual_run_id"=NEW."factual_run_id"
+      UNION
+      SELECT value FROM "outcome_hpn_pav_input_row" member
+       CROSS JOIN LATERAL jsonb_array_elements_text(jsonb_build_array(
+         member."row_json"#>>'{player,resolutionDecision,id}',
+         member."row_json"#>>'{club,resolutionDecision,id}',
+         member."row_json"#>>'{match,resolutionDecision,id}',
+         member."row_json"#>>'{homeClub,resolutionDecision,id}',
+         member."row_json"#>>'{awayClub,resolutionDecision,id}'
+       )) ids(value)
+       WHERE member."input_set_id"=NEW."input_set_id" AND value IS NOT NULL
+    )
+    ORDER BY 1
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtextextended('outcome-review-subject:'||lock_subject,0));
+  END LOOP;
+  FOR lock_subject IN
+    SELECT DISTINCT (member."row_json"#>>'{player,canonicalId}')||':'||
+      (member."row_json"#>>'{club,canonicalId}')
+      FROM "outcome_hpn_pav_input_row" member
+     WHERE member."input_set_id"=NEW."input_set_id"
+       AND member."row_kind"='player_match_stats'
+     ORDER BY 1
+  LOOP
+    PERFORM pg_advisory_xact_lock(
+      hashtextextended('outcome-acquisition-spell-scope:'||lock_subject,0));
+  END LOOP;
+  FOR lock_subject IN
+    SELECT DISTINCT member."row_json"#>>'{acquisitionSpell,spellId}'
+      FROM "outcome_hpn_pav_input_row" member
+     WHERE member."input_set_id"=NEW."input_set_id"
+       AND member."row_kind"='player_match_stats'
+     ORDER BY 1
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtextextended('outcome-acquisition-spell:'||lock_subject,0));
+  END LOOP;
+
+  SELECT count(*) INTO actual_runs FROM "outcome_hpn_pav_input_run"
+   WHERE "input_set_id"=NEW."input_set_id";
+  SELECT count(*),count(*) FILTER (WHERE "row_kind"='completed_match_result'),
+    count(*) FILTER (WHERE "row_kind"='player_match_stats' AND "role"='primary'),
+    count(*) FILTER (WHERE "row_kind"='player_match_stats' AND "role"='corroborating')
+    INTO actual_rows,actual_results,actual_primary,actual_corroborating
+    FROM "outcome_hpn_pav_input_row" WHERE "input_set_id"=NEW."input_set_id";
+  SELECT count(*) INTO actual_matches FROM "outcome_hpn_pav_input_match"
+   WHERE "input_set_id"=NEW."input_set_id";
+  SELECT count(*) INTO actual_factual_matches
+    FROM "outcome_hpn_pav_input_factual_match_member"
+   WHERE "input_set_id"=NEW."input_set_id";
+  SELECT count(*) INTO actual_factual_appearances
+    FROM "outcome_hpn_pav_input_factual_appearance_member"
+   WHERE "input_set_id"=NEW."input_set_id";
+  SELECT COALESCE(sum(jsonb_array_length(value->'factIds')),0)::INTEGER
+    INTO json_factual_matches
+    FROM jsonb_array_elements(
+      NEW."input_set_json"#>'{content,factualUniverse,completedMatchFacts}') value;
+  SELECT COALESCE(sum(jsonb_array_length(value->'factIds')),0)::INTEGER
+    INTO json_factual_appearances
+    FROM jsonb_array_elements(
+      NEW."input_set_json"#>'{content,factualUniverse,playerAppearanceFacts}') value;
+  IF actual_runs<>NEW."source_run_count" OR actual_rows<>NEW."source_row_count"
+    OR actual_matches<>NEW."completed_match_count" OR actual_results<>NEW."result_row_count"
+    OR actual_primary<>NEW."primary_player_row_count"
+    OR actual_corroborating<>NEW."corroborating_player_row_count"
+    OR jsonb_array_length(NEW."input_set_json"#>'{content,fieldMaps}')<>actual_runs
+    OR jsonb_array_length(NEW."input_set_json"#>'{content,sourceRuns}')<>actual_runs
+    OR jsonb_array_length(NEW."input_set_json"#>'{content,rows}')<>actual_rows
+    OR jsonb_array_length(NEW."input_set_json"#>'{content,completedMatches}')<>actual_matches
+    OR actual_factual_matches=0 OR actual_factual_appearances=0
+    OR actual_factual_matches<>json_factual_matches
+    OR actual_factual_appearances<>json_factual_appearances THEN
+    RAISE EXCEPTION 'HPN PAV input counts do not match durable membership';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM "outcome_factual_reconciliation_run" factual_run
+      JOIN "outcome_factual_reconciliation_policy" policy
+        ON policy."policy_id"=factual_run."policy_id"
+      JOIN "outcome_review_decision" decision
+        ON decision."decision_id"=policy."approval_decision_id"
+     WHERE factual_run."factual_run_id"=NEW."factual_run_id"
+       AND factual_run."input_set_sha256"=NEW."factual_input_set_sha256"
+       AND factual_run."environment"=NEW."environment"
+       AND factual_run."competition"=NEW."competition"
+       AND factual_run."season_year"=NEW."season_year"
+       AND factual_run."status"='approved' AND factual_run."conflict_count"=0
+       AND factual_run."finalized_at"=NEW."factual_finalized_at"
+       AND factual_run."finalized_at"<=NEW."created_at"
+       AND policy."status"='approved'
+       AND NEW."input_set_json"#>>'{content,factualUniverse,policyId}'=policy."policy_id"
+       AND NEW."input_set_json"#>>'{content,factualUniverse,status}'='approved'
+       AND decision."decision"='approved'
+       AND NOT EXISTS (SELECT 1 FROM "outcome_review_decision" successor
+         WHERE successor."supersedes_decision_id"=decision."decision_id")
+  ) THEN
+    RAISE EXCEPTION 'HPN PAV factual universe is not an exact current approved finalization';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM "outcome_hpn_pav_input_factual_match_member" member
+      JOIN "outcome_provider_match_universe_fact" fact ON fact."match_fact_id"=member."fact_id"
+      LEFT JOIN "outcome_factual_reconciliation_match_input" factual_input
+        ON factual_input."factual_run_id"=NEW."factual_run_id"
+       AND factual_input."match_fact_id"=member."fact_id"
+      LEFT JOIN LATERAL (
+        SELECT value FROM jsonb_array_elements(
+          NEW."input_set_json"#>'{content,factualUniverse,completedMatchFacts}') value
+         WHERE value->'factIds' ? member."fact_id"
+      ) envelope ON TRUE
+     WHERE member."input_set_id"=NEW."input_set_id" AND (
+       factual_input."match_fact_id" IS NULL OR fact."availability"<>'measured'
+       OR fact."completion_state"<>'completed' OR fact."competition"<>NEW."competition"
+       OR fact."season_year"<>NEW."season_year" OR envelope.value IS NULL
+       OR envelope.value->>'matchId'<>fact."match_id"
+       OR (envelope.value->>'effectiveAt')::TIMESTAMPTZ<>fact."effective_at"
+       OR envelope.value->>'homeClubId'<>fact."fact_json"#>>'{content,match,homeClub,clubId}'
+       OR envelope.value->>'awayClubId'<>fact."fact_json"#>>'{content,match,awayClub,clubId}'
+     )
+  ) OR EXISTS (
+    SELECT 1 FROM "outcome_factual_reconciliation_match_input" factual_input
+    JOIN "outcome_provider_match_universe_fact" fact
+      ON fact."match_fact_id"=factual_input."match_fact_id"
+    LEFT JOIN "outcome_hpn_pav_input_factual_match_member" member
+      ON member."input_set_id"=NEW."input_set_id" AND member."fact_id"=fact."match_fact_id"
+    WHERE factual_input."factual_run_id"=NEW."factual_run_id"
+      AND fact."availability"='measured' AND fact."completion_state"='completed'
+      AND member."fact_id" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'HPN PAV completed-match facts do not equal the approved factual universe';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM "outcome_hpn_pav_input_factual_appearance_member" member
+      JOIN "outcome_provider_player_appearance_fact" fact
+        ON fact."appearance_fact_id"=member."fact_id"
+      LEFT JOIN "outcome_factual_reconciliation_appearance_input" factual_input
+        ON factual_input."factual_run_id"=NEW."factual_run_id"
+       AND factual_input."appearance_fact_id"=member."fact_id"
+      LEFT JOIN LATERAL (
+        SELECT value FROM jsonb_array_elements(
+          NEW."input_set_json"#>'{content,factualUniverse,playerAppearanceFacts}') value
+         WHERE value->'factIds' ? member."fact_id"
+      ) envelope ON TRUE
+     WHERE member."input_set_id"=NEW."input_set_id" AND (
+       factual_input."appearance_fact_id" IS NULL OR fact."availability"<>'measured'
+       OR fact."appeared" IS DISTINCT FROM TRUE OR fact."competition"<>NEW."competition"
+       OR fact."season_year"<>NEW."season_year" OR envelope.value IS NULL
+       OR envelope.value->>'matchId'<>fact."match_id"
+       OR envelope.value->>'playerId'<>fact."player_id"
+       OR envelope.value->>'clubId'<>fact."represented_club_id"
+     )
+  ) OR EXISTS (
+    SELECT 1 FROM "outcome_factual_reconciliation_appearance_input" factual_input
+    JOIN "outcome_provider_player_appearance_fact" fact
+      ON fact."appearance_fact_id"=factual_input."appearance_fact_id"
+    LEFT JOIN "outcome_hpn_pav_input_factual_appearance_member" member
+      ON member."input_set_id"=NEW."input_set_id"
+     AND member."fact_id"=fact."appearance_fact_id"
+    WHERE factual_input."factual_run_id"=NEW."factual_run_id"
+      AND fact."availability"='measured' AND fact."appeared"=TRUE
+      AND member."fact_id" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'HPN PAV appearance facts do not equal the approved factual universe';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM "outcome_hpn_pav_input_run" member
+    JOIN "outcome_provider_normalization_run" run
+      ON run."normalization_run_id"=member."normalization_run_id"
+    JOIN "outcome_provider_field_map" decode_map ON decode_map."field_map_id"=run."field_map_id"
+    JOIN "outcome_source_capture" capture ON capture."capture_id"=run."capture_id"
+    JOIN "outcome_hpn_projected_field_map" map ON map."field_map_id"=member."projected_field_map_id"
+    JOIN "outcome_hpn_field_map_review_decision" decision
+      ON decision."decision_id"=map."approval_decision_id"
+    LEFT JOIN LATERAL (
+      SELECT value FROM jsonb_array_elements(NEW."input_set_json"#>'{content,sourceRuns}') value
+       WHERE value->>'normalizationRunId'=member."normalization_run_id"
+    ) source_json ON TRUE
+    WHERE member."input_set_id"=NEW."input_set_id" AND (
+      run."status"<>'staged' OR run."finalized_at" IS NULL
+      OR run."source_row_count"<>run."accepted_row_count" OR run."quarantined_row_count"<>0
+      OR run."issue_count"<>0 OR capture."environment"<>NEW."environment"
+      OR capture."provider" IS DISTINCT FROM map."provider"
+      OR capture."capability_id" IS DISTINCT FROM map."capability_id"
+      OR decode_map."capability_id"<>map."capability_id"
+      OR decode_map."source_schema_sha256"<>map."source_schema_sha256"
+      OR run."field_map_id" IS DISTINCT FROM (
+        SELECT candidate."candidate_json"#>>'{content,providerDecodeMapId}'
+          FROM "outcome_hpn_field_map_candidate" candidate
+         WHERE candidate."candidate_id"=map."candidate_id")
+      OR map."environment"<>NEW."environment" OR map."competition"<>NEW."competition"
+      OR NOT COALESCE(
+        "outcome_hpn_projected_field_map_authority_is_exact"(
+          map."field_map_id",clock_timestamp()),FALSE
+      )
+      OR map."input_kind"<>member."input_kind" OR NEW."season_year" NOT BETWEEN
+        map."valid_from_season" AND map."valid_through_season"
+      OR NOT (NEW."input_set_json"#>'{content,fieldMaps}' @> jsonb_build_array(map."map_json"))
+      OR source_json.value IS NULL
+      OR source_json.value->>'captureId'<>run."capture_id"
+      OR source_json.value->>'sourceSnapshotId'<>capture."source_snapshot_id"
+      OR source_json.value->>'sourceArtifactId'<>capture."source_artifact_id"
+      OR source_json.value->>'provider'<>map."provider"
+      OR source_json.value->>'capabilityId'<>map."capability_id"
+      OR source_json.value->>'fieldMapId'<>map."field_map_id"
+      OR source_json.value->>'competition'<>NEW."competition"
+      OR (source_json.value->>'seasonYear')::INTEGER<>NEW."season_year"
+      OR source_json.value->>'stagingSha256'<>run."staging_sha256"
+      OR (source_json.value->>'sourceRowCount')::INTEGER<>run."source_row_count"
+      OR (source_json.value->>'acceptedRowCount')::INTEGER<>run."accepted_row_count"
+      OR (source_json.value->>'issueCount')::INTEGER<>run."issue_count"
+      OR source_json.value->>'status'<>run."status"::TEXT
+      OR (source_json.value->>'capturedAt')::TIMESTAMPTZ<>capture."captured_at"
+      OR (source_json.value->>'finalizedAt')::TIMESTAMPTZ<>run."finalized_at"
+      OR decision."decision"<>'approved'
+      OR decision."decision_id" IS DISTINCT FROM (
+        SELECT latest."decision_id"
+          FROM "outcome_hpn_field_map_review_decision" latest
+         WHERE latest."candidate_id"=map."candidate_id"
+         ORDER BY latest."registered_at" DESC,latest."decision_id" DESC LIMIT 1)
+      OR decision."source_use_assessment_json"#>>'{content,state}'<>
+        'permitted_private_calculation'
+      OR decision."source_use_assessment_json"#>>'{content,rightsArtifactId}'<>
+        capture."manifest_json"#>>'{gate0aReceipt,content,request,rightsArtifactId}'
+      OR NOT EXISTS (SELECT 1 FROM "outcome_source_capture_season" scope
+        WHERE scope."capture_id"=capture."capture_id" AND scope."competition"=NEW."competition"
+          AND scope."season_year"=NEW."season_year")
+      OR run."finalized_at">NEW."created_at" OR capture."captured_at">NEW."effective_through"
+    )
+  ) THEN RAISE EXCEPTION 'HPN PAV source run is incomplete, stale, or outside reviewed scope'; END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM "outcome_hpn_pav_input_run" run_member
+    JOIN "outcome_provider_decoded_row" decoded
+      ON decoded."normalization_run_id"=run_member."normalization_run_id"
+    LEFT JOIN "outcome_hpn_pav_input_row" row_member
+      ON row_member."input_set_id"=run_member."input_set_id"
+      AND row_member."provider_decoded_row_id"=decoded."provider_decoded_row_id"
+    WHERE run_member."input_set_id"=NEW."input_set_id"
+      AND (row_member."provider_decoded_row_id" IS NULL OR decoded."row_status"<>'staged'
+        OR decoded."competition"<>NEW."competition" OR decoded."season_year"<>NEW."season_year")
+  ) OR EXISTS (
+    SELECT 1 FROM "outcome_hpn_pav_input_row" row_member
+    JOIN "outcome_provider_decoded_row" decoded
+      ON decoded."provider_decoded_row_id"=row_member."provider_decoded_row_id"
+    WHERE row_member."input_set_id"=NEW."input_set_id" AND (
+      decoded."normalization_run_id"<>row_member."normalization_run_id"
+      OR decoded."source_row_sha256"<>row_member."source_row_sha256"
+      OR row_member."row_json"#>>'{source,normalizationRunId}'<>row_member."normalization_run_id"
+      OR row_member."row_json"#>>'{source,providerDecodedRowId}'<>
+        row_member."provider_decoded_row_id"
+      OR row_member."row_json"#>>'{source,sourceRowSha256}'<>row_member."source_row_sha256"
+      OR row_member."row_json"#>>'{source,typedPayloadSha256}'<>
+        row_member."typed_payload_sha256"
+      OR row_member."row_json"->>'kind'<>row_member."row_kind"
+      OR row_member."row_json"->>'role' IS DISTINCT FROM row_member."role"
+      OR encode(sha256(convert_to(row_member."row_canonical_json",'UTF8')),'hex')<>
+        row_member."row_sha256"
+      OR row_member."row_canonical_json"::JSONB IS DISTINCT FROM row_member."row_json"
+      OR NOT (NEW."input_set_json"#>'{content,rows}' @> jsonb_build_array(row_member."row_json"))
+    )
+  ) THEN RAISE EXCEPTION 'HPN PAV rows do not exactly conserve finalized decoded rows'; END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM "outcome_hpn_pav_input_row" row_member
+    JOIN "outcome_provider_decoded_row" decoded
+      ON decoded."provider_decoded_row_id"=row_member."provider_decoded_row_id"
+    JOIN "outcome_hpn_pav_input_run" run_member
+      ON run_member."input_set_id"=row_member."input_set_id"
+     AND run_member."normalization_run_id"=row_member."normalization_run_id"
+    JOIN "outcome_hpn_projected_field_map" map ON map."field_map_id"=run_member."projected_field_map_id"
+    CROSS JOIN LATERAL (
+      SELECT COALESCE(jsonb_agg(field ORDER BY field COLLATE "C"),'[]'::JSONB) fields
+      FROM jsonb_object_keys(row_member."row_json"#>'{source,sourceValues}') field
+    ) source_keys
+    WHERE row_member."input_set_id"=NEW."input_set_id" AND (
+      row_member."typed_payload_sha256"<>
+        encode(sha256(convert_to("outcome_hpn_pav_canonical_json"(decoded."typed_payload"),'UTF8')),'hex')
+      OR row_member."row_json"#>'{source,sourceFields}' IS DISTINCT FROM
+        "outcome_hpn_pav_projected_reviewed_fields"(map."map_json")
+      OR source_keys.fields IS DISTINCT FROM "outcome_hpn_pav_projected_reviewed_fields"(map."map_json")
+      OR EXISTS (
+        SELECT 1
+        FROM jsonb_each(row_member."row_json"#>'{source,sourceValues}') value
+        WHERE "outcome_hpn_pav_scalar"(decoded."typed_payload",value.key)
+          IS DISTINCT FROM value.value
+      )
+      OR (row_member."row_kind"='player_match_stats' AND (
+        map."input_kind"<>'player_match_stats'
+        OR row_member."row_json"->'stats' IS DISTINCT FROM
+          "outcome_hpn_pav_projected_expected_player_stats"(decoded."typed_payload",map."map_json")
+        OR EXISTS (
+          SELECT 1 FROM jsonb_each(row_member."row_json"->'stats') stat
+           WHERE NOT COALESCE("outcome_hpn_pav_nonnegative_integer"(stat.value),FALSE)
+        )
+      ))
+      OR (row_member."row_kind"='completed_match_result' AND (
+        map."input_kind"<>'completed_match_result'
+        OR row_member."row_json"->'homePoints' IS DISTINCT FROM
+          "outcome_hpn_pav_projected_scalar"(
+            decoded."typed_payload",map."map_json",'homePoints')
+        OR row_member."row_json"->'awayPoints' IS DISTINCT FROM
+          "outcome_hpn_pav_projected_scalar"(
+            decoded."typed_payload",map."map_json",'awayPoints')
+        OR row_member."row_json"->>'completionStatus'<>'completed'
+        OR "outcome_hpn_pav_projected_result_completed"(
+          decoded."typed_payload",map."map_json") IS DISTINCT FROM TRUE
+      ))
+    )
+  ) THEN
+    RAISE EXCEPTION 'HPN PAV rows differ from reviewed immutable typed payloads';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM "outcome_hpn_pav_input_row" row_member
+    JOIN "outcome_hpn_pav_input_run" run_member
+      ON run_member."input_set_id"=row_member."input_set_id"
+      AND run_member."normalization_run_id"=row_member."normalization_run_id"
+    JOIN "outcome_hpn_projected_field_map" map ON map."field_map_id"=run_member."projected_field_map_id"
+    LEFT JOIN "outcome_provider_match_candidate" match_candidate
+      ON match_candidate."provider_decoded_row_id"=row_member."provider_decoded_row_id"
+    LEFT JOIN "outcome_provider_identity_candidate" identity_candidate
+      ON identity_candidate."provider_decoded_row_id"=row_member."provider_decoded_row_id"
+    WHERE row_member."input_set_id"=NEW."input_set_id" AND (
+      match_candidate."provider" IS DISTINCT FROM map."provider"
+      OR (row_member."row_kind"='player_match_stats'
+        AND identity_candidate."provider" IS DISTINCT FROM map."provider")
+    )
+  ) THEN RAISE EXCEPTION 'HPN PAV decoded-row provider differs from its reviewed map'; END IF;
+
+  FOR row_record IN SELECT * FROM "outcome_hpn_pav_input_row"
+    WHERE "input_set_id"=NEW."input_set_id"
+  LOOP
+    IF row_record."row_kind"='completed_match_result' THEN
+      IF NOT "outcome_hpn_pav_match_resolution_current"(
+          row_record."provider_decoded_row_id",row_record."row_json"->'match')
+        OR NOT "outcome_hpn_pav_club_resolution_current"(
+          row_record."provider_decoded_row_id",row_record."row_json"->'homeClub','home')
+        OR NOT "outcome_hpn_pav_club_resolution_current"(
+          row_record."provider_decoded_row_id",row_record."row_json"->'awayClub','away') THEN
+        RAISE EXCEPTION 'HPN PAV completed-match resolution is not current';
+      END IF;
+    ELSE
+      IF NOT "outcome_hpn_pav_player_resolution_current"(
+          row_record."provider_decoded_row_id",row_record."row_json"->'player')
+        OR NOT "outcome_hpn_pav_match_resolution_current"(
+          row_record."provider_decoded_row_id",row_record."row_json"->'match')
+        OR NOT (
+          "outcome_hpn_pav_club_resolution_current"(
+            row_record."provider_decoded_row_id",row_record."row_json"->'club','home')
+          OR "outcome_hpn_pav_club_resolution_current"(
+            row_record."provider_decoded_row_id",row_record."row_json"->'club','away')
+        ) THEN
+        RAISE EXCEPTION 'HPN PAV player, match, or represented-club resolution is not current';
+      END IF;
+      SELECT count(*) INTO eligible_spell_count
+        FROM "outcome_acquisition_spell_version" eligible
+        JOIN "outcome_hpn_pav_input_match" eligible_match
+          ON eligible_match."input_set_id"=row_record."input_set_id"
+         AND eligible_match."match_id"=row_record."row_json"#>>'{match,canonicalId}'
+        JOIN "outcome_event_asset" eligible_asset
+          ON eligible_asset."asset_version_id"=eligible."start_asset_version_id"
+        JOIN "outcome_acquisition_spell_rule" eligible_rule
+          ON eligible_rule."rule_id"=eligible."rule_id"
+       WHERE eligible."player_id"=row_record."row_json"#>>'{player,canonicalId}'
+         AND eligible."club_id"=row_record."row_json"#>>'{club,canonicalId}'
+         AND eligible."status"='approved'
+         AND eligible."recorded_at"<=NEW."created_at"
+         AND eligible."start_date"<=eligible_match."effective_at"::DATE
+         AND (eligible."end_date" IS NULL
+           OR eligible."end_date">=eligible_match."effective_at"::DATE)
+         AND eligible_asset."event_version_id"=eligible."start_event_version_id"
+         AND eligible_asset."kind"='player'::"OutcomeAssetKind"
+         AND eligible_asset."player_id"=eligible."player_id"
+         AND eligible_asset."to_club_id"=eligible."club_id"
+         AND eligible_asset."status"='approved'::"OutcomeRecordStatus"
+         AND eligible_rule."status"='approved'::"OutcomeRecordStatus"
+         AND NOT EXISTS (SELECT 1 FROM "outcome_acquisition_spell_version" successor
+           WHERE successor."supersedes_spell_version_id"=eligible."spell_version_id");
+      IF eligible_spell_count<>1 OR NOT EXISTS (
+        SELECT 1
+          FROM "outcome_acquisition_spell_version" spell
+          JOIN "outcome_hpn_pav_input_match" match_member
+            ON match_member."input_set_id"=row_record."input_set_id"
+           AND match_member."match_id"=row_record."row_json"#>>'{match,canonicalId}'
+         WHERE spell."spell_version_id"=
+             row_record."row_json"#>>'{acquisitionSpell,spellVersionId}'
+           AND spell."spell_id"=row_record."row_json"#>>'{acquisitionSpell,spellId}'
+           AND spell."version"=
+             (row_record."row_json"#>>'{acquisitionSpell,version}')::INTEGER
+           AND spell."player_id"=row_record."row_json"#>>'{player,canonicalId}'
+           AND spell."player_id"=row_record."row_json"#>>'{acquisitionSpell,playerId}'
+           AND spell."club_id"=row_record."row_json"#>>'{club,canonicalId}'
+           AND spell."club_id"=row_record."row_json"#>>'{acquisitionSpell,clubId}'
+           AND spell."start_event_version_id"=
+             row_record."row_json"#>>'{acquisitionSpell,startEventVersionId}'
+           AND spell."start_asset_version_id"=
+             row_record."row_json"#>>'{acquisitionSpell,startAssetVersionId}'
+           AND spell."start_date"=
+             (row_record."row_json"#>>'{acquisitionSpell,startDate}')::DATE
+           AND spell."end_date" IS NOT DISTINCT FROM
+             (row_record."row_json"#>>'{acquisitionSpell,endDate}')::DATE
+           AND spell."end_reason" IS NOT DISTINCT FROM
+             row_record."row_json"#>>'{acquisitionSpell,endReason}'
+           AND spell."rule_id"=row_record."row_json"#>>'{acquisitionSpell,ruleId}'
+           AND spell."status"='approved'
+           AND row_record."row_json"#>>'{acquisitionSpell,status}'='approved'
+           AND spell."supersedes_spell_version_id" IS NOT DISTINCT FROM
+             row_record."row_json"#>>'{acquisitionSpell,supersedesSpellVersionId}'
+           AND spell."recorded_at"=
+             (row_record."row_json"#>>'{acquisitionSpell,recordedAt}')::TIMESTAMPTZ
+           AND spell."recorded_at"<=NEW."created_at"
+           AND spell."start_date"<=match_member."effective_at"::DATE
+           AND (spell."end_date" IS NULL OR spell."end_date">=match_member."effective_at"::DATE)
+           AND EXISTS (
+             SELECT 1 FROM "outcome_event_asset" asset
+             JOIN "outcome_acquisition_spell_rule" rule ON rule."rule_id"=spell."rule_id"
+             WHERE asset."asset_version_id"=spell."start_asset_version_id"
+               AND asset."event_version_id"=spell."start_event_version_id"
+               AND asset."kind"='player'::"OutcomeAssetKind"
+               AND asset."player_id"=spell."player_id"
+               AND asset."to_club_id"=spell."club_id"
+               AND asset."status"='approved'::"OutcomeRecordStatus"
+               AND rule."status"='approved'::"OutcomeRecordStatus"
+           )
+           AND NOT EXISTS (SELECT 1 FROM "outcome_acquisition_spell_version" successor
+             WHERE successor."supersedes_spell_version_id"=spell."spell_version_id")
+         FOR SHARE OF spell
+      ) THEN
+        RAISE EXCEPTION 'HPN PAV player row acquisition spell is not exact and current';
+      END IF;
+    END IF;
+  END LOOP;
+
+  IF EXISTS (
+    SELECT 1 FROM "outcome_hpn_pav_input_match" member
+    JOIN "outcome_match" match ON match."match_id"=member."match_id"
+    JOIN "outcome_hpn_pav_input_row" result
+      ON result."input_set_id"=member."input_set_id"
+      AND result."provider_decoded_row_id"=member."result_provider_decoded_row_id"
+    WHERE member."input_set_id"=NEW."input_set_id" AND (
+      match."competition"<>NEW."competition" OR match."season_year"<>NEW."season_year"
+      OR match."home_club_id"<>member."home_club_id"
+      OR match."away_club_id"<>member."away_club_id"
+      OR result."row_json"#>>'{match,canonicalId}'<>member."match_id"
+      OR result."row_json"#>>'{homeClub,canonicalId}'<>member."home_club_id"
+      OR result."row_json"#>>'{awayClub,canonicalId}'<>member."away_club_id"
+      OR (result."row_json"->>'effectiveAt')::TIMESTAMPTZ<>member."effective_at"
+      OR encode(sha256(convert_to(member."match_canonical_json",'UTF8')),'hex')<>member."match_sha256"
+      OR member."match_canonical_json"::JSONB IS DISTINCT FROM jsonb_build_object(
+        'matchId',member."match_id",'effectiveAt',to_char(member."effective_at" AT TIME ZONE 'UTC',
+          'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),'homeClubId',member."home_club_id",
+        'awayClubId',member."away_club_id")
+      OR NOT (NEW."input_set_json"#>'{content,completedMatches}' @>
+        jsonb_build_array(jsonb_build_object('matchId',member."match_id",
+          'effectiveAt',to_char(member."effective_at" AT TIME ZONE 'UTC',
+            'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+          'homeClubId',member."home_club_id",'awayClubId',member."away_club_id")))
+    )
+  ) THEN RAISE EXCEPTION 'HPN PAV completed-match membership mismatch'; END IF;
+
+  IF EXISTS (
+    (SELECT member."match_id",member."effective_at",member."home_club_id",member."away_club_id"
+       FROM "outcome_hpn_pav_input_match" member
+      WHERE member."input_set_id"=NEW."input_set_id"
+     EXCEPT
+     SELECT DISTINCT fact."match_id",fact."effective_at",
+       fact."fact_json"#>>'{content,match,homeClub,clubId}',
+       fact."fact_json"#>>'{content,match,awayClub,clubId}'
+       FROM "outcome_hpn_pav_input_factual_match_member" factual_member
+       JOIN "outcome_provider_match_universe_fact" fact
+         ON fact."match_fact_id"=factual_member."fact_id"
+      WHERE factual_member."input_set_id"=NEW."input_set_id")
+    UNION ALL
+    (SELECT DISTINCT fact."match_id",fact."effective_at",
+       fact."fact_json"#>>'{content,match,homeClub,clubId}',
+       fact."fact_json"#>>'{content,match,awayClub,clubId}'
+       FROM "outcome_hpn_pav_input_factual_match_member" factual_member
+       JOIN "outcome_provider_match_universe_fact" fact
+         ON fact."match_fact_id"=factual_member."fact_id"
+      WHERE factual_member."input_set_id"=NEW."input_set_id"
+     EXCEPT
+     SELECT member."match_id",member."effective_at",member."home_club_id",member."away_club_id"
+       FROM "outcome_hpn_pav_input_match" member
+      WHERE member."input_set_id"=NEW."input_set_id")
+  ) THEN
+    RAISE EXCEPTION 'HPN PAV match set differs from the factual completed-match universe';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM "outcome_hpn_pav_input_match" match_member
+    CROSS JOIN LATERAL (VALUES (match_member."home_club_id"),(match_member."away_club_id"))
+      club("club_id")
+    WHERE match_member."input_set_id"=NEW."input_set_id" AND (
+      EXISTS (
+        (SELECT DISTINCT fact."player_id"
+           FROM "outcome_hpn_pav_input_factual_appearance_member" factual_member
+           JOIN "outcome_provider_player_appearance_fact" fact
+             ON fact."appearance_fact_id"=factual_member."fact_id"
+          WHERE factual_member."input_set_id"=NEW."input_set_id"
+            AND fact."match_id"=match_member."match_id"
+            AND fact."represented_club_id"=club."club_id"
+         EXCEPT
+         SELECT row_member."row_json"#>>'{player,canonicalId}'
+           FROM "outcome_hpn_pav_input_row" row_member
+          WHERE row_member."input_set_id"=NEW."input_set_id"
+            AND row_member."row_kind"='player_match_stats' AND row_member."role"='primary'
+            AND row_member."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+            AND row_member."row_json"#>>'{club,canonicalId}'=club."club_id")
+        UNION ALL
+        (SELECT row_member."row_json"#>>'{player,canonicalId}'
+           FROM "outcome_hpn_pav_input_row" row_member
+          WHERE row_member."input_set_id"=NEW."input_set_id"
+            AND row_member."row_kind"='player_match_stats' AND row_member."role"='primary'
+            AND row_member."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+            AND row_member."row_json"#>>'{club,canonicalId}'=club."club_id"
+         EXCEPT
+         SELECT DISTINCT fact."player_id"
+           FROM "outcome_hpn_pav_input_factual_appearance_member" factual_member
+           JOIN "outcome_provider_player_appearance_fact" fact
+             ON fact."appearance_fact_id"=factual_member."fact_id"
+          WHERE factual_member."input_set_id"=NEW."input_set_id"
+            AND fact."match_id"=match_member."match_id"
+            AND fact."represented_club_id"=club."club_id")
+      )
+      OR
+      (SELECT count(*) FROM "outcome_hpn_pav_input_row" row_member
+        WHERE row_member."input_set_id"=NEW."input_set_id"
+          AND row_member."row_kind"='player_match_stats' AND row_member."role"='primary'
+          AND row_member."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+          AND row_member."row_json"#>>'{club,canonicalId}'=club."club_id")=0
+      OR (SELECT count(*) FROM "outcome_hpn_pav_input_row" row_member
+        WHERE row_member."input_set_id"=NEW."input_set_id"
+          AND row_member."row_kind"='player_match_stats' AND row_member."role"='primary'
+          AND row_member."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+          AND row_member."row_json"#>>'{club,canonicalId}'=club."club_id")
+        <> (SELECT count(DISTINCT row_member."row_json"#>>'{player,canonicalId}')
+          FROM "outcome_hpn_pav_input_row" row_member
+          WHERE row_member."input_set_id"=NEW."input_set_id"
+            AND row_member."row_kind"='player_match_stats' AND row_member."role"='primary'
+            AND row_member."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+            AND row_member."row_json"#>>'{club,canonicalId}'=club."club_id")
+      OR (SELECT count(DISTINCT map."provider")
+        FROM "outcome_hpn_pav_input_row" row_member
+        JOIN "outcome_hpn_pav_input_run" run_member
+          ON run_member."input_set_id"=row_member."input_set_id"
+          AND run_member."normalization_run_id"=row_member."normalization_run_id"
+        JOIN "outcome_hpn_projected_field_map" map ON map."field_map_id"=run_member."projected_field_map_id"
+        WHERE row_member."input_set_id"=NEW."input_set_id"
+          AND row_member."row_kind"='player_match_stats' AND row_member."role"='primary'
+          AND row_member."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+          AND row_member."row_json"#>>'{club,canonicalId}'=club."club_id")<>1
+      OR (SELECT count(DISTINCT map."provider")
+        FROM "outcome_hpn_pav_input_row" row_member
+        JOIN "outcome_hpn_pav_input_run" run_member
+          ON run_member."input_set_id"=row_member."input_set_id"
+          AND run_member."normalization_run_id"=row_member."normalization_run_id"
+        JOIN "outcome_hpn_projected_field_map" map ON map."field_map_id"=run_member."projected_field_map_id"
+        WHERE row_member."input_set_id"=NEW."input_set_id"
+          AND row_member."row_kind"='player_match_stats' AND row_member."role"='corroborating'
+          AND row_member."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+          AND row_member."row_json"#>>'{club,canonicalId}'=club."club_id")<1
+      OR EXISTS (
+        SELECT 1
+        FROM "outcome_hpn_pav_input_row" primary_row
+        JOIN "outcome_hpn_pav_input_run" primary_run
+          ON primary_run."input_set_id"=primary_row."input_set_id"
+          AND primary_run."normalization_run_id"=primary_row."normalization_run_id"
+        JOIN "outcome_hpn_projected_field_map" primary_map
+          ON primary_map."field_map_id"=primary_run."projected_field_map_id"
+        JOIN "outcome_hpn_pav_input_row" corroborating_row
+          ON corroborating_row."input_set_id"=primary_row."input_set_id"
+          AND corroborating_row."row_kind"='player_match_stats'
+          AND corroborating_row."role"='corroborating'
+          AND corroborating_row."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+          AND corroborating_row."row_json"#>>'{club,canonicalId}'=club."club_id"
+        JOIN "outcome_hpn_pav_input_run" corroborating_run
+          ON corroborating_run."input_set_id"=corroborating_row."input_set_id"
+          AND corroborating_run."normalization_run_id"=corroborating_row."normalization_run_id"
+        JOIN "outcome_hpn_projected_field_map" corroborating_map
+          ON corroborating_map."field_map_id"=corroborating_run."projected_field_map_id"
+        WHERE primary_row."input_set_id"=NEW."input_set_id"
+          AND primary_row."row_kind"='player_match_stats' AND primary_row."role"='primary'
+          AND primary_row."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+          AND primary_row."row_json"#>>'{club,canonicalId}'=club."club_id"
+          AND primary_map."provider"=corroborating_map."provider"
+      )
+      OR EXISTS (
+        SELECT corroborating_map."provider"
+        FROM "outcome_hpn_pav_input_row" corroborating_row
+        JOIN "outcome_hpn_pav_input_run" corroborating_run
+          ON corroborating_run."input_set_id"=corroborating_row."input_set_id"
+          AND corroborating_run."normalization_run_id"=corroborating_row."normalization_run_id"
+        JOIN "outcome_hpn_projected_field_map" corroborating_map
+          ON corroborating_map."field_map_id"=corroborating_run."projected_field_map_id"
+        WHERE corroborating_row."input_set_id"=NEW."input_set_id"
+          AND corroborating_row."row_kind"='player_match_stats'
+          AND corroborating_row."role"='corroborating'
+          AND corroborating_row."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+          AND corroborating_row."row_json"#>>'{club,canonicalId}'=club."club_id"
+        GROUP BY corroborating_map."provider"
+        HAVING count(*)<>count(DISTINCT corroborating_row."row_json"#>>'{player,canonicalId}')
+          OR EXISTS (
+          (SELECT primary_row."row_json"#>>'{player,canonicalId}'
+             FROM "outcome_hpn_pav_input_row" primary_row
+            WHERE primary_row."input_set_id"=NEW."input_set_id"
+              AND primary_row."row_kind"='player_match_stats' AND primary_row."role"='primary'
+              AND primary_row."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+              AND primary_row."row_json"#>>'{club,canonicalId}'=club."club_id"
+           EXCEPT
+           SELECT provider_row."row_json"#>>'{player,canonicalId}'
+             FROM "outcome_hpn_pav_input_row" provider_row
+             JOIN "outcome_hpn_pav_input_run" provider_run
+               ON provider_run."input_set_id"=provider_row."input_set_id"
+               AND provider_run."normalization_run_id"=provider_row."normalization_run_id"
+             JOIN "outcome_hpn_projected_field_map" provider_map
+               ON provider_map."field_map_id"=provider_run."projected_field_map_id"
+            WHERE provider_row."input_set_id"=NEW."input_set_id"
+              AND provider_row."row_kind"='player_match_stats'
+              AND provider_row."role"='corroborating'
+              AND provider_map."provider"=corroborating_map."provider"
+              AND provider_row."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+              AND provider_row."row_json"#>>'{club,canonicalId}'=club."club_id")
+          UNION ALL
+          (SELECT provider_row."row_json"#>>'{player,canonicalId}'
+             FROM "outcome_hpn_pav_input_row" provider_row
+             JOIN "outcome_hpn_pav_input_run" provider_run
+               ON provider_run."input_set_id"=provider_row."input_set_id"
+               AND provider_run."normalization_run_id"=provider_row."normalization_run_id"
+             JOIN "outcome_hpn_projected_field_map" provider_map
+               ON provider_map."field_map_id"=provider_run."projected_field_map_id"
+            WHERE provider_row."input_set_id"=NEW."input_set_id"
+              AND provider_row."row_kind"='player_match_stats'
+              AND provider_row."role"='corroborating'
+              AND provider_map."provider"=corroborating_map."provider"
+              AND provider_row."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+              AND provider_row."row_json"#>>'{club,canonicalId}'=club."club_id"
+           EXCEPT
+           SELECT primary_row."row_json"#>>'{player,canonicalId}'
+             FROM "outcome_hpn_pav_input_row" primary_row
+            WHERE primary_row."input_set_id"=NEW."input_set_id"
+              AND primary_row."row_kind"='player_match_stats' AND primary_row."role"='primary'
+              AND primary_row."row_json"#>>'{match,canonicalId}'=match_member."match_id"
+              AND primary_row."row_json"#>>'{club,canonicalId}'=club."club_id")
+        )
+      )
+    )
+  ) THEN RAISE EXCEPTION 'HPN PAV player membership is not independently corroborated'; END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER "outcome_hpn_pav_input_set_finalize_guard"
+  ON "outcome_hpn_pav_input_set";
+CREATE TRIGGER "outcome_hpn_pav_input_set_finalize_guard_v1"
+  BEFORE UPDATE ON "outcome_hpn_pav_input_set"
+  FOR EACH ROW
+  WHEN (NEW."input_set_json"#>>'{content,schemaVersion}'=
+    'afl-trade-hpn-pav-input-set/v1')
+  EXECUTE FUNCTION "finalize_outcome_hpn_pav_input_set"();
+CREATE TRIGGER "outcome_hpn_pav_input_set_finalize_guard_v2"
+  BEFORE UPDATE ON "outcome_hpn_pav_input_set"
+  FOR EACH ROW
+  WHEN (NEW."input_set_json"#>>'{content,schemaVersion}'=
+    'afl-trade-hpn-pav-input-set/v2')
+  EXECUTE FUNCTION "finalize_outcome_hpn_pav_input_set_v2"();

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -1316,6 +1316,7 @@ model OutcomeHpnProjectedFieldMap {
   approvalDecision      OutcomeHpnFieldMapReviewDecision   @relation(fields: [approvalDecisionId], references: [decisionId], onDelete: Restrict)
   reviewedResultSeasons OutcomeHpnReviewedSeasonUniverse[] @relation("OutcomeHpnReviewedResultFieldMap")
   reviewedPlayerSeasons OutcomeHpnReviewedSeasonUniverse[] @relation("OutcomeHpnReviewedPlayerFieldMap")
+  pavInputRuns          OutcomeHpnPavInputRun[]
 
   @@index([environment, competition, provider, capabilityId, inputKind, validFromSeason, validThroughSeason], map: "outcome_hpn_projected_field_map_lookup_idx")
   @@map("outcome_hpn_projected_field_map")
@@ -1532,12 +1533,14 @@ model OutcomeHpnPavInputRun {
   inputSetId         String                          @map("input_set_id")
   ordinal            Int
   normalizationRunId String                          @map("normalization_run_id")
-  fieldMapId         String                          @map("field_map_id")
+  fieldMapId         String?                         @map("field_map_id")
+  projectedFieldMapId String?                        @map("projected_field_map_id")
   inputKind          String                          @map("input_kind")
   role               String?
   inputSet           OutcomeHpnPavInputSet           @relation(fields: [inputSetId], references: [inputSetId], onDelete: Restrict)
   normalizationRun   OutcomeProviderNormalizationRun @relation(fields: [normalizationRunId], references: [normalizationRunId], onDelete: Restrict)
-  fieldMap           OutcomeHpnPavFieldMap           @relation(fields: [fieldMapId], references: [fieldMapId], onDelete: Restrict)
+  fieldMap           OutcomeHpnPavFieldMap?          @relation(fields: [fieldMapId], references: [fieldMapId], onDelete: Restrict)
+  projectedFieldMap  OutcomeHpnProjectedFieldMap?    @relation(fields: [projectedFieldMapId], references: [fieldMapId], onDelete: Restrict)
   rows               OutcomeHpnPavInputRow[]
 
   @@id([inputSetId, normalizationRunId])
@@ -5402,7 +5405,7 @@ model OutcomePrivateValuationDispatchRequest {
   claimSequence         Int       @default(0) @map("claim_sequence")
   transientFailureCount Int       @default(0) @map("transient_failure_count")
   attempts              OutcomePrivateValuationDispatchAttempt[]
-  captureBinding        OutcomePrivateValuationCaptureBinding?
+  captureBindings       OutcomePrivateValuationCaptureBinding[]
   sourceAdmission       OutcomePrivateValuationSourceAdmission?
   factualOutput         OutcomePrivateValuationFactualOutput?
 
@@ -5434,7 +5437,8 @@ model OutcomePrivateValuationDispatchAttempt {
 
 model OutcomePrivateValuationCaptureBinding {
   bindingId             String                                    @id @map("binding_id") @outcomes.Text
-  requestId             String                                    @unique @map("request_id") @outcomes.Text
+  requestId             String                                    @map("request_id") @outcomes.Text
+  sourceRole            String                                    @default("factual_input") @map("source_role") @outcomes.Text
   dispatchClaimId       String                                    @map("dispatch_claim_id") @outcomes.Text
   attemptSequence       Int                                       @map("attempt_sequence")
   attemptNumber         Int                                       @map("attempt_number")
@@ -5452,6 +5456,7 @@ model OutcomePrivateValuationCaptureBinding {
   sourceAdmission       OutcomePrivateValuationSourceAdmission?
   factualOutput         OutcomePrivateValuationFactualOutput?
 
+  @@unique([requestId, sourceRole], map: "outcome_private_valuation_capture_binding_request_role_key")
   @@unique([bindingId, normalizationRunId], map: "outcome_private_valuation_capture_binding_id_run_key")
   @@index([normalizationRunId, sourceCaptureId], map: "outcome_private_valuation_capture_binding_source_idx")
   @@map("outcome_private_valuation_capture_binding")

--- a/src/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority.ts
+++ b/src/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority.ts
@@ -3,7 +3,9 @@ import {
   sha256AflTradeCanonicalJson,
 } from '../artifacts/contentAddress';
 import {
+  AFL_TRADE_FITZROY_CAPTURE_REQUEST_SCHEMA_VERSION,
   createAflTradeFitzRoyInvocation,
+  parseAflTradeFitzRoyCaptureRequest,
   type AflTradeFitzRoyCaptureRequest,
 } from '../source/fitzRoyCaptureContracts';
 import type { AflTradeFitzRoyCaptureCommand } from '../source/fitzRoyCaptureRuntime';
@@ -137,6 +139,25 @@ export const LOCAL_AFL_TABLES_PLAYER_STATS_FIELD_SCHEMA = [
   character('Home.Away'),
 ] satisfies readonly LocalAflTablesFieldDescriptor[];
 
+export const LOCAL_AFL_TABLES_RESULTS_FIELD_SCHEMA = [
+  number('Game'),
+  { ...number('Date'), classes: ['Date'] },
+  character('Round'),
+  character('Home.Team'),
+  integer('Home.Goals'),
+  integer('Home.Behinds'),
+  integer('Home.Points'),
+  character('Away.Team'),
+  integer('Away.Goals'),
+  integer('Away.Behinds'),
+  integer('Away.Points'),
+  character('Venue'),
+  integer('Margin'),
+  integer('Season'),
+  character('Round.Type'),
+  integer('Round.Number'),
+] satisfies readonly LocalAflTablesFieldDescriptor[];
+
 function artifact(label: string): string {
   return `artifact:${sha256AflTradeCanonicalJson({
     boundary: 'local-five-season-afl-tables',
@@ -151,7 +172,7 @@ function sourceFieldUse(sourceField: string) {
     uses: {
       archive_fact: 'allowed' as const,
       model_training: 'blocked' as const,
-      derived_feature: 'blocked' as const,
+      derived_feature: 'allowed' as const,
       public_display: 'blocked' as const,
     },
     attributionRequired: true,
@@ -163,10 +184,17 @@ function requireCaptureRequest(season: number): AflTradeFitzRoyCaptureRequest {
   const captureRequest = createLocalAflTradeFiveSeasonCapturePlan().find(
     ({ authorizationSeason }) => authorizationSeason === season
   );
-  if (!captureRequest) {
-    throw new TypeError('The local AFL Tables authority is limited to seasons 2021 through 2025.');
+  if (captureRequest) return captureRequest;
+  if (season === 2026) {
+    return parseAflTradeFitzRoyCaptureRequest({
+      schemaVersion: AFL_TRADE_FITZROY_CAPTURE_REQUEST_SCHEMA_VERSION,
+      capabilityId: 'afl-tables-player-stats',
+      competition: 'AFLM',
+      authorizationSeason: season,
+      parameters: { season, rescrape: false, rescrapeStartSeason: null },
+    });
   }
-  return captureRequest;
+  throw new TypeError('The local AFL Tables authority is limited to seasons 2021 through 2026.');
 }
 
 export function createLocalAflTradeFiveSeasonAflTablesAuthority(season: number) {
@@ -210,14 +238,14 @@ export function createLocalAflTradeFiveSeasonAflTablesAuthority(season: number) 
   const rightsContent = {
     ...approvedPolicy.content,
     intendedPurpose:
-      'Private identity, match, and factual review for the disposable local workbook rehearsal.',
+      'Private identity, factual review, and derived HPN calculation for the disposable local workbook rehearsal.',
     operations: {
       bounded_evaluation_capture: 'allowed' as const,
       raw_evidence_retention: 'allowed' as const,
       metadata_hash_retention: 'allowed' as const,
       internal_quality_evaluation: 'allowed' as const,
       model_training: 'blocked' as const,
-      derived_feature_creation: 'blocked' as const,
+      derived_feature_creation: 'allowed' as const,
       public_derived_output: 'blocked' as const,
       public_fact_display: 'blocked' as const,
       raw_field_redistribution: 'blocked' as const,
@@ -345,6 +373,122 @@ export function createLocalAflTradeFiveSeasonAflTablesAuthority(season: number) 
         zeroSemantics: 'provider_zero_may_mean_missing',
       },
     ],
+    achievement: null,
+  });
+  return { capture, fieldMap, gateDecisionId: gate.decision.decisionId };
+}
+
+export function createLocalAflTradeAflTablesResultsAuthority(season: number) {
+  const playerAuthority = createLocalAflTradeFiveSeasonAflTablesAuthority(season);
+  const captureRequest = parseAflTradeFitzRoyCaptureRequest({
+    schemaVersion: AFL_TRADE_FITZROY_CAPTURE_REQUEST_SCHEMA_VERSION,
+    capabilityId: 'afl-tables-results',
+    competition: 'AFLM',
+    authorizationSeason: season,
+    parameters: { season, roundNumber: null },
+  });
+  const invocation = createAflTradeFitzRoyInvocation(captureRequest);
+  const exactFields = LOCAL_AFL_TABLES_RESULTS_FIELD_SCHEMA.map(({ name }) => name);
+  const rightsContent = {
+    ...playerAuthority.capture.sourceRights.content,
+    registerId: `afl-tables-results-local-${season}-fitzroy-1.7.0`,
+    dataset: 'AFL Tables completed match results through fitzRoy',
+    intendedPurpose:
+      'Private completed-match universe for the non-production HPN calculation input.',
+    acquisition: {
+      ...playerAuthority.capture.sourceRights.content.acquisition,
+      capabilities: [
+        {
+          capabilityId: 'afl-tables-results',
+          provider: 'afl_tables' as const,
+          directFunction: 'fetch_results_afltables',
+        },
+      ],
+    },
+    fields: exactFields.map(sourceFieldUse),
+  };
+  const sourceRights = aflTradeSourceRightsProposalSchema.parse({
+    rightsArtifactId: createAflTradeContentAddress('source-rights', rightsContent),
+    content: rightsContent,
+  });
+  const gate = createApprovedAflTradeFitzRoyGateRecords({
+    sourceRights,
+    environment: 'non_production',
+    version: 1,
+    supersedesDecisionId: null,
+    decidedAt: '2026-08-14T00:00:02.000Z',
+    effectiveAt: '2026-08-14T00:00:02.000Z',
+    revalidateAt: '2027-08-13T00:00:00.000Z',
+    accountableOwner: 'local-factual-release-owner',
+    reviewer: {
+      id: 'local-source-governance-reviewer',
+      role: 'source-governance-reviewer',
+      evidenceId: artifact('results-source-governance-review'),
+    },
+    authorityEvidenceId: artifact('local-user-approval'),
+    rateLimitEvidenceId: artifact('rate-limit'),
+  });
+  const capture: AflTradeFitzRoyCaptureCommand = {
+    sourceRights,
+    ledger: { proposals: [gate.proposal], decisions: [gate.decision] },
+    gateRequest: {
+      decisionKey: gate.proposal.content.decisionKey,
+      environment: 'non_production',
+      rightsArtifactId: sourceRights.rightsArtifactId,
+      competition: 'AFLM',
+      season,
+      accessMechanism: 'automated_web',
+      capabilityId: 'afl-tables-results',
+      geography: 'global',
+      commercialContext: 'internal-evaluation',
+      audience: 'internal',
+      operations: [
+        'bounded_evaluation_capture',
+        'raw_evidence_retention',
+        'metadata_hash_retention',
+        'internal_quality_evaluation',
+      ],
+      fieldUses: exactFields.map((sourceField) => ({
+        sourceField,
+        use: 'archive_fact' as const,
+      })),
+      rawRetentionDays: 365,
+      metadataRetentionDays: null,
+      cacheSeconds: 86_400,
+    },
+    captureRequest,
+  };
+  const fieldMap = parseAflTradeFitzRoyFieldMap({
+    schemaVersion: AFL_TRADE_FITZROY_FIELD_MAP_SCHEMA_VERSION,
+    mapId: `afl-tables-results-local-${season}-v1`,
+    capabilityId: 'afl-tables-results',
+    fitzRoyVersion: '1.7.0',
+    sourceSchemaSha256: createDecodedFieldSchemaSha256(LOCAL_AFL_TABLES_RESULTS_FIELD_SCHEMA),
+    exactOrderedFields: exactFields,
+    observationKind: 'match_universe',
+    competition: 'AFLM',
+    invocationArgumentsSha256: sha256AflTradeCanonicalJson(invocation.arguments),
+    validFromSeason: season,
+    validThroughSeason: season,
+    seasonField: { sourceField: 'Season', required: true },
+    roundLabelField: { sourceField: 'Round', required: true },
+    observedDateField: { sourceField: 'Date', required: true },
+    naturalKeyFields: ['Season', 'Round', 'Date', 'Home.Team', 'Away.Team'],
+    approvedAt: '2026-08-14T00:00:03.000Z',
+    approvalDecisionId: `local-afl-tables-results-field-map-review-${season}`,
+    identity: null,
+    match: {
+      nativeMatchId: { sourceField: 'Game', required: true },
+      season: { sourceField: 'Season', required: true },
+      roundLabel: { sourceField: 'Round', required: true },
+      matchDate: { sourceField: 'Date', required: true },
+      homeClubNativeId: null,
+      homeClubName: { sourceField: 'Home.Team', required: true },
+      awayClubNativeId: null,
+      awayClubName: { sourceField: 'Away.Team', required: true },
+      status: null,
+    },
+    metrics: [],
     achievement: null,
   });
   return { capture, fieldMap, gateDecisionId: gate.decision.decisionId };

--- a/src/server/aflTradeIntelligence/development/localHpnFieldMapCandidates.ts
+++ b/src/server/aflTradeIntelligence/development/localHpnFieldMapCandidates.ts
@@ -115,39 +115,47 @@ export function createLocalAflTradeHpnCompletedResultFieldMapCandidate(input: {
   readonly createdAt: string;
 }) {
   const decodeMap = decodeMapIdentitySchema.parse(input.providerDecodeMap);
-  if (decodeMap.capabilityId !== 'afl-tables-player-stats') {
+  if (
+    decodeMap.capabilityId !== 'afl-tables-results' &&
+    decodeMap.capabilityId !== 'afl-tables-player-stats'
+  ) {
     throw new TypeError(
       'The retained provider decode map has the wrong HPN result capability.'
     );
   }
+  const dedicatedResults = decodeMap.capabilityId === 'afl-tables-results';
+  const homeClubField = dedicatedResults ? 'Home.Team' : 'Home.team';
+  const awayClubField = dedicatedResults ? 'Away.Team' : 'Away.team';
+  const homePointsField = dedicatedResults ? 'Home.Points' : 'Home.score';
+  const awayPointsField = dedicatedResults ? 'Away.Points' : 'Away.score';
   const semanticBindings = listAflTradeHpnRequiredSemanticFields(
     'completed_match_result'
   ).map<AflTradeHpnSemanticBindingCandidate>((semanticField) => {
     switch (semanticField) {
       case 'awayClub':
-        return { semanticField, mapping: { kind: 'direct', sourceField: 'Away.team' } };
+        return { semanticField, mapping: { kind: 'direct', sourceField: awayClubField } };
       case 'awayPoints':
-        return { semanticField, mapping: { kind: 'direct', sourceField: 'Away.score' } };
+        return { semanticField, mapping: { kind: 'direct', sourceField: awayPointsField } };
       case 'completionStatus':
         return {
           semanticField,
           mapping: {
             kind: 'reviewed_final_scores',
             matchDateField: 'Date',
-            homePointsField: 'Home.score',
-            awayPointsField: 'Away.score',
+            homePointsField,
+            awayPointsField,
           },
         };
       case 'homeClub':
-        return { semanticField, mapping: { kind: 'direct', sourceField: 'Home.team' } };
+        return { semanticField, mapping: { kind: 'direct', sourceField: homeClubField } };
       case 'homePoints':
-        return { semanticField, mapping: { kind: 'direct', sourceField: 'Home.score' } };
+        return { semanticField, mapping: { kind: 'direct', sourceField: homePointsField } };
       case 'match':
         return {
           semanticField,
           mapping: {
             kind: 'composite_key',
-            sourceFields: ['Date', 'Home.team', 'Away.team'],
+            sourceFields: ['Date', homeClubField, awayClubField],
           },
         };
       default:
@@ -158,7 +166,7 @@ export function createLocalAflTradeHpnCompletedResultFieldMapCandidate(input: {
     environment: 'non_production',
     competition: 'AFLM',
     provider: 'afl_tables',
-    capabilityId: 'afl-tables-player-stats',
+    capabilityId: decodeMap.capabilityId,
     sourceSchemaSha256: decodeMap.sourceSchemaSha256,
     inputKind: 'completed_match_result',
     validFromSeason: input.seasonYear,

--- a/src/server/aflTradeIntelligence/development/localHpnFieldMapReview.ts
+++ b/src/server/aflTradeIntelligence/development/localHpnFieldMapReview.ts
@@ -69,7 +69,8 @@ export async function approveLocalAflTradeHpnFieldMapCandidates(
   authority: ProjectionWriter
 ): Promise<readonly LocalAflTradeHpnFieldMapApproval[]> {
   const keys = input.candidates.map(
-    ({ seasonYear, candidate }) => `${seasonYear}:${candidate.content.inputKind}`
+    ({ seasonYear, candidate }) =>
+      `${seasonYear}:${candidate.content.provider}:${candidate.content.capabilityId}:${candidate.content.inputKind}`
   );
   if (
     input.candidates.length === 0 ||
@@ -167,7 +168,7 @@ export async function reviewLocalAflTradeHpnFieldMaps(
     },
     new PostgresAflTradeHpnProjectedFieldMapAuthority(client)
   );
-  const expectedCount = (input.throughSeason - input.fromSeason + 1) * 2;
+  const expectedCount = (input.throughSeason - input.fromSeason + 1) * 3;
   if (approvals.length !== expectedCount) {
     throw new TypeError('The complete requested HPN field-map review set was not approved.');
   }

--- a/src/server/aflTradeIntelligence/development/localHpnFieldMapReview.ts
+++ b/src/server/aflTradeIntelligence/development/localHpnFieldMapReview.ts
@@ -159,6 +159,17 @@ export async function reviewLocalAflTradeHpnFieldMaps(
   }>
 ) {
   const assembled = await assembleLocalAflTradeHpnLeagueSeasonReviewPacket(client, input);
+  const expectedCount = assembled.eligibilityReports.reduce(
+    (count, { report }) =>
+      count + report.content.sources.filter(({ selectionState }) => selectionState === 'selected').length,
+    0
+  );
+  if (
+    assembled.fieldMapCandidates.length !== expectedCount ||
+    assembled.sourceUseAssessments.length !== expectedCount
+  ) {
+    throw new TypeError('The complete requested HPN field-map review set was not assembled.');
+  }
   const approvals = await approveLocalAflTradeHpnFieldMapCandidates(
     {
       candidates: assembled.fieldMapCandidates,
@@ -168,7 +179,6 @@ export async function reviewLocalAflTradeHpnFieldMaps(
     },
     new PostgresAflTradeHpnProjectedFieldMapAuthority(client)
   );
-  const expectedCount = (input.throughSeason - input.fromSeason + 1) * 3;
   if (approvals.length !== expectedCount) {
     throw new TypeError('The complete requested HPN field-map review set was not approved.');
   }

--- a/src/server/aflTradeIntelligence/development/localHpnLeagueSeasonReviewAssembler.ts
+++ b/src/server/aflTradeIntelligence/development/localHpnLeagueSeasonReviewAssembler.ts
@@ -11,7 +11,6 @@ import {
 } from '../artifacts/contentAddress';
 import {
   createAflTradeHpnCalculationEligibilityReport,
-  type AflTradeHpnCalculationFieldAssessmentInput,
 } from '../modeling/hpnCalculationEligibility';
 import {
   aflTradeHpnFieldMapCandidateSchema,
@@ -42,6 +41,7 @@ import {
 } from './localHpnReviewFieldAssessments';
 import {
   loadLocalAflTradeHpnReviewSnapshot,
+  type LocalAflTradeHpnReviewSnapshot,
 } from './localHpnReviewSnapshot';
 
 type DocumentBinding = Readonly<{ artifactRef: AflTradeArtifactRef; document: unknown }>;
@@ -222,216 +222,216 @@ export async function assembleLocalAflTradeHpnLeagueSeasonReviewPacket(
     artifact: AflTradeArtifactRef;
   }> = [];
 
-  for (let seasonYear = input.fromSeason; seasonYear <= input.throughSeason; seasonYear += 1) {
-    const selected = snapshot.sources.filter((source) => source.seasonYear === seasonYear);
-    if (selected.length > 1) {
-      throw new TypeError('The local HPN primary source selection is ambiguous.');
+  type SnapshotSource = LocalAflTradeHpnReviewSnapshot['sources'][number];
+  const requireAtMostOne = (
+    values: readonly SnapshotSource[],
+    description: string
+  ): SnapshotSource | undefined => {
+    if (values.length > 1) {
+      throw new TypeError(`The local HPN ${description} source selection is ambiguous.`);
     }
-    const primary = selected[0];
-    let resultSource:
-      | {
-          selectionState: 'selected';
-          normalizationRunId: string;
-          provider: string;
-          inputKind: 'completed_match_result';
-          role: null;
-          selectionEvidenceRefs: readonly AflTradeArtifactRef[];
-          fields: readonly AflTradeHpnCalculationFieldAssessmentInput[];
-        }
-      | {
-          selectionState: 'missing';
-          normalizationRunId: null;
-          provider: null;
-          inputKind: 'completed_match_result';
-          role: null;
-          selectionEvidenceRefs: readonly AflTradeArtifactRef[];
-        };
-    let primarySource:
-      | {
-          selectionState: 'selected';
-          normalizationRunId: string;
-          provider: string;
-          inputKind: 'player_match_stats';
-          role: 'primary';
-          selectionEvidenceRefs: readonly AflTradeArtifactRef[];
-          fields: readonly AflTradeHpnCalculationFieldAssessmentInput[];
-        }
-      | {
-          selectionState: 'missing';
-          normalizationRunId: null;
-          provider: null;
-          inputKind: 'player_match_stats';
-          role: 'primary';
-          selectionEvidenceRefs: readonly AflTradeArtifactRef[];
-        };
-    if (!primary) {
-      resultSource = {
-        selectionState: 'missing', normalizationRunId: null, provider: null,
-        inputKind: 'completed_match_result', role: null,
-        selectionEvidenceRefs: [authoritySnapshotArtifact],
-      };
-      primarySource = {
-        selectionState: 'missing', normalizationRunId: null, provider: null,
-        inputKind: 'player_match_stats', role: 'primary',
-        selectionEvidenceRefs: [authoritySnapshotArtifact],
-      };
-    } else {
-      addDocument(primary.rights, primary.rightsArtifact);
+    return values[0];
+  };
 
-      const retainedResult = authenticateProjectedFieldMap(primary.hpnResultProjection);
-      const provisionalResultDecodeMapArtifact = createAflTradeCanonicalJsonArtifactRef(
-        primary.providerDecodeMap,
-        snapshot.trustedAt
-      );
-      const resultCandidate = retainedResult?.candidate ??
-        createLocalAflTradeHpnCompletedResultFieldMapCandidate({
-          seasonYear,
-          providerDecodeMap: primary.providerDecodeMap,
-          providerDecodeMapArtifact: provisionalResultDecodeMapArtifact,
-          createdAt: snapshot.trustedAt,
-        });
-      const resultCandidateArtifact = retainedResult?.candidateArtifact ??
-        createAflTradeCanonicalJsonArtifactRef(resultCandidate, snapshot.trustedAt);
-      const resultDecodeMapArtifact = resultCandidate.content.providerDecodeMapArtifact;
-      if (!doesAflTradeArtifactRefMatchCanonicalJson(
-        resultDecodeMapArtifact,
-        primary.providerDecodeMap
-      )) {
-        throw new TypeError('The result projection does not bind the current decode map.');
-      }
-      addDocument(primary.providerDecodeMap, resultDecodeMapArtifact);
-      addDocument(resultCandidate, resultCandidateArtifact);
-      if (retainedResult) {
-        addDocument(
-          retainedResult.sourceUseAssessment,
-          retainedResult.sourceUseAssessmentArtifact
-        );
-        addDocument(retainedResult.decision, retainedResult.decisionArtifact);
-        addDocument(retainedResult.map, retainedResult.mapArtifact);
-      }
-      fieldMapCandidates.push({
-        seasonYear,
-        candidate: resultCandidate,
-        artifact: resultCandidateArtifact,
-      });
-      const resultSourceFields = [...new Set(
-        resultCandidate.content.semanticBindings.flatMap(
-          listAflTradeHpnCandidateSourceFields
-        )
-      )].sort();
-      const resultAssessment = assessAflTradeHpnPrivateCalculationSourceUse({
-        rights: primary.rights,
-        rightsArtifact: primary.rightsArtifact,
-        evidenceBundle,
-        admission,
-        competition: 'AFLM',
-        seasonYear,
-        sourceFields: resultSourceFields,
-        evaluatedAt: snapshot.trustedAt,
-      });
-      const resultAssessmentArtifact = createAflTradeCanonicalJsonArtifactRef(
-        resultAssessment,
-        snapshot.trustedAt
-      );
-      addDocument(resultAssessment, resultAssessmentArtifact);
-      sourceUseAssessments.push({
-        seasonYear,
-        assessment: resultAssessment,
-        artifact: resultAssessmentArtifact,
-      });
-      resultSource = {
-        selectionState: 'selected',
-        normalizationRunId: primary.normalizationRunId,
-        provider: primary.provider,
-        inputKind: 'completed_match_result',
+  const prepareResultSource = (source: SnapshotSource | undefined, seasonYear: number) => {
+    if (!source) {
+      return {
+        selectionState: 'missing' as const,
+        normalizationRunId: null,
+        provider: null,
+        inputKind: 'completed_match_result' as const,
         role: null,
         selectionEvidenceRefs: [authoritySnapshotArtifact],
-        fields: createSelectedLocalAflTradeHpnFields({
-          candidate: resultCandidate,
-          candidateArtifact: resultCandidateArtifact,
-          decodeMapArtifact: resultDecodeMapArtifact,
-          sourceUseAssessment: resultAssessment,
-          sourceUseAssessmentArtifact: resultAssessmentArtifact,
-          currentMap: retainedResult?.map ?? null,
-          currentMapArtifact: retainedResult?.mapArtifact ?? null,
-          factualRunId: null,
-          hpnResolutionsCurrent: false,
-          authoritySnapshotArtifact,
-        }),
-      };
-
-      const retainedPlayer = authenticateProjectedFieldMap(primary.hpnPlayerProjection);
-      const provisionalPlayerDecodeMapArtifact = createAflTradeCanonicalJsonArtifactRef(
-        primary.providerDecodeMap,
-        snapshot.trustedAt
-      );
-      const candidate = retainedPlayer?.candidate ??
-        createLocalAflTradeHpnPlayerFieldMapCandidate({
-          provider: primary.provider,
-          seasonYear,
-          providerDecodeMap: primary.providerDecodeMap,
-          providerDecodeMapArtifact: provisionalPlayerDecodeMapArtifact,
-          createdAt: snapshot.trustedAt,
-        });
-      const candidateArtifact = retainedPlayer?.candidateArtifact ??
-        createAflTradeCanonicalJsonArtifactRef(candidate, snapshot.trustedAt);
-      const playerDecodeMapArtifact = candidate.content.providerDecodeMapArtifact;
-      if (!doesAflTradeArtifactRefMatchCanonicalJson(
-        playerDecodeMapArtifact,
-        primary.providerDecodeMap
-      )) {
-        throw new TypeError('The player projection does not bind the current decode map.');
-      }
-      addDocument(primary.providerDecodeMap, playerDecodeMapArtifact);
-      addDocument(candidate, candidateArtifact);
-      if (retainedPlayer) {
-        addDocument(
-          retainedPlayer.sourceUseAssessment,
-          retainedPlayer.sourceUseAssessmentArtifact
-        );
-        addDocument(retainedPlayer.decision, retainedPlayer.decisionArtifact);
-        addDocument(retainedPlayer.map, retainedPlayer.mapArtifact);
-      }
-      fieldMapCandidates.push({ seasonYear, candidate, artifact: candidateArtifact });
-
-      const requiredSourceFields = [...new Set(
-        candidate.content.semanticBindings.flatMap(listAflTradeHpnCandidateSourceFields)
-      )].sort();
-      const assessment = assessAflTradeHpnPrivateCalculationSourceUse({
-        rights: primary.rights,
-        rightsArtifact: primary.rightsArtifact,
-        evidenceBundle,
-        admission,
-        competition: 'AFLM',
-        seasonYear,
-        sourceFields: requiredSourceFields,
-        evaluatedAt: snapshot.trustedAt,
-      });
-      const assessmentArtifact = createAflTradeCanonicalJsonArtifactRef(
-        assessment,
-        snapshot.trustedAt
-      );
-      addDocument(assessment, assessmentArtifact);
-      sourceUseAssessments.push({ seasonYear, assessment, artifact: assessmentArtifact });
-
-      const fields = createSelectedLocalAflTradeHpnFields({
-        candidate,
-        candidateArtifact,
-        decodeMapArtifact: playerDecodeMapArtifact,
-        sourceUseAssessment: assessment,
-        sourceUseAssessmentArtifact: assessmentArtifact,
-        currentMap: retainedPlayer?.map ?? null,
-        currentMapArtifact: retainedPlayer?.mapArtifact ?? null,
-        factualRunId: primary.factualRunId,
-        hpnResolutionsCurrent: primary.hpnResolutionsCurrent,
-        authoritySnapshotArtifact,
-      });
-      primarySource = {
-        selectionState: 'selected', normalizationRunId: primary.normalizationRunId,
-        provider: primary.provider, inputKind: 'player_match_stats', role: 'primary',
-        selectionEvidenceRefs: [authoritySnapshotArtifact], fields,
       };
     }
+    addDocument(source.rights, source.rightsArtifact);
+    const retained = authenticateProjectedFieldMap(source.hpnResultProjection);
+    const provisionalDecodeMapArtifact = createAflTradeCanonicalJsonArtifactRef(
+      source.providerDecodeMap,
+      snapshot.trustedAt
+    );
+    const candidate = retained?.candidate ??
+      createLocalAflTradeHpnCompletedResultFieldMapCandidate({
+        seasonYear,
+        providerDecodeMap: source.providerDecodeMap,
+        providerDecodeMapArtifact: provisionalDecodeMapArtifact,
+        createdAt: snapshot.trustedAt,
+      });
+    const candidateArtifact = retained?.candidateArtifact ??
+      createAflTradeCanonicalJsonArtifactRef(candidate, snapshot.trustedAt);
+    const decodeMapArtifact = candidate.content.providerDecodeMapArtifact;
+    if (!doesAflTradeArtifactRefMatchCanonicalJson(
+      decodeMapArtifact,
+      source.providerDecodeMap
+    )) {
+      throw new TypeError('The result projection does not bind the current decode map.');
+    }
+    addDocument(source.providerDecodeMap, decodeMapArtifact);
+    addDocument(candidate, candidateArtifact);
+    if (retained) {
+      addDocument(retained.sourceUseAssessment, retained.sourceUseAssessmentArtifact);
+      addDocument(retained.decision, retained.decisionArtifact);
+      addDocument(retained.map, retained.mapArtifact);
+    }
+    fieldMapCandidates.push({ seasonYear, candidate, artifact: candidateArtifact });
+    const sourceFields = [...new Set(
+      candidate.content.semanticBindings.flatMap(listAflTradeHpnCandidateSourceFields)
+    )].sort();
+    const assessment = assessAflTradeHpnPrivateCalculationSourceUse({
+      rights: source.rights,
+      rightsArtifact: source.rightsArtifact,
+      evidenceBundle,
+      admission,
+      competition: 'AFLM',
+      seasonYear,
+      sourceFields,
+      evaluatedAt: snapshot.trustedAt,
+    });
+    const assessmentArtifact = createAflTradeCanonicalJsonArtifactRef(
+      assessment,
+      snapshot.trustedAt
+    );
+    addDocument(assessment, assessmentArtifact);
+    sourceUseAssessments.push({ seasonYear, assessment, artifact: assessmentArtifact });
+    return {
+      selectionState: 'selected' as const,
+      normalizationRunId: source.normalizationRunId,
+      provider: source.provider,
+      inputKind: 'completed_match_result' as const,
+      role: null,
+      selectionEvidenceRefs: [authoritySnapshotArtifact],
+      fields: createSelectedLocalAflTradeHpnFields({
+        candidate,
+        candidateArtifact,
+        decodeMapArtifact,
+        sourceUseAssessment: assessment,
+        sourceUseAssessmentArtifact: assessmentArtifact,
+        currentMap: retained?.map ?? null,
+        currentMapArtifact: retained?.mapArtifact ?? null,
+        factualRunId: null,
+        hpnResolutionsCurrent: false,
+        authoritySnapshotArtifact,
+      }),
+    };
+  };
+
+  const preparePlayerSource = (
+    source: SnapshotSource | undefined,
+    seasonYear: number,
+    role: 'primary' | 'corroborating'
+  ) => {
+    if (!source) {
+      return {
+        selectionState: 'missing' as const,
+        normalizationRunId: null,
+        provider: null,
+        inputKind: 'player_match_stats' as const,
+        role,
+        selectionEvidenceRefs: [authoritySnapshotArtifact],
+      };
+    }
+    addDocument(source.rights, source.rightsArtifact);
+    const retained = authenticateProjectedFieldMap(source.hpnPlayerProjection);
+    const provisionalDecodeMapArtifact = createAflTradeCanonicalJsonArtifactRef(
+      source.providerDecodeMap,
+      snapshot.trustedAt
+    );
+    const candidate = retained?.candidate ?? createLocalAflTradeHpnPlayerFieldMapCandidate({
+      provider: source.provider,
+      seasonYear,
+      providerDecodeMap: source.providerDecodeMap,
+      providerDecodeMapArtifact: provisionalDecodeMapArtifact,
+      createdAt: snapshot.trustedAt,
+    });
+    const candidateArtifact = retained?.candidateArtifact ??
+      createAflTradeCanonicalJsonArtifactRef(candidate, snapshot.trustedAt);
+    const decodeMapArtifact = candidate.content.providerDecodeMapArtifact;
+    if (!doesAflTradeArtifactRefMatchCanonicalJson(
+      decodeMapArtifact,
+      source.providerDecodeMap
+    )) {
+      throw new TypeError('The player projection does not bind the current decode map.');
+    }
+    addDocument(source.providerDecodeMap, decodeMapArtifact);
+    addDocument(candidate, candidateArtifact);
+    if (retained) {
+      addDocument(retained.sourceUseAssessment, retained.sourceUseAssessmentArtifact);
+      addDocument(retained.decision, retained.decisionArtifact);
+      addDocument(retained.map, retained.mapArtifact);
+    }
+    fieldMapCandidates.push({ seasonYear, candidate, artifact: candidateArtifact });
+    const sourceFields = [...new Set(
+      candidate.content.semanticBindings.flatMap(listAflTradeHpnCandidateSourceFields)
+    )].sort();
+    const assessment = assessAflTradeHpnPrivateCalculationSourceUse({
+      rights: source.rights,
+      rightsArtifact: source.rightsArtifact,
+      evidenceBundle,
+      admission,
+      competition: 'AFLM',
+      seasonYear,
+      sourceFields,
+      evaluatedAt: snapshot.trustedAt,
+    });
+    const assessmentArtifact = createAflTradeCanonicalJsonArtifactRef(
+      assessment,
+      snapshot.trustedAt
+    );
+    addDocument(assessment, assessmentArtifact);
+    sourceUseAssessments.push({ seasonYear, assessment, artifact: assessmentArtifact });
+    return {
+      selectionState: 'selected' as const,
+      normalizationRunId: source.normalizationRunId,
+      provider: source.provider,
+      inputKind: 'player_match_stats' as const,
+      role,
+      selectionEvidenceRefs: [authoritySnapshotArtifact],
+      fields: createSelectedLocalAflTradeHpnFields({
+        candidate,
+        candidateArtifact,
+        decodeMapArtifact,
+        sourceUseAssessment: assessment,
+        sourceUseAssessmentArtifact: assessmentArtifact,
+        currentMap: retained?.map ?? null,
+        currentMapArtifact: retained?.mapArtifact ?? null,
+        factualRunId: source.factualRunId,
+        hpnResolutionsCurrent: source.hpnResolutionsCurrent,
+        authoritySnapshotArtifact,
+      }),
+    };
+  };
+
+  for (let seasonYear = input.fromSeason; seasonYear <= input.throughSeason; seasonYear += 1) {
+    const selected = snapshot.sources.filter((source) => source.seasonYear === seasonYear);
+    const resultSource = prepareResultSource(
+      requireAtMostOne(
+        selected.filter(({ capabilityId }) => capabilityId === 'afl-tables-results'),
+        'completed-results'
+      ),
+      seasonYear
+    );
+    const primarySource = preparePlayerSource(
+      requireAtMostOne(
+        selected.filter(
+          ({ provider, capabilityId }) =>
+            provider === 'afl_tables' && capabilityId === 'afl-tables-player-stats'
+        ),
+        'primary player-stat'
+      ),
+      seasonYear,
+      'primary'
+    );
+    const corroboratingSource = preparePlayerSource(
+      requireAtMostOne(
+        selected.filter(
+          ({ provider, capabilityId }) =>
+            provider === 'official_afl' && capabilityId === 'official-afl-player-stats'
+        ),
+        'corroborating player-stat'
+      ),
+      seasonYear,
+      'corroborating'
+    );
 
     const report = createAflTradeHpnCalculationEligibilityReport({
       valuationScopeKey: input.valuationScopeKey,
@@ -441,11 +441,7 @@ export async function assembleLocalAflTradeHpnLeagueSeasonReviewPacket(
       sources: [
         resultSource,
         primarySource,
-        {
-          selectionState: 'missing', normalizationRunId: null, provider: null,
-          inputKind: 'player_match_stats', role: 'corroborating',
-          selectionEvidenceRefs: [authoritySnapshotArtifact],
-        },
+        corroboratingSource,
       ],
       evaluatedAt: snapshot.trustedAt,
     });

--- a/src/server/aflTradeIntelligence/development/localHpnLeagueSeasonReviewAssembler.ts
+++ b/src/server/aflTradeIntelligence/development/localHpnLeagueSeasonReviewAssembler.ts
@@ -403,21 +403,23 @@ export async function assembleLocalAflTradeHpnLeagueSeasonReviewPacket(
 
   for (let seasonYear = input.fromSeason; seasonYear <= input.throughSeason; seasonYear += 1) {
     const selected = snapshot.sources.filter((source) => source.seasonYear === seasonYear);
-    const resultSource = prepareResultSource(
-      requireAtMostOne(
-        selected.filter(({ capabilityId }) => capabilityId === 'afl-tables-results'),
-        'completed-results'
+    const primary = requireAtMostOne(
+      selected.filter(
+        ({ provider, capabilityId }) =>
+          provider === 'afl_tables' && capabilityId === 'afl-tables-player-stats'
       ),
+      'primary player-stat'
+    );
+    const dedicatedResults = requireAtMostOne(
+      selected.filter(({ capabilityId }) => capabilityId === 'afl-tables-results'),
+      'completed-results'
+    );
+    const resultSource = prepareResultSource(
+      dedicatedResults ?? primary,
       seasonYear
     );
     const primarySource = preparePlayerSource(
-      requireAtMostOne(
-        selected.filter(
-          ({ provider, capabilityId }) =>
-            provider === 'afl_tables' && capabilityId === 'afl-tables-player-stats'
-        ),
-        'primary player-stat'
-      ),
+      primary,
       seasonYear,
       'primary'
     );

--- a/src/server/aflTradeIntelligence/development/localHpnReviewSnapshot.ts
+++ b/src/server/aflTradeIntelligence/development/localHpnReviewSnapshot.ts
@@ -11,6 +11,7 @@ const sourceSchema = z
     captureId: publicIdSchema,
     provider: z.enum(['afl_tables', 'official_afl']),
     capabilityId: z.enum([
+      'afl-tables-results',
       'afl-tables-player-stats',
       'official-afl-player-stats',
     ]),
@@ -49,7 +50,10 @@ export type LocalAflTradeHpnReviewSnapshot = Readonly<{
     seasonYear: number;
     captureId: string;
     provider: 'afl_tables' | 'official_afl';
-    capabilityId: 'afl-tables-player-stats' | 'official-afl-player-stats';
+    capabilityId:
+      | 'afl-tables-results'
+      | 'afl-tables-player-stats'
+      | 'official-afl-player-stats';
     normalizationRunId: string;
     providerDecodeMap: unknown;
     rights: unknown;
@@ -189,7 +193,7 @@ const LOAD_REVIEW_SNAPSHOT_SQL = `WITH authority AS MATERIALIZED (
    WHERE capture.environment='non_production' AND capture.status='staged'
      AND capture.anchor_season_year BETWEEN $2 AND $3
      AND capture.capability_id IN (
-       'afl-tables-player-stats','official-afl-player-stats'
+       'afl-tables-results','afl-tables-player-stats','official-afl-player-stats'
      )
 )
 SELECT transaction_timestamp() AS trusted_at,authority.bundle_json AS reviewed_evidence_bundle_json,

--- a/src/server/aflTradeIntelligence/development/localOfficialAfl2026Authority.ts
+++ b/src/server/aflTradeIntelligence/development/localOfficialAfl2026Authority.ts
@@ -182,7 +182,7 @@ function sourceFieldUse(sourceField: string) {
     uses: {
       archive_fact: 'allowed' as const,
       model_training: 'blocked' as const,
-      derived_feature: 'blocked' as const,
+      derived_feature: 'allowed' as const,
       public_display: 'blocked' as const,
     },
     attributionRequired: true,
@@ -208,7 +208,7 @@ export function createLocalAflTradeOfficialAfl2026Authority() {
     dataset: 'Official AFL 2026 player match statistics',
     datasetVersion: `fitzroy-${AFL_TRADE_FITZROY_PINNED_VERSION}`,
     intendedPurpose:
-      'Current-season concluded AFL player appearances and goals for the disposable local factual-release rehearsal.',
+      'Current-season concluded AFL player appearances, goals, and private HPN calculation for the disposable local rehearsal.',
     scope: {
       competitions: ['AFLM'],
       seasonRanges: [{ from: 2026, to: 2026 }],
@@ -232,7 +232,7 @@ export function createLocalAflTradeOfficialAfl2026Authority() {
       metadata_hash_retention: 'allowed' as const,
       internal_quality_evaluation: 'allowed' as const,
       model_training: 'blocked' as const,
-      derived_feature_creation: 'blocked' as const,
+      derived_feature_creation: 'allowed' as const,
       public_derived_output: 'blocked' as const,
       public_fact_display: 'blocked' as const,
       raw_field_redistribution: 'blocked' as const,

--- a/src/server/aflTradeIntelligence/development/localReviewedProviderEvidence.ts
+++ b/src/server/aflTradeIntelligence/development/localReviewedProviderEvidence.ts
@@ -360,12 +360,15 @@ async function loadCaptureEvidence(transaction: AflOutcomeSqlTransaction): Promi
               AND capture.anchor_season_year BETWEEN 2021 AND 2025)
           OR (capture.provider='official_afl'
               AND capture.capability_id='official-afl-player-stats'
+              AND capture.anchor_season_year=2026)
+          OR (capture.provider='afl_tables'
+              AND capture.capability_id='afl-tables-results'
               AND capture.anchor_season_year=2026))
       ORDER BY capture.capture_id
       FOR KEY SHARE OF capture,custody,rights`
   );
-  if (result.rows.length !== 6) {
-    throw new TypeError('The exact retained provider capture set must contain six captures.');
+  if (result.rows.length !== 7) {
+    throw new TypeError('The exact retained provider capture set must contain seven captures.');
   }
   const rightsByArtifactId = new Map<string, AflTradeArtifactRef>();
   const sourceCaptures = result.rows.map((row) => {
@@ -401,9 +404,9 @@ async function loadCaptureEvidence(transaction: AflOutcomeSqlTransaction): Promi
       }),
     };
   });
-  if (rightsByArtifactId.size !== 2) {
+  if (rightsByArtifactId.size !== 3) {
     throw new TypeError(
-      'The exact retained provider capture set must retain two rights artifacts.'
+      'The exact retained provider capture set must retain three rights artifacts.'
     );
   }
   return {
@@ -415,9 +418,9 @@ async function loadCaptureEvidence(transaction: AflOutcomeSqlTransaction): Promi
 }
 
 /**
- * Authenticates the complete retained AFL Tables 2021-2025 and official-AFL 2026 private review
- * sets in one database snapshot. Missing, superseded, extra, or custody-mismatched evidence fails
- * before an evaluation bundle can exist.
+ * Authenticates the complete retained AFL Tables 2021-2025 player data, official-AFL 2026 player
+ * data, and AFL Tables 2026 results evidence in one database snapshot. Missing, superseded, extra,
+ * or custody-mismatched evidence fails before an evaluation bundle can exist.
  */
 export async function loadExactLocalReviewedProviderEvidenceBundle(
   transaction: AflOutcomeSqlTransaction,

--- a/src/server/aflTradeIntelligence/modeling/hpnPavInputContracts.ts
+++ b/src/server/aflTradeIntelligence/modeling/hpnPavInputContracts.ts
@@ -6,9 +6,20 @@ import {
   aflTradeSha256Schema,
   createAflTradeContentAddress,
 } from '../artifacts/contentAddress';
+import {
+  listAflTradeHpnCandidateSourceFields,
+  type AflTradeHpnSemanticBindingCandidate,
+} from './hpnFieldMapCandidate';
+import { listAflTradeHpnRequiredSemanticFields } from './hpnCalculationEligibility';
+import {
+  aflTradeHpnProjectedFieldMapSchema,
+  type AflTradeHpnProjectedFieldMap,
+} from './hpnProjectedFieldMap';
 
 export const AFL_TRADE_HPN_PAV_FIELD_MAP_SCHEMA_VERSION = 'afl-trade-hpn-pav-field-map/v1' as const;
 export const AFL_TRADE_HPN_PAV_INPUT_SET_SCHEMA_VERSION = 'afl-trade-hpn-pav-input-set/v1' as const;
+export const AFL_TRADE_HPN_PAV_INPUT_SET_V2_SCHEMA_VERSION =
+  'afl-trade-hpn-pav-input-set/v2' as const;
 export const AFL_TRADE_HPN_PAV_INPUT_AUTHORITY_BOUNDARY =
   'private_exact_finalized_provider_rows_current_resolutions_no_publication_or_fantasy_ownership' as const;
 
@@ -397,33 +408,54 @@ function isOrdered(values: readonly string[]): boolean {
   return values.every((value, index) => index === 0 || values[index - 1]! < value);
 }
 
-const inputSetContentSchema = z
+const inputSetCountsSchema = z
   .object({
+    completedMatches: z.number().int().positive(),
+    resultRows: z.number().int().positive(),
+    primaryPlayerRows: z.number().int().positive(),
+    corroboratingPlayerRows: z.number().int().positive(),
+  })
+  .strict();
+
+const inputSetBase = {
+  authorityBoundary: z.literal(AFL_TRADE_HPN_PAV_INPUT_AUTHORITY_BOUNDARY),
+  publicationEligible: z.literal(false),
+  competition: z.literal('AFLM'),
+  seasonYear: seasonSchema,
+  effectiveThrough: instantSchema,
+  createdAt: instantSchema,
+  methodId: aflTradeContentAddressedIdSchema('hpn-pav-method'),
+  factualUniverse: factualUniverseSchema,
+  sourceRuns: z.array(sourceRunSchema).min(3).max(100),
+  completedMatches: z.array(completedMatchSchema).min(1).max(1_000),
+  rows: z.array(inputRowSchema).min(3).max(100_000),
+  counts: inputSetCountsSchema,
+};
+
+const legacyInputSetContentSchema = z
+  .object({
+    ...inputSetBase,
     schemaVersion: z.literal(AFL_TRADE_HPN_PAV_INPUT_SET_SCHEMA_VERSION),
-    authorityBoundary: z.literal(AFL_TRADE_HPN_PAV_INPUT_AUTHORITY_BOUNDARY),
-    publicationEligible: z.literal(false),
     environment: z.enum(['test_fixture', 'non_production', 'production']),
-    competition: z.literal('AFLM'),
-    seasonYear: seasonSchema,
-    effectiveThrough: instantSchema,
-    createdAt: instantSchema,
-    methodId: aflTradeContentAddressedIdSchema('hpn-pav-method'),
-    factualUniverse: factualUniverseSchema,
     fieldMaps: z.array(aflTradeHpnPavFieldMapSchema).min(3).max(100),
-    sourceRuns: z.array(sourceRunSchema).min(3).max(100),
-    completedMatches: z.array(completedMatchSchema).min(1).max(1_000),
-    rows: z.array(inputRowSchema).min(3).max(100_000),
-    counts: z
-      .object({
-        completedMatches: z.number().int().positive(),
-        resultRows: z.number().int().positive(),
-        primaryPlayerRows: z.number().int().positive(),
-        corroboratingPlayerRows: z.number().int().positive(),
-      })
-      .strict(),
   })
   .strict()
   .superRefine(addInputSetIssues);
+
+const projectedInputSetContentSchema = z
+  .object({
+    ...inputSetBase,
+    schemaVersion: z.literal(AFL_TRADE_HPN_PAV_INPUT_SET_V2_SCHEMA_VERSION),
+    environment: z.literal('non_production'),
+    fieldMaps: z.array(aflTradeHpnProjectedFieldMapSchema).min(3).max(100),
+  })
+  .strict()
+  .superRefine(addInputSetIssues);
+
+const inputSetContentSchema = z.union([
+  legacyInputSetContentSchema,
+  projectedInputSetContentSchema,
+]);
 
 export const aflTradeHpnPavSeasonInputSetSchema = z
   .object({
@@ -442,6 +474,9 @@ export const aflTradeHpnPavSeasonInputSetSchema = z
   });
 
 export type AflTradeHpnPavFieldMap = z.infer<typeof aflTradeHpnPavFieldMapSchema>;
+export type AflTradeHpnPavInputFieldMap =
+  | AflTradeHpnPavFieldMap
+  | AflTradeHpnProjectedFieldMap;
 export type AflTradeHpnPavSeasonInputSet = z.infer<typeof aflTradeHpnPavSeasonInputSetSchema>;
 
 export function aflTradeHpnPavReviewedFields(
@@ -486,10 +521,50 @@ function sourceNumber(row: z.infer<typeof playerRowSchema>, field: string): numb
   return value;
 }
 
+function projectedBinding(
+  fieldMap: AflTradeHpnProjectedFieldMap['content'],
+  semanticField: AflTradeHpnSemanticBindingCandidate['semanticField']
+): AflTradeHpnSemanticBindingCandidate['mapping'] | undefined {
+  return fieldMap.semanticBindings.find(
+    (binding) => binding.semanticField === semanticField
+  )?.mapping;
+}
+
+function projectedSourceNumber(
+  row: z.infer<typeof playerRowSchema>,
+  fieldMap: AflTradeHpnProjectedFieldMap['content'],
+  semanticField: AflTradeHpnSemanticBindingCandidate['semanticField']
+): number {
+  const mapping = projectedBinding(fieldMap, semanticField);
+  if (mapping?.kind === 'direct') return sourceNumber(row, mapping.sourceField);
+  if (mapping?.kind === 'goals_plus_behinds') {
+    return sourceNumber(row, mapping.goals) * 6 + sourceNumber(row, mapping.behinds);
+  }
+  return Number.NaN;
+}
+
 function statsFromSource(
   row: z.infer<typeof playerRowSchema>,
-  fieldMap: Extract<z.infer<typeof fieldMapContentSchema>, { inputKind: 'player_match_stats' }>
+  fieldMap:
+    | Extract<z.infer<typeof fieldMapContentSchema>, { inputKind: 'player_match_stats' }>
+    | AflTradeHpnProjectedFieldMap['content']
 ) {
+  if (fieldMap.schemaVersion === 'afl-trade-hpn-projected-field-map/v1') {
+    return {
+      totalPoints: projectedSourceNumber(row, fieldMap, 'totalPoints'),
+      hitOuts: projectedSourceNumber(row, fieldMap, 'hitOuts'),
+      goalAssists: projectedSourceNumber(row, fieldMap, 'goalAssists'),
+      inside50s: projectedSourceNumber(row, fieldMap, 'inside50s'),
+      marks: projectedSourceNumber(row, fieldMap, 'marks'),
+      marksInside50: projectedSourceNumber(row, fieldMap, 'marksInside50'),
+      freeKicksFor: projectedSourceNumber(row, fieldMap, 'freeKicksFor'),
+      freeKicksAgainst: projectedSourceNumber(row, fieldMap, 'freeKicksAgainst'),
+      rebound50s: projectedSourceNumber(row, fieldMap, 'rebound50s'),
+      onePercenters: projectedSourceNumber(row, fieldMap, 'onePercenters'),
+      clearances: projectedSourceNumber(row, fieldMap, 'clearances'),
+      tackles: projectedSourceNumber(row, fieldMap, 'tackles'),
+    };
+  }
   const bindings = fieldMap.bindings;
   const totalPoints =
     bindings.totalPoints.kind === 'total_points'
@@ -510,6 +585,49 @@ function statsFromSource(
     clearances: sourceNumber(row, bindings.clearances),
     tackles: sourceNumber(row, bindings.tackles),
   };
+}
+
+function reviewedFields(fieldMap: AflTradeHpnPavInputFieldMap['content']): string[] {
+  if (fieldMap.schemaVersion === 'afl-trade-hpn-projected-field-map/v1') {
+    return [
+      ...new Set(
+        fieldMap.semanticBindings.flatMap(listAflTradeHpnCandidateSourceFields)
+      ),
+    ].sort(ordinalCompare);
+  }
+  return aflTradeHpnPavReviewedFields(fieldMap);
+}
+
+function projectedResultMatchesSource(
+  row: z.infer<typeof resultRowSchema>,
+  fieldMap: AflTradeHpnProjectedFieldMap['content']
+): boolean {
+  const homePoints = projectedBinding(fieldMap, 'homePoints');
+  const awayPoints = projectedBinding(fieldMap, 'awayPoints');
+  if (
+    homePoints?.kind !== 'direct' ||
+    awayPoints?.kind !== 'direct' ||
+    row.homePoints !== row.source.sourceValues[homePoints.sourceField] ||
+    row.awayPoints !== row.source.sourceValues[awayPoints.sourceField]
+  ) {
+    return false;
+  }
+  const completion = projectedBinding(fieldMap, 'completionStatus');
+  if (fieldMap.completionRule?.kind === 'source_status') {
+    return (
+      completion?.kind === 'direct' &&
+      typeof row.source.sourceValues[completion.sourceField] === 'string' &&
+      fieldMap.completionRule.completedValues.includes(
+        row.source.sourceValues[completion.sourceField] as string
+      )
+    );
+  }
+  return (
+    fieldMap.completionRule?.kind === 'reviewed_final_score_presence' &&
+    completion?.kind === 'reviewed_final_scores' &&
+    row.source.sourceValues[completion.homePointsField] === row.homePoints &&
+    row.source.sourceValues[completion.awayPointsField] === row.awayPoints
+  );
 }
 
 function addInputSetIssues(
@@ -576,6 +694,20 @@ function addInputSetIssues(
         message: 'Every PAV source run must match its reviewed map, season, scope, and chronology.',
       });
     }
+    if (fieldMap?.content.schemaVersion === 'afl-trade-hpn-projected-field-map/v1') {
+      const expected = listAflTradeHpnRequiredSemanticFields(fieldMap.content.inputKind);
+      const actual = fieldMap.content.semanticBindings.map(({ semanticField }) => semanticField);
+      if (
+        actual.length !== expected.length ||
+        actual.some((semanticField, index) => semanticField !== expected[index])
+      ) {
+        context.addIssue({
+          code: 'custom',
+          path: ['fieldMaps'],
+          message: 'A projected PAV map must bind every required semantic field exactly once.',
+        });
+      }
+    }
     const runRows = input.rows.filter(
       ({ source }) => source.normalizationRunId === run.normalizationRunId
     );
@@ -604,7 +736,7 @@ function addInputSetIssues(
       });
       continue;
     }
-    const reviewed = aflTradeHpnPavReviewedFields(fieldMap.content);
+    const reviewed = reviewedFields(fieldMap.content);
     if (
       row.source.sourceFields.length !== reviewed.length ||
       row.source.sourceFields.some((field, index) => field !== reviewed[index])
@@ -626,14 +758,19 @@ function addInputSetIssues(
           message: 'Result authority has the wrong entity kind.',
         });
       }
-      const bindings = fieldMap.content.bindings;
-      const sourceStatus = row.source.sourceValues[bindings.completionStatus];
-      if (
-        row.homePoints !== row.source.sourceValues[bindings.homePoints] ||
-        row.awayPoints !== row.source.sourceValues[bindings.awayPoints] ||
-        typeof sourceStatus !== 'string' ||
-        !bindings.completedValues.includes(sourceStatus)
-      ) {
+      const valuesMatch =
+        fieldMap.content.schemaVersion === 'afl-trade-hpn-projected-field-map/v1'
+          ? projectedResultMatchesSource(row, fieldMap.content)
+          : row.homePoints === row.source.sourceValues[fieldMap.content.bindings.homePoints] &&
+            row.awayPoints === row.source.sourceValues[fieldMap.content.bindings.awayPoints] &&
+            typeof row.source.sourceValues[fieldMap.content.bindings.completionStatus] ===
+              'string' &&
+            fieldMap.content.bindings.completedValues.includes(
+              row.source.sourceValues[
+                fieldMap.content.bindings.completionStatus
+              ] as string
+            );
+      if (!valuesMatch) {
         context.addIssue({
           code: 'custom',
           message: 'Result values do not match staged source fields.',
@@ -832,10 +969,15 @@ export function createAflTradeHpnPavFieldMap(
   });
 }
 
-type CreateInputSet = Omit<
-  z.input<typeof inputSetContentSchema>,
+type CreateLegacyInputSet = Omit<
+  z.input<typeof legacyInputSetContentSchema>,
   'schemaVersion' | 'authorityBoundary' | 'publicationEligible' | 'counts'
 >;
+type CreateProjectedInputSet = Omit<
+  z.input<typeof projectedInputSetContentSchema>,
+  'schemaVersion' | 'authorityBoundary' | 'publicationEligible' | 'counts'
+>;
+type CreateInputSet = CreateLegacyInputSet | CreateProjectedInputSet;
 
 export function createAflTradeHpnPavSeasonInputSet(
   unparsedInput: CreateInputSet
@@ -846,6 +988,15 @@ export function createAflTradeHpnPavSeasonInputSet(
   const fieldMaps = [...unparsedInput.fieldMaps].sort((left, right) =>
     ordinalCompare(left.fieldMapId, right.fieldMapId)
   );
+  const usesProjectedMaps = fieldMaps.every(
+    ({ content }) => content.schemaVersion === 'afl-trade-hpn-projected-field-map/v1'
+  );
+  const usesLegacyMaps = fieldMaps.every(
+    ({ content }) => content.schemaVersion === AFL_TRADE_HPN_PAV_FIELD_MAP_SCHEMA_VERSION
+  );
+  if (!usesProjectedMaps && !usesLegacyMaps) {
+    throw new TypeError('One HPN input set cannot mix legacy and projected map authority.');
+  }
   const sourceRuns = [...unparsedInput.sourceRuns].sort((left, right) =>
     ordinalCompare(left.normalizationRunId, right.normalizationRunId)
   );
@@ -871,7 +1022,9 @@ export function createAflTradeHpnPavSeasonInputSet(
   };
   const content = inputSetContentSchema.parse({
     ...unparsedInput,
-    schemaVersion: AFL_TRADE_HPN_PAV_INPUT_SET_SCHEMA_VERSION,
+    schemaVersion: usesProjectedMaps
+      ? AFL_TRADE_HPN_PAV_INPUT_SET_V2_SCHEMA_VERSION
+      : AFL_TRADE_HPN_PAV_INPUT_SET_SCHEMA_VERSION,
     authorityBoundary: AFL_TRADE_HPN_PAV_INPUT_AUTHORITY_BOUNDARY,
     publicationEligible: false,
     fieldMaps,

--- a/src/server/aflTradeIntelligence/modeling/postgresHpnPavInputRepository.ts
+++ b/src/server/aflTradeIntelligence/modeling/postgresHpnPavInputRepository.ts
@@ -9,8 +9,17 @@ import {
   aflTradeHpnPavSeasonInputSetSchema,
   createAflTradeHpnPavSeasonInputSet,
   type AflTradeHpnPavFieldMap,
+  type AflTradeHpnPavInputFieldMap,
   type AflTradeHpnPavSeasonInputSet,
 } from './hpnPavInputContracts';
+import {
+  listAflTradeHpnCandidateSourceFields,
+  type AflTradeHpnSemanticBindingCandidate,
+} from './hpnFieldMapCandidate';
+import {
+  type AflTradeHpnProjectedFieldMap,
+} from './hpnProjectedFieldMap';
+import { PostgresAflTradeHpnProjectedFieldMapAuthority } from './postgresHpnProjectedFieldMapAuthority';
 import {
   AflTradeHpnPavInputError,
   aflTradeFinalizedHpnPavInputSetRequestSchema,
@@ -30,6 +39,8 @@ interface RunRow {
   source_snapshot_id: string;
   source_artifact_id: string;
   capture_environment: string;
+  capture_provider: string;
+  capture_capability_id: string | null;
   capture_status: string;
   captured_at: Date | string;
   finalized_at: Date | string | null;
@@ -41,7 +52,6 @@ interface RunRow {
   run_status: string;
   capability_id: string;
   source_schema_sha256: string;
-  field_map_json: unknown;
 }
 
 interface DecodedRow {
@@ -146,8 +156,29 @@ function iso(value: Date | string | null, label: string): string {
   return parsed.toISOString();
 }
 
+function transactionClient(transaction: AflOutcomeSqlTransaction): AflOutcomeSqlClient {
+  return {
+    query: transaction.query.bind(transaction),
+    transaction: async (work) => work(transaction),
+  };
+}
+
 function isoDate(value: Date | string | null, label: string): string {
-  return iso(value, label).slice(0, 10);
+  if (typeof value === 'string') {
+    const match = /^(\d{4}-\d{2}-\d{2})(?:T.*)?$/u.exec(value);
+    if (match?.[1]) return match[1];
+  }
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return [
+      value.getFullYear(),
+      String(value.getMonth() + 1).padStart(2, '0'),
+      String(value.getDate()).padStart(2, '0'),
+    ].join('-');
+  }
+  throw new AflTradeHpnPavInputError(
+    'SOURCE_AUTHORITY_MISMATCH',
+    `${label} is invalid.`
+  );
 }
 
 function asObject(value: unknown, label: string): Record<string, unknown> {
@@ -263,10 +294,78 @@ function nonnegativeInteger(value: unknown, field: string): number {
   return value;
 }
 
-function sourceValues(row: DecodedRow, fieldMap: AflTradeHpnPavFieldMap) {
-  const fields = aflTradeHpnPavReviewedFields(fieldMap.content);
+function reviewedFields(fieldMap: AflTradeHpnPavInputFieldMap): string[] {
+  if (isProjectedFieldMap(fieldMap)) {
+    return [
+      ...new Set(
+        fieldMap.content.semanticBindings.flatMap(listAflTradeHpnCandidateSourceFields)
+      ),
+    ].sort();
+  }
+  return aflTradeHpnPavReviewedFields(fieldMap.content);
+}
+
+function isProjectedFieldMap(
+  fieldMap: AflTradeHpnPavInputFieldMap
+): fieldMap is AflTradeHpnProjectedFieldMap {
+  return fieldMap.content.schemaVersion === 'afl-trade-hpn-projected-field-map/v1';
+}
+
+function sourceValues(row: DecodedRow, fieldMap: AflTradeHpnPavInputFieldMap) {
+  const fields = reviewedFields(fieldMap);
   return Object.fromEntries(
     fields.map((field) => [field, decodedScalar(row.typed_payload, field)])
+  );
+}
+
+function projectedBinding(
+  fieldMap: AflTradeHpnProjectedFieldMap,
+  semanticField: AflTradeHpnSemanticBindingCandidate['semanticField']
+): AflTradeHpnSemanticBindingCandidate['mapping'] {
+  const binding = fieldMap.content.semanticBindings.find(
+    (candidate) => candidate.semanticField === semanticField
+  );
+  if (!binding) {
+    throw new AflTradeHpnPavInputError(
+      'SOURCE_AUTHORITY_MISMATCH',
+      `Projected field map is missing ${semanticField}.`
+    );
+  }
+  return binding.mapping;
+}
+
+function projectedDirectField(
+  fieldMap: AflTradeHpnProjectedFieldMap,
+  semanticField: AflTradeHpnSemanticBindingCandidate['semanticField']
+): string {
+  const mapping = projectedBinding(fieldMap, semanticField);
+  if (mapping.kind !== 'direct') {
+    throw new AflTradeHpnPavInputError(
+      'SOURCE_AUTHORITY_MISMATCH',
+      `Projected ${semanticField} must use one direct source field.`
+    );
+  }
+  return mapping.sourceField;
+}
+
+function projectedNonnegativeInteger(
+  values: Readonly<Record<string, unknown>>,
+  fieldMap: AflTradeHpnProjectedFieldMap,
+  semanticField: AflTradeHpnSemanticBindingCandidate['semanticField']
+): number {
+  const mapping = projectedBinding(fieldMap, semanticField);
+  if (mapping.kind === 'direct') {
+    return nonnegativeInteger(values[mapping.sourceField], mapping.sourceField);
+  }
+  if (semanticField === 'totalPoints' && mapping.kind === 'goals_plus_behinds') {
+    return (
+      nonnegativeInteger(values[mapping.goals], mapping.goals) * 6 +
+      nonnegativeInteger(values[mapping.behinds], mapping.behinds)
+    );
+  }
+  throw new AflTradeHpnPavInputError(
+    'SOURCE_AUTHORITY_MISMATCH',
+    `Projected ${semanticField} has an unsupported numeric mapping.`
   );
 }
 
@@ -345,25 +444,27 @@ async function loadDecodedRows(
 async function loadRuns(
   transaction: AflOutcomeSqlTransaction,
   selections: readonly SourceSelection[]
-): Promise<Map<string, { row: RunRow; map: AflTradeHpnPavFieldMap; selection: SourceSelection }>> {
+): Promise<
+  Map<string, { row: RunRow; map: AflTradeHpnPavInputFieldMap; selection: SourceSelection }>
+> {
   const requested = canonicalizeAflTradeJson(selections);
   const result = await transaction.query<RunRow>(
     `SELECT run.normalization_run_id, run.capture_id, capture.source_snapshot_id,
             capture.source_artifact_id, capture.environment::text AS capture_environment,
+            capture.provider AS capture_provider,
+            capture.capability_id AS capture_capability_id,
             capture.status::text AS capture_status, capture.captured_at, run.finalized_at,
             run.staging_sha256, run.source_row_count, run.accepted_row_count,
             run.quarantined_row_count, run.issue_count, run.status::text AS run_status,
-            decode_map.capability_id, decode_map.source_schema_sha256,
-            pav_map.map_json AS field_map_json
+            decode_map.capability_id, decode_map.source_schema_sha256
        FROM jsonb_to_recordset($1::jsonb) AS requested(
          "normalizationRunId" text, "fieldMapId" text, "inputKind" text, role text)
        JOIN outcome_provider_normalization_run run
          ON run.normalization_run_id=requested."normalizationRunId"
        JOIN outcome_provider_field_map decode_map ON decode_map.field_map_id=run.field_map_id
        JOIN outcome_source_capture capture ON capture.capture_id=run.capture_id
-       JOIN outcome_hpn_pav_field_map pav_map ON pav_map.field_map_id=requested."fieldMapId"
       ORDER BY run.normalization_run_id
-      FOR SHARE OF run, capture, decode_map, pav_map`,
+      FOR SHARE OF run, capture, decode_map`,
     [requested]
   );
   if (result.rows.length !== selections.length) {
@@ -374,7 +475,7 @@ async function loadRuns(
   }
   const output = new Map<
     string,
-    { row: RunRow; map: AflTradeHpnPavFieldMap; selection: SourceSelection }
+    { row: RunRow; map: AflTradeHpnPavInputFieldMap; selection: SourceSelection }
   >();
   for (const row of result.rows) {
     const selection = selections.find(
@@ -382,7 +483,36 @@ async function loadRuns(
     );
     if (!selection)
       throw new AflTradeHpnPavInputError('INVALID_REQUEST', 'Source selection drifted.');
-    const map = aflTradeHpnPavFieldMapSchema.parse(row.field_map_json);
+    const storedMap = await transaction.query<{ legacy_map_json: unknown | null }>(
+      `SELECT legacy.map_json AS legacy_map_json
+         FROM (VALUES ($1::text)) requested(field_map_id)
+         LEFT JOIN outcome_hpn_pav_field_map legacy
+           ON legacy.field_map_id=requested.field_map_id`,
+      [selection.fieldMapId]
+    );
+    const legacyMap = storedMap.rows[0]?.legacy_map_json
+      ? aflTradeHpnPavFieldMapSchema.parse(storedMap.rows[0].legacy_map_json)
+      : null;
+    let projectedMap: AflTradeHpnProjectedFieldMap | null;
+    try {
+      projectedMap = await new PostgresAflTradeHpnProjectedFieldMapAuthority(
+        transactionClient(transaction)
+      ).loadCurrentExact(selection.fieldMapId);
+    } catch (error) {
+      throw new AflTradeHpnPavInputError(
+        'SOURCE_AUTHORITY_MISMATCH',
+        error instanceof Error
+          ? error.message
+          : 'The projected HPN field map failed exact authentication.'
+      );
+    }
+    if ((legacyMap === null) === (projectedMap === null)) {
+      throw new AflTradeHpnPavInputError(
+        'SOURCE_AUTHORITY_MISMATCH',
+        'Each selected HPN field map must resolve to exactly one current authority.'
+      );
+    }
+    const map = legacyMap ?? projectedMap!;
     output.set(row.normalization_run_id, { row, map, selection });
   }
   return output;
@@ -476,11 +606,13 @@ async function loadFactualUniverse(
 function requireRunAuthority(
   request: AflTradeHpnPavSeasonInputRequest,
   createdAt: string,
-  context: { row: RunRow; map: AflTradeHpnPavFieldMap; selection: SourceSelection }
+  context: { row: RunRow; map: AflTradeHpnPavInputFieldMap; selection: SourceSelection }
 ): void {
   const { row, map, selection } = context;
   if (
     row.capture_environment !== request.environment ||
+    row.capture_provider !== map.content.provider ||
+    row.capture_capability_id !== map.content.capabilityId ||
     row.capture_status !== 'approved' ||
     row.run_status !== 'staged' ||
     row.finalized_at === null ||
@@ -528,7 +660,7 @@ function buildRows(
   decodedRows: readonly DecodedRow[],
   contexts: ReadonlyMap<
     string,
-    { row: RunRow; map: AflTradeHpnPavFieldMap; selection: SourceSelection }
+    { row: RunRow; map: AflTradeHpnPavInputFieldMap; selection: SourceSelection }
   >
 ): UnboundInputRow[] {
   return decodedRows.map((decoded) => {
@@ -546,6 +678,35 @@ function buildRows(
       sourceValues: values,
     };
     if (context.map.content.inputKind === 'completed_match_result') {
+      if (isProjectedFieldMap(context.map)) {
+        const homePointsField = projectedDirectField(context.map, 'homePoints');
+        const awayPointsField = projectedDirectField(context.map, 'awayPoints');
+        const completion = projectedBinding(context.map, 'completionStatus');
+        const completionRule = context.map.content.completionRule;
+        const isCompleted =
+          completionRule?.kind === 'source_status'
+            ? completion.kind === 'direct' &&
+              typeof values[completion.sourceField] === 'string' &&
+              completionRule.completedValues.includes(values[completion.sourceField] as string)
+            : completionRule?.kind === 'reviewed_final_score_presence' &&
+              completion.kind === 'reviewed_final_scores' &&
+              values[completion.homePointsField] !== null &&
+              values[completion.awayPointsField] !== null;
+        if (!isCompleted) {
+          throw new AflTradeHpnPavInputError('INCOMPLETE_SOURCE_ROWS', 'Match is not completed.');
+        }
+        return {
+          kind: 'completed_match_result' as const,
+          source,
+          match: currentResolution('match', decoded.match_resolution),
+          effectiveAt: iso(decoded.canonical_match_date, 'canonical match date'),
+          homeClub: exactOneResolution('club', decoded.home_club_resolutions, 'home'),
+          awayClub: exactOneResolution('club', decoded.away_club_resolutions, 'away'),
+          homePoints: nonnegativeInteger(values[homePointsField], homePointsField),
+          awayPoints: nonnegativeInteger(values[awayPointsField], awayPointsField),
+          completionStatus: 'completed' as const,
+        };
+      }
       const bindings = context.map.content.bindings;
       const status = values[bindings.completionStatus];
       if (typeof status !== 'string' || !bindings.completedValues.includes(status)) {
@@ -561,6 +722,37 @@ function buildRows(
         homePoints: nonnegativeInteger(values[bindings.homePoints], bindings.homePoints),
         awayPoints: nonnegativeInteger(values[bindings.awayPoints], bindings.awayPoints),
         completionStatus: 'completed' as const,
+      };
+    }
+    if (isProjectedFieldMap(context.map)) {
+      return {
+        kind: 'player_match_stats' as const,
+        role: context.selection.role as 'primary' | 'corroborating',
+        source,
+        match: currentResolution('match', decoded.match_resolution),
+        player: currentResolution('player', decoded.player_resolution),
+        club: choosePlayerClub(
+          decoded,
+          values[projectedDirectField(context.map, 'club')]
+        ),
+        stats: {
+          totalPoints: projectedNonnegativeInteger(values, context.map, 'totalPoints'),
+          hitOuts: projectedNonnegativeInteger(values, context.map, 'hitOuts'),
+          goalAssists: projectedNonnegativeInteger(values, context.map, 'goalAssists'),
+          inside50s: projectedNonnegativeInteger(values, context.map, 'inside50s'),
+          marks: projectedNonnegativeInteger(values, context.map, 'marks'),
+          marksInside50: projectedNonnegativeInteger(values, context.map, 'marksInside50'),
+          freeKicksFor: projectedNonnegativeInteger(values, context.map, 'freeKicksFor'),
+          freeKicksAgainst: projectedNonnegativeInteger(
+            values,
+            context.map,
+            'freeKicksAgainst'
+          ),
+          rebound50s: projectedNonnegativeInteger(values, context.map, 'rebound50s'),
+          onePercenters: projectedNonnegativeInteger(values, context.map, 'onePercenters'),
+          clearances: projectedNonnegativeInteger(values, context.map, 'clearances'),
+          tackles: projectedNonnegativeInteger(values, context.map, 'tackles'),
+        },
       };
     }
     const bindings = context.map.content.bindings;
@@ -686,7 +878,7 @@ async function bindAcquisitionSpells(
 function requireFactualUniverseCoverage(
   rows: AflTradeHpnPavSeasonInputSet['content']['rows'],
   universe: AflTradeHpnPavSeasonInputSet['content']['factualUniverse'],
-  contexts: ReadonlyMap<string, { map: AflTradeHpnPavFieldMap }>
+  contexts: ReadonlyMap<string, { map: AflTradeHpnPavInputFieldMap }>
 ): void {
   const exactSet = (left: readonly string[], right: readonly string[]) =>
     left.length === right.length && left.every((value, index) => value === right[index]);
@@ -739,7 +931,10 @@ function requireFactualUniverseCoverage(
 async function persistInputSet(
   transaction: AflOutcomeSqlTransaction,
   inputSet: AflTradeHpnPavSeasonInputSet,
-  contexts: ReadonlyMap<string, { selection: SourceSelection }>
+  contexts: ReadonlyMap<
+    string,
+    { selection: SourceSelection; map: AflTradeHpnPavInputFieldMap }
+  >
 ): Promise<void> {
   const content = inputSet.content;
   const inputSetSha256 = digestFromId(inputSet.inputSetId, 'hpn-pav-input-set');
@@ -775,25 +970,28 @@ async function persistInputSet(
     ]
   );
   const runRows = content.sourceRuns.map((run, ordinal) => {
-    const selection = contexts.get(run.normalizationRunId)?.selection;
-    if (!selection)
+    const context = contexts.get(run.normalizationRunId);
+    if (!context)
       throw new AflTradeHpnPavInputError('PERSISTENCE_REJECTED', 'Run selection vanished.');
+    const { selection, map } = context;
+    const projected = isProjectedFieldMap(map);
     return {
       inputSetId: inputSet.inputSetId,
       ordinal,
       normalizationRunId: run.normalizationRunId,
-      fieldMapId: run.fieldMapId,
+      legacyFieldMapId: projected ? null : run.fieldMapId,
+      projectedFieldMapId: projected ? run.fieldMapId : null,
       inputKind: selection.inputKind,
       role: selection.role,
     };
   });
   await transaction.query(
     `INSERT INTO outcome_hpn_pav_input_run
-      (input_set_id,ordinal,normalization_run_id,field_map_id,input_kind,role)
-     SELECT "inputSetId",ordinal,"normalizationRunId","fieldMapId","inputKind",role
+      (input_set_id,ordinal,normalization_run_id,field_map_id,projected_field_map_id,input_kind,role)
+     SELECT "inputSetId",ordinal,"normalizationRunId","legacyFieldMapId","projectedFieldMapId","inputKind",role
        FROM jsonb_to_recordset($1::jsonb) AS value(
          "inputSetId" text, ordinal integer, "normalizationRunId" text,
-         "fieldMapId" text, "inputKind" text, role text)`,
+         "legacyFieldMapId" text, "projectedFieldMapId" text, "inputKind" text, role text)`,
     [canonicalizeAflTradeJson(runRows)]
   );
   const rowRows = content.rows.map((row, ordinal) => ({
@@ -1105,19 +1303,36 @@ export class PostgresAflTradeHpnPavInputRepository implements AflTradeHpnPavInpu
           createdAt
         );
         requireFactualUniverseCoverage(rows, factualUniverse, contexts);
-        const inputSet = createAflTradeHpnPavSeasonInputSet({
-          environment: request.environment,
+        const fieldMaps = [...contexts.values()].map(({ map }) => map);
+        const inputSetBase = {
           competition: request.competition,
           seasonYear: request.seasonYear,
           effectiveThrough: request.effectiveThrough,
           createdAt,
           methodId: request.methodId,
           factualUniverse,
-          fieldMaps: [...contexts.values()].map(({ map }) => map),
           sourceRuns,
           completedMatches,
           rows,
-        });
+        };
+        const inputSet = fieldMaps.every(isProjectedFieldMap)
+          ? createAflTradeHpnPavSeasonInputSet({
+              ...inputSetBase,
+              environment: 'non_production',
+              fieldMaps,
+            })
+          : fieldMaps.every((fieldMap) => !isProjectedFieldMap(fieldMap))
+            ? createAflTradeHpnPavSeasonInputSet({
+                ...inputSetBase,
+                environment: request.environment,
+                fieldMaps: fieldMaps as AflTradeHpnPavFieldMap[],
+              })
+            : (() => {
+                throw new AflTradeHpnPavInputError(
+                  'SOURCE_AUTHORITY_MISMATCH',
+                  'One HPN input set cannot mix legacy and projected field-map authority.'
+                );
+              })();
         const replay = await transaction.query<{
           input_set_json: unknown;
           finalized_at: Date | string | null;

--- a/src/server/aflTradeIntelligence/modeling/postgresHpnProjectedFieldMapAuthority.ts
+++ b/src/server/aflTradeIntelligence/modeling/postgresHpnProjectedFieldMapAuthority.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import {
   doAflTradeArtifactRefsExactlyMatch,
   doesAflTradeArtifactRefMatchCanonicalJson,
@@ -46,6 +48,19 @@ interface StoredProjectionRow {
   map_json: unknown;
   current_decision_id: string;
 }
+
+const currentSourceSelectionSchema = z
+  .object({
+    provider: z.string().trim().min(1).max(240),
+    capabilityId: z.string().trim().min(1).max(240),
+    inputKind: z.enum(['completed_match_result', 'player_match_stats']),
+    sourceSchemaSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+    providerDecodeMapId: z.string().trim().min(1).max(240),
+    seasonYear: z.number().int().min(1998).max(2200),
+    rightsArtifactId: z.string().regex(/^source-rights:[a-f0-9]{64}$/u),
+    valuationScopeKey: z.string().trim().min(1).max(240),
+  })
+  .strict();
 
 function digestFromId(id: string): string {
   return id.slice(id.indexOf(':') + 1);
@@ -331,5 +346,92 @@ export class PostgresAflTradeHpnProjectedFieldMapAuthority {
       throw new Error('Durable HPN projected field-map ancestry failed exact authentication.');
     }
     return projectedFieldMap;
+  }
+
+  async loadCurrentForSource(
+    input: z.input<typeof currentSourceSelectionSchema>
+  ): Promise<AflTradeHpnProjectedFieldMap | null> {
+    const source = currentSourceSelectionSchema.parse(input);
+    const result = await this.client.query<{ readonly field_map_id: string }>(
+      `SELECT map.field_map_id
+         FROM outcome_hpn_projected_field_map map
+         JOIN outcome_hpn_field_map_candidate candidate
+           ON candidate.candidate_id=map.candidate_id
+         JOIN outcome_hpn_field_map_review_decision approval
+           ON approval.decision_id=map.approval_decision_id
+         JOIN outcome_private_reviewed_evaluation_decision evaluation
+           ON evaluation.decision_id=
+                approval.source_use_assessment_json#>>'{content,evaluationDecisionId}'
+          AND evaluation.evidence_bundle_id=
+                approval.source_use_assessment_json#>>'{content,evidenceBundleId}'
+          AND evaluation.valuation_scope_key=
+                approval.source_use_assessment_json#>>'{content,valuationScopeKey}'
+          AND evaluation.status='authorized'
+         JOIN outcome_private_reviewed_evaluation_head evaluation_head
+           ON evaluation_head.decision_id=evaluation.decision_id
+          AND evaluation_head.evidence_bundle_id=evaluation.evidence_bundle_id
+          AND evaluation_head.valuation_scope_key=evaluation.valuation_scope_key
+          AND evaluation_head.status='authorized'
+         JOIN outcome_private_reviewed_evidence_bundle evidence_bundle
+           ON evidence_bundle.evidence_bundle_id=evaluation.evidence_bundle_id
+          AND evidence_bundle.evidence_scope_key=evaluation_head.evidence_scope_key
+         JOIN LATERAL (
+           SELECT latest.decision_id,latest.decision
+             FROM outcome_hpn_field_map_review_decision latest
+            WHERE latest.candidate_id=candidate.candidate_id
+            ORDER BY latest.registered_at DESC,latest.decision_id DESC LIMIT 1
+         ) current_decision ON true
+        WHERE map.environment='non_production'
+          AND map.competition='AFLM'
+          AND map.provider=$1
+          AND map.capability_id=$2
+          AND map.input_kind=$3
+          AND map.source_schema_sha256=$4
+          AND map.valid_from_season<=$5
+          AND map.valid_through_season>=$5
+          AND approval.source_use_assessment_json#>>'{content,rightsArtifactId}'=$6
+          AND candidate.candidate_json#>>'{content,providerDecodeMapId}'=$7
+          AND approval.source_use_assessment_json#>>'{content,valuationScopeKey}'=$8
+          AND approval.source_use_assessment_json#>'{content,reasons}'='[]'::jsonb
+          AND evaluation.decision_json#>>'{content,status}'='authorized'
+          AND evaluation.decision_json#>>'{content,valuationScopeKey}'=$8
+          AND evaluation.decision_json#>>'{content,evidenceBundleId}'=
+                evidence_bundle.evidence_bundle_id
+          AND evaluation.decision_json#>'{content,permissions,derivedCalculations}'=
+                'true'::jsonb
+          AND evaluation.decision_json#>'{content,permissions,internalEvaluation}'=
+                'true'::jsonb
+          AND evaluation.decision_json#>'{content,publicationProhibited}'='true'::jsonb
+          AND current_decision.decision_id=approval.decision_id
+          AND current_decision.decision='approved'
+        ORDER BY map.field_map_id`,
+      [
+        source.provider,
+        source.capabilityId,
+        source.inputKind,
+        source.sourceSchemaSha256,
+        source.seasonYear,
+        source.rightsArtifactId,
+        source.providerDecodeMapId,
+        source.valuationScopeKey,
+      ]
+    );
+    if (result.rows.length === 0) return null;
+    if (result.rows.length !== 1) {
+      throw new TypeError('More than one current HPN field map matches the exact source.');
+    }
+    const fieldMap = await this.loadCurrentExact(result.rows[0]!.field_map_id);
+    if (
+      fieldMap === null ||
+      fieldMap.content.provider !== source.provider ||
+      fieldMap.content.capabilityId !== source.capabilityId ||
+      fieldMap.content.inputKind !== source.inputKind ||
+      fieldMap.content.sourceSchemaSha256 !== source.sourceSchemaSha256 ||
+      fieldMap.content.validFromSeason > source.seasonYear ||
+      fieldMap.content.validThroughSeason < source.seasonYear
+    ) {
+      throw new TypeError('The selected HPN field map failed exact source authentication.');
+    }
+    return fieldMap;
   }
 }

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateReviewedEvidenceEvaluationAuthority.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateReviewedEvidenceEvaluationAuthority.ts
@@ -91,6 +91,57 @@ function exactJson(left: unknown, right: unknown): boolean {
   }
 }
 
+function exactEvidenceWithoutBundleTime(
+  left: AflTradePrivateReviewedEvidenceBundle,
+  right: AflTradePrivateReviewedEvidenceBundle
+): boolean {
+  const { createdAt: _leftCreatedAt, ...leftEvidence } = left.content;
+  const { createdAt: _rightCreatedAt, ...rightEvidence } = right.content;
+  return exactJson(leftEvidence, rightEvidence);
+}
+
+function isExactResultsSuccessor(
+  current: AflTradePrivateReviewedEvidenceBundle,
+  successor: AflTradePrivateReviewedEvidenceBundle
+): boolean {
+  const currentCaptures = current.content.sourceCaptures.map((capture) =>
+    canonicalizeAflTradeJson(capture)
+  );
+  const currentRights = current.content.sourceRightsEvidenceRefs.map((reference) =>
+    canonicalizeAflTradeJson(reference)
+  );
+  const addedCaptures = successor.content.sourceCaptures.filter(
+    (capture) => !currentCaptures.includes(canonicalizeAflTradeJson(capture))
+  );
+  const addedRights = successor.content.sourceRightsEvidenceRefs.filter(
+    (reference) => !currentRights.includes(canonicalizeAflTradeJson(reference))
+  );
+  return (
+    current.content.sourceCaptures.length === 6 &&
+    current.content.sourceRightsEvidenceRefs.length === 2 &&
+    successor.content.sourceCaptures.length === 7 &&
+    successor.content.sourceRightsEvidenceRefs.length === 3 &&
+    successor.content.candidateCount === current.content.candidateCount &&
+    successor.content.decisionCount === current.content.decisionCount &&
+    exactJson(successor.content.reviewSets, current.content.reviewSets) &&
+    currentCaptures.every((capture) =>
+      successor.content.sourceCaptures.some(
+        (candidate) => canonicalizeAflTradeJson(candidate) === capture
+      )
+    ) &&
+    currentRights.every((reference) =>
+      successor.content.sourceRightsEvidenceRefs.some(
+        (candidate) => canonicalizeAflTradeJson(candidate) === reference
+      )
+    ) &&
+    addedCaptures.length === 1 &&
+    addedCaptures[0]?.provider === 'afl_tables' &&
+    addedCaptures[0]?.capabilityId === 'afl-tables-results' &&
+    addedCaptures[0]?.seasonYear === 2026 &&
+    addedRights.length === 1
+  );
+}
+
 function assertBundleRow(row: BundleRow, bundle: AflTradePrivateReviewedEvidenceBundle): void {
   if (
     bundle.evidenceBundleId !== row.evidence_bundle_id ||
@@ -263,10 +314,7 @@ export class PostgresAflTradePrivateReviewedEvidenceEvaluationAuthority {
           'The private reviewed-evidence decision changed before this write.'
         );
       }
-      if (
-        (!current && input.status === 'withdrawn') ||
-        current?.decision.content.status === input.status
-      ) {
+      if (!current && input.status === 'withdrawn') {
         throw new AflTradePrivateReviewedEvidenceEvaluationPersistenceError(
           'INVALID_INPUT',
           'A private reviewed-evidence decision must change the current authority state.'
@@ -276,11 +324,38 @@ export class PostgresAflTradePrivateReviewedEvidenceEvaluationAuthority {
         `SELECT transaction_timestamp()::timestamptz(3) AS decided_at`
       );
       const decidedAt = isoTimestamp(clock.rows[0]!.decided_at);
-      const bundle =
-        current?.bundle ??
-        (await loadExactLocalReviewedProviderEvidenceBundle(transaction, decidedAt));
-      if (current) await requireCurrentEvidence(transaction, bundle);
-      else await persistBundle(transaction, bundle);
+      let bundle = current?.bundle ?? null;
+      if (current?.decision.content.status === input.status) {
+        if (input.status !== 'authorized') {
+          throw new AflTradePrivateReviewedEvidenceEvaluationPersistenceError(
+            'INVALID_INPUT',
+            'A private reviewed-evidence decision must change the current authority state.'
+          );
+        }
+        const successor = await loadExactLocalReviewedProviderEvidenceBundle(
+          transaction,
+          decidedAt
+        );
+        if (exactEvidenceWithoutBundleTime(current.bundle, successor)) {
+          throw new AflTradePrivateReviewedEvidenceEvaluationPersistenceError(
+            'INVALID_INPUT',
+            'The exact reviewed-evidence authority is already current.'
+          );
+        }
+        if (!isExactResultsSuccessor(current.bundle, successor)) {
+          throw new AflTradePrivateReviewedEvidenceEvaluationPersistenceError(
+            'EVIDENCE_MISMATCH',
+            'Reviewed evidence may advance only by the exact AFL Tables results successor.'
+          );
+        }
+        await persistBundle(transaction, successor);
+        bundle = successor;
+      } else if (bundle === null) {
+        bundle = await loadExactLocalReviewedProviderEvidenceBundle(transaction, decidedAt);
+        await persistBundle(transaction, bundle);
+      } else {
+        await requireCurrentEvidence(transaction, bundle);
+      }
 
       const decision = createAflTradePrivateReviewedEvidenceEvaluationDecision({
         status: input.status,

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateReviewedEvidenceEvaluationAuthority.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateReviewedEvidenceEvaluationAuthority.ts
@@ -282,6 +282,44 @@ async function persistBundle(
   }
 }
 
+async function resolveDecisionBundle(
+  transaction: AflOutcomeSqlTransaction,
+  current: CurrentDecision | null,
+  status: RecordAflTradePrivateReviewedEvidenceEvaluationDecisionInput['status'],
+  decidedAt: string
+): Promise<AflTradePrivateReviewedEvidenceBundle> {
+  if (current?.decision.content.status === status) {
+    if (status !== 'authorized') {
+      throw new AflTradePrivateReviewedEvidenceEvaluationPersistenceError(
+        'INVALID_INPUT',
+        'A private reviewed-evidence decision must change the current authority state.'
+      );
+    }
+    const successor = await loadExactLocalReviewedProviderEvidenceBundle(transaction, decidedAt);
+    if (exactEvidenceWithoutBundleTime(current.bundle, successor)) {
+      throw new AflTradePrivateReviewedEvidenceEvaluationPersistenceError(
+        'INVALID_INPUT',
+        'The exact reviewed-evidence authority is already current.'
+      );
+    }
+    if (!isExactResultsSuccessor(current.bundle, successor)) {
+      throw new AflTradePrivateReviewedEvidenceEvaluationPersistenceError(
+        'EVIDENCE_MISMATCH',
+        'Reviewed evidence may advance only by the exact AFL Tables results successor.'
+      );
+    }
+    await persistBundle(transaction, successor);
+    return successor;
+  }
+  if (current === null) {
+    const initial = await loadExactLocalReviewedProviderEvidenceBundle(transaction, decidedAt);
+    await persistBundle(transaction, initial);
+    return initial;
+  }
+  await requireCurrentEvidence(transaction, current.bundle);
+  return current.bundle;
+}
+
 export class PostgresAflTradePrivateReviewedEvidenceEvaluationAuthority {
   constructor(private readonly client: AflOutcomeSqlClient) {}
 
@@ -324,38 +362,7 @@ export class PostgresAflTradePrivateReviewedEvidenceEvaluationAuthority {
         `SELECT transaction_timestamp()::timestamptz(3) AS decided_at`
       );
       const decidedAt = isoTimestamp(clock.rows[0]!.decided_at);
-      let bundle = current?.bundle ?? null;
-      if (current?.decision.content.status === input.status) {
-        if (input.status !== 'authorized') {
-          throw new AflTradePrivateReviewedEvidenceEvaluationPersistenceError(
-            'INVALID_INPUT',
-            'A private reviewed-evidence decision must change the current authority state.'
-          );
-        }
-        const successor = await loadExactLocalReviewedProviderEvidenceBundle(
-          transaction,
-          decidedAt
-        );
-        if (exactEvidenceWithoutBundleTime(current.bundle, successor)) {
-          throw new AflTradePrivateReviewedEvidenceEvaluationPersistenceError(
-            'INVALID_INPUT',
-            'The exact reviewed-evidence authority is already current.'
-          );
-        }
-        if (!isExactResultsSuccessor(current.bundle, successor)) {
-          throw new AflTradePrivateReviewedEvidenceEvaluationPersistenceError(
-            'EVIDENCE_MISMATCH',
-            'Reviewed evidence may advance only by the exact AFL Tables results successor.'
-          );
-        }
-        await persistBundle(transaction, successor);
-        bundle = successor;
-      } else if (bundle === null) {
-        bundle = await loadExactLocalReviewedProviderEvidenceBundle(transaction, decidedAt);
-        await persistBundle(transaction, bundle);
-      } else {
-        await requireCurrentEvidence(transaction, bundle);
-      }
+      const bundle = await resolveDecisionBundle(transaction, current, input.status, decidedAt);
 
       const decision = createAflTradePrivateReviewedEvidenceEvaluationDecision({
         status: input.status,

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationCaptureBindingRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationCaptureBindingRepository.ts
@@ -5,8 +5,11 @@ import { z } from 'zod';
 import { canonicalizeAflTradeJson } from '../artifacts/contentAddress';
 import type { AflOutcomeSqlClient } from '../outcomes/postgresOutcomeReleaseRepository';
 import {
+  aflTradePrivateValuationCaptureSourceRoleSchema,
+  getAflTradePrivateValuationCaptureSourceRole,
   parseAflTradePrivateValuationCaptureBinding,
   type AflTradePrivateValuationCaptureBinding,
+  type AflTradePrivateValuationCaptureSourceRole,
 } from './privateValuationCaptureBinding';
 import type { AflTradePrivateValuationCaptureBindingRepository } from './privateValuationRawDataCoordinator';
 import { aflTradePrivateValuationDispatchRequestSchema } from './privateValuationScheduling';
@@ -38,16 +41,18 @@ export class PostgresAflTradePrivateValuationCaptureBindingRepository
   constructor(private readonly client: AflOutcomeSqlClient) {}
 
   async load(
-    unparsedRequest: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>
+    unparsedRequest: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>,
+    unparsedSourceRole: AflTradePrivateValuationCaptureSourceRole = 'factual_input'
   ): Promise<AflTradePrivateValuationCaptureBinding | null> {
     const request = aflTradePrivateValuationDispatchRequestSchema.parse(unparsedRequest);
+    const sourceRole = aflTradePrivateValuationCaptureSourceRoleSchema.parse(unparsedSourceRole);
     const result = await this.client.transaction(async (transaction) => {
       await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
       return transaction.query<{ readonly binding_json: unknown }>(
         `SELECT binding_json
            FROM outcome_private_valuation_capture_binding
-          WHERE request_id=$1`,
-        [request.requestId]
+          WHERE request_id=$1 AND source_role=$2`,
+        [request.requestId, sourceRole]
       );
     });
     const row = result.rows[0];
@@ -55,24 +60,35 @@ export class PostgresAflTradePrivateValuationCaptureBindingRepository
     if (result.rows.length !== 1) {
       throw new TypeError('Dispatch has more than one accepted capture binding.');
     }
-    return requireExactRequest(parseAflTradePrivateValuationCaptureBinding(row.binding_json), request);
+    const binding = requireExactRequest(
+      parseAflTradePrivateValuationCaptureBinding(row.binding_json),
+      request
+    );
+    if (getAflTradePrivateValuationCaptureSourceRole(binding) !== sourceRole) {
+      throw new TypeError('Retained capture binding conflicts with the requested source role.');
+    }
+    return binding;
   }
 
   async accept(input: {
     readonly request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>;
     readonly claim: { readonly claimId: string; readonly leaseToken: string };
+    readonly sourceRole?: AflTradePrivateValuationCaptureSourceRole;
     readonly normalizationRunId: string;
   }): Promise<AflTradePrivateValuationCaptureBinding> {
     const request = aflTradePrivateValuationDispatchRequestSchema.parse(input.request);
     const claimId = claimIdSchema.parse(input.claim.claimId);
     const leaseToken = leaseTokenSchema.parse(input.claim.leaseToken);
+    const sourceRole = aflTradePrivateValuationCaptureSourceRoleSchema.parse(
+      input.sourceRole ?? 'factual_input'
+    );
     const normalizationRunId = normalizationRunIdSchema.parse(input.normalizationRunId);
     const result = await this.client.transaction(async (transaction) => {
       await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
       return transaction.query<{ readonly binding_json: unknown }>(
-        `SELECT accept_outcome_private_valuation_dispatch_capture($1,$2,$3,$4)
+        `SELECT accept_outcome_private_valuation_dispatch_capture($1,$2,$3,$4,$5)
                 AS binding_json`,
-        [request.requestId, claimId, sha256(leaseToken), normalizationRunId]
+        [request.requestId, claimId, sha256(leaseToken), sourceRole, normalizationRunId]
       );
     });
     const binding = requireExactRequest(
@@ -82,6 +98,7 @@ export class PostgresAflTradePrivateValuationCaptureBindingRepository
     if (
       result.rows.length !== 1 ||
       binding.content.dispatchClaimId !== claimId ||
+      getAflTradePrivateValuationCaptureSourceRole(binding) !== sourceRole ||
       binding.content.normalizationRunId !== normalizationRunId
     ) {
       throw new TypeError('Accepted capture binding disagrees with its dispatch claim or source.');

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationHpnPreparation.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationHpnPreparation.ts
@@ -1,0 +1,308 @@
+import { createHash } from 'node:crypto';
+
+import { z } from 'zod';
+
+import {
+  createLocalAflTradeAflTablesResultsAuthority,
+  createLocalAflTradeFiveSeasonAflTablesAuthority,
+} from '../development/localFiveSeasonAflTablesAuthority';
+import { createLocalAflTradeOfficialAfl2026Authority } from '../development/localOfficialAfl2026Authority';
+import type { AflTradeHpnPavMethodAuthority } from '../modeling/hpnPavCalculationService';
+import { PostgresAflTradeHpnPavCalculationRepository } from '../modeling/postgresHpnPavCalculationRepository';
+import { PostgresAflTradeHpnPavInputRepository } from '../modeling/postgresHpnPavInputRepository';
+import { PostgresAflTradeHpnProjectedFieldMapAuthority } from '../modeling/postgresHpnProjectedFieldMapAuthority';
+import type { AflOutcomeSqlClient } from '../outcomes/postgresOutcomeReleaseRepository';
+import type { AflTradeFitzRoyCaptureCommand } from '../source/fitzRoyCaptureRuntime';
+import type { AflTradeFitzRoyFieldMap } from '../source/fitzRoyObservationContracts';
+import {
+  type AflTradePrivateValuationCaptureBinding,
+  type AflTradePrivateValuationCaptureSourceRole,
+} from './privateValuationCaptureBinding';
+import { createAflTradePrivateValuationRawDataCoordinator } from './privateValuationRawDataCoordinator';
+import { aflTradePrivateValuationDispatchRequestSchema } from './privateValuationScheduling';
+import type { AflTradePrivateValuationFactualPreparationResult } from './postgresPrivateValuationFactualPreparation';
+import { PostgresAflTradePrivateValuationCaptureBindingRepository } from './postgresPrivateValuationCaptureBindingRepository';
+import { PostgresAflTradePrivateValuationScheduleRepository } from './postgresPrivateValuationScheduling';
+
+const EXECUTION_DATABASE_ROLE = 'afl_trade_private_evaluation_coordinator';
+const SUPPORTED_VALUATION_SCOPE_KEY = 'afl-men:2026-trades';
+const requestIdSchema = z.string().regex(/^private-valuation-dispatch:[a-f0-9]{64}$/u);
+const claimSchema = z
+  .object({
+    claimId: z.string().regex(/^private-valuation-dispatch-claim:[a-f0-9]{64}$/u),
+    leaseToken: z.string().regex(/^[a-f0-9]{64}$/u),
+  })
+  .strict();
+const methodIdSchema = z.string().regex(/^hpn-pav-method:[a-f0-9]{64}$/u);
+
+type SourceAuthority = Readonly<{
+  capture: AflTradeFitzRoyCaptureCommand;
+  fieldMap: AflTradeFitzRoyFieldMap;
+}>;
+
+type SourceLane = Readonly<{
+  sourceRole: Exclude<AflTradePrivateValuationCaptureSourceRole, 'factual_input'>;
+  inputKind: 'completed_match_result' | 'player_match_stats';
+  role: 'primary' | 'corroborating' | null;
+  authority: SourceAuthority;
+}>;
+
+export type AflTradePrivateValuationHpnPreparationResult = Readonly<{
+  state: 'prepared' | 'already_prepared';
+  requestId: string;
+  factualOutputId: string;
+  inputSetId: string;
+  calculationId: string;
+  captureBindingIds: readonly string[];
+  publicationEligible: false;
+}>;
+
+export interface AflTradePrivateValuationHpnPreparationDependencies {
+  readonly factualPreparation: {
+    prepare(input: {
+      readonly requestId: string;
+      readonly claim: { readonly claimId: string; readonly leaseToken: string };
+    }): Promise<AflTradePrivateValuationFactualPreparationResult>;
+  };
+  readonly methodId: string;
+  readonly methodAuthority: AflTradeHpnPavMethodAuthority;
+  readonly captureSource: (input: {
+    readonly requestId: string;
+    readonly claim: { readonly claimId: string; readonly leaseToken: string };
+    readonly sourceRole: Exclude<AflTradePrivateValuationCaptureSourceRole, 'factual_input'>;
+    readonly capture: AflTradeFitzRoyCaptureCommand;
+    readonly fieldMap: AflTradeFitzRoyFieldMap;
+  }) => Promise<{ readonly normalizationRunId: string }>;
+}
+
+function sourceLanes(seasonYear: number): readonly SourceLane[] {
+  return [
+    {
+      sourceRole: 'hpn_completed_results',
+      inputKind: 'completed_match_result',
+      role: null,
+      authority: createLocalAflTradeAflTablesResultsAuthority(seasonYear),
+    },
+    {
+      sourceRole: 'hpn_primary_player_stats',
+      inputKind: 'player_match_stats',
+      role: 'primary',
+      authority: createLocalAflTradeFiveSeasonAflTablesAuthority(seasonYear),
+    },
+    {
+      sourceRole: 'hpn_corroborating_player_stats',
+      inputKind: 'player_match_stats',
+      role: 'corroborating',
+      authority: createLocalAflTradeOfficialAfl2026Authority(),
+    },
+  ];
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function requireExactLaneBinding(
+  lane: SourceLane,
+  binding: AflTradePrivateValuationCaptureBinding,
+  seasonYear: number
+): void {
+  if (
+    binding.content.schemaVersion !==
+    'afl-trade-private-valuation-capture-binding/v2'
+  ) {
+    throw new TypeError(`Accepted source custody does not match ${lane.sourceRole}.`);
+  }
+  const source = binding.content.sourcePlan;
+  if (
+    source.provider !== lane.authority.capture.sourceRights.content.provider ||
+    source.dataset !== lane.authority.capture.sourceRights.content.dataset ||
+    source.capabilityId !== lane.authority.capture.gateRequest.capabilityId ||
+    source.competition !== 'AFLM' ||
+    source.seasonYear !== seasonYear ||
+    source.fieldMapId !== lane.authority.fieldMap.mapId ||
+    source.rightsArtifactId !== lane.authority.capture.sourceRights.rightsArtifactId
+  ) {
+    throw new TypeError(`Accepted source custody does not match ${lane.sourceRole}.`);
+  }
+}
+
+export class PostgresAflTradePrivateValuationHpnPreparation {
+  constructor(
+    private readonly client: AflOutcomeSqlClient,
+    private readonly dependencies: AflTradePrivateValuationHpnPreparationDependencies
+  ) {}
+
+  private async loadRequest(
+    requestId: string,
+    claim: z.infer<typeof claimSchema>
+  ) {
+    const result = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<{ readonly request_json: unknown }>(
+        `SELECT load_outcome_private_valuation_dispatch_request_for_claim($1,$2,$3)
+                AS request_json`,
+        [requestId, claim.claimId, sha256(claim.leaseToken)]
+      );
+    });
+    if (result.rows.length !== 1) {
+      throw new TypeError('HPN preparation requires one exact retained dispatch request.');
+    }
+    const request = aflTradePrivateValuationDispatchRequestSchema.parse(
+      result.rows[0]!.request_json
+    );
+    if (request.requestId !== requestId) {
+      throw new TypeError('HPN preparation request differs from retained dispatch custody.');
+    }
+    return request;
+  }
+
+  private async captureLane(
+    request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>,
+    claim: z.infer<typeof claimSchema>,
+    lane: SourceLane
+  ): Promise<AflTradePrivateValuationCaptureBinding> {
+    const coordinator = createAflTradePrivateValuationRawDataCoordinator({
+      captureBindings: new PostgresAflTradePrivateValuationCaptureBindingRepository(
+        this.client
+      ),
+      sourceRole: lane.sourceRole,
+      capture: async () =>
+        this.dependencies.captureSource({
+          requestId: request.requestId,
+          claim,
+          sourceRole: lane.sourceRole,
+          capture: lane.authority.capture,
+          fieldMap: lane.authority.fieldMap,
+        }),
+    });
+    return (await coordinator.run({ request, claim })).binding;
+  }
+
+  private async loadEffectiveThrough(normalizationRunIds: readonly string[]): Promise<string> {
+    const result = await this.client.query<{ readonly effective_through: Date | string | null }>(
+      `SELECT max(capture.captured_at) AS effective_through
+         FROM outcome_provider_normalization_run run
+         JOIN outcome_source_capture capture ON capture.capture_id=run.capture_id
+        WHERE run.normalization_run_id=ANY($1::text[])`,
+      [normalizationRunIds]
+    );
+    const value = result.rows[0]?.effective_through;
+    if (value === null || value === undefined) {
+      throw new TypeError('HPN preparation could not establish its exact evidence cutoff.');
+    }
+    return new Date(value).toISOString();
+  }
+
+  private async renewClaim(claim: z.infer<typeof claimSchema>): Promise<void> {
+    await new PostgresAflTradePrivateValuationScheduleRepository(this.client).heartbeat(claim);
+  }
+
+  async prepare(input: {
+    readonly requestId: string;
+    readonly claim: { readonly claimId: string; readonly leaseToken: string };
+  }): Promise<AflTradePrivateValuationHpnPreparationResult> {
+    const requestId = requestIdSchema.parse(input.requestId);
+    const claim = claimSchema.parse(input.claim);
+    const seasonYear = 2026;
+    const methodId = methodIdSchema.parse(this.dependencies.methodId);
+    const request = await this.loadRequest(requestId, claim);
+    if (request.scopeKey !== SUPPORTED_VALUATION_SCOPE_KEY) {
+      throw new TypeError(
+        `HPN preparation supports only ${SUPPORTED_VALUATION_SCOPE_KEY}.`
+      );
+    }
+    const factual = await this.dependencies.factualPreparation.prepare({ requestId, claim });
+    if (
+      factual.output.content.requestId !== requestId ||
+      factual.output.content.valuationScopeKey !== request.scopeKey
+    ) {
+      throw new TypeError('HPN preparation received factual output from another dispatch scope.');
+    }
+
+    const lanes = sourceLanes(seasonYear);
+    const bindings: AflTradePrivateValuationCaptureBinding[] = [];
+    for (const lane of lanes) {
+      const binding = await this.captureLane(request, claim, lane);
+      requireExactLaneBinding(lane, binding, seasonYear);
+      bindings.push(binding);
+    }
+
+    const fieldMapAuthority = new PostgresAflTradeHpnProjectedFieldMapAuthority(this.client);
+    const sources = [];
+    for (let index = 0; index < lanes.length; index += 1) {
+      const lane = lanes[index]!;
+      const binding = bindings[index]!;
+      if (binding.content.schemaVersion !== 'afl-trade-private-valuation-capture-binding/v2') {
+        throw new TypeError(`HPN source custody must use the role-aware binding contract.`);
+      }
+      await this.renewClaim(claim);
+      const fieldMap = await fieldMapAuthority.loadCurrentForSource({
+        provider: binding.content.sourcePlan.provider,
+        capabilityId: binding.content.sourcePlan.capabilityId,
+        inputKind: lane.inputKind,
+        sourceSchemaSha256: lane.authority.fieldMap.sourceSchemaSha256,
+        providerDecodeMapId: binding.content.sourcePlan.fieldMapId,
+        seasonYear,
+        rightsArtifactId: binding.content.sourcePlan.rightsArtifactId,
+        valuationScopeKey: request.scopeKey,
+      });
+      if (fieldMap === null) {
+        throw new TypeError(`No current reviewed HPN field map exists for ${lane.sourceRole}.`);
+      }
+      sources.push({
+        normalizationRunId: binding.content.normalizationRunId,
+        fieldMapId: fieldMap.fieldMapId,
+        inputKind: lane.inputKind,
+        role: lane.role,
+      });
+    }
+
+    await this.renewClaim(claim);
+    const inputSet = await new PostgresAflTradeHpnPavInputRepository(
+      this.client
+    ).buildAndPersistSeasonInputSet(
+      {
+        environment: 'non_production',
+        competition: 'AFLM',
+        seasonYear,
+        methodId,
+        factualRunId: factual.output.content.reconciliation.factualRunId,
+        effectiveThrough: await this.loadEffectiveThrough(
+          bindings.map(({ content }) => content.normalizationRunId)
+        ),
+        sources,
+      },
+      { environment: 'non_production' }
+    );
+    await this.renewClaim(claim);
+    const calculation = await new PostgresAflTradeHpnPavCalculationRepository(
+      this.client,
+      this.dependencies.methodAuthority
+    ).calculateAndPersist(
+      {
+        inputSetId: inputSet.inputSet.inputSetId,
+        environment: 'non_production',
+        competition: 'AFLM',
+        seasonYear,
+        methodId,
+      },
+      { environment: 'non_production' }
+    );
+
+    return {
+      state:
+        factual.state === 'already_prepared' &&
+        inputSet.idempotentReplay &&
+        calculation.idempotentReplay
+          ? 'already_prepared'
+          : 'prepared',
+      requestId,
+      factualOutputId: factual.output.outputId,
+      inputSetId: inputSet.inputSet.inputSetId,
+      calculationId: calculation.calculation.calculationId,
+      captureBindingIds: bindings.map(({ bindingId }) => bindingId),
+      publicationEligible: false,
+    };
+  }
+}

--- a/src/server/aflTradeIntelligence/valuation/privateValuationCaptureBinding.ts
+++ b/src/server/aflTradeIntelligence/valuation/privateValuationCaptureBinding.ts
@@ -9,61 +9,109 @@ import { aflTradePrivateValuationDispatchRequestSchema } from './privateValuatio
 
 export const AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_SCHEMA_VERSION =
   'afl-trade-private-valuation-capture-binding/v1' as const;
+export const AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_V2_SCHEMA_VERSION =
+  'afl-trade-private-valuation-capture-binding/v2' as const;
 export const AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_LIMITATION =
   'Accepted non-production source custody only; it grants no factual, model, private-evaluation, or publication authority.' as const;
 
 const instantSchema = z.string().datetime({ offset: true });
 const boundedSourceIdSchema = z.string().trim().min(1).max(300);
 
+export const aflTradePrivateValuationCaptureSourceRoleSchema = z.enum([
+  'factual_input',
+  'hpn_completed_results',
+  'hpn_primary_player_stats',
+  'hpn_corroborating_player_stats',
+]);
+export type AflTradePrivateValuationCaptureSourceRole = z.infer<
+  typeof aflTradePrivateValuationCaptureSourceRoleSchema
+>;
+
 // This is the exact selected source lineage retained as Stage-1 output custody. Stage 2 must
 // compare it with its intended factual scope before it can grant any downstream authority.
-export const aflTradePrivateValuationCaptureSourcePlanSchema = z
+const captureSourcePlanShape = {
+  provider: boundedSourceIdSchema,
+  dataset: boundedSourceIdSchema,
+  capabilityId: boundedSourceIdSchema,
+  competition: z.enum(['AFLM', 'AFLW']),
+  seasonYear: z.number().int().min(1897).max(2200),
+  fieldMapId: boundedSourceIdSchema,
+  gate0AReceiptId: aflTradeContentAddressedIdSchema('gate0a-evaluation'),
+} as const;
+
+export const aflTradePrivateValuationCaptureSourcePlanSchema = z.object(captureSourcePlanShape).strict();
+
+export const aflTradePrivateValuationCaptureSourcePlanV2Schema = z
   .object({
-    provider: boundedSourceIdSchema,
-    dataset: boundedSourceIdSchema,
-    capabilityId: boundedSourceIdSchema,
-    competition: z.enum(['AFLM', 'AFLW']),
-    seasonYear: z.number().int().min(1897).max(2200),
-    fieldMapId: boundedSourceIdSchema,
-    gate0AReceiptId: aflTradeContentAddressedIdSchema('gate0a-evaluation'),
+    ...captureSourcePlanShape,
+    rightsArtifactId: aflTradeContentAddressedIdSchema('source-rights'),
   })
   .strict();
 
-export const aflTradePrivateValuationCaptureBindingContentSchema = z
+const captureBindingContentShape = {
+  request: aflTradePrivateValuationDispatchRequestSchema,
+  dispatchClaimId: z.string().regex(/^private-valuation-dispatch-claim:[a-f0-9]{64}$/),
+  attemptSequence: z.number().int().positive(),
+  attemptNumber: z.number().int().min(1).max(3),
+  sourceCaptureAttemptId: aflTradeContentAddressedIdSchema('source-capture-attempt'),
+  captureReceiptId: aflTradeContentAddressedIdSchema('fitzroy-capture'),
+  snapshotId: aflTradeContentAddressedIdSchema('source-snapshot'),
+  sourceCaptureId: aflTradeContentAddressedIdSchema('source-capture'),
+  normalizationRunId: aflTradeContentAddressedIdSchema('provider-normalization-run'),
+  acceptedAt: instantSchema,
+  environment: z.literal('non_production'),
+  publicationEligible: z.literal(false),
+  limitation: z.literal(AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_LIMITATION),
+} as const;
+
+function refineCaptureBindingChronology(
+  content: {
+    readonly attemptNumber: number;
+    readonly attemptSequence: number;
+    readonly acceptedAt: string;
+    readonly request: { readonly scheduledFor: string };
+  },
+  context: z.RefinementCtx
+): void {
+  if (content.attemptNumber > content.attemptSequence) {
+    context.addIssue({
+      code: 'custom',
+      path: ['attemptNumber'],
+      message: 'The technical attempt number cannot exceed its dispatch claim sequence.',
+    });
+  }
+  if (Date.parse(content.acceptedAt) < Date.parse(content.request.scheduledFor)) {
+    context.addIssue({
+      code: 'custom',
+      path: ['acceptedAt'],
+      message: 'A capture cannot be accepted before its dispatch was scheduled.',
+    });
+  }
+}
+
+export const aflTradePrivateValuationCaptureBindingV1ContentSchema = z
   .object({
     schemaVersion: z.literal(AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_SCHEMA_VERSION),
-    request: aflTradePrivateValuationDispatchRequestSchema,
-    dispatchClaimId: z.string().regex(/^private-valuation-dispatch-claim:[a-f0-9]{64}$/),
-    attemptSequence: z.number().int().positive(),
-    attemptNumber: z.number().int().min(1).max(3),
+    ...captureBindingContentShape,
     sourcePlan: aflTradePrivateValuationCaptureSourcePlanSchema,
-    sourceCaptureAttemptId: aflTradeContentAddressedIdSchema('source-capture-attempt'),
-    captureReceiptId: aflTradeContentAddressedIdSchema('fitzroy-capture'),
-    snapshotId: aflTradeContentAddressedIdSchema('source-snapshot'),
-    sourceCaptureId: aflTradeContentAddressedIdSchema('source-capture'),
-    normalizationRunId: aflTradeContentAddressedIdSchema('provider-normalization-run'),
-    acceptedAt: instantSchema,
-    environment: z.literal('non_production'),
-    publicationEligible: z.literal(false),
-    limitation: z.literal(AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_LIMITATION),
   })
   .strict()
-  .superRefine((content, context) => {
-    if (content.attemptNumber > content.attemptSequence) {
-      context.addIssue({
-        code: 'custom',
-        path: ['attemptNumber'],
-        message: 'The technical attempt number cannot exceed its dispatch claim sequence.',
-      });
-    }
-    if (Date.parse(content.acceptedAt) < Date.parse(content.request.scheduledFor)) {
-      context.addIssue({
-        code: 'custom',
-        path: ['acceptedAt'],
-        message: 'A capture cannot be accepted before its dispatch was scheduled.',
-      });
-    }
-  });
+  .superRefine(refineCaptureBindingChronology);
+
+export const aflTradePrivateValuationCaptureBindingV2ContentSchema = z
+  .object({
+    schemaVersion: z.literal(AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_V2_SCHEMA_VERSION),
+    ...captureBindingContentShape,
+    sourceRole: aflTradePrivateValuationCaptureSourceRoleSchema,
+    sourcePlan: aflTradePrivateValuationCaptureSourcePlanV2Schema,
+  })
+  .strict()
+  .superRefine(refineCaptureBindingChronology);
+
+export const aflTradePrivateValuationCaptureBindingContentSchema = z.union([
+  aflTradePrivateValuationCaptureBindingV1ContentSchema,
+  aflTradePrivateValuationCaptureBindingV2ContentSchema,
+]);
 
 export const aflTradePrivateValuationCaptureBindingSchema = z
   .object({
@@ -87,7 +135,7 @@ export type AflTradePrivateValuationCaptureBinding = z.infer<
 
 export function createAflTradePrivateValuationCaptureBinding(
   input: Omit<
-    z.input<typeof aflTradePrivateValuationCaptureBindingContentSchema>,
+    z.input<typeof aflTradePrivateValuationCaptureBindingV1ContentSchema>,
     'schemaVersion' | 'environment' | 'publicationEligible' | 'limitation'
   >
 ): AflTradePrivateValuationCaptureBinding {
@@ -102,6 +150,15 @@ export function createAflTradePrivateValuationCaptureBinding(
     bindingId: createAflTradeContentAddress('private-valuation-capture-binding', content),
     content,
   });
+}
+
+export function getAflTradePrivateValuationCaptureSourceRole(
+  binding: AflTradePrivateValuationCaptureBinding
+): AflTradePrivateValuationCaptureSourceRole {
+  return binding.content.schemaVersion ===
+    AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_SCHEMA_VERSION
+    ? 'factual_input'
+    : binding.content.sourceRole;
 }
 
 export function parseAflTradePrivateValuationCaptureBinding(

--- a/src/server/aflTradeIntelligence/valuation/privateValuationRawDataCoordinator.ts
+++ b/src/server/aflTradeIntelligence/valuation/privateValuationRawDataCoordinator.ts
@@ -2,8 +2,11 @@ import { z } from 'zod';
 
 import { canonicalizeAflTradeJson } from '../artifacts/contentAddress';
 import {
+  aflTradePrivateValuationCaptureSourceRoleSchema,
+  getAflTradePrivateValuationCaptureSourceRole,
   parseAflTradePrivateValuationCaptureBinding,
   type AflTradePrivateValuationCaptureBinding,
+  type AflTradePrivateValuationCaptureSourceRole,
 } from './privateValuationCaptureBinding';
 import { aflTradePrivateValuationDispatchRequestSchema } from './privateValuationScheduling';
 
@@ -21,31 +24,39 @@ const capturedNormalizationSchema = z
 
 export interface AflTradePrivateValuationCaptureBindingRepository {
   load(
-    request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>
+    request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>,
+    sourceRole?: AflTradePrivateValuationCaptureSourceRole
   ): Promise<AflTradePrivateValuationCaptureBinding | null>;
   accept(input: {
     readonly request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>;
     readonly claim: z.infer<typeof claimSchema>;
+    readonly sourceRole?: AflTradePrivateValuationCaptureSourceRole;
     readonly normalizationRunId: string;
   }): Promise<AflTradePrivateValuationCaptureBinding>;
 }
 
 function requireBindingForRequest(
   binding: AflTradePrivateValuationCaptureBinding,
-  request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>
+  request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>,
+  sourceRole: AflTradePrivateValuationCaptureSourceRole
 ): AflTradePrivateValuationCaptureBinding {
   const parsed = parseAflTradePrivateValuationCaptureBinding(binding);
   if (canonicalizeAflTradeJson(parsed.content.request) !== canonicalizeAflTradeJson(request)) {
     throw new TypeError('Accepted capture binding conflicts with the requested dispatch.');
+  }
+  if (getAflTradePrivateValuationCaptureSourceRole(parsed) !== sourceRole) {
+    throw new TypeError('Accepted capture binding conflicts with the requested source role.');
   }
   return parsed;
 }
 
 export function createAflTradePrivateValuationRawDataCoordinator(dependencies: {
   readonly captureBindings: AflTradePrivateValuationCaptureBindingRepository;
+  readonly sourceRole?: AflTradePrivateValuationCaptureSourceRole;
   readonly capture: (input: {
     readonly request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>;
     readonly claim: z.infer<typeof claimSchema>;
+    readonly sourceRole: AflTradePrivateValuationCaptureSourceRole;
   }) => Promise<z.infer<typeof capturedNormalizationSchema>>;
 }) {
   return {
@@ -55,9 +66,12 @@ export function createAflTradePrivateValuationRawDataCoordinator(dependencies: {
     }) {
       const request = aflTradePrivateValuationDispatchRequestSchema.parse(input.request);
       const claim = claimSchema.parse(input.claim);
-      const retained = await dependencies.captureBindings.load(request);
+      const sourceRole = aflTradePrivateValuationCaptureSourceRoleSchema.parse(
+        dependencies.sourceRole ?? 'factual_input'
+      );
+      const retained = await dependencies.captureBindings.load(request, sourceRole);
       if (retained !== null) {
-        const binding = requireBindingForRequest(retained, request);
+        const binding = requireBindingForRequest(retained, request, sourceRole);
         return {
           state: 'capture_accepted' as const,
           requestId: request.requestId,
@@ -67,15 +81,17 @@ export function createAflTradePrivateValuationRawDataCoordinator(dependencies: {
       }
 
       const captured = capturedNormalizationSchema.parse(
-        await dependencies.capture({ request, claim })
+        await dependencies.capture({ request, claim, sourceRole })
       );
       const binding = requireBindingForRequest(
         await dependencies.captureBindings.accept({
           request,
           claim,
+          sourceRole,
           normalizationRunId: captured.normalizationRunId,
         }),
-        request
+        request,
+        sourceRole
       );
       if (binding.content.dispatchClaimId !== claim.claimId) {
         throw new TypeError('Accepted capture binding disagrees with the live dispatch claim.');

--- a/tests/outcomes-integration/afl-hpn-pav-projected-input-postgres.test.ts
+++ b/tests/outcomes-integration/afl-hpn-pav-projected-input-postgres.test.ts
@@ -1,0 +1,2232 @@
+import { createHash } from 'node:crypto';
+
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import {
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { createAflTradeByteArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import {
+  createLocalAflTradeAflTablesResultsAuthority,
+  createLocalAflTradeFiveSeasonAflTablesAuthority,
+} from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority';
+import {
+  createLocalAflTradeHpnCompletedResultFieldMapCandidate,
+  createLocalAflTradeHpnPlayerFieldMapCandidate,
+} from '@/server/aflTradeIntelligence/development/localHpnFieldMapCandidates';
+import { createLocalAflTradeOfficialAfl2026Authority } from '@/server/aflTradeIntelligence/development/localOfficialAfl2026Authority';
+import {
+  listAflTradeHpnCandidateSourceFields,
+} from '@/server/aflTradeIntelligence/modeling/hpnFieldMapCandidate';
+import {
+  createAflTradeHpnFieldMapReviewDecision,
+  createAflTradeHpnProjectedFieldMap,
+} from '@/server/aflTradeIntelligence/modeling/hpnProjectedFieldMap';
+import { createAflTradeHpnPavMethod } from '@/server/aflTradeIntelligence/modeling/hpnPlayerApproximateValue';
+import { PostgresAflTradeHpnProjectedFieldMapAuthority } from '@/server/aflTradeIntelligence/modeling/postgresHpnProjectedFieldMapAuthority';
+import { PostgresAflTradeHpnPavInputRepository } from '@/server/aflTradeIntelligence/modeling/postgresHpnPavInputRepository';
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import {
+  AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_LIMITATION,
+  AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_V2_SCHEMA_VERSION,
+  aflTradePrivateValuationCaptureBindingSchema,
+} from '@/server/aflTradeIntelligence/valuation/privateValuationCaptureBinding';
+import { createAflTradePrivateValuationFactualOutput } from '@/server/aflTradeIntelligence/valuation/privateValuationFactualOutput';
+import { PostgresAflTradePrivateValuationHpnPreparation } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationHpnPreparation';
+import { PostgresAflTradePrivateValuationScheduleRepository } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationScheduling';
+import {
+  createAflTradePrivateReviewedEvidenceBundle,
+  createAflTradePrivateReviewedEvidenceEvaluationDecision,
+} from '@/server/aflTradeIntelligence/valuation/privateReviewedEvidenceEvaluation';
+import { aflTradeSourceRightsProposalSchema } from '@/server/aflTradeIntelligence/source/sourceRights';
+
+import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('A disposable AFL_OUTCOMES_TEST_DATABASE_URL is required.');
+  })();
+const schemaName = `afl_hpn_projected_input_${process.pid}_${Date.now()}`;
+const adminPool = new Pool({ connectionString: databaseUrl });
+const outcomesPool = new Pool({
+  connectionString: databaseUrl,
+  options: `-c search_path=${schemaName}`,
+  max: 4,
+});
+const client = createPgAflOutcomeSqlClient(outcomesPool);
+
+const seasonYear = 2026;
+const competition = 'AFLM';
+const matchId = 'match:fixture-final';
+const homeClubId = 'club:home';
+const awayClubId = 'club:away';
+const playerIds = ['player:home', 'player:away'] as const;
+const fixtureAt = '2026-08-09T00:00:00.000Z';
+const finalizedAt = '2026-08-09T02:00:00.000Z';
+const legacyReviewAt = '2026-08-14T00:00:00.000Z';
+const projectionAt = '2026-08-15T00:00:00.000Z';
+
+const sha256 = (value: string) => createHash('sha256').update(value).digest('hex');
+const id = (prefix: string, value: string) => `${prefix}:${sha256(value)}`;
+const scalar = (value: string | number) =>
+  typeof value === 'number'
+    ? { kind: 'integer', value: String(value) }
+    : { kind: 'text', value };
+
+function scopedDatabaseUrl(): string {
+  const scoped = new URL(databaseUrl);
+  scoped.searchParams.set('schema', schemaName);
+  return scoped.toString();
+}
+
+type Lane = Readonly<{
+  inputKind: 'completed_match_result' | 'player_match_stats';
+  role: 'primary' | 'corroborating' | null;
+  suffix: string;
+  sourceRole:
+    | 'hpn_completed_results'
+    | 'hpn_primary_player_stats'
+    | 'hpn_corroborating_player_stats';
+  authority:
+    | ReturnType<typeof createLocalAflTradeFiveSeasonAflTablesAuthority>
+    | ReturnType<typeof createLocalAflTradeOfficialAfl2026Authority>;
+}>;
+
+type ReviewedCaptureSource = Readonly<{
+  suffix: string;
+  seasonYear: number;
+  authority: Lane['authority'];
+}>;
+
+const lanes: readonly Lane[] = [
+  {
+    inputKind: 'completed_match_result',
+    role: null,
+    suffix: 'results',
+    sourceRole: 'hpn_completed_results',
+    authority: createLocalAflTradeAflTablesResultsAuthority(seasonYear),
+  },
+  {
+    inputKind: 'player_match_stats',
+    role: 'primary',
+    suffix: 'primary',
+    sourceRole: 'hpn_primary_player_stats',
+    authority: createLocalAflTradeFiveSeasonAflTablesAuthority(seasonYear),
+  },
+  {
+    inputKind: 'player_match_stats',
+    role: 'corroborating',
+    suffix: 'corroborating',
+    sourceRole: 'hpn_corroborating_player_stats',
+    authority: createLocalAflTradeOfficialAfl2026Authority(),
+  },
+];
+
+const reviewedCaptureSources = [
+  ...[2021, 2022, 2023, 2024, 2025].map((reviewedSeasonYear) => ({
+    suffix: `reviewed-afl-tables-${reviewedSeasonYear}`,
+    seasonYear: reviewedSeasonYear,
+    authority: createLocalAflTradeFiveSeasonAflTablesAuthority(reviewedSeasonYear),
+  })),
+  {
+    suffix: 'reviewed-official-2026',
+    seasonYear,
+    authority: createLocalAflTradeOfficialAfl2026Authority(),
+  },
+  {
+    suffix: 'reviewed-results-2026',
+    seasonYear,
+    authority: createLocalAflTradeAflTablesResultsAuthority(seasonYear),
+  },
+] as const satisfies readonly ReviewedCaptureSource[];
+
+const reviewedSourceArtifact = (suffix: string) =>
+  createAflTradeCanonicalJsonArtifactRef({ sourceCapture: suffix }, fixtureAt);
+
+function reviewedEvaluation(
+  valuationScopeKey = 'afl-men:2026-trades',
+  includeResults = true,
+  createdAt = projectionAt,
+  revision = 1,
+  supersedesDecisionId: string | null = null,
+  sources: readonly ReviewedCaptureSource[] = reviewedCaptureSources
+) {
+  const includedSources = sources.filter(
+    ({ authority }) =>
+      includeResults || authority.fieldMap.capabilityId !== 'afl-tables-results'
+  );
+  const sourceRightsEvidenceRefs = [
+    ...new Map(
+      includedSources.map(({ authority }) => {
+        const reference = createAflTradeCanonicalJsonArtifactRef(
+          authority.capture.sourceRights,
+          authority.capture.sourceRights.content.proposedAt
+        );
+        return [reference.artifactId, reference] as const;
+      })
+    ).values(),
+  ]
+    .sort((left, right) => left.artifactId.localeCompare(right.artifactId));
+  const evidenceBundle = createAflTradePrivateReviewedEvidenceBundle({
+    evidenceScopeKey: 'afl-player-match-reviewed-2021-2026',
+    reviewSets: [
+      {
+        reviewSetId: sha256('projected-hpn-input-review-set'),
+        reviewSetDecisionId: 'projected-hpn-input-review-set-decision',
+        reviewerId: 'projected-hpn-input-fixture-reviewer',
+        candidateCount: 1,
+        decisionCount: 1,
+        reviewSetArtifact: createAflTradeCanonicalJsonArtifactRef(
+          { reviewSet: 'projected-hpn-input' },
+          legacyReviewAt
+        ),
+      },
+    ],
+    sourceCaptures: includedSources.map((source) => ({
+      captureId: id('source-capture', source.suffix),
+      provider: source.authority.capture.sourceRights.content.provider,
+      capabilityId: source.authority.fieldMap.capabilityId,
+      seasonYear: source.seasonYear,
+      sourceArtifact: reviewedSourceArtifact(source.suffix),
+    })),
+    sourceRightsEvidenceRefs,
+    createdAt,
+  });
+  const evidenceBundleArtifact = createAflTradeCanonicalJsonArtifactRef(
+    evidenceBundle,
+    createdAt
+  );
+  const evaluationDecision = createAflTradePrivateReviewedEvidenceEvaluationDecision({
+    status: 'authorized',
+    valuationScopeKey,
+    evidenceBundle,
+    evidenceBundleArtifact,
+    revision,
+    supersedesDecisionId,
+    reviewerId: 'projected-hpn-input-fixture-reviewer',
+    rationale: 'Authorize exact retained review evidence for the private HPN fixture.',
+    decidedAt: createdAt,
+  });
+  return { evidenceBundle, evidenceBundleArtifact, evaluationDecision };
+}
+
+function reviewedEvaluationSuccessor(
+  valuationScopeKey = 'afl-men:2026-trades',
+  sources: readonly ReviewedCaptureSource[] = reviewedCaptureSources
+) {
+  const legacy = reviewedEvaluation(
+    valuationScopeKey,
+    false,
+    legacyReviewAt
+  );
+  return {
+    legacy,
+    successor: reviewedEvaluation(
+      valuationScopeKey,
+      true,
+      projectionAt,
+      2,
+      legacy.evaluationDecision.decisionId,
+      sources
+    ),
+  };
+}
+
+function projection(
+  lane: Lane,
+  valuationScopeKey = 'afl-men:2026-trades',
+  reviewed = reviewedEvaluationSuccessor(valuationScopeKey).successor
+) {
+  const decodeMap = lane.authority.fieldMap;
+  const decodeMapArtifact = createAflTradeCanonicalJsonArtifactRef(decodeMap, projectionAt);
+  const candidate = lane.inputKind === 'completed_match_result'
+    ? createLocalAflTradeHpnCompletedResultFieldMapCandidate({
+        seasonYear,
+        providerDecodeMap: decodeMap,
+        providerDecodeMapArtifact: decodeMapArtifact,
+        createdAt: projectionAt,
+      })
+    : createLocalAflTradeHpnPlayerFieldMapCandidate({
+        provider: lane.suffix === 'corroborating' ? 'official_afl' : 'afl_tables',
+        seasonYear,
+        providerDecodeMap: decodeMap,
+        providerDecodeMapArtifact: decodeMapArtifact,
+        createdAt: projectionAt,
+      });
+  const exactOrderedFields = [
+    ...new Set(candidate.content.semanticBindings.flatMap(listAflTradeHpnCandidateSourceFields)),
+  ].sort();
+  const candidateArtifact = createAflTradeCanonicalJsonArtifactRef(candidate, projectionAt);
+  const sourceUseContent = {
+    schemaVersion: 'afl-trade-hpn-private-source-use-assessment/v1' as const,
+    environment: 'non_production' as const,
+    purpose: 'private_confirmed_realized_hpn_pav' as const,
+    competition,
+    seasonYear,
+    valuationScopeKey,
+    evaluationDecisionId: reviewed.evaluationDecision.decisionId,
+    state: 'permitted_private_calculation' as const,
+    rightsArtifactId: lane.authority.capture.sourceRights.rightsArtifactId,
+    evidenceBundleId: reviewed.evidenceBundle.evidenceBundleId,
+    fields: exactOrderedFields.map((sourceField) => ({
+      sourceField,
+      state: 'permitted_private_calculation' as const,
+      reasons: [],
+    })),
+    reasons: [],
+    evidenceRefs: [
+      createAflTradeCanonicalJsonArtifactRef(
+        lane.authority.capture.sourceRights,
+        projectionAt
+      ),
+      reviewed.evidenceBundleArtifact,
+    ],
+    effectiveRestriction: null,
+    evaluatedAt: projectionAt,
+    publicationEligible: false as const,
+    publicationProhibited: true as const,
+  };
+  const sourceUseAssessment = {
+    assessmentId: createAflTradeContentAddress(
+      'hpn-private-source-use-assessment',
+      sourceUseContent
+    ),
+    content: sourceUseContent,
+  };
+  const sourceUseAssessmentArtifact = createAflTradeCanonicalJsonArtifactRef(
+    sourceUseAssessment,
+    projectionAt
+  );
+  const reviewDecision = createAflTradeHpnFieldMapReviewDecision({
+    candidate,
+    candidateArtifact,
+    sourceUseAssessment,
+    sourceUseAssessmentArtifact,
+    decision: 'approved',
+    reviewerId: 'projected-hpn-input-fixture-reviewer',
+    rationale: 'Approve the exact disposable PostgreSQL projection.',
+    decidedAt: projectionAt,
+  });
+  const decisionArtifact = createAflTradeCanonicalJsonArtifactRef(reviewDecision, projectionAt);
+  const projectedFieldMap = createAflTradeHpnProjectedFieldMap({
+    candidate,
+    candidateArtifact,
+    decision: reviewDecision,
+    decisionArtifact,
+  });
+  return {
+    lane,
+    decodeMap,
+    candidate,
+    candidateArtifact,
+    sourceUseAssessment,
+    sourceUseAssessmentArtifact,
+    reviewDecision,
+    decisionArtifact,
+    projectedFieldMap,
+  };
+}
+
+async function seedSourceAndFactualAuthority(
+  projections: readonly ReturnType<typeof projection>[]
+): Promise<void> {
+  await client.transaction(async (transaction) => {
+    await transaction.query(`SET LOCAL session_replication_role='replica'`);
+    const reviewed = reviewedEvaluationSuccessor();
+    const bundleCanonical = canonicalizeAflTradeJson(
+      reviewed.legacy.evidenceBundle.content
+    );
+    const decisionCanonical = canonicalizeAflTradeJson(
+      reviewed.legacy.evaluationDecision.content
+    );
+    await transaction.query(
+      `INSERT INTO outcome_private_reviewed_evidence_bundle
+        (evidence_bundle_id,evidence_scope_key,candidate_count,decision_count,
+         source_capture_count,source_rights_count,created_at,bundle_sha256,
+         bundle_content_canonical_json,bundle_json,registered_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10::jsonb,$7)`,
+      [
+        reviewed.legacy.evidenceBundle.evidenceBundleId,
+        reviewed.legacy.evidenceBundle.content.evidenceScopeKey,
+        reviewed.legacy.evidenceBundle.content.candidateCount,
+        reviewed.legacy.evidenceBundle.content.decisionCount,
+        reviewed.legacy.evidenceBundle.content.sourceCaptures.length,
+        reviewed.legacy.evidenceBundle.content.sourceRightsEvidenceRefs.length,
+        reviewed.legacy.evidenceBundle.content.createdAt,
+        reviewed.legacy.evidenceBundle.evidenceBundleId.split(':').at(-1),
+        bundleCanonical,
+        canonicalizeAflTradeJson(reviewed.legacy.evidenceBundle),
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_private_reviewed_evaluation_decision
+        (decision_id,valuation_scope_key,evidence_bundle_id,status,revision,
+         supersedes_decision_id,reviewer_id,decided_at,decision_sha256,
+         decision_content_canonical_json,decision_json,registered_at)
+       VALUES ($1,$2,$3,'authorized',1,NULL,$4,$5,$6,$7,$8::jsonb,$5)`,
+      [
+        reviewed.legacy.evaluationDecision.decisionId,
+        reviewed.legacy.evaluationDecision.content.valuationScopeKey,
+        reviewed.legacy.evidenceBundle.evidenceBundleId,
+        reviewed.legacy.evaluationDecision.content.reviewerId,
+        reviewed.legacy.evaluationDecision.content.decidedAt,
+        reviewed.legacy.evaluationDecision.decisionId.split(':').at(-1),
+        decisionCanonical,
+        canonicalizeAflTradeJson(reviewed.legacy.evaluationDecision),
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_private_reviewed_evaluation_head
+        (valuation_scope_key,evidence_scope_key,revision,decision_id,
+         evidence_bundle_id,status,updated_at)
+       VALUES ($1,$2,1,$3,$4,'authorized',$5)`,
+      [
+        reviewed.legacy.evaluationDecision.content.valuationScopeKey,
+        reviewed.legacy.evidenceBundle.content.evidenceScopeKey,
+        reviewed.legacy.evaluationDecision.decisionId,
+        reviewed.legacy.evidenceBundle.evidenceBundleId,
+        reviewed.legacy.evaluationDecision.content.decidedAt,
+      ]
+    );
+    for (const source of reviewedCaptureSources) {
+      const sourceRights = source.authority.capture.sourceRights;
+      const sourceArtifact = reviewedSourceArtifact(source.suffix);
+      await transaction.query(
+        `INSERT INTO outcome_source_rights_proposal
+          (rights_artifact_id,provider,dataset,dataset_version,capability_id,
+           proposed_at,content_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb)
+         ON CONFLICT (rights_artifact_id) DO NOTHING`,
+        [
+          sourceRights.rightsArtifactId,
+          sourceRights.content.provider,
+          sourceRights.content.dataset,
+          sourceRights.content.datasetVersion,
+          source.authority.fieldMap.capabilityId,
+          sourceRights.content.proposedAt,
+          canonicalizeAflTradeJson(sourceRights),
+        ]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_artifact_custody
+          (artifact_id,content_sha256,storage_uri,media_type,byte_length,artifact_class,
+           environment,custody_profile_id,created_at,verified_at,custody_json)
+         VALUES ($1,$2,$3,$4,$5,'raw_source','non_production',NULL,$6,$6,'{}'::jsonb)
+         ON CONFLICT (artifact_id) DO NOTHING`,
+        [
+          sourceArtifact.artifactId,
+          sourceArtifact.contentSha256,
+          sourceArtifact.storageUri,
+          sourceArtifact.mediaType,
+          sourceArtifact.byteLength,
+          sourceArtifact.createdAt,
+        ]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_source_capture
+          (capture_id,attempt_id,source_snapshot_id,source_artifact_id,environment,
+           provider,dataset,dataset_version,access_mechanism,capability_id,competition,
+           anchor_season_year,effective_at,captured_at,status,manifest_json)
+         VALUES ($1,$2,$3,$4,'non_production',$5,$6,'fixture','fixture',$7,$8,$9,$10,$10,
+                 'staged',$11::jsonb)
+         ON CONFLICT (capture_id) DO NOTHING`,
+        [
+          id('source-capture', source.suffix),
+          id('source-capture-attempt', source.suffix),
+          id('source-snapshot', source.suffix),
+          sourceArtifact.artifactId,
+          sourceRights.content.provider,
+          sourceRights.content.dataset,
+          source.authority.fieldMap.capabilityId,
+          competition,
+          source.seasonYear,
+          fixtureAt,
+          canonicalizeAflTradeJson({
+            gate0aReceipt: {
+              content: { request: { rightsArtifactId: sourceRights.rightsArtifactId } },
+            },
+            sourceRightsProposal: sourceRights,
+          }),
+        ]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_source_capture_season(capture_id,competition,season_year)
+         VALUES ($1,$2,$3) ON CONFLICT DO NOTHING`,
+        [id('source-capture', source.suffix), competition, source.seasonYear]
+      );
+    }
+    for (const projected of projections) {
+      const { lane, decodeMap } = projected;
+      const sourceRights = lane.authority.capture.sourceRights;
+      const captureId = id('source-capture', lane.suffix);
+      const normalizationRunId = id('provider-normalization-run', lane.suffix);
+      const rowCount = lane.inputKind === 'completed_match_result' ? 1 : 2;
+      const sourceArtifact = reviewedSourceArtifact(lane.suffix);
+      await transaction.query(
+        `INSERT INTO outcome_source_rights_proposal
+          (rights_artifact_id,provider,dataset,dataset_version,capability_id,
+           proposed_at,content_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb)
+         ON CONFLICT (rights_artifact_id) DO NOTHING`,
+        [
+          sourceRights.rightsArtifactId,
+          sourceRights.content.provider,
+          sourceRights.content.dataset,
+          sourceRights.content.datasetVersion,
+          decodeMap.capabilityId,
+          sourceRights.content.proposedAt,
+          canonicalizeAflTradeJson(sourceRights),
+        ]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_artifact_custody
+          (artifact_id,content_sha256,storage_uri,media_type,byte_length,artifact_class,
+           environment,custody_profile_id,created_at,verified_at,custody_json)
+         VALUES ($1,$2,$3,$4,$5,'raw_source','non_production',NULL,$6,$6,'{}'::jsonb)
+         ON CONFLICT (artifact_id) DO NOTHING`,
+        [
+          sourceArtifact.artifactId,
+          sourceArtifact.contentSha256,
+          sourceArtifact.storageUri,
+          sourceArtifact.mediaType,
+          sourceArtifact.byteLength,
+          sourceArtifact.createdAt,
+        ]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_review_decision
+          (decision_id,subject_type,subject_id,decision,rationale,evidence_json,
+           decided_by,decided_at)
+         VALUES ($1,'provider_field_map',$2,'approved',$3,
+                 jsonb_build_object('fieldMapSha256',$4::text),$5,$6)`,
+        [
+          decodeMap.approvalDecisionId,
+          decodeMap.mapId,
+          'Approve the exact disposable HPN source decode map.',
+          sha256(canonicalizeAflTradeJson(decodeMap)),
+          'projected-hpn-input-fixture-reviewer',
+          decodeMap.approvedAt,
+        ]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_provider_field_map
+          (field_map_id,capability_id,fitzroy_version,source_schema_sha256,
+           field_map_sha256,approval_decision_id,approved_at,map_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb)`,
+        [
+          decodeMap.mapId,
+          decodeMap.capabilityId,
+          decodeMap.fitzRoyVersion,
+          decodeMap.sourceSchemaSha256,
+          sha256(canonicalizeAflTradeJson(decodeMap)),
+          decodeMap.approvalDecisionId,
+          decodeMap.approvedAt,
+          canonicalizeAflTradeJson(decodeMap),
+        ]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_source_capture
+          (capture_id,attempt_id,source_snapshot_id,source_artifact_id,environment,
+           provider,dataset,dataset_version,access_mechanism,capability_id,competition,
+           anchor_season_year,effective_at,captured_at,status,manifest_json)
+         VALUES ($1,$2,$3,$4,'non_production',$5,$6,'fixture','fixture',$7,$8,$9,$10,$10,
+                 'approved',$11::jsonb)
+         ON CONFLICT (capture_id) DO NOTHING`,
+        [
+          captureId,
+          id('source-capture-attempt', lane.suffix),
+          id('source-snapshot', lane.suffix),
+          sourceArtifact.artifactId,
+          sourceRights.content.provider,
+          sourceRights.content.dataset,
+          decodeMap.capabilityId,
+          competition,
+          seasonYear,
+          fixtureAt,
+          canonicalizeAflTradeJson({
+            gate0aReceipt: {
+              content: { request: { rightsArtifactId: sourceRights.rightsArtifactId } },
+            },
+            sourceRightsProposal: sourceRights,
+          }),
+        ]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_source_capture_season(capture_id,competition,season_year)
+         VALUES ($1,$2,$3) ON CONFLICT DO NOTHING`,
+        [captureId, competition, seasonYear]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_provider_normalization_run
+          (normalization_run_id,capture_id,field_map_id,decoder_version,normalizer_version,
+           source_rds_sha256,decoded_sha256,receipt_sha256,staging_sha256,status,
+           source_row_count,accepted_row_count,quarantined_row_count,issue_count,
+           identity_candidate_count,match_candidate_count,metric_candidate_count,
+           achievement_candidate_count,started_at,completed_at,finalized_at,receipt_json)
+         VALUES ($1,$2,$3,'fixture','fixture',$4,$5,$6,$7,'staged',$8,$8,0,0,$9,$8,0,0,
+                 $10,$11,$11,'{}'::jsonb)`,
+        [
+          normalizationRunId,
+          captureId,
+          decodeMap.mapId,
+          sha256(`rds:${lane.suffix}`),
+          sha256(`decoded:${lane.suffix}`),
+          sha256(`receipt:${lane.suffix}`),
+          sha256(`staging:${lane.suffix}`),
+          rowCount,
+          lane.inputKind === 'player_match_stats' ? 2 : 0,
+          fixtureAt,
+          finalizedAt,
+        ]
+      );
+      const rows =
+        lane.inputKind === 'completed_match_result'
+          ? [
+              {
+                playerId: null,
+                clubId: null,
+                payload: {
+                  Date: { kind: 'date', value: '2026-08-08' },
+                  'Home.Team': scalar('HOME'),
+                  'Away.Team': scalar('AWAY'),
+                  'Home.Points': scalar(100),
+                  'Away.Points': scalar(80),
+                },
+              },
+            ]
+          : playerIds.map((playerId, index) => ({
+              playerId,
+              clubId: index === 0 ? homeClubId : awayClubId,
+              payload:
+                lane.suffix === 'primary'
+                  ? {
+                      ID: scalar(index + 1),
+                      Date: { kind: 'date', value: '2026-08-08' },
+                      'Home.team': scalar('HOME'),
+                      'Away.team': scalar('AWAY'),
+                      'Playing.for': scalar(index === 0 ? 'HOME' : 'AWAY'),
+                      Goals: scalar(3),
+                      Behinds: scalar(2 + index),
+                      'Hit.Outs': scalar(index),
+                      'Goal.Assists': scalar(1),
+                      'Inside.50s': scalar(10 + index),
+                      Marks: scalar(5),
+                      'Marks.Inside.50': scalar(1),
+                      'Frees.For': scalar(2),
+                      'Frees.Against': scalar(1),
+                      Rebounds: scalar(3),
+                      'One.Percenters': scalar(2),
+                      Clearances: scalar(4),
+                      Tackles: scalar(5),
+                    }
+                  : {
+                      'player.player.player.playerId': scalar(`native-${playerId}`),
+                      providerId: scalar('provider-match-1'),
+                      teamId: scalar(index === 0 ? 'HOME' : 'AWAY'),
+                      goals: scalar(3),
+                      behinds: scalar(2 + index),
+                      hitouts: scalar(index),
+                      goalAssists: scalar(1),
+                      inside50s: scalar(10 + index),
+                      marks: scalar(5),
+                      marksInside50: scalar(1),
+                      freesFor: scalar(2),
+                      freesAgainst: scalar(1),
+                      rebound50s: scalar(3),
+                      onePercenters: scalar(2),
+                      'clearances.totalClearances': scalar(4),
+                      tackles: scalar(5),
+                    },
+            }));
+      for (const [index, row] of rows.entries()) {
+        const decodedRowId = `provider-row:${lane.suffix}:${index}`;
+        await transaction.query(
+          `INSERT INTO outcome_provider_decoded_row
+            (provider_decoded_row_id,normalization_run_id,capture_id,competition,season_year,
+             source_row_number,source_row_sha256,row_status,typed_payload,recorded_at)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,'staged',$8::jsonb,$9)`,
+          [
+            decodedRowId,
+            normalizationRunId,
+            captureId,
+            competition,
+            seasonYear,
+            index + 1,
+            sha256(`row:${lane.suffix}:${index}`),
+            canonicalizeAflTradeJson(row.payload),
+            finalizedAt,
+          ]
+        );
+        await seedResolutionAuthority(transaction, {
+          decodedRowId,
+          provider: lane.authority.capture.sourceRights.content.provider,
+          suffix: `${lane.suffix}:${index}`,
+          playerId: row.playerId,
+        });
+      }
+    }
+
+    await transaction.query(`SET LOCAL session_replication_role='origin'`);
+    const successorBundleCanonical = canonicalizeAflTradeJson(
+      reviewed.successor.evidenceBundle.content
+    );
+    const successorDecisionCanonical = canonicalizeAflTradeJson(
+      reviewed.successor.evaluationDecision.content
+    );
+    await transaction.query(
+      `INSERT INTO outcome_private_reviewed_evidence_bundle
+        (evidence_bundle_id,evidence_scope_key,candidate_count,decision_count,
+         source_capture_count,source_rights_count,created_at,bundle_sha256,
+         bundle_content_canonical_json,bundle_json,registered_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10::jsonb,$7)`,
+      [
+        reviewed.successor.evidenceBundle.evidenceBundleId,
+        reviewed.successor.evidenceBundle.content.evidenceScopeKey,
+        reviewed.successor.evidenceBundle.content.candidateCount,
+        reviewed.successor.evidenceBundle.content.decisionCount,
+        reviewed.successor.evidenceBundle.content.sourceCaptures.length,
+        reviewed.successor.evidenceBundle.content.sourceRightsEvidenceRefs.length,
+        reviewed.successor.evidenceBundle.content.createdAt,
+        reviewed.successor.evidenceBundle.evidenceBundleId.split(':').at(-1),
+        successorBundleCanonical,
+        canonicalizeAflTradeJson(reviewed.successor.evidenceBundle),
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_private_reviewed_evaluation_decision
+        (decision_id,valuation_scope_key,evidence_bundle_id,status,revision,
+         supersedes_decision_id,reviewer_id,decided_at,decision_sha256,
+         decision_content_canonical_json,decision_json,registered_at)
+       VALUES ($1,$2,$3,'authorized',2,$4,$5,$6,$7,$8,$9::jsonb,$6)`,
+      [
+        reviewed.successor.evaluationDecision.decisionId,
+        reviewed.successor.evaluationDecision.content.valuationScopeKey,
+        reviewed.successor.evidenceBundle.evidenceBundleId,
+        reviewed.successor.evaluationDecision.content.supersedesDecisionId,
+        reviewed.successor.evaluationDecision.content.reviewerId,
+        reviewed.successor.evaluationDecision.content.decidedAt,
+        reviewed.successor.evaluationDecision.decisionId.split(':').at(-1),
+        successorDecisionCanonical,
+        canonicalizeAflTradeJson(reviewed.successor.evaluationDecision),
+      ]
+    );
+    await transaction.query(
+      `UPDATE outcome_private_reviewed_evaluation_head
+          SET revision=2,decision_id=$3,evidence_bundle_id=$4,status='authorized',updated_at=$5
+        WHERE valuation_scope_key=$1 AND evidence_scope_key=$2`,
+      [
+        reviewed.successor.evaluationDecision.content.valuationScopeKey,
+        reviewed.successor.evidenceBundle.content.evidenceScopeKey,
+        reviewed.successor.evaluationDecision.decisionId,
+        reviewed.successor.evidenceBundle.evidenceBundleId,
+        reviewed.successor.evaluationDecision.content.decidedAt,
+      ]
+    );
+    await transaction.query(`SET LOCAL session_replication_role='replica'`);
+
+    const factualRunId = id('factual-reconciliation-run', 'projected-input');
+    const policyId = id('factual-reconciliation-policy', 'projected-input');
+    const matchFactId = id('source-fact', 'match');
+    await transaction.query(
+      `INSERT INTO outcome_review_decision
+        (decision_id,subject_type,subject_id,decision,rationale,evidence_json,decided_by,decided_at)
+       VALUES ('review-decision:factual-policy','factual_reconciliation_policy',$1,
+               'approved','Disposable factual-policy approval','{}'::jsonb,
+               'projected-hpn-input-fixture-reviewer',$2)`,
+      [policyId, fixtureAt]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_factual_reconciliation_policy
+        (policy_id,policy_version,environment,competition,valid_from_season,valid_through_season,
+         policy_sha256,approval_decision_id,status,policy_json,created_at)
+       VALUES ($1,'fixture','non_production',$2,$3,$3,$4,$5,'approved','{}'::jsonb,$6)`,
+      [policyId, competition, seasonYear, sha256('policy'), 'review-decision:factual-policy', fixtureAt]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_factual_reconciliation_run
+        (factual_run_id,policy_id,environment,competition,season_year,algorithm_version,
+         input_set_sha256,output_set_sha256,status,source_fact_count,reconciled_fact_count,
+         conflict_count,started_at,completed_at,finalized_at,receipt_json,run_sha256)
+       VALUES ($1,$2,'non_production',$3,$4,'fixture',$5,$6,'approved',3,3,0,$7,$8,$8,
+               '{}'::jsonb,$9)`,
+      [
+        factualRunId,
+        policyId,
+        competition,
+        seasonYear,
+        sha256('factual-input'),
+        sha256('factual-output'),
+        fixtureAt,
+        finalizedAt,
+        sha256('factual-run'),
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_provider_match_universe_fact
+        (match_fact_id,fact_batch_id,normalization_run_id,provider_decoded_row_id,
+         match_candidate_id,match_resolution_decision_id,match_assignment_decision_id,
+         match_identity_id,match_id,competition,season_year,availability,completion_state,
+         reason_code,effective_at,recorded_at,candidate_sha256,candidate_digests_json,
+         fact_sha256,fact_json)
+       VALUES ($1,$2,$3,'provider-row:results:0',$4,$5,$5,$6,$7,$8,$9,'measured',
+               'completed',NULL,$10,$11,$12,'{}'::jsonb,$13,$14::jsonb)`,
+      [
+        matchFactId,
+        id('source-fact-batch', 'fixture'),
+        id('provider-normalization-run', 'results'),
+        id('provider-match-candidate', 'results:0'),
+        id('provider-resolution-decision', 'match:results:0'),
+        'match-identity:fixture',
+        matchId,
+        competition,
+        seasonYear,
+        '2026-08-08T10:00:00.000Z',
+        finalizedAt,
+        sha256('match-candidate'),
+        sha256('match-fact'),
+        canonicalizeAflTradeJson({
+          content: {
+            match: {
+              homeClub: { clubId: homeClubId },
+              awayClub: { clubId: awayClubId },
+            },
+          },
+        }),
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_factual_reconciliation_match_input
+        (factual_run_id,match_fact_id,ordinal,membership_sha256,membership_json)
+       VALUES ($1,$2,1,$3,'{}'::jsonb)`,
+      [factualRunId, matchFactId, sha256('match-membership')]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_acquisition_spell_rule
+        (rule_id,rule_version,definition_json,status,created_at)
+       VALUES ('spell-rule:fixture','fixture','{}'::jsonb,'approved',$1)`,
+      [fixtureAt]
+    );
+    for (const [index, playerId] of playerIds.entries()) {
+      const clubId = index === 0 ? homeClubId : awayClubId;
+      const appearanceFactId = id('source-fact', `appearance:${playerId}`);
+      await transaction.query(
+        `INSERT INTO outcome_provider_player_appearance_fact
+          (appearance_fact_id,fact_batch_id,normalization_run_id,provider_decoded_row_id,
+           appearance_candidate_id,identity_candidate_id,match_candidate_id,
+           player_resolution_decision_id,player_assignment_decision_id,
+           match_resolution_decision_id,match_assignment_decision_id,
+           represented_club_resolution_decision_id,represented_club_assignment_decision_id,
+           player_identity_id,match_identity_id,represented_club_identity_id,player_id,match_id,
+           represented_club_id,competition,season_year,availability,appeared,reason_code,
+           effective_at,recorded_at,candidate_sha256,candidate_digests_json,fact_sha256,fact_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$8,$9,$9,$10,$10,$11,$12,$13,$14,$15,$16,$17,$18,
+                 'measured',TRUE,NULL,$19,$20,$21::text,
+                 jsonb_build_object('appearance',$21::text,'identity',$23::text,'match',$24::text),
+                 $22::text,'{}'::jsonb)`,
+        [
+          appearanceFactId,
+          id('source-fact-batch', 'fixture'),
+          id('provider-normalization-run', 'primary'),
+          `provider-row:primary:${index}`,
+          id('provider-appearance-candidate', playerId),
+          id('provider-identity-candidate', `primary:${index}`),
+          id('provider-match-candidate', `primary:${index}`),
+          id('provider-resolution-decision', `player:primary:${index}`),
+          id('provider-resolution-decision', `match:primary:${index}`),
+          id('provider-resolution-decision', `${index === 0 ? 'home' : 'away'}:primary:${index}`),
+          `player-identity:${playerId}`,
+          'match-identity:fixture',
+          `club-identity:${clubId}`,
+          playerId,
+          matchId,
+          clubId,
+          competition,
+          seasonYear,
+          '2026-08-08T10:00:00.000Z',
+          finalizedAt,
+          sha256(`appearance-candidate:${playerId}`),
+          sha256(`appearance-fact:${playerId}`),
+          sha256(`identity-candidate:${playerId}`),
+          sha256(`match-candidate:${playerId}`),
+        ]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_factual_reconciliation_appearance_input
+          (factual_run_id,appearance_fact_id,ordinal,membership_sha256,membership_json)
+         VALUES ($1,$2,$3,$4,'{}'::jsonb)`,
+        [
+          factualRunId,
+          appearanceFactId,
+          index + 1,
+          sha256(`appearance-membership:${playerId}`),
+        ]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_event_asset
+          (asset_version_id,event_version_id,asset_key,kind,player_id,player_identity_id,
+           pick_id,from_club_id,to_club_id,source_import_row_id,raw_description,status)
+         VALUES ($1,$2,$3,'player',$4,$5,NULL,NULL,$6,$7,'Fixture player','approved')`,
+        [
+          `asset-version:${playerId}`,
+          `event-version:${playerId}`,
+          `asset:${playerId}`,
+          playerId,
+          `player-identity:${playerId}`,
+          clubId,
+          `import-row:${playerId}`,
+        ]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_acquisition_spell_version
+          (spell_version_id,spell_id,version,player_id,club_id,start_event_version_id,
+           start_asset_version_id,start_date,end_date,end_reason,rule_id,status,
+           supersedes_spell_version_id,recorded_at)
+         VALUES ($1,$2,1,$3,$4,$5,$6,'2026-01-01',NULL,NULL,'spell-rule:fixture',
+                 'approved',NULL,$7)`,
+        [
+          id('acquisition-spell-version', playerId),
+          `spell:${playerId}`,
+          playerId,
+          clubId,
+          `event-version:${playerId}`,
+          `asset-version:${playerId}`,
+          fixtureAt,
+        ]
+      );
+    }
+    await transaction.query(
+      `INSERT INTO outcome_club(club_id,current_name,status)
+       VALUES ($1,'Home Club','approved'),($2,'Away Club','approved')`,
+      [homeClubId, awayClubId]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_player(player_id,display_name,status)
+       VALUES ($1,'Home Player','approved'),($2,'Away Player','approved')`,
+      playerIds
+    );
+    await transaction.query(
+      `INSERT INTO outcome_match
+        (match_id,competition,season_year,provider,native_match_id,round_label,match_date,
+         home_club_id,away_club_id)
+       VALUES ($1,$2,$3,NULL,NULL,'Final',$4,$5,$6)`,
+      [matchId, competition, seasonYear, '2026-08-08T10:00:00.000Z', homeClubId, awayClubId]
+    );
+  });
+}
+
+async function seedResolutionAuthority(
+  transaction: Parameters<Parameters<typeof client.transaction>[0]>[0],
+  input: {
+    decodedRowId: string;
+    provider: string;
+    suffix: string;
+    playerId: string | null;
+  }
+): Promise<void> {
+  const matchCandidateId = id('provider-match-candidate', input.suffix);
+  const matchCandidateJson = canonicalizeAflTradeJson({
+    kind: 'match',
+    suffix: input.suffix,
+  });
+  await transaction.query(
+    `INSERT INTO outcome_provider_match_candidate
+      (match_candidate_id,provider_decoded_row_id,provider,native_match_id,round_label,
+       match_date_text,home_club_native_id,home_club_name,away_club_native_id,
+       away_club_name,provider_status,order_independent_sha256,candidate_sha256,
+       candidate_canonical_json,candidate_json)
+       VALUES ($1,$2,$3,'provider-match-1','Final','2026-08-08','HOME','Home Club','AWAY',
+             'Away Club','CONCLUDED',$4,$5,$6::text,$6::jsonb)`,
+    [
+      matchCandidateId,
+      input.decodedRowId,
+      input.provider,
+      sha256(`order:${input.suffix}`),
+      sha256(matchCandidateJson),
+      matchCandidateJson,
+    ]
+  );
+  await seedResolution(transaction, 'match', input.suffix, matchCandidateId, matchId, null);
+  await seedResolution(transaction, 'home', input.suffix, matchCandidateId, homeClubId, null);
+  await seedResolution(transaction, 'away', input.suffix, matchCandidateId, awayClubId, null);
+  if (input.playerId !== null) {
+    const identityCandidateId = id('provider-identity-candidate', input.suffix);
+    const identityCandidateJson = canonicalizeAflTradeJson({
+      kind: 'player',
+      suffix: input.suffix,
+    });
+    await transaction.query(
+      `INSERT INTO outcome_provider_identity_candidate
+        (identity_candidate_id,provider_decoded_row_id,provider,entity_kind,native_entity_id,
+         recorded_name,recorded_club_id,recorded_club_name,locator_sha256,candidate_sha256,
+         candidate_canonical_json,candidate_json)
+       VALUES ($1,$2,$3,'player',$4,$5,NULL,NULL,$6,$7,$8::text,$8::jsonb)`,
+      [
+        identityCandidateId,
+        input.decodedRowId,
+        input.provider,
+        `native-${input.playerId}`,
+        input.playerId,
+        sha256(`locator:${input.suffix}`),
+        sha256(identityCandidateJson),
+        identityCandidateJson,
+      ]
+    );
+    await seedResolution(
+      transaction,
+      'player',
+      input.suffix,
+      identityCandidateId,
+      input.playerId,
+      null
+    );
+  }
+}
+
+async function seedResolution(
+  transaction: Parameters<Parameters<typeof client.transaction>[0]>[0],
+  kind: 'player' | 'match' | 'home' | 'away',
+  suffix: string,
+  candidateId: string,
+  canonicalId: string,
+  unused: null
+): Promise<void> {
+  void unused;
+  const entity = kind === 'player' ? 'player' : kind === 'match' ? 'match' : 'club';
+  const resolutionId = id(`provider-${entity}-resolution`, `${kind}:${suffix}`);
+  const resolutionCaseId = id(`provider-${entity}-resolution-case`, `${kind}:${suffix}`);
+  const decisionId = id('provider-resolution-decision', `${kind}:${suffix}`);
+  const assignmentCaseId = id(
+    'provider-identity-assignment-case',
+    `${kind}:${suffix}`
+  );
+  const assignmentIdentityId = `${entity}-identity:${kind}:${suffix}`;
+  await transaction.query(
+    `INSERT INTO outcome_provider_identity_assignment_head
+      (assignment_case_id,entity_kind,identity_id,revision,decision_id,status,updated_at)
+     VALUES ($1,$2,$3,1,$4,'active',$5)`,
+    [assignmentCaseId, entity, assignmentIdentityId, decisionId, fixtureAt]
+  );
+  if (kind === 'player') {
+    await transaction.query(
+      `INSERT INTO outcome_provider_player_resolution
+        (resolution_id,resolution_case_id,identity_candidate_id,revision,outcome,
+         assignment_case_id,assignment_entity_kind,assignment_identity_id,assignment_revision,
+         assignment_status,player_identity_id,player_id,decision_id,proposal_id,
+         resolution_sha256,decided_at,effective_at,decision_json)
+       VALUES ($1,$2,$3,1,'approved',$4,'player',$5,1,'active',$5,$6,$7,$8,$9,$10,$10,'{}'::jsonb)`,
+      [resolutionId, resolutionCaseId, candidateId, assignmentCaseId, assignmentIdentityId, canonicalId, decisionId, `proposal:${kind}:${suffix}`, sha256(`resolution:${kind}:${suffix}`), fixtureAt]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_provider_player_resolution_head
+        (resolution_case_id,identity_candidate_id,revision,resolution_id,updated_at)
+       VALUES ($1,$2,1,$3,$4)`,
+      [resolutionCaseId, candidateId, resolutionId, fixtureAt]
+    );
+    return;
+  }
+  if (kind === 'match') {
+    await transaction.query(
+      `INSERT INTO outcome_provider_match_resolution
+        (resolution_id,resolution_case_id,match_candidate_id,revision,outcome,
+         assignment_case_id,assignment_entity_kind,assignment_identity_id,assignment_revision,
+         assignment_status,match_identity_id,match_id,decision_id,proposal_id,
+         resolution_sha256,decided_at,effective_at,decision_json)
+       VALUES ($1,$2,$3,1,'approved',$4,'match',$5,1,'active',$5,$6,$7,$8,$9,$10,$10,'{}'::jsonb)`,
+      [resolutionId, resolutionCaseId, candidateId, assignmentCaseId, assignmentIdentityId, canonicalId, decisionId, `proposal:${kind}:${suffix}`, sha256(`resolution:${kind}:${suffix}`), fixtureAt]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_provider_match_resolution_head
+        (resolution_case_id,match_candidate_id,revision,resolution_id,updated_at)
+       VALUES ($1,$2,1,$3,$4)`,
+      [resolutionCaseId, candidateId, resolutionId, fixtureAt]
+    );
+    return;
+  }
+  await transaction.query(
+    `INSERT INTO outcome_provider_club_resolution
+      (resolution_id,resolution_case_id,occurrence_source,match_candidate_id,side,revision,
+       outcome,assignment_case_id,assignment_entity_kind,assignment_identity_id,
+       assignment_revision,assignment_status,club_identity_id,club_id,valid_from_season,
+       valid_through_season,decision_id,proposal_id,resolution_sha256,decided_at,effective_at,
+       decision_json)
+     VALUES ($1,$2,'match_candidate',$3,$4,1,'approved',$5,'club',$6,1,'active',$6,$7,
+             $8,$8,$9,$10,$11,$12,$12,'{}'::jsonb)`,
+    [resolutionId, resolutionCaseId, candidateId, kind, assignmentCaseId, assignmentIdentityId, canonicalId, seasonYear, decisionId, `proposal:${kind}:${suffix}`, sha256(`resolution:${kind}:${suffix}`), fixtureAt]
+  );
+  await transaction.query(
+    `INSERT INTO outcome_provider_club_resolution_head
+      (resolution_case_id,revision,resolution_id,updated_at)
+     VALUES ($1,1,$2,$3)`,
+    [resolutionCaseId, resolutionId, fixtureAt]
+  );
+}
+
+async function enqueueAndClaim(operationKey: string) {
+  const requestId = await client.transaction(async (transaction) => {
+    await transaction.query('SET LOCAL ROLE afl_trade_private_valuation_scheduler_owner');
+    const result = await transaction.query<{ request_id: string }>(
+      `SELECT enqueue_outcome_private_valuation_dispatch(
+         'afl-men:2026-trades','ad_hoc',$1::timestamptz,$2) AS request_id`,
+      [fixtureAt, operationKey]
+    );
+    return result.rows[0]!.request_id;
+  });
+  const claim = await new PostgresAflTradePrivateValuationScheduleRepository(client).claim(
+    'system:weekly-valuation-coordinator',
+    requestId
+  );
+  if (claim === null) throw new TypeError('The HPN coordinator fixture did not claim its dispatch.');
+  return { requestId, claim };
+}
+
+async function retainHpnCaptureBindings(
+  request: Awaited<ReturnType<typeof enqueueAndClaim>>['claim']['request'],
+  claim: Awaited<ReturnType<typeof enqueueAndClaim>>['claim']
+) {
+  const bindings = lanes.map((lane) => {
+    const sourceRights = lane.authority.capture.sourceRights;
+    const content = {
+      schemaVersion: AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_V2_SCHEMA_VERSION,
+      request,
+      sourceRole: lane.sourceRole,
+      dispatchClaimId: claim.claimId,
+      attemptSequence: 1,
+      attemptNumber: 1,
+      sourcePlan: {
+        provider: sourceRights.content.provider,
+        dataset: sourceRights.content.dataset,
+        capabilityId: lane.authority.fieldMap.capabilityId,
+        competition,
+        seasonYear,
+        fieldMapId: lane.authority.fieldMap.mapId,
+        gate0AReceiptId: id('gate0a-evaluation', lane.suffix),
+        rightsArtifactId: sourceRights.rightsArtifactId,
+      },
+      sourceCaptureAttemptId: id('source-capture-attempt', lane.suffix),
+      captureReceiptId: id('fitzroy-capture', lane.suffix),
+      snapshotId: id('source-snapshot', lane.suffix),
+      sourceCaptureId: id('source-capture', lane.suffix),
+      normalizationRunId: id('provider-normalization-run', lane.suffix),
+      acceptedAt: projectionAt,
+      environment: 'non_production' as const,
+      publicationEligible: false as const,
+      limitation: AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_LIMITATION,
+    };
+    return aflTradePrivateValuationCaptureBindingSchema.parse({
+      bindingId: createAflTradeContentAddress('private-valuation-capture-binding', content),
+      content,
+    });
+  });
+  await client.transaction(async (transaction) => {
+    for (const binding of bindings) {
+      if (
+        binding.content.schemaVersion !==
+        AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_V2_SCHEMA_VERSION
+      ) {
+        throw new TypeError('The HPN fixture requires role-aware capture custody.');
+      }
+      await transaction.query(
+        `INSERT INTO outcome_private_valuation_capture_binding
+          (binding_id,request_id,dispatch_claim_id,attempt_sequence,attempt_number,
+           source_capture_id,source_capture_attempt_id,source_snapshot_id,capture_receipt_id,
+           normalization_run_id,accepted_at,binding_json,source_role)
+         VALUES ($1,$2,$3,1,1,$4,$5,$6,$7,$8,$9,$10::jsonb,$11)`,
+        [
+          binding.bindingId,
+          request.requestId,
+          claim.claimId,
+          binding.content.sourceCaptureId,
+          binding.content.sourceCaptureAttemptId,
+          binding.content.snapshotId,
+          binding.content.captureReceiptId,
+          binding.content.normalizationRunId,
+          binding.content.acceptedAt,
+          canonicalizeAflTradeJson(binding),
+          binding.content.sourceRole,
+        ]
+      );
+    }
+  });
+  return bindings;
+}
+
+function factualOutput(requestId: string) {
+  const factualRunId = id('factual-reconciliation-run', 'projected-input');
+  return createAflTradePrivateValuationFactualOutput({
+    requestId,
+    valuationScopeKey: 'afl-men:2026-trades',
+    captureBindingId: id('private-valuation-capture-binding', 'factual-input'),
+    sourceAdmissionId: id('private-valuation-source-admission', 'factual-input'),
+    normalizationRunId: id('provider-normalization-run', 'primary'),
+    factBatch: {
+      batchId: id('source-fact-batch', 'fixture'),
+      batchSha256: sha256('fixture'),
+    },
+    reconciliation: {
+      factualRunId,
+      runSha256: factualRunId.slice('factual-reconciliation-run:'.length),
+      outputSetSha256: sha256('factual-output'),
+      finalizedAt,
+    },
+    spellMetricBatches: [
+      {
+        batchId: id('acquisition-spell-metric-batch', 'fixture'),
+        batchSha256: sha256('fixture'),
+      },
+    ],
+    candidate: {
+      candidateId: id('factual-release-candidate', 'fixture'),
+      candidateSha256: sha256('fixture'),
+      memberSetSha256: sha256('factual-members'),
+    },
+    factualRelease: {
+      releaseId: id('outcome-release', 'fixture'),
+      releaseSha256: sha256('fixture'),
+    },
+    preparedAt: projectionAt,
+  });
+}
+
+async function attemptProjectedRun(input: {
+  readonly fieldMapId: string;
+  readonly normalizationRunId: string;
+  readonly effectiveThrough: string;
+  readonly tamper?: 'candidate' | 'decision';
+}): Promise<void> {
+  await client.transaction(async (transaction) => {
+    if (input.tamper !== undefined) {
+      await transaction.query(`SET LOCAL session_replication_role='replica'`);
+      if (input.tamper === 'candidate') {
+        await transaction.query(
+          `WITH target AS (
+             SELECT candidate.candidate_id,candidate.created_at,
+                    jsonb_set(candidate.candidate_json,'{content,purpose}',
+                      to_jsonb('forged_candidate_purpose'::text),false) AS forged_json
+               FROM outcome_hpn_field_map_candidate candidate
+               JOIN outcome_hpn_projected_field_map map
+                 ON map.candidate_id=candidate.candidate_id
+              WHERE map.field_map_id=$1
+           ), addressed AS (
+             SELECT target.*,
+                    outcome_afl_trade_canonical_json(forged_json) AS canonical,
+                    encode(sha256(convert_to(
+                      outcome_afl_trade_canonical_json(forged_json),'UTF8')),'hex') AS artifact_sha
+               FROM target
+           )
+           UPDATE outcome_hpn_field_map_candidate candidate
+              SET candidate_json=addressed.forged_json,
+                  candidate_canonical_json=addressed.canonical,
+                  candidate_artifact_json=jsonb_build_object(
+                    'artifactId','artifact:'||addressed.artifact_sha,
+                    'contentSha256',addressed.artifact_sha,
+                    'storageUri','artifact://sha256/'||addressed.artifact_sha,
+                    'mediaType','application/json',
+                    'byteLength',octet_length(convert_to(addressed.canonical,'UTF8')),
+                    'createdAt',to_char(addressed.created_at AT TIME ZONE 'UTC',
+                      'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'))
+             FROM addressed WHERE candidate.candidate_id=addressed.candidate_id`,
+          [input.fieldMapId]
+        );
+      } else {
+        await transaction.query(
+          `WITH target AS (
+             SELECT decision.decision_id,decision.decided_at,
+                    jsonb_set(decision.decision_json,'{content,purpose}',
+                      to_jsonb('forged_review_purpose'::text),false) AS forged_json
+               FROM outcome_hpn_field_map_review_decision decision
+               JOIN outcome_hpn_projected_field_map map
+                 ON map.approval_decision_id=decision.decision_id
+              WHERE map.field_map_id=$1
+           ), addressed AS (
+             SELECT target.*,
+                    outcome_afl_trade_canonical_json(forged_json) AS canonical,
+                    encode(sha256(convert_to(
+                      outcome_afl_trade_canonical_json(forged_json),'UTF8')),'hex') AS artifact_sha
+               FROM target
+           )
+           UPDATE outcome_hpn_field_map_review_decision decision
+              SET decision_json=addressed.forged_json,
+                  decision_canonical_json=addressed.canonical,
+                  decision_artifact_json=jsonb_build_object(
+                    'artifactId','artifact:'||addressed.artifact_sha,
+                    'contentSha256',addressed.artifact_sha,
+                    'storageUri','artifact://sha256/'||addressed.artifact_sha,
+                    'mediaType','application/json',
+                    'byteLength',octet_length(convert_to(addressed.canonical,'UTF8')),
+                    'createdAt',to_char(addressed.decided_at AT TIME ZONE 'UTC',
+                      'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'))
+             FROM addressed WHERE decision.decision_id=addressed.decision_id`,
+          [input.fieldMapId]
+        );
+      }
+      await transaction.query(`SET LOCAL session_replication_role='origin'`);
+    }
+    const map = await transaction.query<{ map_json: unknown }>(
+      `SELECT map_json FROM outcome_hpn_projected_field_map WHERE field_map_id=$1`,
+      [input.fieldMapId]
+    );
+    const parent = await transaction.query<{ input_set_id: string }>(
+      `WITH original AS (
+         SELECT * FROM outcome_hpn_pav_input_set
+          WHERE status='finalized' ORDER BY created_at,input_set_id LIMIT 1
+       ), trusted AS (
+         SELECT date_trunc('milliseconds',transaction_timestamp()) AS trusted_at
+       ), prepared AS (
+         SELECT original.*,trusted.trusted_at,
+                jsonb_set(
+                  jsonb_set(
+                    jsonb_set(original.input_set_json->'content','{fieldMaps}',
+                      jsonb_build_array($1::jsonb),false),
+                    '{effectiveThrough}',to_jsonb($2::text),false),
+                  '{createdAt}',to_jsonb(to_char(trusted.trusted_at AT TIME ZONE 'UTC',
+                    'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')),false
+                ) AS next_content
+           FROM original CROSS JOIN trusted
+       ), addressed AS (
+         SELECT prepared.*,
+                outcome_afl_trade_canonical_json(next_content) AS next_canonical,
+                encode(sha256(convert_to(
+                  outcome_afl_trade_canonical_json(next_content),'UTF8')),'hex') AS next_sha256
+           FROM prepared
+       )
+       INSERT INTO outcome_hpn_pav_input_set
+         (input_set_id,factual_run_id,factual_input_set_sha256,factual_finalized_at,
+          environment,competition,season_year,method_id,effective_through,created_at,
+          input_set_sha256,status,source_run_count,source_row_count,completed_match_count,
+          result_row_count,primary_player_row_count,corroborating_player_row_count,
+          input_set_canonical_json,input_set_json,finalized_at)
+       SELECT 'hpn-pav-input-set:'||next_sha256,factual_run_id,factual_input_set_sha256,
+              factual_finalized_at,environment,competition,season_year,method_id,
+              $2::timestamptz,trusted_at,next_sha256,'building',source_run_count,
+              source_row_count,completed_match_count,result_row_count,
+              primary_player_row_count,corroborating_player_row_count,next_canonical,
+              jsonb_build_object('inputSetId','hpn-pav-input-set:'||next_sha256,
+                                 'content',next_content),NULL
+         FROM addressed
+       RETURNING input_set_id`,
+      [map.rows[0]!.map_json, input.effectiveThrough]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_hpn_pav_input_run
+        (input_set_id,ordinal,normalization_run_id,field_map_id,
+         projected_field_map_id,input_kind,role)
+       SELECT $1,0,$2,NULL,$3,map.input_kind,NULL
+         FROM outcome_hpn_projected_field_map map WHERE map.field_map_id=$3`,
+      [parent.rows[0]!.input_set_id, input.normalizationRunId, input.fieldMapId]
+    );
+  });
+}
+
+async function prepareShortLivedResultsInput(): Promise<{
+  readonly expiresAt: string;
+  readonly inputSetId: string;
+  readonly normalizationRunId: string;
+  readonly projectedFieldMapId: string;
+}> {
+  const trustedExpiry = await client.query<{ expires_at: Date | string }>(
+    `SELECT date_trunc('milliseconds',clock_timestamp()+interval '15 seconds') AS expires_at`
+  );
+  const expiresAt = new Date(trustedExpiry.rows[0]!.expires_at).toISOString();
+  const baseResults = createLocalAflTradeAflTablesResultsAuthority(seasonYear);
+  const rightsContent = { ...baseResults.capture.sourceRights.content, termsExpireAt: expiresAt };
+  const sourceRights = aflTradeSourceRightsProposalSchema.parse({
+    rightsArtifactId: createAflTradeContentAddress('source-rights', rightsContent),
+    content: rightsContent,
+  });
+  const suffix = 'results-short-lived';
+  const authority = {
+    ...baseResults,
+    capture: {
+      ...baseResults.capture,
+      sourceRights,
+      gateRequest: {
+        ...baseResults.capture.gateRequest,
+        rightsArtifactId: sourceRights.rightsArtifactId,
+      },
+    },
+  } satisfies Lane['authority'];
+  const expiringLane: Lane = {
+    ...lanes[0]!,
+    suffix,
+    authority,
+  };
+  const expiringReviewedSources = [
+    ...reviewedCaptureSources.filter(
+      ({ authority: candidate }) =>
+        candidate.fieldMap.capabilityId !== 'afl-tables-results'
+    ),
+    { suffix: `reviewed-${suffix}`, seasonYear, authority },
+  ] satisfies readonly ReviewedCaptureSource[];
+  const reviewed = reviewedEvaluationSuccessor(
+    'afl-men:2026-trades',
+    expiringReviewedSources
+  );
+  const projected = [
+    projection(expiringLane, 'afl-men:2026-trades', reviewed.successor),
+    ...lanes.slice(1).map((lane) =>
+      projection(lane, 'afl-men:2026-trades', reviewed.successor)
+    ),
+  ];
+  const reviewedCaptureId = id('source-capture', `reviewed-${suffix}`);
+  const captureId = id('source-capture', suffix);
+  const normalizationRunId = id('provider-normalization-run', suffix);
+  const sourceArtifact = reviewedSourceArtifact(`reviewed-${suffix}`);
+  const laneSourceArtifact = reviewedSourceArtifact(suffix);
+
+  await client.transaction(async (transaction) => {
+    await transaction.query(`SET LOCAL session_replication_role='replica'`);
+    await transaction.query(
+      `UPDATE outcome_private_reviewed_evaluation_head head
+          SET revision=legacy.revision,decision_id=legacy.decision_id,
+              evidence_bundle_id=legacy.evidence_bundle_id,status=legacy.status,
+              updated_at=legacy.decided_at
+         FROM outcome_private_reviewed_evaluation_decision legacy
+        WHERE head.valuation_scope_key=legacy.valuation_scope_key
+          AND head.evidence_scope_key='afl-player-match-reviewed-2021-2026'
+          AND legacy.revision=1`
+    );
+    await transaction.query(
+      `INSERT INTO outcome_source_rights_proposal
+        (rights_artifact_id,provider,dataset,dataset_version,capability_id,
+         proposed_at,content_json)
+       VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb)`,
+      [
+        sourceRights.rightsArtifactId,
+        sourceRights.content.provider,
+        sourceRights.content.dataset,
+        sourceRights.content.datasetVersion,
+        authority.fieldMap.capabilityId,
+        sourceRights.content.proposedAt,
+        canonicalizeAflTradeJson(sourceRights),
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_artifact_custody
+        (artifact_id,content_sha256,storage_uri,media_type,byte_length,artifact_class,
+         environment,custody_profile_id,created_at,verified_at,custody_json)
+       VALUES ($1,$2,$3,$4,$5,'raw_source','non_production',NULL,$6,$6,'{}'::jsonb)`,
+      [
+        sourceArtifact.artifactId,
+        sourceArtifact.contentSha256,
+        sourceArtifact.storageUri,
+        sourceArtifact.mediaType,
+        sourceArtifact.byteLength,
+        sourceArtifact.createdAt,
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_source_capture
+        (capture_id,attempt_id,source_snapshot_id,source_artifact_id,environment,
+         provider,dataset,dataset_version,access_mechanism,capability_id,competition,
+         anchor_season_year,effective_at,captured_at,status,manifest_json)
+       VALUES ($1,$2,$3,$4,'non_production',$5,$6,'fixture','fixture',$7,$8,$9,$10,$10,
+               'staged',$11::jsonb)`,
+      [
+        reviewedCaptureId,
+        id('source-capture-attempt', `reviewed-${suffix}`),
+        id('source-snapshot', `reviewed-${suffix}`),
+        sourceArtifact.artifactId,
+        sourceRights.content.provider,
+        sourceRights.content.dataset,
+        authority.fieldMap.capabilityId,
+        competition,
+        seasonYear,
+        fixtureAt,
+        canonicalizeAflTradeJson({
+          gate0aReceipt: {
+            content: { request: { rightsArtifactId: sourceRights.rightsArtifactId } },
+          },
+          sourceRightsProposal: sourceRights,
+        }),
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_source_capture_season(capture_id,competition,season_year)
+       VALUES ($1,$2,$3)`,
+      [reviewedCaptureId, competition, seasonYear]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_artifact_custody
+        (artifact_id,content_sha256,storage_uri,media_type,byte_length,artifact_class,
+         environment,custody_profile_id,created_at,verified_at,custody_json)
+       VALUES ($1,$2,$3,$4,$5,'raw_source','non_production',NULL,$6,$6,'{}'::jsonb)`,
+      [
+        laneSourceArtifact.artifactId,
+        laneSourceArtifact.contentSha256,
+        laneSourceArtifact.storageUri,
+        laneSourceArtifact.mediaType,
+        laneSourceArtifact.byteLength,
+        laneSourceArtifact.createdAt,
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_source_capture
+        (capture_id,attempt_id,source_snapshot_id,source_artifact_id,environment,
+         provider,dataset,dataset_version,access_mechanism,capability_id,competition,
+         anchor_season_year,effective_at,captured_at,status,manifest_json)
+       VALUES ($1,$2,$3,$4,'non_production',$5,$6,'fixture','fixture',$7,$8,$9,$10,$10,
+               'approved',$11::jsonb)`,
+      [
+        captureId,
+        id('source-capture-attempt', suffix),
+        id('source-snapshot', suffix),
+        laneSourceArtifact.artifactId,
+        sourceRights.content.provider,
+        sourceRights.content.dataset,
+        authority.fieldMap.capabilityId,
+        competition,
+        seasonYear,
+        fixtureAt,
+        canonicalizeAflTradeJson({
+          gate0aReceipt: {
+            content: { request: { rightsArtifactId: sourceRights.rightsArtifactId } },
+          },
+          sourceRightsProposal: sourceRights,
+        }),
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_source_capture_season(capture_id,competition,season_year)
+       VALUES ($1,$2,$3)`,
+      [captureId, competition, seasonYear]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_provider_normalization_run
+        (normalization_run_id,capture_id,field_map_id,decoder_version,normalizer_version,
+         source_rds_sha256,decoded_sha256,receipt_sha256,staging_sha256,status,
+         source_row_count,accepted_row_count,quarantined_row_count,issue_count,
+         identity_candidate_count,match_candidate_count,metric_candidate_count,
+         achievement_candidate_count,started_at,completed_at,finalized_at,receipt_json)
+       VALUES ($1,$2,$3,'fixture','fixture',$4,$5,$6,$7,'staged',1,1,0,0,0,1,0,0,
+               $8,$9,$9,'{}'::jsonb)`,
+      [
+        normalizationRunId,
+        captureId,
+        authority.fieldMap.mapId,
+        sha256(`rds:${suffix}`),
+        sha256(`decoded:${suffix}`),
+        sha256(`receipt:${suffix}`),
+        sha256(`staging:${suffix}`),
+        fixtureAt,
+        finalizedAt,
+      ]
+    );
+    const decodedRowId = `provider-row:${suffix}:0`;
+    await transaction.query(
+      `INSERT INTO outcome_provider_decoded_row
+        (provider_decoded_row_id,normalization_run_id,capture_id,competition,season_year,
+         source_row_number,source_row_sha256,row_status,typed_payload,recorded_at)
+       VALUES ($1,$2,$3,$4,$5,1,$6,'staged',$7::jsonb,$8)`,
+      [
+        decodedRowId,
+        normalizationRunId,
+        captureId,
+        competition,
+        seasonYear,
+        sha256(`row:${suffix}:0`),
+        canonicalizeAflTradeJson({
+          Date: { kind: 'date', value: '2026-08-08' },
+          'Home.Team': scalar('HOME'),
+          'Away.Team': scalar('AWAY'),
+          'Home.Points': scalar(100),
+          'Away.Points': scalar(80),
+        }),
+        finalizedAt,
+      ]
+    );
+    await seedResolutionAuthority(transaction, {
+      decodedRowId,
+      provider: sourceRights.content.provider,
+      suffix: `${suffix}:0`,
+      playerId: null,
+    });
+    await transaction.query(
+      `UPDATE outcome_private_reviewed_evaluation_decision
+          SET supersedes_decision_id=(
+            SELECT decision_id
+              FROM outcome_private_reviewed_evaluation_decision
+             WHERE valuation_scope_key='afl-men:2025-trades' AND revision=1)
+        WHERE valuation_scope_key='afl-men:2026-trades' AND revision=2`
+    );
+    await transaction.query(`SET LOCAL session_replication_role='origin'`);
+    const bundleCanonical = canonicalizeAflTradeJson(reviewed.successor.evidenceBundle.content);
+    const decisionCanonical = canonicalizeAflTradeJson(
+      reviewed.successor.evaluationDecision.content
+    );
+    await transaction.query(
+      `INSERT INTO outcome_private_reviewed_evidence_bundle
+        (evidence_bundle_id,evidence_scope_key,candidate_count,decision_count,
+         source_capture_count,source_rights_count,created_at,bundle_sha256,
+         bundle_content_canonical_json,bundle_json,registered_at)
+       VALUES ($1,$2,$3,$4,7,3,$5,$6,$7,$8::jsonb,$5)`,
+      [
+        reviewed.successor.evidenceBundle.evidenceBundleId,
+        reviewed.successor.evidenceBundle.content.evidenceScopeKey,
+        reviewed.successor.evidenceBundle.content.candidateCount,
+        reviewed.successor.evidenceBundle.content.decisionCount,
+        reviewed.successor.evidenceBundle.content.createdAt,
+        reviewed.successor.evidenceBundle.evidenceBundleId.split(':').at(-1),
+        bundleCanonical,
+        canonicalizeAflTradeJson(reviewed.successor.evidenceBundle),
+      ]
+    );
+    await transaction.query(
+      `INSERT INTO outcome_private_reviewed_evaluation_decision
+        (decision_id,valuation_scope_key,evidence_bundle_id,status,revision,
+         supersedes_decision_id,reviewer_id,decided_at,decision_sha256,
+         decision_content_canonical_json,decision_json,registered_at)
+       VALUES ($1,$2,$3,'authorized',2,$4,$5,$6,$7,$8,$9::jsonb,$6)`,
+      [
+        reviewed.successor.evaluationDecision.decisionId,
+        reviewed.successor.evaluationDecision.content.valuationScopeKey,
+        reviewed.successor.evidenceBundle.evidenceBundleId,
+        reviewed.successor.evaluationDecision.content.supersedesDecisionId,
+        reviewed.successor.evaluationDecision.content.reviewerId,
+        reviewed.successor.evaluationDecision.content.decidedAt,
+        reviewed.successor.evaluationDecision.decisionId.split(':').at(-1),
+        decisionCanonical,
+        canonicalizeAflTradeJson(reviewed.successor.evaluationDecision),
+      ]
+    );
+    await transaction.query(
+      `UPDATE outcome_private_reviewed_evaluation_head
+          SET revision=2,decision_id=$3,evidence_bundle_id=$4,status='authorized',updated_at=$5
+        WHERE valuation_scope_key=$1 AND evidence_scope_key=$2`,
+      [
+        reviewed.successor.evaluationDecision.content.valuationScopeKey,
+        reviewed.successor.evidenceBundle.content.evidenceScopeKey,
+        reviewed.successor.evaluationDecision.decisionId,
+        reviewed.successor.evidenceBundle.evidenceBundleId,
+        reviewed.successor.evaluationDecision.content.decidedAt,
+      ]
+    );
+  });
+
+  const fieldMapAuthority = new PostgresAflTradeHpnProjectedFieldMapAuthority(client);
+  for (const item of projected) await fieldMapAuthority.registerApprovedProjection(item);
+  const original = await client.query<{
+    factual_run_id: string;
+    method_id: string;
+  }>(
+    `SELECT factual_run_id,method_id FROM outcome_hpn_pav_input_set
+      WHERE status='finalized' ORDER BY created_at,input_set_id LIMIT 1`
+  );
+  const inputSet = await new PostgresAflTradeHpnPavInputRepository(client)
+    .buildAndPersistSeasonInputSet(
+      {
+        environment: 'non_production',
+        competition,
+        seasonYear,
+        methodId: original.rows[0]!.method_id,
+        factualRunId: original.rows[0]!.factual_run_id,
+        effectiveThrough: '2026-08-09T23:59:59.999Z',
+        sources: [
+          {
+            normalizationRunId,
+            fieldMapId: projected[0]!.projectedFieldMap!.fieldMapId,
+            inputKind: 'completed_match_result',
+            role: null,
+          },
+          ...projected.slice(1).map((item, index) => ({
+            normalizationRunId: id(
+              'provider-normalization-run',
+              index === 0 ? 'primary' : 'corroborating'
+            ),
+            fieldMapId: item.projectedFieldMap!.fieldMapId,
+            inputKind: 'player_match_stats' as const,
+            role: index === 0 ? ('primary' as const) : ('corroborating' as const),
+          })),
+        ],
+      },
+      { environment: 'non_production' }
+    );
+  return {
+    expiresAt,
+    inputSetId: inputSet.inputSet.inputSetId,
+    normalizationRunId,
+    projectedFieldMapId: projected[0]!.projectedFieldMap!.fieldMapId,
+  };
+}
+
+beforeAll(async () => {
+  await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
+  runOutcomesPrismaTestCommand(['migrate', 'deploy'], { databaseUrl: scopedDatabaseUrl() });
+});
+
+afterAll(async () => {
+  const failures: unknown[] = [];
+  try {
+    await outcomesPool.end();
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await adminPool.end();
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Projected HPN input PostgreSQL cleanup failed.');
+  }
+});
+
+describe.sequential('private valuation HPN preparation with projected authority in PostgreSQL', () => {
+  it('runs the real coordinator through three current maps, v2 input, calculation, and restart replay', async () => {
+    const projections = lanes.map((lane) => projection(lane));
+    const authority = new PostgresAflTradeHpnProjectedFieldMapAuthority(client);
+    for (const projected of projections) {
+      await authority.registerApprovedProjection(projected);
+    }
+    await seedSourceAndFactualAuthority(projections);
+    const exactAuthorities = await client.query<{ field_map_id: string; exact: boolean }>(
+      `SELECT field_map_id,
+              outcome_hpn_projected_field_map_authority_is_exact(
+                field_map_id,$1::timestamptz) AS exact
+         FROM outcome_hpn_projected_field_map ORDER BY field_map_id`,
+      [projectionAt]
+    );
+    expect(exactAuthorities.rows).toEqual(
+      expect.arrayContaining(
+        projections.map(({ projectedFieldMap }) => ({
+          field_map_id: projectedFieldMap!.fieldMapId,
+          exact: true,
+        }))
+      )
+    );
+    const { requestId, claim } = await enqueueAndClaim('projected-hpn-coordinator');
+    const bindings = await retainHpnCaptureBindings(claim.request, claim);
+    const output = factualOutput(requestId);
+    const methodBytes = new TextEncoder().encode('<html>Disposable HPN method evidence</html>');
+    const method = createAflTradeHpnPavMethod({
+      sourceArtifact: createAflTradeByteArtifactRef(
+        methodBytes,
+        'text/html',
+        projectionAt
+      ),
+      sourceBytes: methodBytes,
+      capturedAt: projectionAt,
+    });
+    await client.query(
+      `INSERT INTO outcome_artifact_custody
+        (artifact_id,content_sha256,storage_uri,media_type,byte_length,artifact_class,
+         environment,custody_profile_id,created_at,verified_at,custody_json)
+       VALUES ($1,$2,$3,$4,$5,'derived_private','non_production',NULL,$6,$6,'{}'::jsonb)`,
+      [
+        method.content.sourceArtifact.artifactId,
+        method.content.sourceArtifact.contentSha256,
+        method.content.sourceArtifact.storageUri,
+        method.content.sourceArtifact.mediaType,
+        method.content.sourceArtifact.byteLength,
+        method.content.sourceArtifact.createdAt,
+      ]
+    );
+    const methodAuthority = { loadExact: async () => ({ method, sourceBytes: methodBytes }) };
+    const captureSource = async () => {
+      throw new Error('Restart-safe HPN preparation must load accepted capture custody.');
+    };
+    const preparationInput = {
+      requestId,
+      claim: { claimId: claim.claimId, leaseToken: claim.leaseToken },
+    };
+    const first = await new PostgresAflTradePrivateValuationHpnPreparation(client, {
+      factualPreparation: { prepare: async () => ({ state: 'prepared' as const, output }) },
+      methodId: method.methodId,
+      methodAuthority,
+      captureSource,
+    }).prepare(preparationInput);
+    const replay = await new PostgresAflTradePrivateValuationHpnPreparation(client, {
+      factualPreparation: {
+        prepare: async () => ({ state: 'already_prepared' as const, output }),
+      },
+      methodId: method.methodId,
+      methodAuthority,
+      captureSource,
+    }).prepare(preparationInput);
+
+    expect(first).toMatchObject({
+      state: 'prepared',
+      requestId,
+      factualOutputId: output.outputId,
+      inputSetId: expect.stringMatching(/^hpn-pav-input-set:[a-f0-9]{64}$/),
+      calculationId: expect.stringMatching(/^hpn-pav-season:[a-f0-9]{64}$/),
+      captureBindingIds: bindings.map(({ bindingId }) => bindingId),
+      publicationEligible: false,
+    });
+    expect(replay).toEqual({ ...first, state: 'already_prepared' });
+    const stored = await client.query<{
+      input_status: string;
+      calculation_status: string;
+      legacy_maps: number;
+      projected_maps: number;
+    }>(
+      `SELECT input.status::text AS input_status,
+              calculation.status::text AS calculation_status,
+              count(run.field_map_id)::integer AS legacy_maps,
+              count(run.projected_field_map_id)::integer AS projected_maps
+         FROM outcome_hpn_pav_input_set input
+         JOIN outcome_hpn_pav_input_run run ON run.input_set_id=input.input_set_id
+         JOIN outcome_hpn_pav_calculation calculation
+           ON calculation.input_set_id=input.input_set_id
+        WHERE input.input_set_id=$1
+        GROUP BY input.status,calculation.status`,
+      [first.inputSetId]
+    );
+    expect(stored.rows).toEqual([
+      {
+        input_status: 'finalized',
+        calculation_status: 'finalized',
+        legacy_maps: 0,
+        projected_maps: 3,
+      },
+    ]);
+  });
+
+  it('rejects a reviewed-evidence successor with duplicated members behind claimed 7/3 counts', async () => {
+    const before = await client.query<{ total: number }>(
+      `SELECT count(*)::integer AS total
+         FROM outcome_private_reviewed_evidence_bundle`
+    );
+    await expect(
+      client.transaction(async (transaction) => {
+        await transaction.query(`SET LOCAL session_replication_role='replica'`);
+        await transaction.query(
+          `UPDATE outcome_private_reviewed_evaluation_head head
+              SET revision=legacy.revision,
+                  decision_id=legacy.decision_id,
+                  evidence_bundle_id=legacy.evidence_bundle_id,
+                  status=legacy.status,
+                  updated_at=legacy.decided_at
+             FROM outcome_private_reviewed_evaluation_decision legacy
+            WHERE head.valuation_scope_key=legacy.valuation_scope_key
+              AND head.evidence_scope_key='afl-player-match-reviewed-2021-2026'
+              AND legacy.revision=1`
+        );
+        await transaction.query(`SET LOCAL session_replication_role='origin'`);
+        await transaction.query(
+          `WITH source AS (
+             SELECT bundle.*,
+                    bundle.bundle_json->'content' AS original_content,
+                    bundle.created_at+interval '1 day' AS next_created_at
+               FROM outcome_private_reviewed_evidence_bundle bundle
+              WHERE bundle.source_capture_count=7 AND bundle.source_rights_count=3
+              ORDER BY bundle.created_at DESC LIMIT 1
+           ), changed AS (
+             SELECT source.*,
+                    jsonb_set(
+                      jsonb_set(
+                        jsonb_set(original_content,'{sourceCaptures}',
+                          (original_content->'sourceCaptures')||
+                            jsonb_build_array(original_content->'sourceCaptures'->0),false),
+                        '{sourceRightsEvidenceRefs}',
+                          (original_content->'sourceRightsEvidenceRefs')||
+                            jsonb_build_array(original_content->'sourceRightsEvidenceRefs'->0),false),
+                      '{createdAt}',to_jsonb(to_char(next_created_at AT TIME ZONE 'UTC',
+                        'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')),false) AS next_content
+               FROM source
+           ), addressed AS (
+             SELECT changed.*,
+                    outcome_afl_trade_canonical_json(next_content) AS next_canonical,
+                    encode(sha256(convert_to(
+                      outcome_afl_trade_canonical_json(next_content),'UTF8')),'hex') AS next_sha256
+               FROM changed
+           )
+           INSERT INTO outcome_private_reviewed_evidence_bundle
+             (evidence_bundle_id,evidence_scope_key,candidate_count,decision_count,
+              source_capture_count,source_rights_count,created_at,bundle_sha256,
+              bundle_content_canonical_json,bundle_json,registered_at)
+           SELECT 'private-reviewed-evidence-bundle:'||next_sha256,evidence_scope_key,
+                  candidate_count,decision_count,7,3,next_created_at,next_sha256,
+                  next_canonical,
+                  jsonb_build_object(
+                    'evidenceBundleId','private-reviewed-evidence-bundle:'||next_sha256,
+                    'content',next_content),
+                  next_created_at
+             FROM addressed`
+        );
+      })
+    ).rejects.toThrow(/results successor failed exact authentication/i);
+    const after = await client.query<{ total: number }>(
+      `SELECT count(*)::integer AS total
+         FROM outcome_private_reviewed_evidence_bundle`
+    );
+    expect(after.rows).toEqual(before.rows);
+  });
+
+  it('rejects malformed direct-SQL projected completion and stat values', async () => {
+    const checked = await client.query<{
+      missing_status: boolean;
+      null_score: boolean;
+      invalid_date: boolean;
+      negative_stat: boolean;
+      fractional_stat: boolean;
+    }>(
+      `SELECT
+         outcome_hpn_pav_projected_result_completed(
+           '{"status":{"kind":"missing"}}'::jsonb,
+           '{"content":{"completionRule":{"kind":"source_status","completedValues":["FINAL"]},
+             "semanticBindings":[{"semanticField":"completionStatus",
+               "mapping":{"kind":"direct","sourceField":"status"}}]}}'::jsonb
+         ) AS missing_status,
+         outcome_hpn_pav_projected_result_completed(
+           '{"Date":{"kind":"date","value":"2026-08-08"},
+             "Home.Points":{"kind":"missing"},"Away.Points":{"kind":"integer","value":"80"}}'::jsonb,
+           '{"content":{"completionRule":{"kind":"reviewed_final_score_presence"},
+             "semanticBindings":[{"semanticField":"completionStatus",
+               "mapping":{"kind":"reviewed_final_scores","matchDateField":"Date",
+                 "homePointsField":"Home.Points","awayPointsField":"Away.Points"}}]}}'::jsonb
+         ) AS null_score,
+         outcome_hpn_pav_projected_result_completed(
+           '{"Date":{"kind":"date","value":"2026-02-30"},
+             "Home.Points":{"kind":"integer","value":"100"},
+             "Away.Points":{"kind":"integer","value":"80"}}'::jsonb,
+           '{"content":{"completionRule":{"kind":"reviewed_final_score_presence"},
+             "semanticBindings":[{"semanticField":"completionStatus",
+               "mapping":{"kind":"reviewed_final_scores","matchDateField":"Date",
+                 "homePointsField":"Home.Points","awayPointsField":"Away.Points"}}]}}'::jsonb
+         ) AS invalid_date,
+         outcome_hpn_pav_nonnegative_integer('-1'::jsonb) AS negative_stat,
+         outcome_hpn_pav_nonnegative_integer('1.5'::jsonb) AS fractional_stat`
+    );
+    expect(checked.rows).toEqual([
+      {
+        missing_status: false,
+        null_score: false,
+        invalid_date: false,
+        negative_stat: false,
+        fractional_stat: false,
+      },
+    ]);
+  });
+
+  it('rejects forged, denied, and expired source rights in the shared authority predicate', async () => {
+    const checked = await client.query<{
+      valid: boolean;
+      forged_id: boolean;
+      denied_operation: boolean;
+      expired: boolean;
+    }>(
+      `WITH selected AS (
+         SELECT rights.content_json AS rights_json,
+                outcome_hpn_pav_projected_reviewed_fields(candidate.candidate_json) AS fields
+           FROM outcome_hpn_projected_field_map map
+           JOIN outcome_hpn_field_map_candidate candidate
+             ON candidate.candidate_id=map.candidate_id
+           JOIN outcome_hpn_field_map_review_decision decision
+             ON decision.decision_id=map.approval_decision_id
+           JOIN outcome_source_rights_proposal rights
+             ON rights.rights_artifact_id=
+               decision.source_use_assessment_json#>>'{content,rightsArtifactId}'
+          WHERE map.input_kind='completed_match_result'
+       ), variants AS (
+         SELECT *,
+                jsonb_set(rights_json,'{rightsArtifactId}',
+                  to_jsonb(('source-rights:'||repeat('0',64))::text),false) AS forged_json,
+                jsonb_set(rights_json->'content','{operations,derived_feature_creation}',
+                  to_jsonb('blocked'::text),false) AS denied_content,
+                jsonb_set(rights_json->'content','{termsExpireAt}',
+                  to_jsonb('2026-08-14T12:00:00.000Z'::text),false) AS expired_content
+           FROM selected
+       ), addressed AS (
+         SELECT *,
+                jsonb_build_object(
+                  'rightsArtifactId','source-rights:'||encode(sha256(convert_to(
+                    outcome_afl_trade_canonical_json(denied_content),'UTF8')),'hex'),
+                  'content',denied_content) AS denied_json,
+                jsonb_build_object(
+                  'rightsArtifactId','source-rights:'||encode(sha256(convert_to(
+                    outcome_afl_trade_canonical_json(expired_content),'UTF8')),'hex'),
+                  'content',expired_content) AS expired_json
+           FROM variants
+       )
+       SELECT outcome_hpn_private_source_rights_permit(
+                rights_json,fields,'AFLM',2026,$1::timestamptz) AS valid,
+              outcome_hpn_private_source_rights_permit(
+                forged_json,fields,'AFLM',2026,$1::timestamptz) AS forged_id,
+              outcome_hpn_private_source_rights_permit(
+                denied_json,fields,'AFLM',2026,$1::timestamptz) AS denied_operation,
+              outcome_hpn_private_source_rights_permit(
+                expired_json,fields,'AFLM',2026,$1::timestamptz) AS expired
+         FROM addressed`,
+      [projectionAt]
+    );
+    expect(checked.rows).toEqual([
+      { valid: true, forged_id: false, denied_operation: false, expired: false },
+    ]);
+  });
+
+  it('rejects a normalization run produced by a different decode map with the same schema', async () => {
+    const validMap = await client.query<{ field_map_id: string }>(
+      `SELECT field_map_id FROM outcome_hpn_projected_field_map
+        WHERE input_kind='completed_match_result'
+        ORDER BY field_map_id LIMIT 1`
+    );
+    const alternateDecodeMapId = 'afl-tables-results-local-2026-v1-alternate';
+    const alternateNormalizationRunId = id(
+      'provider-normalization-run',
+      'results-alternate-map'
+    );
+    await client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL session_replication_role='replica'`);
+      await transaction.query(
+        `INSERT INTO outcome_provider_field_map
+          (field_map_id,capability_id,fitzroy_version,source_schema_sha256,
+           field_map_sha256,approval_decision_id,approved_at,map_json)
+         SELECT $1,capability_id,fitzroy_version,source_schema_sha256,$2,
+                approval_decision_id,approved_at,
+                jsonb_set(map_json,'{mapId}',to_jsonb($1::text),false)
+           FROM outcome_provider_field_map
+          WHERE field_map_id='afl-tables-results-local-2026-v1'`,
+        [alternateDecodeMapId, sha256(alternateDecodeMapId)]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_provider_normalization_run
+          (normalization_run_id,capture_id,field_map_id,decoder_version,
+           normalizer_version,source_rds_sha256,decoded_sha256,receipt_sha256,
+           staging_sha256,status,source_row_count,accepted_row_count,
+           quarantined_row_count,issue_count,identity_candidate_count,
+           match_candidate_count,metric_candidate_count,achievement_candidate_count,
+           started_at,completed_at,finalized_at,receipt_json)
+         SELECT $1,capture_id,$2,decoder_version,normalizer_version,source_rds_sha256,
+                decoded_sha256,receipt_sha256,staging_sha256,status,source_row_count,
+                accepted_row_count,quarantined_row_count,issue_count,
+                identity_candidate_count,match_candidate_count,metric_candidate_count,
+                achievement_candidate_count,started_at,completed_at,finalized_at,receipt_json
+           FROM outcome_provider_normalization_run
+          WHERE normalization_run_id=$3`,
+        [
+          alternateNormalizationRunId,
+          alternateDecodeMapId,
+          id('provider-normalization-run', 'results'),
+        ]
+      );
+      await transaction.query(`SET LOCAL session_replication_role='origin'`);
+    });
+
+    await expect(
+      attemptProjectedRun({
+        fieldMapId: validMap.rows[0]!.field_map_id,
+        normalizationRunId: alternateNormalizationRunId,
+        effectiveThrough: '2026-08-20T00:00:00.000Z',
+      })
+    ).rejects.toThrow(/exact current source authority/i);
+  });
+
+  it('rechecks the exact decode map when finalizing an already-populated input set', async () => {
+    await expect(
+      client.transaction(async (transaction) => {
+        await transaction.query(`SET LOCAL session_replication_role='replica'`);
+        await transaction.query(
+          `UPDATE outcome_hpn_pav_input_set
+              SET status='building',finalized_at=NULL
+            WHERE status='finalized'`
+        );
+        await transaction.query(
+          `DELETE FROM outcome_provider_normalization_run
+            WHERE normalization_run_id=$1`,
+          [id('provider-normalization-run', 'results-alternate-map')]
+        );
+        await transaction.query(
+          `UPDATE outcome_provider_normalization_run
+              SET field_map_id='afl-tables-results-local-2026-v1-alternate'
+            WHERE normalization_run_id=$1`,
+          [id('provider-normalization-run', 'results')]
+        );
+        await transaction.query(`SET LOCAL session_replication_role='origin'`);
+        await transaction.query(
+          `UPDATE outcome_hpn_pav_input_set
+              SET status='finalized',finalized_at=created_at
+            WHERE status='building'`
+        );
+      })
+    ).rejects.toThrow(/source run is incomplete, stale, or outside reviewed scope/i);
+  });
+
+  it.each([
+    ['candidate', '2026-08-22T00:00:00.000Z'],
+    ['decision', '2026-08-23T00:00:00.000Z'],
+  ] as const)(
+    'rejects a forged retained projected-map %s through the real input-run boundary',
+    async (tamper, effectiveThrough) => {
+      const validMap = await client.query<{ field_map_id: string }>(
+        `SELECT field_map_id FROM outcome_hpn_projected_field_map
+          WHERE input_kind='completed_match_result'
+          ORDER BY field_map_id LIMIT 1`
+      );
+      await expect(
+        attemptProjectedRun({
+          fieldMapId: validMap.rows[0]!.field_map_id,
+          normalizationRunId: id('provider-normalization-run', 'results'),
+          effectiveThrough,
+          tamper,
+        })
+      ).rejects.toThrow(/exact current source authority/i);
+    }
+  );
+
+  it('rejects a content-addressed projected map that cannot be reconstructed from its retained review', async () => {
+    const forged = await client.query<{ field_map_id: string }>(
+      `WITH original AS (
+         SELECT * FROM outcome_hpn_projected_field_map
+          WHERE input_kind='completed_match_result'
+          ORDER BY field_map_id
+          LIMIT 1
+       ), changed AS (
+         SELECT original.*,
+                jsonb_set(
+                  map_json,
+                  '{content,semanticBindings,0,mapping,sourceField}',
+                  to_jsonb('forged_source_field'::text),
+                  false
+                ) AS forged_json
+           FROM original
+       ), addressed AS (
+         SELECT changed.*,
+                encode(sha256(convert_to(
+                  outcome_afl_trade_canonical_json(forged_json->'content'),
+                  'UTF8'
+                )),'hex') AS forged_sha256
+           FROM changed
+       )
+       INSERT INTO outcome_hpn_projected_field_map
+         (field_map_id,candidate_id,approval_decision_id,environment,competition,
+          provider,capability_id,input_kind,source_schema_sha256,valid_from_season,
+          valid_through_season,field_map_sha256,field_map_canonical_json,map_json,
+          created_at)
+       SELECT 'hpn-pav-field-map:'||forged_sha256,candidate_id,approval_decision_id,
+              environment,competition,provider,capability_id,input_kind,
+              source_schema_sha256,valid_from_season,valid_through_season,
+              forged_sha256,outcome_afl_trade_canonical_json(
+                jsonb_set(
+                  forged_json,
+                  '{fieldMapId}',
+                  to_jsonb('hpn-pav-field-map:'||forged_sha256),
+                  false
+                )
+              ),
+              jsonb_set(
+                forged_json,
+                '{fieldMapId}',
+                to_jsonb('hpn-pav-field-map:'||forged_sha256),
+                false
+              ),
+              created_at
+         FROM addressed
+       RETURNING field_map_id`
+    );
+    const checked = await client.query<{ valid: boolean; forged: boolean }>(
+      `SELECT outcome_hpn_projected_field_map_authority_is_exact(
+                (SELECT field_map_id FROM outcome_hpn_projected_field_map
+                  WHERE input_kind='completed_match_result' AND field_map_id<>$1
+                  ORDER BY field_map_id LIMIT 1)
+              ,$2::timestamptz) AS valid,
+              outcome_hpn_projected_field_map_authority_is_exact(
+                $1,$2::timestamptz) AS forged`,
+      [forged.rows[0]?.field_map_id, projectionAt]
+    );
+
+    expect(checked.rows).toEqual([{ valid: true, forged: false }]);
+    await expect(
+      attemptProjectedRun({
+        fieldMapId: forged.rows[0]!.field_map_id,
+        normalizationRunId: id('provider-normalization-run', 'results'),
+        effectiveThrough: '2026-08-19T00:00:00.000Z',
+      })
+    ).rejects.toThrow(/exact current source authority/i);
+  });
+
+  it('rejects an otherwise exact projected map approved for another valuation scope', async () => {
+    const otherScope = 'afl-men:2025-trades';
+    const reviewed = reviewedEvaluation(otherScope);
+    const crossScopeProjection = projection(lanes[0]!, otherScope);
+    await client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL session_replication_role='replica'`);
+      await transaction.query(
+        `INSERT INTO outcome_private_reviewed_evaluation_decision
+          (decision_id,valuation_scope_key,evidence_bundle_id,status,revision,
+           supersedes_decision_id,reviewer_id,decided_at,decision_sha256,
+           decision_content_canonical_json,decision_json,registered_at)
+         VALUES ($1,$2,$3,'authorized',1,NULL,$4,$5,$6,$7,$8::jsonb,$5)`,
+        [
+          reviewed.evaluationDecision.decisionId,
+          otherScope,
+          reviewed.evidenceBundle.evidenceBundleId,
+          reviewed.evaluationDecision.content.reviewerId,
+          reviewed.evaluationDecision.content.decidedAt,
+          reviewed.evaluationDecision.decisionId.split(':').at(-1),
+          canonicalizeAflTradeJson(reviewed.evaluationDecision.content),
+          canonicalizeAflTradeJson(reviewed.evaluationDecision),
+        ]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_private_reviewed_evaluation_head
+          (valuation_scope_key,evidence_scope_key,revision,decision_id,
+           evidence_bundle_id,status,updated_at)
+         VALUES ($1,$2,1,$3,$4,'authorized',$5)`,
+        [
+          otherScope,
+          reviewed.evidenceBundle.content.evidenceScopeKey,
+          reviewed.evaluationDecision.decisionId,
+          reviewed.evidenceBundle.evidenceBundleId,
+          reviewed.evaluationDecision.content.decidedAt,
+        ]
+      );
+    });
+    await new PostgresAflTradeHpnProjectedFieldMapAuthority(
+      client
+    ).registerApprovedProjection(crossScopeProjection);
+
+    await expect(
+      attemptProjectedRun({
+        fieldMapId: crossScopeProjection.projectedFieldMap!.fieldMapId,
+        normalizationRunId: id('provider-normalization-run', 'results'),
+        effectiveThrough: '2026-08-21T00:00:00.000Z',
+      })
+    ).rejects.toThrow(/exact current source authority/i);
+  });
+
+  it('rejects coherent expired rights at input finalization and source-run attachment', async () => {
+    const shortLivedInput = await prepareShortLivedResultsInput();
+    for (;;) {
+      const expiry = await client.query<{ expired: boolean }>(
+        `SELECT clock_timestamp()>=$1::timestamptz AS expired`,
+        [shortLivedInput.expiresAt]
+      );
+      if (expiry.rows[0]?.expired) break;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    await expect(
+      client.transaction(async (transaction) => {
+        await transaction.query(`SET LOCAL session_replication_role='replica'`);
+        await transaction.query(
+          `UPDATE outcome_hpn_pav_input_set
+              SET status='building',finalized_at=NULL
+            WHERE input_set_id=$1`,
+          [shortLivedInput.inputSetId]
+        );
+        await transaction.query(`SET LOCAL session_replication_role='origin'`);
+        await transaction.query(
+          `UPDATE outcome_hpn_pav_input_set
+              SET status='finalized',finalized_at=created_at
+            WHERE input_set_id=$1`,
+          [shortLivedInput.inputSetId]
+        );
+      })
+    ).rejects.toThrow(/source run is incomplete, stale, or outside reviewed scope/i);
+    await expect(
+      attemptProjectedRun({
+        fieldMapId: shortLivedInput.projectedFieldMapId,
+        normalizationRunId: shortLivedInput.normalizationRunId,
+        effectiveThrough: '2026-08-10T23:59:59.999Z',
+      })
+    ).rejects.toThrow(/exact current source authority/i);
+  }, 60_000);
+});

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1102,6 +1102,8 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0073_automated_nonproduction_source_admission',
       '0074_bind_factual_output_to_source_admission',
       '0075_versioned_release_acquisition_spell_eligibility',
+      '0076_role_aware_private_valuation_capture_binding',
+      '0077_projected_hpn_pav_input_authority',
     ]);
 
     const tables = await query<{ table_name: string }>(

--- a/tests/outcomes-integration/afl-private-valuation-hpn-preparation-postgres.test.ts
+++ b/tests/outcomes-integration/afl-private-valuation-hpn-preparation-postgres.test.ts
@@ -1,0 +1,142 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import { PostgresAflTradePrivateValuationHpnPreparation } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationHpnPreparation';
+import { PostgresAflTradePrivateValuationScheduleRepository } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationScheduling';
+
+import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('A disposable AFL_OUTCOMES_TEST_DATABASE_URL is required.');
+  })();
+const schemaName = `afl_private_valuation_hpn_preparation_${process.pid}_${Date.now()}`;
+const adminPool = new Pool({ connectionString: databaseUrl });
+const outcomesPool = new Pool({
+  connectionString: databaseUrl,
+  options: `-c search_path=${schemaName}`,
+  max: 4,
+});
+
+function scopedDatabaseUrl(): string {
+  const scoped = new URL(databaseUrl);
+  scoped.searchParams.set('schema', schemaName);
+  return scoped.toString();
+}
+
+beforeAll(async () => {
+  await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
+  runOutcomesPrismaTestCommand(['migrate', 'deploy'], { databaseUrl: scopedDatabaseUrl() });
+});
+
+afterAll(async () => {
+  const failures: unknown[] = [];
+  try {
+    await outcomesPool.end();
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await adminPool.end();
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Private HPN-preparation PostgreSQL cleanup failed.');
+  }
+});
+
+describe.sequential('private valuation HPN preparation in PostgreSQL', () => {
+  it('fails closed at the migrated dispatch boundary before invoking any stage owner', async () => {
+    const prepareFactual = vi.fn();
+    const captureSource = vi.fn();
+    const preparation = new PostgresAflTradePrivateValuationHpnPreparation(
+      createPgAflOutcomeSqlClient(outcomesPool),
+      {
+        factualPreparation: { prepare: prepareFactual },
+        methodId: `hpn-pav-method:${'1'.repeat(64)}`,
+        methodAuthority: { loadExact: vi.fn() },
+        captureSource,
+      }
+    );
+
+    await expect(
+      preparation.prepare({
+        requestId: `private-valuation-dispatch:${'2'.repeat(64)}`,
+        claim: {
+          claimId: `private-valuation-dispatch-claim:${'3'.repeat(64)}`,
+          leaseToken: '4'.repeat(64),
+        },
+      })
+    ).rejects.toThrow(/lost its live claim fence/i);
+    expect(prepareFactual).not.toHaveBeenCalled();
+    expect(captureSource).not.toHaveBeenCalled();
+  });
+
+  it('returns the exact request only to its live claim before Stage 2 begins', async () => {
+    const client = createPgAflOutcomeSqlClient(outcomesPool);
+    const schedule = new PostgresAflTradePrivateValuationScheduleRepository(client);
+    const requestId = await client.transaction(async (transaction) => {
+      await transaction.query(
+        'SET LOCAL ROLE afl_trade_private_valuation_scheduler_owner'
+      );
+      const retained = await transaction.query<{ readonly request_id: string }>(
+        `SELECT enqueue_outcome_private_valuation_dispatch(
+           'afl-men:2026-trades','ad_hoc','2026-08-12T00:00:00.000Z'::timestamptz,
+           'hpn-preparation-claim-fence') AS request_id`
+      );
+      return retained.rows[0]!.request_id;
+    });
+    const retainedClaim = await schedule.claim(
+      'system:weekly-valuation-coordinator',
+      requestId
+    );
+    expect(retainedClaim).not.toBeNull();
+    const prepareFactual = vi.fn(async () => {
+      throw new Error('Stage 2 sentinel.');
+    });
+    const captureSource = vi.fn();
+    const preparation = new PostgresAflTradePrivateValuationHpnPreparation(client, {
+      factualPreparation: { prepare: prepareFactual },
+      methodId: `hpn-pav-method:${'5'.repeat(64)}`,
+      methodAuthority: { loadExact: vi.fn() },
+      captureSource,
+    });
+
+    await expect(
+      preparation.prepare({
+        requestId,
+        claim: {
+          claimId: retainedClaim!.claimId,
+          leaseToken: retainedClaim!.leaseToken,
+        },
+      })
+    ).rejects.toThrow(/Stage 2 sentinel/i);
+    expect(prepareFactual).toHaveBeenCalledWith({
+      requestId,
+      claim: {
+        claimId: retainedClaim!.claimId,
+        leaseToken: retainedClaim!.leaseToken,
+      },
+    });
+    expect(captureSource).not.toHaveBeenCalled();
+
+    await expect(
+      preparation.prepare({
+        requestId,
+        claim: {
+          claimId: retainedClaim!.claimId,
+          leaseToken: '6'.repeat(64),
+        },
+      })
+    ).rejects.toThrow(/lost its live claim fence/i);
+    expect(prepareFactual).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/afl-trade-intelligence-hpn-field-map-candidate.test.ts
+++ b/tests/unit/afl-trade-intelligence-hpn-field-map-candidate.test.ts
@@ -8,7 +8,10 @@ import {
   createLocalAflTradeHpnCompletedResultFieldMapCandidate,
   createLocalAflTradeHpnPlayerFieldMapCandidate,
 } from '@/server/aflTradeIntelligence/development/localHpnFieldMapCandidates';
-import { createLocalAflTradeFiveSeasonAflTablesAuthority } from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority';
+import {
+  createLocalAflTradeAflTablesResultsAuthority,
+  createLocalAflTradeFiveSeasonAflTablesAuthority,
+} from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority';
 import { createLocalAflTradeOfficialAfl2026Authority } from '@/server/aflTradeIntelligence/development/localOfficialAfl2026Authority';
 
 const createdAt = '2026-08-16T04:00:00.000Z';
@@ -190,9 +193,9 @@ describe('HPN field-map review candidate', () => {
   });
 
   it('proposes an explicit reviewed final-score projection instead of inventing a status field', () => {
-    const providerDecodeMap = createLocalAflTradeFiveSeasonAflTablesAuthority(2025).fieldMap;
+    const providerDecodeMap = createLocalAflTradeAflTablesResultsAuthority(2026).fieldMap;
     const resultCandidate = createLocalAflTradeHpnCompletedResultFieldMapCandidate({
-      seasonYear: 2025,
+      seasonYear: 2026,
       providerDecodeMap,
       providerDecodeMapArtifact: createAflTradeCanonicalJsonArtifactRef(
         providerDecodeMap,
@@ -218,7 +221,7 @@ describe('HPN field-map review candidate', () => {
     ).toMatchObject({
       mapping: {
         kind: 'composite_key',
-        sourceFields: ['Date', 'Home.team', 'Away.team'],
+        sourceFields: ['Date', 'Home.Team', 'Away.Team'],
       },
     });
     expect(
@@ -229,8 +232,8 @@ describe('HPN field-map review candidate', () => {
       mapping: {
         kind: 'reviewed_final_scores',
         matchDateField: 'Date',
-        homePointsField: 'Home.score',
-        awayPointsField: 'Away.score',
+        homePointsField: 'Home.Points',
+        awayPointsField: 'Away.Points',
       },
     });
     expect(resultCandidate.content).not.toHaveProperty('completedValues');

--- a/tests/unit/afl-trade-intelligence-hpn-pav-input-contracts.test.ts
+++ b/tests/unit/afl-trade-intelligence-hpn-pav-input-contracts.test.ts
@@ -2,11 +2,13 @@ import { createHash } from 'node:crypto';
 
 import { describe, expect, it } from 'vitest';
 
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
 import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import {
   createAflTradeHpnPavFieldMap,
   createAflTradeHpnPavSeasonInputSet,
 } from '@/server/aflTradeIntelligence/modeling/hpnPavInputContracts';
+import { aflTradeHpnProjectedFieldMapSchema } from '@/server/aflTradeIntelligence/modeling/hpnProjectedFieldMap';
 
 const sha = (character: string) => character.repeat(64);
 const digest = (value: string) => createHash('sha256').update(value).digest('hex');
@@ -96,6 +98,81 @@ function resultFieldMap() {
       completionStatus: 'status',
       completedValues: ['completed'],
     },
+  });
+}
+
+function projectedFieldMap(
+  fieldMap: ReturnType<typeof resultFieldMap> | ReturnType<typeof playerFieldMap>,
+  character: string
+) {
+  const createdAt = '2026-08-09T00:00:00.000Z';
+  const candidateArtifact = createAflTradeCanonicalJsonArtifactRef(
+    { candidate: character },
+    createdAt
+  );
+  const approvalDecisionArtifact = createAflTradeCanonicalJsonArtifactRef(
+    { decision: character },
+    createdAt
+  );
+  const semanticBindings =
+    fieldMap.content.inputKind === 'completed_match_result'
+      ? [
+          { semanticField: 'awayClub', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.awayClub } },
+          { semanticField: 'awayPoints', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.awayPoints } },
+          { semanticField: 'completionStatus', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.completionStatus } },
+          { semanticField: 'homeClub', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.homeClub } },
+          { semanticField: 'homePoints', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.homePoints } },
+          { semanticField: 'match', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.match } },
+        ]
+      : [
+          { semanticField: 'clearances', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.clearances } },
+          { semanticField: 'club', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.club } },
+          { semanticField: 'freeKicksAgainst', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.freeKicksAgainst } },
+          { semanticField: 'freeKicksFor', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.freeKicksFor } },
+          { semanticField: 'goalAssists', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.goalAssists } },
+          { semanticField: 'hitOuts', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.hitOuts } },
+          { semanticField: 'inside50s', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.inside50s } },
+          { semanticField: 'marks', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.marks } },
+          { semanticField: 'marksInside50', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.marksInside50 } },
+          { semanticField: 'match', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.match } },
+          { semanticField: 'onePercenters', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.onePercenters } },
+          { semanticField: 'player', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.player } },
+          { semanticField: 'rebound50s', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.rebound50s } },
+          { semanticField: 'tackles', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.tackles } },
+          { semanticField: 'totalPoints', mapping: fieldMap.content.bindings.totalPoints },
+        ];
+  const content = {
+    schemaVersion: 'afl-trade-hpn-projected-field-map/v1' as const,
+    environment: 'non_production' as const,
+    purpose: 'private_confirmed_realized_hpn_pav' as const,
+    competition: 'AFLM' as const,
+    provider: fieldMap.content.provider,
+    capabilityId: fieldMap.content.capabilityId,
+    sourceSchemaSha256: fieldMap.content.sourceSchemaSha256,
+    inputKind: fieldMap.content.inputKind,
+    validFromSeason: fieldMap.content.validFromSeason,
+    validThroughSeason: fieldMap.content.validThroughSeason,
+    candidateId: `hpn-field-map-candidate:${sha(character)}`,
+    candidateArtifact,
+    approvalDecisionId: `hpn-field-map-review-decision:${sha(character)}`,
+    approvalDecisionArtifact,
+    semanticBindings,
+    completionRule:
+      fieldMap.content.inputKind === 'completed_match_result'
+        ? {
+            kind: 'source_status' as const,
+            completedValues: fieldMap.content.bindings.completedValues,
+          }
+        : null,
+    createdAt,
+    publicationEligible: false as const,
+    publicationProhibited: true as const,
+    limitation:
+      'Private non-production projection map only; it grants no factual release, model training, publication, production, activation, or live-capture authority.' as const,
+  };
+  return aflTradeHpnProjectedFieldMapSchema.parse({
+    fieldMapId: createAflTradeContentAddress('hpn-pav-field-map', content),
+    content,
   });
 }
 
@@ -283,6 +360,29 @@ describe('HPN PAV governed input contracts', () => {
       corroboratingPlayerRows: 4,
     });
     expect(inputSet.content.publicationEligible).toBe(false);
+  });
+
+  it('seals projected-map authority without manufacturing legacy field maps', () => {
+    const legacy = fixture();
+    const projectedMaps = legacy.fieldMaps.map((fieldMap, index) =>
+      projectedFieldMap(fieldMap, String(index + 1))
+    );
+    const sourceRuns = legacy.sourceRuns.map((run, index) => ({
+      ...run,
+      fieldMapId: projectedMaps[index]!.fieldMapId,
+    }));
+
+    const inputSet = createAflTradeHpnPavSeasonInputSet({
+      ...legacy,
+      environment: 'non_production',
+      fieldMaps: projectedMaps,
+      sourceRuns,
+    });
+
+    expect(inputSet.content.schemaVersion).toBe('afl-trade-hpn-pav-input-set/v2');
+    expect(inputSet.content.fieldMaps).toEqual(
+      [...projectedMaps].sort((left, right) => left.fieldMapId.localeCompare(right.fieldMapId))
+    );
   });
 
   it('rejects an omitted completed match or a run row that is not conserved', () => {

--- a/tests/unit/afl-trade-intelligence-local-five-season-afl-tables-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-local-five-season-afl-tables-authority.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import { sha256AflTradeCanonicalJson } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import {
   LOCAL_AFL_TABLES_PLAYER_STATS_FIELD_SCHEMA,
+  LOCAL_AFL_TABLES_RESULTS_FIELD_SCHEMA,
+  createLocalAflTradeAflTablesResultsAuthority,
   createLocalAflTradeFiveSeasonAflTablesAuthority,
 } from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority';
 import { createAflTradeFitzRoyInvocation } from '@/server/aflTradeIntelligence/source/fitzRoyCaptureContracts';
@@ -38,7 +40,7 @@ describe('local five-season AFL Tables authority', () => {
         operations: {
           internal_quality_evaluation: 'allowed',
           model_training: 'blocked',
-          derived_feature_creation: 'blocked',
+          derived_feature_creation: 'allowed',
           public_derived_output: 'blocked',
           public_fact_display: 'blocked',
         },
@@ -114,9 +116,59 @@ describe('local five-season AFL Tables authority', () => {
     expect(authority.fieldMap.validThroughSeason).toBe(2021);
   });
 
+  it('binds current-season completed results to their exact offline-inspected fitzRoy schema', () => {
+    const authority = createLocalAflTradeAflTablesResultsAuthority(2026);
+    const invocation = createAflTradeFitzRoyInvocation(authority.capture.captureRequest);
+
+    expect(LOCAL_AFL_TABLES_RESULTS_FIELD_SCHEMA.map(({ name }) => name)).toEqual([
+      'Game',
+      'Date',
+      'Round',
+      'Home.Team',
+      'Home.Goals',
+      'Home.Behinds',
+      'Home.Points',
+      'Away.Team',
+      'Away.Goals',
+      'Away.Behinds',
+      'Away.Points',
+      'Venue',
+      'Margin',
+      'Season',
+      'Round.Type',
+      'Round.Number',
+    ]);
+    expect(authority.capture.captureRequest).toMatchObject({
+      capabilityId: 'afl-tables-results',
+      authorizationSeason: 2026,
+      parameters: { season: 2026, roundNumber: null },
+    });
+    expect(authority.capture.sourceRights.content.acquisition.capabilities).toEqual([
+      {
+        capabilityId: 'afl-tables-results',
+        provider: 'afl_tables',
+        directFunction: 'fetch_results_afltables',
+      },
+    ]);
+    expect(authority.capture.ledger.decisions[0]?.content).toMatchObject({
+      state: 'approved',
+      authorityKind: 'external_human_record',
+    });
+    expect(authority.fieldMap).toMatchObject({
+      capabilityId: 'afl-tables-results',
+      observationKind: 'match_universe',
+      invocationArgumentsSha256: sha256AflTradeCanonicalJson(invocation.arguments),
+      match: {
+        nativeMatchId: { sourceField: 'Game', required: true },
+        homeClubName: { sourceField: 'Home.Team', required: true },
+        awayClubName: { sourceField: 'Away.Team', required: true },
+      },
+    });
+  });
+
   it('rejects seasons outside the approved five-season local load', () => {
-    expect(() => createLocalAflTradeFiveSeasonAflTablesAuthority(2026)).toThrow(
-      '2021 through 2025'
+    expect(() => createLocalAflTradeFiveSeasonAflTablesAuthority(2027)).toThrow(
+      '2021 through 2026'
     );
   });
 });

--- a/tests/unit/afl-trade-intelligence-local-hpn-review-assembler.test.ts
+++ b/tests/unit/afl-trade-intelligence-local-hpn-review-assembler.test.ts
@@ -31,7 +31,8 @@ const method = createAflTradeHpnPavMethod({
   capturedAt: '2026-08-16T02:00:00.000Z',
 });
 
-function snapshot(input: { withMethod?: boolean } = {}) {
+function snapshot(input: { withMethod?: boolean; withResults?: boolean } = {}) {
+  const withResults = input.withResults ?? true;
   const authority2024 = createLocalAflTradeFiveSeasonAflTablesAuthority(2024);
   const authority2025 = createLocalAflTradeFiveSeasonAflTablesAuthority(2025);
   const results2024 = createLocalAflTradeAflTablesResultsAuthority(2024);
@@ -81,22 +82,28 @@ function snapshot(input: { withMethod?: boolean } = {}) {
         seasonYear: 2025,
         sourceArtifact: sourceArtifact(2025),
       },
-      {
-        captureId: 'capture:afl-tables-results:2024',
-        provider: 'afl_tables',
-        capabilityId: 'afl-tables-results',
-        seasonYear: 2024,
-        sourceArtifact: sourceArtifact(2024),
-      },
-      {
-        captureId: 'capture:afl-tables-results:2025',
-        provider: 'afl_tables',
-        capabilityId: 'afl-tables-results',
-        seasonYear: 2025,
-        sourceArtifact: sourceArtifact(2025),
-      },
+      ...(withResults
+        ? [
+            {
+              captureId: 'capture:afl-tables-results:2024',
+              provider: 'afl_tables' as const,
+              capabilityId: 'afl-tables-results',
+              seasonYear: 2024,
+              sourceArtifact: sourceArtifact(2024),
+            },
+            {
+              captureId: 'capture:afl-tables-results:2025',
+              provider: 'afl_tables' as const,
+              capabilityId: 'afl-tables-results',
+              seasonYear: 2025,
+              sourceArtifact: sourceArtifact(2025),
+            },
+          ]
+        : []),
     ],
-    sourceRightsEvidenceRefs: [rightsArtifact, resultsRightsArtifact],
+    sourceRightsEvidenceRefs: withResults
+      ? [rightsArtifact, resultsRightsArtifact]
+      : [rightsArtifact],
     createdAt: '2026-08-16T03:30:00.000Z',
   });
   const evidenceBundleArtifact = createAflTradeCanonicalJsonArtifactRef(
@@ -159,9 +166,9 @@ function snapshot(input: { withMethod?: boolean } = {}) {
     method_json: input.withMethod ? method : null,
     method_registered_at: input.withMethod ? methodRegisteredAt : null,
     sources_json: [
-      resultSource(2024, results2024.fieldMap, '2'),
+      ...(withResults ? [resultSource(2024, results2024.fieldMap, '2')] : []),
       playerSource(2024, authority2024.fieldMap, '4'),
-      resultSource(2025, results2025.fieldMap, '3'),
+      ...(withResults ? [resultSource(2025, results2025.fieldMap, '3')] : []),
       playerSource(2025, authority2025.fieldMap, '5'),
     ],
   };
@@ -287,5 +294,29 @@ describe('local HPN league-season review assembler', () => {
         expect.objectContaining({ document: method }),
       ])
     );
+  });
+
+  it('preserves historical result and player mappings from one AFL Tables source', async () => {
+    const assembled = await assembleLocalAflTradeHpnLeagueSeasonReviewPacket(
+      new FixtureClient(snapshot({ withResults: false })),
+      {
+        valuationScopeKey: 'workbook:2025',
+        fromSeason: 2024,
+        throughSeason: 2025,
+      }
+    );
+
+    expect(assembled.fieldMapCandidates).toHaveLength(4);
+    expect(assembled.sourceUseAssessments).toHaveLength(4);
+    for (const { report } of assembled.eligibilityReports) {
+      expect(report.content.sources).toMatchObject([
+        { selectionState: 'selected', inputKind: 'completed_match_result', role: null },
+        { selectionState: 'selected', inputKind: 'player_match_stats', role: 'primary' },
+        { selectionState: 'missing', inputKind: 'player_match_stats', role: 'corroborating' },
+      ]);
+      expect(report.content.sources[0]!.normalizationRunId).toBe(
+        report.content.sources[1]!.normalizationRunId
+      );
+    }
   });
 });

--- a/tests/unit/afl-trade-intelligence-local-hpn-review-assembler.test.ts
+++ b/tests/unit/afl-trade-intelligence-local-hpn-review-assembler.test.ts
@@ -2,7 +2,10 @@ import {
   createAflTradeByteArtifactRef,
   createAflTradeCanonicalJsonArtifactRef,
 } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
-import { createLocalAflTradeFiveSeasonAflTablesAuthority } from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority';
+import {
+  createLocalAflTradeAflTablesResultsAuthority,
+  createLocalAflTradeFiveSeasonAflTablesAuthority,
+} from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority';
 import { assembleLocalAflTradeHpnLeagueSeasonReviewPacket } from '@/server/aflTradeIntelligence/development/localHpnLeagueSeasonReviewAssembler';
 import { createAflTradeHpnPavMethod } from '@/server/aflTradeIntelligence/modeling/hpnPlayerApproximateValue';
 import type {
@@ -31,10 +34,17 @@ const method = createAflTradeHpnPavMethod({
 function snapshot(input: { withMethod?: boolean } = {}) {
   const authority2024 = createLocalAflTradeFiveSeasonAflTablesAuthority(2024);
   const authority2025 = createLocalAflTradeFiveSeasonAflTablesAuthority(2025);
+  const results2024 = createLocalAflTradeAflTablesResultsAuthority(2024);
+  const results2025 = createLocalAflTradeAflTablesResultsAuthority(2025);
   const rights = authority2025.capture.sourceRights;
   const rightsArtifact = createAflTradeCanonicalJsonArtifactRef(
     rights,
     rights.content.proposedAt
+  );
+  const resultsRights = results2025.capture.sourceRights;
+  const resultsRightsArtifact = createAflTradeCanonicalJsonArtifactRef(
+    resultsRights,
+    resultsRights.content.proposedAt
   );
   const sourceArtifact = (seasonYear: number) =>
     createAflTradeCanonicalJsonArtifactRef(
@@ -71,8 +81,22 @@ function snapshot(input: { withMethod?: boolean } = {}) {
         seasonYear: 2025,
         sourceArtifact: sourceArtifact(2025),
       },
+      {
+        captureId: 'capture:afl-tables-results:2024',
+        provider: 'afl_tables',
+        capabilityId: 'afl-tables-results',
+        seasonYear: 2024,
+        sourceArtifact: sourceArtifact(2024),
+      },
+      {
+        captureId: 'capture:afl-tables-results:2025',
+        provider: 'afl_tables',
+        capabilityId: 'afl-tables-results',
+        seasonYear: 2025,
+        sourceArtifact: sourceArtifact(2025),
+      },
     ],
-    sourceRightsEvidenceRefs: [rightsArtifact],
+    sourceRightsEvidenceRefs: [rightsArtifact, resultsRightsArtifact],
     createdAt: '2026-08-16T03:30:00.000Z',
   });
   const evidenceBundleArtifact = createAflTradeCanonicalJsonArtifactRef(
@@ -90,7 +114,7 @@ function snapshot(input: { withMethod?: boolean } = {}) {
     rationale: 'Private local calculation evaluation only.',
     decidedAt: '2026-08-16T04:00:00.000Z',
   });
-  const source = (
+  const playerSource = (
     seasonYear: number,
     fieldMap: typeof authority2025.fieldMap,
     character: string
@@ -108,6 +132,24 @@ function snapshot(input: { withMethod?: boolean } = {}) {
     factualRunId: null,
     hpnResolutionsCurrent: false,
   });
+  const resultSource = (
+    seasonYear: number,
+    fieldMap: typeof results2025.fieldMap,
+    character: string
+  ) => ({
+    seasonYear,
+    captureId: `capture:afl-tables-results:${seasonYear}`,
+    provider: 'afl_tables',
+    capabilityId: 'afl-tables-results',
+    normalizationRunId: `provider-normalization-run:${character.repeat(64)}`,
+    providerDecodeMap: fieldMap,
+    rights: resultsRights,
+    rightsArtifact: resultsRightsArtifact,
+    hpnResultProjection: null,
+    hpnPlayerProjection: null,
+    factualRunId: null,
+    hpnResolutionsCurrent: false,
+  });
   return {
     trusted_at: trustedAt,
     reviewed_evidence_bundle_json: evidenceBundle,
@@ -117,8 +159,10 @@ function snapshot(input: { withMethod?: boolean } = {}) {
     method_json: input.withMethod ? method : null,
     method_registered_at: input.withMethod ? methodRegisteredAt : null,
     sources_json: [
-      source(2024, authority2024.fieldMap, '4'),
-      source(2025, authority2025.fieldMap, '5'),
+      resultSource(2024, results2024.fieldMap, '2'),
+      playerSource(2024, authority2024.fieldMap, '4'),
+      resultSource(2025, results2025.fieldMap, '3'),
+      playerSource(2025, authority2025.fieldMap, '5'),
     ],
   };
 }
@@ -152,6 +196,7 @@ describe('local HPN league-season review assembler', () => {
     expect(client.statements[0]).toContain('transaction_timestamp()');
     expect(client.statements[0]).toContain('outcome_private_reviewed_evidence_is_current()');
     expect(client.statements[0]).toContain('outcome_hpn_pav_method');
+    expect(client.statements[0]).toContain("'afl-tables-results'");
     expect(assembled.packet.content).toMatchObject({
       state: 'blocked',
       methodSelection: { state: 'missing', methodId: null },
@@ -173,12 +218,7 @@ describe('local HPN league-season review assembler', () => {
     expect(assembled.sourceUseAssessments).toHaveLength(4);
     expect(
       assembled.sourceUseAssessments.map(({ assessment }) => assessment.content.reasons)
-    ).toEqual(
-      Array.from({ length: 4 }, () => [
-        'derived_feature_operation_blocked',
-        'derived_source_field_blocked',
-      ])
-    );
+    ).toEqual(Array.from({ length: 4 }, () => []));
     for (const { report } of assembled.eligibilityReports) {
       expect(report.content.sources).toMatchObject([
         {
@@ -197,7 +237,7 @@ describe('local HPN league-season review assembler', () => {
           role: 'corroborating',
         },
       ]);
-      expect(report.content.sources[0]!.normalizationRunId).toBe(
+      expect(report.content.sources[0]!.normalizationRunId).not.toBe(
         report.content.sources[1]!.normalizationRunId
       );
     }
@@ -207,7 +247,7 @@ describe('local HPN league-season review assembler', () => {
     expect(primary.selectionState).toBe('selected');
     expect(primary.fields.every(({ state }) => state === 'blocked')).toBe(true);
     expect(primary.fields[0]!.fieldMapReview.state).toBe('missing');
-    expect(primary.fields[0]!.sourceUse.state).toBe('not_permitted');
+    expect(primary.fields[0]!.sourceUse.state).toBe('permitted_private_calculation');
     expect(primary.fields[0]!.factualReview.state).toBe('missing');
     expect(assembled.documents).toEqual(
       expect.arrayContaining([

--- a/tests/unit/afl-trade-intelligence-local-official-afl-2026-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-local-official-afl-2026-authority.test.ts
@@ -39,7 +39,7 @@ describe('local official AFL 2026 authority', () => {
         operations: {
           internal_quality_evaluation: 'allowed',
           model_training: 'blocked',
-          derived_feature_creation: 'blocked',
+          derived_feature_creation: 'allowed',
           public_derived_output: 'blocked',
           public_fact_display: 'blocked',
         },

--- a/tests/unit/afl-trade-intelligence-postgres-hpn-pav-input.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-hpn-pav-input.test.ts
@@ -1,12 +1,16 @@
 import { createHash } from 'node:crypto';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   canonicalizeAflTradeJson,
   sha256AflTradeCanonicalJson,
 } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
-import { createAflTradeByteArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import {
+  createAflTradeByteArtifactRef,
+  createAflTradeCanonicalJsonArtifactRef,
+} from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import { createAflTradeFinalizedHpnPavCalculationService } from '@/server/aflTradeIntelligence/modeling/hpnPavCalculationService';
 import { PostgresAflTradeHpnPavCalculationRepository } from '@/server/aflTradeIntelligence/modeling/postgresHpnPavCalculationRepository';
 import type {
@@ -18,9 +22,11 @@ import {
   aflTradeHpnPavSeasonInputSetSchema,
   createAflTradeHpnPavFieldMap,
 } from '@/server/aflTradeIntelligence/modeling/hpnPavInputContracts';
+import { aflTradeHpnProjectedFieldMapSchema } from '@/server/aflTradeIntelligence/modeling/hpnProjectedFieldMap';
 import { AflTradeHpnPavInputError } from '@/server/aflTradeIntelligence/modeling/hpnPavInputRepository';
 import { createAflTradeHpnPavMethod } from '@/server/aflTradeIntelligence/modeling/hpnPlayerApproximateValue';
 import { PostgresAflTradeHpnPavInputRepository } from '@/server/aflTradeIntelligence/modeling/postgresHpnPavInputRepository';
+import { PostgresAflTradeHpnProjectedFieldMapAuthority } from '@/server/aflTradeIntelligence/modeling/postgresHpnProjectedFieldMapAuthority';
 
 const sha = (value: string) => createHash('sha256').update(value).digest('hex');
 const addressed = (prefix: string, value: string) => `${prefix}:${sha(value)}`;
@@ -105,6 +111,81 @@ function resultMap() {
   });
 }
 
+function projectedMap(
+  fieldMap: ReturnType<typeof resultMap> | ReturnType<typeof playerMap>,
+  suffix: string
+) {
+  const createdAt = '2026-08-09T00:00:00.000Z';
+  const candidateArtifact = createAflTradeCanonicalJsonArtifactRef(
+    { candidate: suffix },
+    createdAt
+  );
+  const approvalDecisionArtifact = createAflTradeCanonicalJsonArtifactRef(
+    { decision: suffix },
+    createdAt
+  );
+  const semanticBindings =
+    fieldMap.content.inputKind === 'completed_match_result'
+      ? [
+          { semanticField: 'awayClub', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.awayClub } },
+          { semanticField: 'awayPoints', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.awayPoints } },
+          { semanticField: 'completionStatus', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.completionStatus } },
+          { semanticField: 'homeClub', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.homeClub } },
+          { semanticField: 'homePoints', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.homePoints } },
+          { semanticField: 'match', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.match } },
+        ]
+      : [
+          { semanticField: 'clearances', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.clearances } },
+          { semanticField: 'club', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.club } },
+          { semanticField: 'freeKicksAgainst', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.freeKicksAgainst } },
+          { semanticField: 'freeKicksFor', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.freeKicksFor } },
+          { semanticField: 'goalAssists', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.goalAssists } },
+          { semanticField: 'hitOuts', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.hitOuts } },
+          { semanticField: 'inside50s', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.inside50s } },
+          { semanticField: 'marks', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.marks } },
+          { semanticField: 'marksInside50', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.marksInside50 } },
+          { semanticField: 'match', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.match } },
+          { semanticField: 'onePercenters', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.onePercenters } },
+          { semanticField: 'player', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.player } },
+          { semanticField: 'rebound50s', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.rebound50s } },
+          { semanticField: 'tackles', mapping: { kind: 'direct', sourceField: fieldMap.content.bindings.tackles } },
+          { semanticField: 'totalPoints', mapping: fieldMap.content.bindings.totalPoints },
+        ];
+  const content = {
+    schemaVersion: 'afl-trade-hpn-projected-field-map/v1' as const,
+    environment: 'non_production' as const,
+    purpose: 'private_confirmed_realized_hpn_pav' as const,
+    competition: 'AFLM' as const,
+    provider: fieldMap.content.provider,
+    capabilityId: fieldMap.content.capabilityId,
+    sourceSchemaSha256: fieldMap.content.sourceSchemaSha256,
+    inputKind: fieldMap.content.inputKind,
+    validFromSeason: fieldMap.content.validFromSeason,
+    validThroughSeason: fieldMap.content.validThroughSeason,
+    candidateId: addressed('hpn-field-map-candidate', suffix),
+    candidateArtifact,
+    approvalDecisionId: addressed('hpn-field-map-review-decision', suffix),
+    approvalDecisionArtifact,
+    semanticBindings,
+    completionRule:
+      fieldMap.content.inputKind === 'completed_match_result'
+        ? {
+            kind: 'source_status' as const,
+            completedValues: fieldMap.content.bindings.completedValues,
+          }
+        : null,
+    createdAt,
+    publicationEligible: false as const,
+    publicationProhibited: true as const,
+    limitation:
+      'Private non-production projection map only; it grants no factual release, model training, publication, production, activation, or live-capture authority.' as const,
+  };
+  return aflTradeHpnProjectedFieldMapSchema.parse({
+    fieldMapId: createAflTradeContentAddress('hpn-pav-field-map', content),
+    content,
+  });
+}
+
 interface FakeOptions {
   omitLastRow?: boolean;
   resultStatus?: string;
@@ -112,14 +193,11 @@ interface FakeOptions {
   omitUniverseAppearance?: boolean;
   membershipDrift?: boolean;
   sourceMembershipDrift?: boolean;
+  projectedMaps?: boolean;
 }
 
 class FakeHpnPavSqlClient implements AflOutcomeSqlClient, AflOutcomeSqlTransaction {
-  readonly maps = [
-    resultMap(),
-    playerMap('afl_tables', 'primary'),
-    playerMap('footywire', 'corroborating'),
-  ];
+  readonly maps;
   readonly resultRunId = addressed('provider-normalization-run', 'result-run');
   readonly primaryRunId = addressed('provider-normalization-run', 'primary-run');
   readonly corroboratingRunId = addressed('provider-normalization-run', 'corroborating-run');
@@ -134,7 +212,16 @@ class FakeHpnPavSqlClient implements AflOutcomeSqlClient, AflOutcomeSqlTransacti
   calculationPlayerCount = 0;
   transactionTimestampReads = 0;
 
-  constructor(private readonly options: FakeOptions = {}) {}
+  constructor(private readonly options: FakeOptions = {}) {
+    const legacyMaps = [
+      resultMap(),
+      playerMap('afl_tables', 'primary'),
+      playerMap('footywire', 'corroborating'),
+    ] as const;
+    this.maps = options.projectedMaps
+      ? legacyMaps.map((map, index) => projectedMap(map, `projected:${index}`))
+      : legacyMaps;
+  }
 
   async transaction<T>(work: (transaction: AflOutcomeSqlTransaction) => Promise<T>): Promise<T> {
     return work(this);
@@ -308,7 +395,10 @@ class FakeHpnPavSqlClient implements AflOutcomeSqlClient, AflOutcomeSqlTransacti
           : [{ input_set_json: this.storedInput, finalized_at: this.finalizedAt }]
       );
     }
-    if (sql.includes('FROM jsonb_to_recordset($1::jsonb)') && sql.includes('pav_map.map_json')) {
+    if (
+      sql.includes('FROM jsonb_to_recordset($1::jsonb)') &&
+      sql.includes('JOIN outcome_provider_normalization_run run')
+    ) {
       const requested = JSON.parse(String(parameters[0])) as Array<{
         normalizationRunId: string;
         fieldMapId: string;
@@ -322,7 +412,9 @@ class FakeHpnPavSqlClient implements AflOutcomeSqlClient, AflOutcomeSqlTransacti
             capture_id: `capture:${map.content.provider}:2025`,
             source_snapshot_id: addressed('source-snapshot', `snapshot:${map.content.provider}`),
             source_artifact_id: addressed('artifact', `artifact:${map.content.provider}`),
-            capture_environment: 'test_fixture',
+            capture_environment: this.options.projectedMaps ? 'non_production' : 'test_fixture',
+            capture_provider: map.content.provider,
+            capture_capability_id: map.content.capabilityId,
             capture_status: 'approved',
             captured_at: '2025-09-27T00:00:00.000Z',
             finalized_at: '2026-08-09T00:00:00.000Z',
@@ -334,11 +426,21 @@ class FakeHpnPavSqlClient implements AflOutcomeSqlClient, AflOutcomeSqlTransacti
             run_status: 'staged',
             capability_id: map.content.capabilityId,
             source_schema_sha256: map.content.sourceSchemaSha256,
-            field_map_json: map,
           };
         })
       );
     }
+    if (sql.includes('SELECT legacy.map_json AS legacy_map_json')) {
+      const fieldMapId = String(parameters[0]);
+      const map = this.maps.find((candidate) => candidate.fieldMapId === fieldMapId);
+      return this.result([
+        {
+          legacy_map_json:
+            map?.content.schemaVersion === 'afl-trade-hpn-pav-field-map/v1' ? map : null,
+        },
+      ]);
+    }
+    if (sql.includes('SELECT candidate.candidate_json')) return this.result([]);
     if (sql.includes('FROM outcome_provider_decoded_row decoded')) {
       const rows = this.decodedRows();
       return this.result(this.options.omitLastRow ? rows.slice(0, -1) : rows);
@@ -431,7 +533,9 @@ class FakeHpnPavSqlClient implements AflOutcomeSqlClient, AflOutcomeSqlTransacti
 
 function request(client: FakeHpnPavSqlClient) {
   return {
-    environment: 'test_fixture' as const,
+    environment: (client.maps[0]!.content.environment === 'non_production'
+      ? 'non_production'
+      : 'test_fixture') as 'test_fixture' | 'non_production',
     competition: 'AFLM' as const,
     seasonYear: 2025,
     methodId: method.methodId,
@@ -461,6 +565,35 @@ function request(client: FakeHpnPavSqlClient) {
 }
 
 describe('PostgresAflTradeHpnPavInputRepository', () => {
+  it('builds and replays through the existing seam from approved projected maps', async () => {
+    const client = new FakeHpnPavSqlClient({ projectedMaps: true });
+    const repository = new PostgresAflTradeHpnPavInputRepository(client);
+    const loadCurrentExact = vi
+      .spyOn(PostgresAflTradeHpnProjectedFieldMapAuthority.prototype, 'loadCurrentExact')
+      .mockImplementation(async (fieldMapId) =>
+        client.maps.find((map) => map.fieldMapId === fieldMapId) ?? null
+      );
+
+    try {
+      const first = await repository.buildAndPersistSeasonInputSet(request(client), {
+        environment: 'non_production',
+      });
+      const replay = await repository.buildAndPersistSeasonInputSet(request(client), {
+        environment: 'non_production',
+      });
+
+      expect(first.idempotentReplay).toBe(false);
+      expect(replay).toEqual({ inputSet: first.inputSet, idempotentReplay: true });
+      expect(first.inputSet.content.schemaVersion).toBe('afl-trade-hpn-pav-input-set/v2');
+      expect(first.inputSet.content.fieldMaps).toEqual(
+        [...client.maps].sort((left, right) => left.fieldMapId.localeCompare(right.fieldMapId))
+      );
+      expect(loadCurrentExact).toHaveBeenCalledTimes(3);
+    } finally {
+      loadCurrentExact.mockRestore();
+    }
+  });
+
   it('derives, persists, and exactly replays a complete cross-provider season input set', async () => {
     const client = new FakeHpnPavSqlClient();
     const repository = new PostgresAflTradeHpnPavInputRepository(client);

--- a/tests/unit/afl-trade-intelligence-postgres-hpn-projected-field-map.test.ts
+++ b/tests/unit/afl-trade-intelligence-postgres-hpn-projected-field-map.test.ts
@@ -36,6 +36,24 @@ async function prepareDatabase(database: PGlite): Promise<void> {
   await database.exec(`
     CREATE EXTENSION IF NOT EXISTS pgcrypto;
     CREATE TYPE "OutcomeEnvironment" AS ENUM ('test_fixture','non_production','production');
+    CREATE TABLE outcome_private_reviewed_evidence_bundle (
+      evidence_bundle_id TEXT PRIMARY KEY,
+      evidence_scope_key TEXT NOT NULL
+    );
+    CREATE TABLE outcome_private_reviewed_evaluation_decision (
+      decision_id TEXT PRIMARY KEY,
+      evidence_bundle_id TEXT NOT NULL,
+      valuation_scope_key TEXT NOT NULL,
+      status TEXT NOT NULL,
+      decision_json JSONB NOT NULL
+    );
+    CREATE TABLE outcome_private_reviewed_evaluation_head (
+      decision_id TEXT PRIMARY KEY,
+      evidence_bundle_id TEXT NOT NULL,
+      valuation_scope_key TEXT NOT NULL,
+      evidence_scope_key TEXT NOT NULL,
+      status TEXT NOT NULL
+    );
   `);
   await database.exec(MIGRATION);
 }
@@ -89,7 +107,7 @@ function approvedProjection(input: { readonly decision: 'approved' | 'rejected';
     valuationScopeKey: 'workbook:2025',
     evaluationDecisionId: 'private-reviewed-evaluation-decision:fixture',
     state: 'permitted_private_calculation' as const,
-    rightsArtifactId: `artifact:${'1'.repeat(64)}`,
+    rightsArtifactId: `source-rights:${'1'.repeat(64)}`,
     evidenceBundleId: 'private-reviewed-evidence:fixture',
     fields: [...new Set(
       candidate.content.semanticBindings.flatMap(listAflTradeHpnCandidateSourceFields)
@@ -145,6 +163,48 @@ function approvedProjection(input: { readonly decision: 'approved' | 'rejected';
   };
 }
 
+async function seedReviewedEvaluation(
+  database: PGlite,
+  projection: ReturnType<typeof approvedProjection>
+): Promise<void> {
+  const { evaluationDecisionId, evidenceBundleId, valuationScopeKey } =
+    projection.sourceUseAssessment.content;
+  if (evaluationDecisionId === null || valuationScopeKey === null) {
+    throw new TypeError('The projected-map fixture requires exact reviewed evaluation authority.');
+  }
+  await database.query(
+    `INSERT INTO outcome_private_reviewed_evidence_bundle
+       (evidence_bundle_id,evidence_scope_key)
+     VALUES ($1,'afl-player-match-reviewed-2021-2026')`,
+    [evidenceBundleId]
+  );
+  await database.query(
+    `INSERT INTO outcome_private_reviewed_evaluation_decision
+       (decision_id,evidence_bundle_id,valuation_scope_key,status,decision_json)
+     VALUES ($1,$2,$3,'authorized',$4::jsonb)`,
+    [
+      evaluationDecisionId,
+      evidenceBundleId,
+      valuationScopeKey,
+      JSON.stringify({
+        content: {
+          status: 'authorized',
+          valuationScopeKey,
+          evidenceBundleId,
+          permissions: { derivedCalculations: true, internalEvaluation: true },
+          publicationProhibited: true,
+        },
+      }),
+    ]
+  );
+  await database.query(
+    `INSERT INTO outcome_private_reviewed_evaluation_head
+       (decision_id,evidence_bundle_id,valuation_scope_key,evidence_scope_key,status)
+     VALUES ($1,$2,$3,'afl-player-match-reviewed-2021-2026','authorized')`,
+    [evaluationDecisionId, evidenceBundleId, valuationScopeKey]
+  );
+}
+
 describe('candidate-first HPN projected field-map PostgreSQL authority', () => {
   let database: PGlite | null = null;
 
@@ -163,6 +223,7 @@ describe('candidate-first HPN projected field-map PostgreSQL authority', () => {
       decision: 'approved',
       rationale: 'Approve the exact private projection.',
     });
+    await seedReviewedEvaluation(database, projection);
 
     await expect(authority.registerApprovedProjection(projection)).resolves.toEqual(
       projection.projectedFieldMap
@@ -173,6 +234,54 @@ describe('candidate-first HPN projected field-map PostgreSQL authority', () => {
     await expect(
       authority.loadCurrentExact(projection.projectedFieldMap!.fieldMapId)
     ).resolves.toEqual(projection.projectedFieldMap);
+    await expect(
+      authority.loadCurrentForSource({
+        provider: projection.candidate.content.provider,
+        capabilityId: projection.candidate.content.capabilityId,
+        inputKind: projection.candidate.content.inputKind,
+        sourceSchemaSha256: projection.candidate.content.sourceSchemaSha256,
+        providerDecodeMapId: projection.candidate.content.providerDecodeMapId,
+        seasonYear: 2025,
+        rightsArtifactId: projection.sourceUseAssessment.content.rightsArtifactId,
+        valuationScopeKey: projection.sourceUseAssessment.content.valuationScopeKey!,
+      })
+    ).resolves.toEqual(projection.projectedFieldMap);
+    await expect(
+      authority.loadCurrentForSource({
+        provider: projection.candidate.content.provider,
+        capabilityId: projection.candidate.content.capabilityId,
+        inputKind: projection.candidate.content.inputKind,
+        sourceSchemaSha256: 'f'.repeat(64),
+        providerDecodeMapId: projection.candidate.content.providerDecodeMapId,
+        seasonYear: 2025,
+        rightsArtifactId: projection.sourceUseAssessment.content.rightsArtifactId,
+        valuationScopeKey: projection.sourceUseAssessment.content.valuationScopeKey!,
+      })
+    ).resolves.toBeNull();
+    await expect(
+      authority.loadCurrentForSource({
+        provider: projection.candidate.content.provider,
+        capabilityId: projection.candidate.content.capabilityId,
+        inputKind: projection.candidate.content.inputKind,
+        sourceSchemaSha256: projection.candidate.content.sourceSchemaSha256,
+        providerDecodeMapId: 'provider-field-map:another-reviewed-map',
+        seasonYear: 2025,
+        rightsArtifactId: projection.sourceUseAssessment.content.rightsArtifactId,
+        valuationScopeKey: projection.sourceUseAssessment.content.valuationScopeKey!,
+      })
+    ).resolves.toBeNull();
+    await expect(
+      authority.loadCurrentForSource({
+        provider: projection.candidate.content.provider,
+        capabilityId: projection.candidate.content.capabilityId,
+        inputKind: projection.candidate.content.inputKind,
+        sourceSchemaSha256: projection.candidate.content.sourceSchemaSha256,
+        providerDecodeMapId: projection.candidate.content.providerDecodeMapId,
+        seasonYear: 2025,
+        rightsArtifactId: projection.sourceUseAssessment.content.rightsArtifactId,
+        valuationScopeKey: 'workbook:another-scope',
+      })
+    ).resolves.toBeNull();
 
     const counts = await database.query<{
       candidates: number;

--- a/tests/unit/afl-trade-intelligence-private-valuation-hpn-preparation.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-hpn-preparation.test.ts
@@ -1,0 +1,327 @@
+import { createHash } from 'node:crypto';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import {
+  createLocalAflTradeAflTablesResultsAuthority,
+  createLocalAflTradeFiveSeasonAflTablesAuthority,
+} from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority';
+import { createLocalAflTradeOfficialAfl2026Authority } from '@/server/aflTradeIntelligence/development/localOfficialAfl2026Authority';
+import { createAflTradePrivateValuationFactualOutput } from '@/server/aflTradeIntelligence/valuation/privateValuationFactualOutput';
+import {
+  aflTradePrivateValuationDispatchRequestSchema,
+  createAflTradePrivateValuationDispatchRequestId,
+} from '@/server/aflTradeIntelligence/valuation/privateValuationScheduling';
+import { PostgresAflTradePrivateValuationHpnPreparation } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationHpnPreparation';
+import { PostgresAflTradePrivateValuationCaptureBindingRepository } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationCaptureBindingRepository';
+import { PostgresAflTradeHpnProjectedFieldMapAuthority } from '@/server/aflTradeIntelligence/modeling/postgresHpnProjectedFieldMapAuthority';
+import { PostgresAflTradeHpnPavInputRepository } from '@/server/aflTradeIntelligence/modeling/postgresHpnPavInputRepository';
+import { PostgresAflTradeHpnPavCalculationRepository } from '@/server/aflTradeIntelligence/modeling/postgresHpnPavCalculationRepository';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlQueryResult,
+  AflOutcomeSqlTransaction,
+} from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+
+const sha = (value: string) => createHash('sha256').update(value).digest('hex');
+const addressed = (prefix: string, value: string) => `${prefix}:${sha(value)}`;
+const claim = {
+  claimId: addressed('private-valuation-dispatch-claim', 'hpn-claim'),
+  leaseToken: sha('hpn-lease'),
+};
+const requestContent = {
+  scopeKey: 'afl-men:2026-trades',
+  trigger: 'ad_hoc' as const,
+  scheduledFor: '2026-08-12T00:00:00.000Z',
+  authorityKey: 'hpn-preparation-test',
+};
+const request = aflTradePrivateValuationDispatchRequestSchema.parse({
+  requestId: createAflTradePrivateValuationDispatchRequestId(requestContent),
+  ...requestContent,
+});
+
+class PreparationSqlClient implements AflOutcomeSqlClient, AflOutcomeSqlTransaction {
+  constructor(private readonly retainedRequest = request) {}
+
+  async transaction<T>(work: (transaction: AflOutcomeSqlTransaction) => Promise<T>): Promise<T> {
+    return work(this);
+  }
+
+  async query<Row>(sql: string): Promise<AflOutcomeSqlQueryResult<Row>> {
+    if (sql.startsWith('SET LOCAL ROLE')) return this.result([]);
+    if (sql.includes('load_outcome_private_valuation_dispatch_request_for_claim')) {
+      return this.result([{ request_json: this.retainedRequest }]);
+    }
+    if (sql.includes('heartbeat_outcome_private_valuation_dispatch')) {
+      return this.result([{ heartbeat_outcome_private_valuation_dispatch: null }]);
+    }
+    if (sql.includes('max(capture.captured_at)')) {
+      return this.result([{ effective_through: '2026-08-12T00:03:00.000Z' }]);
+    }
+    throw new Error(`Unexpected SQL: ${sql}`);
+  }
+
+  private result<Row>(rows: readonly unknown[]): AflOutcomeSqlQueryResult<Row> {
+    return { rows: rows as readonly Row[], rowCount: rows.length };
+  }
+}
+
+function factualOutput() {
+  return createAflTradePrivateValuationFactualOutput({
+    requestId: request.requestId,
+    valuationScopeKey: request.scopeKey,
+    captureBindingId: addressed('private-valuation-capture-binding', 'factual'),
+    sourceAdmissionId: addressed('private-valuation-source-admission', 'source-admission'),
+    normalizationRunId: addressed('provider-normalization-run', 'factual'),
+    factBatch: {
+      batchId: addressed('source-fact-batch', 'fact-batch'),
+      batchSha256: sha('fact-batch'),
+    },
+    reconciliation: {
+      factualRunId: addressed('factual-reconciliation-run', 'factual-run'),
+      runSha256: sha('factual-run'),
+      outputSetSha256: sha('factual-output'),
+      finalizedAt: '2026-08-12T00:01:00.000Z',
+    },
+    spellMetricBatches: [
+      {
+        batchId: addressed('acquisition-spell-metric-batch', 'spell-batch'),
+        batchSha256: sha('spell-batch'),
+      },
+    ],
+    candidate: {
+      candidateId: addressed('factual-release-candidate', 'candidate'),
+      candidateSha256: sha('candidate'),
+      memberSetSha256: sha('members'),
+    },
+    factualRelease: {
+      releaseId: addressed('outcome-release', 'release'),
+      releaseSha256: sha('release'),
+    },
+    preparedAt: '2026-08-12T00:02:00.000Z',
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('private valuation HPN preparation', () => {
+  it('composes three exact capture lanes into the existing HPN input and calculation owners', async () => {
+    const roles = [
+      'hpn_completed_results',
+      'hpn_primary_player_stats',
+      'hpn_corroborating_player_stats',
+    ] as const;
+    const sourcePlanByRole = {
+      hpn_completed_results: {
+        provider: 'afl_tables',
+        dataset: 'AFL Tables completed match results through fitzRoy',
+        capabilityId: 'afl-tables-results',
+        fieldMapId: 'afl-tables-results-local-2026-v1',
+        rightsArtifactId:
+          createLocalAflTradeAflTablesResultsAuthority(2026).capture.sourceRights.rightsArtifactId,
+      },
+      hpn_primary_player_stats: {
+        provider: 'afl_tables',
+        dataset: 'AFL Tables historical player match statistics',
+        capabilityId: 'afl-tables-player-stats',
+        fieldMapId: 'afl-tables-player-stats-local-2026-v1',
+        rightsArtifactId:
+          createLocalAflTradeFiveSeasonAflTablesAuthority(2026).capture.sourceRights.rightsArtifactId,
+      },
+      hpn_corroborating_player_stats: {
+        provider: 'official_afl',
+        dataset: 'Official AFL 2026 player match statistics',
+        capabilityId: 'official-afl-player-stats',
+        fieldMapId: 'official-afl-player-stats-local-2026-v1',
+        rightsArtifactId:
+          createLocalAflTradeOfficialAfl2026Authority().capture.sourceRights.rightsArtifactId,
+      },
+    } as const;
+    const retainedBindings = new Map<string, Awaited<ReturnType<
+      PostgresAflTradePrivateValuationCaptureBindingRepository['accept']
+    >>>();
+    const loadBinding = vi
+      .spyOn(PostgresAflTradePrivateValuationCaptureBindingRepository.prototype, 'load')
+      .mockImplementation(async (_request, sourceRole = 'factual_input') =>
+        retainedBindings.get(sourceRole) ?? null
+      );
+    const acceptBinding = vi
+      .spyOn(PostgresAflTradePrivateValuationCaptureBindingRepository.prototype, 'accept')
+      .mockImplementation(async ({ sourceRole, normalizationRunId }) => {
+        const exactRole = sourceRole as (typeof roles)[number];
+        const sourcePlan = sourcePlanByRole[exactRole];
+        const content = {
+          schemaVersion: 'afl-trade-private-valuation-capture-binding/v2' as const,
+          request,
+          sourceRole: exactRole,
+          dispatchClaimId: claim.claimId,
+          attemptSequence: 1,
+          attemptNumber: 1,
+          sourcePlan: {
+            ...sourcePlan,
+            competition: 'AFLM' as const,
+            seasonYear: 2026,
+            gate0AReceiptId: addressed('gate0a-evaluation', exactRole),
+          },
+          sourceCaptureAttemptId: addressed('source-capture-attempt', exactRole),
+          captureReceiptId: addressed('fitzroy-capture', exactRole),
+          snapshotId: addressed('source-snapshot', exactRole),
+          sourceCaptureId: addressed('source-capture', exactRole),
+          normalizationRunId,
+          acceptedAt: '2026-08-12T00:03:00.000Z',
+          environment: 'non_production' as const,
+          publicationEligible: false as const,
+          limitation:
+            'Accepted non-production source custody only; it grants no factual, model, private-evaluation, or publication authority.' as const,
+        };
+        const binding = {
+          bindingId: createAflTradeContentAddress(
+            'private-valuation-capture-binding',
+            content
+          ),
+          content,
+        };
+        retainedBindings.set(exactRole, binding);
+        return binding;
+      });
+    const selectedMaps = vi
+      .spyOn(PostgresAflTradeHpnProjectedFieldMapAuthority.prototype, 'loadCurrentForSource')
+      .mockImplementation(async ({ inputKind, provider }) => ({
+        fieldMapId: addressed('hpn-pav-field-map', `${provider}:${inputKind}`),
+      }) as never);
+    const buildInput = vi
+      .spyOn(PostgresAflTradeHpnPavInputRepository.prototype, 'buildAndPersistSeasonInputSet')
+      .mockResolvedValue({
+        inputSet: { inputSetId: addressed('hpn-pav-input-set', 'input') } as never,
+        idempotentReplay: false,
+      });
+    const calculate = vi
+      .spyOn(PostgresAflTradeHpnPavCalculationRepository.prototype, 'calculateAndPersist')
+      .mockResolvedValue({
+        calculation: { calculationId: addressed('hpn-pav-season', 'calculation') } as never,
+        idempotentReplay: false,
+      });
+    const captureSource = vi.fn(async ({ sourceRole }: { sourceRole: string }) => ({
+      normalizationRunId: addressed('provider-normalization-run', sourceRole),
+    }));
+    const prepareFactual = vi
+      .fn()
+      .mockResolvedValueOnce({ state: 'prepared' as const, output: factualOutput() })
+      .mockResolvedValue({ state: 'already_prepared' as const, output: factualOutput() });
+    const preparation = new PostgresAflTradePrivateValuationHpnPreparation(
+      new PreparationSqlClient(),
+      {
+        factualPreparation: { prepare: prepareFactual },
+        methodId: addressed('hpn-pav-method', 'method'),
+        methodAuthority: { loadExact: vi.fn() },
+        captureSource,
+      }
+    );
+
+    await expect(preparation.prepare({ requestId: request.requestId, claim })).resolves.toEqual({
+      state: 'prepared',
+      requestId: request.requestId,
+      factualOutputId: factualOutput().outputId,
+      inputSetId: addressed('hpn-pav-input-set', 'input'),
+      calculationId: addressed('hpn-pav-season', 'calculation'),
+      captureBindingIds: roles.map((_role) =>
+        expect.stringMatching(/^private-valuation-capture-binding:[a-f0-9]{64}$/u)
+      ),
+      publicationEligible: false,
+    });
+    expect(loadBinding).toHaveBeenCalledTimes(3);
+    expect(acceptBinding).toHaveBeenCalledTimes(3);
+    expect(captureSource.mock.calls.map(([input]) => input.sourceRole)).toEqual(roles);
+    expect(selectedMaps).toHaveBeenCalledTimes(3);
+    expect(buildInput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        environment: 'non_production',
+        competition: 'AFLM',
+        seasonYear: 2026,
+        factualRunId: factualOutput().content.reconciliation.factualRunId,
+        sources: expect.arrayContaining([
+          expect.objectContaining({ inputKind: 'completed_match_result', role: null }),
+          expect.objectContaining({ inputKind: 'player_match_stats', role: 'primary' }),
+          expect.objectContaining({ inputKind: 'player_match_stats', role: 'corroborating' }),
+        ]),
+      }),
+      { environment: 'non_production' }
+    );
+    expect(calculate).toHaveBeenCalledTimes(1);
+
+    buildInput.mockResolvedValue({
+      inputSet: { inputSetId: addressed('hpn-pav-input-set', 'input') } as never,
+      idempotentReplay: true,
+    });
+    calculate.mockResolvedValue({
+      calculation: { calculationId: addressed('hpn-pav-season', 'calculation') } as never,
+      idempotentReplay: true,
+    });
+    await expect(preparation.prepare({ requestId: request.requestId, claim })).resolves.toMatchObject({
+      state: 'already_prepared',
+      inputSetId: addressed('hpn-pav-input-set', 'input'),
+      calculationId: addressed('hpn-pav-season', 'calculation'),
+    });
+    expect(captureSource).toHaveBeenCalledTimes(3);
+    expect(acceptBinding).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails closed before HPN persistence when exact accepted source custody is missing', async () => {
+    vi.spyOn(
+      PostgresAflTradePrivateValuationCaptureBindingRepository.prototype,
+      'load'
+    ).mockRejectedValue(new Error('No accepted exact source custody.'));
+    const buildInput = vi.spyOn(
+      PostgresAflTradeHpnPavInputRepository.prototype,
+      'buildAndPersistSeasonInputSet'
+    );
+    const preparation = new PostgresAflTradePrivateValuationHpnPreparation(
+      new PreparationSqlClient(),
+      {
+        factualPreparation: {
+          prepare: vi.fn(async () => ({ state: 'prepared' as const, output: factualOutput() })),
+        },
+        methodId: addressed('hpn-pav-method', 'method'),
+        methodAuthority: { loadExact: vi.fn() },
+        captureSource: vi.fn(),
+      }
+    );
+
+    await expect(preparation.prepare({ requestId: request.requestId, claim })).rejects.toThrow(
+      /exact source custody/i
+    );
+    expect(buildInput).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported dispatch scope before factual or capture work', async () => {
+    const unsupportedContent = {
+      ...requestContent,
+      scopeKey: 'aflw:2026-trades',
+      authorityKey: 'unsupported-hpn-scope',
+    };
+    const unsupportedRequest = aflTradePrivateValuationDispatchRequestSchema.parse({
+      requestId: createAflTradePrivateValuationDispatchRequestId(unsupportedContent),
+      ...unsupportedContent,
+    });
+    const prepareFactual = vi.fn();
+    const captureSource = vi.fn();
+    const preparation = new PostgresAflTradePrivateValuationHpnPreparation(
+      new PreparationSqlClient(unsupportedRequest),
+      {
+        factualPreparation: { prepare: prepareFactual },
+        methodId: addressed('hpn-pav-method', 'method'),
+        methodAuthority: { loadExact: vi.fn() },
+        captureSource,
+      }
+    );
+
+    await expect(
+      preparation.prepare({ requestId: unsupportedRequest.requestId, claim })
+    ).rejects.toThrow(/supports only afl-men:2026-trades/i);
+    expect(prepareFactual).not.toHaveBeenCalled();
+    expect(captureSource).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/afl-trade-intelligence-private-valuation-raw-data-coordinator.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-raw-data-coordinator.test.ts
@@ -57,7 +57,7 @@ describe('private valuation raw-data coordinator', () => {
       binding: retained,
       idempotentReplay: true,
     });
-    expect(load).toHaveBeenCalledWith(request);
+    expect(load).toHaveBeenCalledWith(request, 'factual_input');
     expect(capture).not.toHaveBeenCalled();
     expect(accept).not.toHaveBeenCalled();
   });
@@ -80,10 +80,11 @@ describe('private valuation raw-data coordinator', () => {
       binding: candidate,
       idempotentReplay: false,
     });
-    expect(capture).toHaveBeenCalledWith({ request, claim });
+    expect(capture).toHaveBeenCalledWith({ request, claim, sourceRole: 'factual_input' });
     expect(accept).toHaveBeenCalledWith({
       request,
       claim,
+      sourceRole: 'factual_input',
       normalizationRunId: candidate.content.normalizationRunId,
     });
   });


### PR DESCRIPTION
## Outcome

Builds and exactly replays governed reviewed HPN inputs and calculations from the retained private factual foundation.

## Boundaries

- Reuses the existing reviewed-evidence authority tables, HPN repositories, and dispatch capture custody.
- Adds no scheduler, queue, workflow ledger, or parallel factual authority.
- Remains local, non-production, and publication-prohibited.
- Does not yet claim the complete raw-data-to-recalculation pipeline: downstream model execution, qualification, prepared-v3 creation, and cohort orchestration remain to be connected.

## Verification

- Canonical migration-history assertion: 1 passed.
- Migrated HPN PostgreSQL suites: 13 passed.
- Focused HPN and coordinator unit tests: 44 passed.
- Prisma schema validation, typecheck, documentation checks, lint, and diff validation passed.

## Summary by Sourcery

Establish the governed non-production HPN preparation boundary over retained factual evidence and reviewed source projections without connecting it to weekly production orchestration.

New Features:
- Add a claim-fenced HPN preparation path that replays retained factual output, authenticates three role-specific source captures, resolves current reviewed projections, and produces governed HPN inputs and calculations.
- Support AFL Tables completed match results as a distinct 2026 source lane and allow derived HPN calculations under private non-production rights.

Bug Fixes:
- Prevent stale, forged, incomplete, cross-scope, expired, or mismatched source and review authority from entering projected HPN inputs or calculations.
- Preserve idempotent restart replay across role-aware capture custody, projected input construction, and calculation persistence.

Enhancements:
- Extend HPN input contracts and PostgreSQL authority checks with content-addressed projected field maps while retaining legacy input compatibility.
- Strengthen reviewed-evidence evolution so the authorized bundle can advance only through the exact AFL Tables results successor.
- Document the governed HPN preparation boundary, operational verification commands, and its remaining separation from weekly execution.

Documentation:
- Document the new non-production HPN preparation seam and clarify that weekly prepared-v3 execution remains unconnected.

Tests:
- Add unit and PostgreSQL integration coverage for projected HPN inputs, role-aware capture binding, claim fencing, exact authority validation, rejection paths, and restart replay.