### PR TITLE
Govern private HPN source admission

### DIFF
--- a/docs/architecture/afl-trade-intelligence.md
+++ b/docs/architecture/afl-trade-intelligence.md
@@ -1921,14 +1921,30 @@ changes and coalesces missed weekly occurrences. An authenticated backend-only c
 same coordinator ad hoc using a caller-supplied stable operation key.
 
 The upstream path now has a claim-fenced HPN preparation boundary, but it is not yet wired into the
-weekly worker. Given one exact dispatch and live claim, it reuses the retained private factual output,
+weekly worker. Given one exact dispatch and live claim, it requires the exact immutable private
+factual output already retained for that request,
 accepts one result capture plus primary and corroborating player-stat captures under distinct source
-roles, resolves one current reviewed HPN map for each exact provider/capability/schema/season lane,
-and delegates input construction and calculation to the existing content-addressed HPN repositories.
-Restart reloads accepted captures and the existing HPN input/calculation records. Missing or stale
-source custody, map approval, identity resolution, factual-universe coverage, or method authority
-fails closed before downstream authority changes. The current public release pointer and publication
-Gates remain untouched.
+roles, and resolves one current reviewed HPN map for each exact provider/capability/schema/season lane.
+Before input construction, PostgreSQL admits each role independently under a live dispatch claim.
+The immutable, content-addressed receipt binds the original accepted claim attempt, capture binding, source capture,
+normalization run, source role, and projected map. That transaction alone may advance the exact capture
+from `staged` to `approved`; it rechecks the current provider-map review, projected-map review,
+reviewed source-use decision, and source rights after taking the same candidate and reviewed-evidence
+locks as their owning writers. Concurrent calls converge on one receipt per request and role. After a
+lease handoff, only the new live claimant may admit or replay the original accepted binding; an expired
+claimant and superseded authority fail closed.
+
+Only after all three receipts exist does preparation delegate input construction and calculation to
+the existing content-addressed HPN repositories. Both repositories run inside one outer PostgreSQL
+transaction that heartbeats and locks the live claim before input persistence, then revalidates the
+claim immediately before commit. Claim loss or any calculation failure rolls back the input set,
+calculation, and head together. Restart reloads accepted captures, revalidates and replays the
+admissions, and reuses the existing HPN input/calculation records. The HPN receipts grant
+private calculation source authority only: they are separate from factual admission and grant no
+model-training, model-qualification, prepared-head, public-display, publication, production, or
+activation authority. Missing or stale source custody, map approval, identity resolution,
+factual-universe coverage, or method authority fails closed before downstream authority changes. The
+current public release pointer and publication Gates remain untouched.
 
 This is still not a complete new-game-data pipeline. The deployed weekly runner continues to consume
 whatever exact prepared-v3 head is current. Model observation rebuild, bounded model execution,

--- a/docs/runbooks/afl-trade-intelligence-operations.md
+++ b/docs/runbooks/afl-trade-intelligence-operations.md
@@ -870,13 +870,46 @@ enqueues immediate work. Neither trigger promotes factual data or prepares model
 begins only from the exact current authenticated prepared-v3 head.
 
 The repository now also contains a backend-only HPN preparation seam for the next upstream cutover.
-It accepts an exact retained dispatch plus its live claim, replays the private factual output, and
+It accepts an exact retained dispatch plus its live claim, requires the exact immutable factual output
+already retained for that request, and
 accepts three separately authenticated source roles: AFL Tables completed results, AFL Tables primary
 player statistics, and Official AFL corroborating player statistics. It then requires one current
-reviewed HPN projection for each exact source and uses the existing HPN input/calculation repositories.
-This seam is not yet invoked by the local worker, and it must not be described as automatic weekly
-raw-data recalculation until the later model and prepared-v3 stages are composed into the same runner.
-Do not bypass missing HPN map reviews or identity resolutions; those states remain backend blockers.
+reviewed HPN projection for each exact source. PostgreSQL must retain one immutable HPN source
+admission for each role before the input repository runs. Each receipt binds the original dispatch
+attempt that accepted its capture, plus the capture binding, staged capture, normalization run, and
+projected field map. Only a caller holding the current live claim may run that transaction, which may
+advance the bound capture to `approved`; never update capture status manually.
+
+For a retained request, inspect the private ledger without reading raw source rows:
+
+```sql
+SELECT admission.source_role,admission.admission_id,admission.capture_binding_id,
+       admission.normalization_run_id,admission.projected_field_map_id,
+       capture.status
+  FROM outcome_private_valuation_hpn_source_admission admission
+  JOIN outcome_source_capture capture
+    ON capture.capture_id=admission.source_capture_id
+ WHERE admission.request_id='<private-valuation-dispatch:64-hex>'
+ ORDER BY admission.source_role;
+```
+
+Success requires exactly the three named roles, three content-addressed admission IDs, and `approved`
+for each exact capture. Concurrent or restarted preparation returns the same receipts and creates no
+new capture, admission, input set, or calculation. A reclaimed worker cannot use its expired claim;
+the new live claimant may admit the original accepted binding or replay its already-retained receipt
+only after PostgreSQL revalidates the current decode map, projected map, reviewed source-use decision,
+and rights under the owning authority locks. The receipt remains bound to the claim that accepted its
+capture, while the caller must hold the request's current live claim.
+
+If admission fails, leave the staged capture and prior prepared/current valuation state unchanged.
+Correct or supersede the provider review, projected HPN review, source-use decision, rights evidence,
+or capture through its owning workflow; do not mutate an admission or weaken HPN input validation.
+The seam then uses the existing HPN input/calculation repositories inside one claim-fenced PostgreSQL
+transaction. It heartbeats before input persistence and immediately before commit, so a lost claim or
+calculation failure rolls back the input set, calculation, and current HPN head together. It is not yet invoked by the local
+worker, and it must not be described as automatic weekly raw-data recalculation until the later model
+and prepared-v3 stages are composed into the same runner. Do not bypass missing HPN map reviews or
+identity resolutions; those states remain backend blockers.
 
 To request the same coordinator ad hoc, supply a stable operation key that can be reused after process
 or response loss:

--- a/prisma/afl-trade-outcomes/migrations/0078_private_valuation_hpn_source_admission/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0078_private_valuation_hpn_source_admission/migration.sql
@@ -1,0 +1,651 @@
+-- Admit the three exact role-aware HPN captures for non-production private calculation.
+-- This authority is narrower than factual admission and never changes public release custody.
+
+DO $roles$ BEGIN
+  EXECUTE format(
+    'GRANT afl_trade_private_valuation_scheduler_owner TO %I',
+    session_user
+  );
+END $roles$;
+
+GRANT SELECT ON
+  "outcome_private_valuation_dispatch_request",
+  "outcome_private_valuation_dispatch_attempt",
+  "outcome_private_valuation_capture_binding",
+  "outcome_private_valuation_source_admission",
+  "outcome_private_valuation_factual_output",
+  "outcome_source_capture",
+  "outcome_provider_normalization_run",
+  "outcome_provider_field_map",
+  "outcome_review_decision",
+  "outcome_hpn_projected_field_map",
+  "outcome_hpn_field_map_candidate",
+  "outcome_hpn_field_map_review_decision",
+  "outcome_private_reviewed_evaluation_decision",
+  "outcome_private_reviewed_evaluation_head",
+  "outcome_private_reviewed_evidence_bundle",
+  "outcome_source_rights_proposal"
+TO afl_trade_private_valuation_scheduler_owner;
+
+GRANT REFERENCES ON
+  "outcome_private_valuation_dispatch_request",
+  "outcome_private_valuation_dispatch_attempt",
+  "outcome_private_valuation_capture_binding",
+  "outcome_source_capture",
+  "outcome_provider_normalization_run",
+  "outcome_hpn_projected_field_map"
+TO afl_trade_private_valuation_scheduler_owner;
+
+SET ROLE afl_trade_private_valuation_scheduler_owner;
+
+CREATE TABLE "outcome_private_valuation_hpn_source_admission" (
+  "admission_id" TEXT PRIMARY KEY,
+  "request_id" TEXT NOT NULL
+    REFERENCES "outcome_private_valuation_dispatch_request"("request_id") ON DELETE RESTRICT,
+  "source_role" TEXT NOT NULL,
+  "dispatch_claim_id" TEXT NOT NULL,
+  "attempt_sequence" INTEGER NOT NULL,
+  "attempt_number" INTEGER NOT NULL,
+  "capture_binding_id" TEXT NOT NULL UNIQUE
+    REFERENCES "outcome_private_valuation_capture_binding"("binding_id") ON DELETE RESTRICT,
+  "source_capture_id" TEXT NOT NULL UNIQUE
+    REFERENCES "outcome_source_capture"("capture_id") ON DELETE RESTRICT,
+  "normalization_run_id" TEXT NOT NULL UNIQUE
+    REFERENCES "outcome_provider_normalization_run"("normalization_run_id") ON DELETE RESTRICT,
+  "projected_field_map_id" TEXT NOT NULL
+    REFERENCES "outcome_hpn_projected_field_map"("field_map_id") ON DELETE RESTRICT,
+  "admitted_at" TIMESTAMPTZ(3) NOT NULL,
+  "admission_json" JSONB NOT NULL,
+  CONSTRAINT "outcome_private_valuation_hpn_source_admission_attempt_fkey"
+    FOREIGN KEY ("request_id","attempt_sequence","dispatch_claim_id")
+    REFERENCES "outcome_private_valuation_dispatch_attempt"(
+      "request_id","attempt_sequence","claim_id"
+    ) ON DELETE RESTRICT,
+  CONSTRAINT "outcome_private_valuation_hpn_source_admission_request_role_key"
+    UNIQUE ("request_id","source_role"),
+  CONSTRAINT "outcome_private_valuation_hpn_source_admission_role_check" CHECK (
+    "source_role" IN (
+      'hpn_completed_results',
+      'hpn_primary_player_stats',
+      'hpn_corroborating_player_stats'
+    )
+  ),
+  CONSTRAINT "outcome_private_valuation_hpn_source_admission_attempt_check" CHECK (
+    "attempt_sequence">0 AND "attempt_number" BETWEEN 1 AND 3
+    AND "attempt_number"<="attempt_sequence"
+  ),
+  CONSTRAINT "outcome_private_valuation_hpn_source_admission_id_check" CHECK (
+    "admission_id" ~ '^private-valuation-hpn-source-admission:[a-f0-9]{64}$'
+  ),
+  CONSTRAINT "outcome_private_valuation_hpn_source_admission_json_check" CHECK (
+    jsonb_typeof("admission_json")='object'
+  )
+);
+
+CREATE INDEX "outcome_private_valuation_hpn_source_admission_map_idx"
+  ON "outcome_private_valuation_hpn_source_admission"(
+    "projected_field_map_id","admitted_at"
+  );
+
+CREATE FUNCTION "create_outcome_private_valuation_hpn_source_admission_id"(
+  target_content JSONB
+) RETURNS TEXT LANGUAGE SQL IMMUTABLE STRICT AS $$
+  SELECT 'private-valuation-hpn-source-admission:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(target_content),'UTF8')),'hex')
+$$;
+
+CREATE FUNCTION "outcome_private_valuation_hpn_source_authority_is_current"(
+  target_request_id TEXT,
+  target_capture_binding_id TEXT,
+  target_projected_field_map_id TEXT,
+  target_source_role TEXT,
+  target_at TIMESTAMPTZ
+) RETURNS BOOLEAN LANGUAGE SQL STABLE AS $$
+  SELECT EXISTS (
+    SELECT 1
+      FROM "outcome_private_valuation_dispatch_request" request
+      JOIN "outcome_private_valuation_dispatch_attempt" attempt
+        ON attempt."request_id"=request."request_id"
+       AND attempt."claim_id"=request."claim_id"
+       AND attempt."attempt_sequence"=request."claim_sequence"
+      JOIN "outcome_private_valuation_factual_output" factual_output
+        ON factual_output."request_id"=request."request_id"
+      JOIN "outcome_private_valuation_source_admission" factual_admission
+        ON factual_admission."admission_id"=factual_output."source_admission_id"
+       AND factual_admission."request_id"=request."request_id"
+      JOIN "outcome_private_valuation_capture_binding" binding
+        ON binding."binding_id"=target_capture_binding_id
+       AND binding."request_id"=request."request_id"
+       AND binding."source_role"=target_source_role
+      JOIN "outcome_source_capture" capture
+        ON capture."capture_id"=binding."source_capture_id"
+      JOIN "outcome_provider_normalization_run" normalization
+        ON normalization."normalization_run_id"=binding."normalization_run_id"
+       AND normalization."capture_id"=binding."source_capture_id"
+      JOIN "outcome_provider_field_map" decode_map
+        ON decode_map."field_map_id"=normalization."field_map_id"
+      JOIN "outcome_review_decision" decode_approval
+        ON decode_approval."decision_id"=decode_map."approval_decision_id"
+      JOIN "outcome_hpn_projected_field_map" projected
+        ON projected."field_map_id"=target_projected_field_map_id
+      JOIN "outcome_hpn_field_map_candidate" candidate
+        ON candidate."candidate_id"=projected."candidate_id"
+      JOIN "outcome_hpn_field_map_review_decision" projected_approval
+        ON projected_approval."decision_id"=projected."approval_decision_id"
+      JOIN LATERAL (
+        SELECT decision."decision_id"
+          FROM "outcome_hpn_field_map_review_decision" decision
+         WHERE decision."candidate_id"=projected."candidate_id"
+         ORDER BY decision."registered_at" DESC,decision."decision_id" DESC
+         LIMIT 1
+      ) latest_projected ON TRUE
+     WHERE request."request_id"=target_request_id
+       AND request."scope_key"='afl-men:2026-trades'
+       AND request."status"='claimed'
+       AND request."lease_expires_at">=target_at
+       AND attempt."lease_expires_at">=target_at
+       AND attempt."finished_at" IS NULL
+       AND binding."binding_json"#>>'{content,schemaVersion}'=
+         'afl-trade-private-valuation-capture-binding/v2'
+       AND binding."binding_json"#>>'{content,request,requestId}'=target_request_id
+       AND binding."binding_json"#>>'{content,sourceRole}'=target_source_role
+       AND binding."binding_json"#>>'{content,dispatchClaimId}'=binding."dispatch_claim_id"
+       AND (binding."binding_json"#>>'{content,attemptSequence}')::integer=
+         binding."attempt_sequence"
+       AND (binding."binding_json"#>>'{content,attemptNumber}')::integer=
+         binding."attempt_number"
+       AND binding."binding_json"#>>'{content,sourceCaptureId}'=
+         binding."source_capture_id"
+       AND binding."binding_json"#>>'{content,normalizationRunId}'=
+         binding."normalization_run_id"
+       AND capture."status" IN ('staged','approved')
+       AND normalization."status"='staged'
+       AND normalization."finalized_at" IS NOT NULL
+       AND normalization."source_row_count"=normalization."accepted_row_count"
+       AND normalization."quarantined_row_count"=0
+       AND normalization."issue_count"=0
+       AND decode_map."capability_id"=
+         binding."binding_json"#>>'{content,sourcePlan,capabilityId}'
+       AND decode_approval."subject_type"='provider_field_map'
+       AND decode_approval."subject_id"=decode_map."field_map_id"
+       AND decode_approval."decision"='approved'
+       AND decode_approval."decided_at"=decode_map."approved_at"
+       AND NOT EXISTS (
+         SELECT 1 FROM "outcome_review_decision" successor
+          WHERE successor."supersedes_decision_id"=decode_approval."decision_id"
+       )
+       AND projected_approval."decision"='approved'
+       AND latest_projected."decision_id"=projected."approval_decision_id"
+       AND projected."provider"=
+         binding."binding_json"#>>'{content,sourcePlan,provider}'
+       AND projected."capability_id"=
+         binding."binding_json"#>>'{content,sourcePlan,capabilityId}'
+       AND projected."competition"='AFLM'
+       AND projected."input_kind"=CASE target_source_role
+         WHEN 'hpn_completed_results' THEN 'completed_match_result'
+         ELSE 'player_match_stats'
+       END
+       AND 2026 BETWEEN projected."valid_from_season" AND projected."valid_through_season"
+       AND projected."source_schema_sha256"=decode_map."source_schema_sha256"
+       AND candidate."candidate_json"#>>'{content,providerDecodeMapId}'=
+         binding."binding_json"#>>'{content,sourcePlan,fieldMapId}'
+       AND projected_approval."source_use_assessment_json"#>>'{content,valuationScopeKey}'=
+         request."scope_key"
+       AND projected_approval."source_use_assessment_json"#>>'{content,rightsArtifactId}'=
+         binding."binding_json"#>>'{content,sourcePlan,rightsArtifactId}'
+       AND "outcome_hpn_projected_field_map_authority_is_exact"(
+         projected."field_map_id",target_at
+       )
+  )
+$$;
+
+CREATE FUNCTION "validate_outcome_private_valuation_hpn_source_admission"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  expected_content JSONB;
+  projected_candidate_id TEXT;
+  decode_map_id TEXT;
+  trusted_at TIMESTAMPTZ(3);
+BEGIN
+  expected_content:=NEW."admission_json"->'content';
+  PERFORM 1
+    FROM "outcome_private_valuation_dispatch_request" request
+    JOIN "outcome_private_valuation_dispatch_attempt" attempt
+      ON attempt."request_id"=request."request_id"
+     AND attempt."claim_id"=request."claim_id"
+   WHERE request."request_id"=NEW."request_id"
+   FOR SHARE OF request,attempt;
+  SELECT map."candidate_id",normalization."field_map_id"
+    INTO projected_candidate_id,decode_map_id
+    FROM "outcome_hpn_projected_field_map" map
+    JOIN "outcome_private_valuation_capture_binding" binding
+      ON binding."binding_id"=NEW."capture_binding_id"
+    JOIN "outcome_provider_normalization_run" normalization
+      ON normalization."normalization_run_id"=binding."normalization_run_id"
+   WHERE map."field_map_id"=NEW."projected_field_map_id";
+  IF FOUND THEN
+    PERFORM pg_advisory_xact_lock(hashtextextended(
+      'outcome-review-subject:provider_field_map:'||decode_map_id,0));
+    PERFORM pg_advisory_xact_lock(hashtextextended(
+      'hpn-field-map-candidate:'||projected_candidate_id,0));
+    PERFORM pg_advisory_xact_lock(hashtextextended(
+      'private-reviewed-evaluation:afl-men:2026-trades:'||
+        'afl-player-match-reviewed-2021-2026',0));
+  END IF;
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF (SELECT count(*) FROM jsonb_object_keys(NEW."admission_json"))<>2
+    OR (SELECT count(*) FROM jsonb_object_keys(expected_content))<>16
+    OR NEW."admission_json"->>'admissionId' IS DISTINCT FROM NEW."admission_id"
+    OR NEW."admission_id" IS DISTINCT FROM
+       "create_outcome_private_valuation_hpn_source_admission_id"(expected_content)
+    OR expected_content->>'schemaVersion' IS DISTINCT FROM
+       'afl-trade-private-valuation-hpn-source-admission/v1'
+    OR expected_content->>'requestId' IS DISTINCT FROM NEW."request_id"
+    OR expected_content->>'dispatchClaimId' IS DISTINCT FROM NEW."dispatch_claim_id"
+    OR (expected_content->>'attemptSequence')::integer
+       IS DISTINCT FROM NEW."attempt_sequence"
+    OR (expected_content->>'attemptNumber')::integer
+       IS DISTINCT FROM NEW."attempt_number"
+    OR expected_content->>'sourceRole' IS DISTINCT FROM NEW."source_role"
+    OR expected_content->>'captureBindingId' IS DISTINCT FROM NEW."capture_binding_id"
+    OR expected_content->>'sourceCaptureId' IS DISTINCT FROM NEW."source_capture_id"
+    OR expected_content->>'normalizationRunId' IS DISTINCT FROM NEW."normalization_run_id"
+    OR expected_content->>'projectedFieldMapId'
+       IS DISTINCT FROM NEW."projected_field_map_id"
+    OR (expected_content->>'admittedAt')::timestamptz IS DISTINCT FROM NEW."admitted_at"
+    OR expected_content->>'principalId' IS DISTINCT FROM
+       'system:weekly-valuation-coordinator'
+    OR expected_content->>'environment' IS DISTINCT FROM 'non_production'
+    OR expected_content->'publicationEligible' IS DISTINCT FROM 'false'::jsonb
+    OR expected_content->'publicationProhibited' IS DISTINCT FROM 'true'::jsonb
+    OR expected_content->>'limitation' IS DISTINCT FROM
+       'Non-production private HPN source admission only; it grants no factual, model-training, public-display, redistribution, publication, production, or activation authority.'
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_private_valuation_capture_binding" binding
+       WHERE binding."binding_id"=NEW."capture_binding_id"
+         AND binding."request_id"=NEW."request_id"
+         AND binding."source_role"=NEW."source_role"
+         AND binding."dispatch_claim_id"=NEW."dispatch_claim_id"
+         AND binding."attempt_sequence"=NEW."attempt_sequence"
+         AND binding."attempt_number"=NEW."attempt_number"
+         AND binding."source_capture_id"=NEW."source_capture_id"
+         AND binding."normalization_run_id"=NEW."normalization_run_id"
+    )
+    OR NOT "outcome_private_valuation_hpn_source_authority_is_current"(
+      NEW."request_id",NEW."capture_binding_id",NEW."projected_field_map_id",
+      NEW."source_role",trusted_at
+    )
+  THEN
+    RAISE EXCEPTION 'Private valuation HPN source admission custody is invalid';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_private_valuation_hpn_source_admission_validate"
+BEFORE INSERT ON "outcome_private_valuation_hpn_source_admission"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_valuation_hpn_source_admission"();
+
+CREATE FUNCTION "reject_outcome_private_valuation_hpn_source_admission_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Private valuation HPN source admissions are immutable';
+END $$;
+
+CREATE TRIGGER "outcome_private_valuation_hpn_source_admission_no_update_delete"
+BEFORE UPDATE OR DELETE ON "outcome_private_valuation_hpn_source_admission"
+FOR EACH ROW EXECUTE FUNCTION
+  "reject_outcome_private_valuation_hpn_source_admission_mutation"();
+
+CREATE OR REPLACE FUNCTION "guard_outcome_private_valuation_source_admission_status"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP='DELETE' THEN
+    RAISE EXCEPTION 'Outcome analytical evidence is append-only';
+  END IF;
+  IF (to_jsonb(NEW)-'status') IS DISTINCT FROM (to_jsonb(OLD)-'status')
+    OR OLD."status" IS DISTINCT FROM 'staged'::"OutcomeRecordStatus"
+    OR NEW."status" IS DISTINCT FROM 'approved'::"OutcomeRecordStatus"
+    OR NOT (
+      EXISTS (
+        SELECT 1 FROM "outcome_private_valuation_source_admission" admission
+         WHERE admission."source_capture_id"=NEW."capture_id"
+      )
+      OR EXISTS (
+        SELECT 1 FROM "outcome_private_valuation_hpn_source_admission" admission
+         WHERE admission."source_capture_id"=NEW."capture_id"
+      )
+    )
+  THEN
+    RAISE EXCEPTION 'Source capture status requires exact automated non-production admission';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE FUNCTION "admit_outcome_private_valuation_hpn_source"(
+  target_request_id TEXT,
+  target_claim_id TEXT,
+  target_lease_token_sha256 TEXT,
+  target_factual_output_id TEXT,
+  target_source_role TEXT,
+  target_capture_binding_id TEXT,
+  target_projected_field_map_id TEXT
+) RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  trusted_at TIMESTAMPTZ(3);
+  dispatch_authority RECORD;
+  binding RECORD;
+  projected RECORD;
+  retained RECORD;
+  admission_content JSONB;
+  target_admission_id TEXT;
+  target_admission_json JSONB;
+  expected_input_kind TEXT;
+  projected_candidate_id TEXT;
+BEGIN
+  IF target_request_id !~ '^private-valuation-dispatch:[a-f0-9]{64}$'
+    OR target_claim_id !~ '^private-valuation-dispatch-claim:[a-f0-9]{64}$'
+    OR target_lease_token_sha256 !~ '^[a-f0-9]{64}$'
+    OR target_factual_output_id
+       !~ '^private-valuation-factual-output:[a-f0-9]{64}$'
+    OR target_source_role NOT IN (
+      'hpn_completed_results',
+      'hpn_primary_player_stats',
+      'hpn_corroborating_player_stats'
+    )
+    OR target_capture_binding_id
+       !~ '^private-valuation-capture-binding:[a-f0-9]{64}$'
+    OR target_projected_field_map_id !~ '^hpn-pav-field-map:[a-f0-9]{64}$'
+  THEN
+    RAISE EXCEPTION 'Private valuation HPN source admission request is malformed';
+  END IF;
+
+  SELECT request."request_id",request."scope_key",request."request_json",
+         request."status",request."claim_id" AS "current_claim_id",
+         request."claim_sequence" AS "current_claim_sequence",
+         request."lease_token_sha256" AS "current_lease_token_sha256",
+         request."lease_expires_at" AS "current_lease_expires_at",
+         attempt."attempt_sequence",attempt."attempt_number",
+         attempt."lease_token_sha256" AS "attempt_lease_token_sha256",
+         attempt."lease_expires_at" AS "attempt_lease_expires_at",
+         attempt."finished_at" AS "attempt_finished_at"
+    INTO dispatch_authority
+    FROM "outcome_private_valuation_dispatch_request" request
+    JOIN "outcome_private_valuation_dispatch_attempt" attempt
+      ON attempt."request_id"=request."request_id"
+     AND attempt."claim_id"=target_claim_id
+   WHERE request."request_id"=target_request_id
+     AND request."claim_id"=target_claim_id
+   FOR UPDATE OF request,attempt;
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF NOT FOUND
+    OR dispatch_authority."status" IS DISTINCT FROM 'claimed'
+    OR dispatch_authority."current_claim_id" IS DISTINCT FROM target_claim_id
+    OR dispatch_authority."current_claim_sequence"
+       IS DISTINCT FROM dispatch_authority."attempt_sequence"
+    OR dispatch_authority."current_lease_token_sha256"
+       IS DISTINCT FROM target_lease_token_sha256
+    OR dispatch_authority."attempt_lease_token_sha256"
+       IS DISTINCT FROM target_lease_token_sha256
+    OR dispatch_authority."current_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_finished_at" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation HPN source admission lost its live dispatch claim fence';
+  END IF;
+  IF dispatch_authority."scope_key" IS DISTINCT FROM 'afl-men:2026-trades'
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_private_valuation_factual_output" output
+      JOIN "outcome_private_valuation_source_admission" factual
+        ON factual."admission_id"=output."source_admission_id"
+       WHERE output."request_id"=target_request_id
+         AND output."output_id"=target_factual_output_id
+         AND factual."request_id"=target_request_id
+    )
+  THEN
+    RAISE EXCEPTION 'Private valuation HPN source admission lacks exact factual authority';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    'outcome-private-valuation-hpn-source-admission:'||target_request_id||':'||
+      target_source_role,0));
+
+  SELECT capture_binding.*,capture."status" AS "capture_status",
+         normalization."status" AS "normalization_status",
+         normalization."finalized_at" AS "normalization_finalized_at",
+         normalization."source_row_count",normalization."accepted_row_count",
+         normalization."quarantined_row_count",normalization."issue_count",
+         decode_map."capability_id" AS "decode_capability_id",
+         decode_map."source_schema_sha256" AS "decode_source_schema_sha256",
+         decode_map."approval_decision_id" AS "decode_approval_decision_id",
+         decode_map."approved_at" AS "decode_approved_at"
+    INTO binding
+    FROM "outcome_private_valuation_capture_binding" capture_binding
+    JOIN "outcome_source_capture" capture
+      ON capture."capture_id"=capture_binding."source_capture_id"
+    JOIN "outcome_provider_normalization_run" normalization
+      ON normalization."normalization_run_id"=capture_binding."normalization_run_id"
+     AND normalization."capture_id"=capture_binding."source_capture_id"
+    JOIN "outcome_provider_field_map" decode_map
+      ON decode_map."field_map_id"=normalization."field_map_id"
+   WHERE capture_binding."binding_id"=target_capture_binding_id
+     AND capture_binding."request_id"=target_request_id
+     AND capture_binding."source_role"=target_source_role
+   FOR UPDATE OF capture;
+  IF NOT FOUND
+    OR binding."binding_json"#>>'{content,schemaVersion}' IS DISTINCT FROM
+       'afl-trade-private-valuation-capture-binding/v2'
+    OR binding."binding_json"#>>'{content,request,requestId}'
+       IS DISTINCT FROM target_request_id
+    OR binding."binding_json"#>>'{content,sourceRole}' IS DISTINCT FROM target_source_role
+    OR binding."binding_json"#>>'{content,dispatchClaimId}'
+       IS DISTINCT FROM binding."dispatch_claim_id"
+    OR (binding."binding_json"#>>'{content,attemptSequence}')::integer
+       IS DISTINCT FROM binding."attempt_sequence"
+    OR (binding."binding_json"#>>'{content,attemptNumber}')::integer
+       IS DISTINCT FROM binding."attempt_number"
+    OR binding."binding_json"#>>'{content,sourceCaptureId}'
+       IS DISTINCT FROM binding."source_capture_id"
+    OR binding."binding_json"#>>'{content,normalizationRunId}'
+       IS DISTINCT FROM binding."normalization_run_id"
+    OR binding."normalization_status" IS DISTINCT FROM 'staged'::"OutcomeRecordStatus"
+    OR binding."normalization_finalized_at" IS NULL
+    OR binding."source_row_count" IS DISTINCT FROM binding."accepted_row_count"
+    OR binding."quarantined_row_count"<>0 OR binding."issue_count"<>0
+    OR binding."capture_status" NOT IN ('staged','approved')
+  THEN
+    RAISE EXCEPTION 'Private valuation HPN source admission capture ancestry is invalid';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    'outcome-review-subject:provider_field_map:'||
+      (binding."binding_json"#>>'{content,sourcePlan,fieldMapId}'),0));
+  IF binding."binding_json"#>>'{content,sourcePlan,fieldMapId}' IS DISTINCT FROM
+       (SELECT run."field_map_id" FROM "outcome_provider_normalization_run" run
+         WHERE run."normalization_run_id"=binding."normalization_run_id")
+    OR binding."decode_capability_id" IS DISTINCT FROM
+       binding."binding_json"#>>'{content,sourcePlan,capabilityId}'
+    OR NOT EXISTS (
+      SELECT 1 FROM "outcome_review_decision" approval
+       WHERE approval."decision_id"=binding."decode_approval_decision_id"
+         AND approval."subject_type"='provider_field_map'
+         AND approval."subject_id"=
+           binding."binding_json"#>>'{content,sourcePlan,fieldMapId}'
+         AND approval."decision"='approved'
+         AND approval."decided_at"=binding."decode_approved_at"
+         AND NOT EXISTS (
+           SELECT 1 FROM "outcome_review_decision" successor
+            WHERE successor."supersedes_decision_id"=approval."decision_id"
+         )
+    )
+  THEN
+    RAISE EXCEPTION 'Private valuation HPN source admission decode map is not current';
+  END IF;
+
+  expected_input_kind:=CASE target_source_role
+    WHEN 'hpn_completed_results' THEN 'completed_match_result'
+    ELSE 'player_match_stats'
+  END;
+  SELECT map."candidate_id" INTO projected_candidate_id
+    FROM "outcome_hpn_projected_field_map" map
+   WHERE map."field_map_id"=target_projected_field_map_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Private valuation HPN source admission projected authority is not current';
+  END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    'hpn-field-map-candidate:'||projected_candidate_id,0));
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    'private-reviewed-evaluation:'||dispatch_authority."scope_key"||
+      ':afl-player-match-reviewed-2021-2026',0));
+  SELECT map.*,candidate."candidate_json",decision."decision",
+         decision."source_use_assessment_json",
+         latest."decision_id" AS "latest_decision_id"
+    INTO projected
+    FROM "outcome_hpn_projected_field_map" map
+    JOIN "outcome_hpn_field_map_candidate" candidate
+      ON candidate."candidate_id"=map."candidate_id"
+    JOIN "outcome_hpn_field_map_review_decision" decision
+      ON decision."decision_id"=map."approval_decision_id"
+    JOIN LATERAL (
+      SELECT current_decision."decision_id"
+        FROM "outcome_hpn_field_map_review_decision" current_decision
+       WHERE current_decision."candidate_id"=map."candidate_id"
+       ORDER BY current_decision."registered_at" DESC,current_decision."decision_id" DESC
+       LIMIT 1
+    ) latest ON TRUE
+   WHERE map."field_map_id"=target_projected_field_map_id;
+  trusted_at:=date_trunc('milliseconds',clock_timestamp());
+  IF NOT FOUND
+    OR projected."decision" IS DISTINCT FROM 'approved'
+    OR projected."latest_decision_id" IS DISTINCT FROM projected."approval_decision_id"
+    OR projected."provider" IS DISTINCT FROM
+       binding."binding_json"#>>'{content,sourcePlan,provider}'
+    OR projected."capability_id" IS DISTINCT FROM
+       binding."binding_json"#>>'{content,sourcePlan,capabilityId}'
+    OR projected."competition" IS DISTINCT FROM 'AFLM'
+    OR projected."input_kind" IS DISTINCT FROM expected_input_kind
+    OR 2026 NOT BETWEEN projected."valid_from_season" AND projected."valid_through_season"
+    OR projected."source_schema_sha256" IS DISTINCT FROM
+       binding."decode_source_schema_sha256"
+    OR projected."candidate_json"#>>'{content,providerDecodeMapId}' IS DISTINCT FROM
+       binding."binding_json"#>>'{content,sourcePlan,fieldMapId}'
+    OR projected."source_use_assessment_json"#>>'{content,valuationScopeKey}'
+       IS DISTINCT FROM dispatch_authority."scope_key"
+    OR projected."source_use_assessment_json"#>>'{content,rightsArtifactId}'
+       IS DISTINCT FROM binding."binding_json"#>>'{content,sourcePlan,rightsArtifactId}'
+    OR NOT COALESCE(
+      "outcome_hpn_projected_field_map_authority_is_exact"(
+        target_projected_field_map_id,trusted_at
+      ),FALSE
+    )
+    OR dispatch_authority."current_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_lease_expires_at"<trusted_at
+    OR dispatch_authority."attempt_finished_at" IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'Private valuation HPN source admission projected authority is not current';
+  END IF;
+  IF NOT "outcome_private_valuation_hpn_source_authority_is_current"(
+    target_request_id,target_capture_binding_id,target_projected_field_map_id,
+    target_source_role,trusted_at
+  ) THEN
+    RAISE EXCEPTION 'Private valuation HPN source admission authority is not current';
+  END IF;
+
+  SELECT * INTO retained
+    FROM "outcome_private_valuation_hpn_source_admission"
+   WHERE "request_id"=target_request_id AND "source_role"=target_source_role
+   FOR SHARE;
+  IF FOUND THEN
+    IF retained."dispatch_claim_id" IS DISTINCT FROM binding."dispatch_claim_id"
+      OR retained."capture_binding_id" IS DISTINCT FROM target_capture_binding_id
+      OR retained."source_capture_id" IS DISTINCT FROM binding."source_capture_id"
+      OR retained."normalization_run_id" IS DISTINCT FROM binding."normalization_run_id"
+      OR retained."projected_field_map_id" IS DISTINCT FROM target_projected_field_map_id
+      OR binding."capture_status" IS DISTINCT FROM 'approved'::"OutcomeRecordStatus"
+    THEN
+      RAISE EXCEPTION 'Private valuation HPN source admission conflicts with retained custody';
+    END IF;
+    RETURN jsonb_build_object(
+      'state','already_admitted','admission',retained."admission_json"
+    );
+  END IF;
+  IF binding."attempt_sequence">dispatch_authority."attempt_sequence"
+    OR binding."capture_status" IS DISTINCT FROM 'staged'::"OutcomeRecordStatus"
+  THEN
+    RAISE EXCEPTION 'Private valuation HPN source admission requires exact staged custody';
+  END IF;
+
+  admission_content:=jsonb_build_object(
+    'schemaVersion','afl-trade-private-valuation-hpn-source-admission/v1',
+    'requestId',target_request_id,
+    'dispatchClaimId',binding."dispatch_claim_id",
+    'attemptSequence',binding."attempt_sequence",
+    'attemptNumber',binding."attempt_number",
+    'sourceRole',target_source_role,
+    'captureBindingId',target_capture_binding_id,
+    'sourceCaptureId',binding."source_capture_id",
+    'normalizationRunId',binding."normalization_run_id",
+    'projectedFieldMapId',target_projected_field_map_id,
+    'admittedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'principalId','system:weekly-valuation-coordinator',
+    'environment','non_production',
+    'publicationEligible',false,
+    'publicationProhibited',true,
+    'limitation','Non-production private HPN source admission only; it grants no factual, model-training, public-display, redistribution, publication, production, or activation authority.'
+  );
+  target_admission_id:=
+    "create_outcome_private_valuation_hpn_source_admission_id"(admission_content);
+  target_admission_json:=jsonb_build_object(
+    'admissionId',target_admission_id,'content',admission_content
+  );
+  INSERT INTO "outcome_private_valuation_hpn_source_admission"(
+    "admission_id","request_id","source_role","dispatch_claim_id",
+    "attempt_sequence","attempt_number","capture_binding_id","source_capture_id",
+    "normalization_run_id","projected_field_map_id","admitted_at","admission_json"
+  ) VALUES (
+    target_admission_id,target_request_id,target_source_role,binding."dispatch_claim_id",
+    binding."attempt_sequence",binding."attempt_number",
+    target_capture_binding_id,binding."source_capture_id",binding."normalization_run_id",
+    target_projected_field_map_id,trusted_at,target_admission_json
+  );
+  UPDATE "outcome_source_capture" SET "status"='approved'
+   WHERE "capture_id"=binding."source_capture_id" AND "status"='staged';
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Private valuation HPN source admission did not advance exact staged custody';
+  END IF;
+  RETURN jsonb_build_object('state','admitted','admission',target_admission_json);
+END $$;
+
+DO $paths$ BEGIN
+  EXECUTE format(
+    'ALTER FUNCTION %I.outcome_private_valuation_hpn_source_authority_is_current(TEXT,TEXT,TEXT,TEXT,TIMESTAMPTZ) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema()
+  );
+  EXECUTE format(
+    'ALTER FUNCTION %I.admit_outcome_private_valuation_hpn_source(TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema()
+  );
+END $paths$;
+
+REVOKE ALL ON FUNCTION "outcome_private_valuation_hpn_source_authority_is_current"(
+  TEXT,TEXT,TEXT,TEXT,TIMESTAMPTZ
+) FROM PUBLIC;
+
+REVOKE ALL ON "outcome_private_valuation_hpn_source_admission"
+  FROM PUBLIC,afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_private_valuation_hpn_source_admission"
+  TO afl_trade_private_evaluation_coordinator;
+REVOKE ALL ON FUNCTION "admit_outcome_private_valuation_hpn_source"(
+  TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "admit_outcome_private_valuation_hpn_source"(
+  TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT
+) TO afl_trade_private_evaluation_coordinator;
+
+RESET ROLE;
+
+DO $membership$ BEGIN
+  EXECUTE format(
+    'REVOKE afl_trade_private_valuation_scheduler_owner FROM %I',
+    session_user
+  );
+END $membership$;

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -394,6 +394,7 @@ model OutcomeSourceCapture {
   valuationDatasetFieldSets   OutcomeValuationDatasetConsumedFieldSet[]
   privateValuationCaptureBindings OutcomePrivateValuationCaptureBinding[] @relation("PrivateValuationCaptureSource")
   privateValuationSourceAdmission OutcomePrivateValuationSourceAdmission?
+  privateValuationHpnSourceAdmission OutcomePrivateValuationHpnSourceAdmission?
 
   @@unique([captureId, attemptId, sourceSnapshotId], map: "outcome_source_capture_exact_ancestry_key")
   @@index([provider, dataset, capturedAt], map: "outcome_source_capture_provider_captured_idx")
@@ -1215,6 +1216,7 @@ model OutcomeProviderNormalizationRun {
   hpnPavInputRuns           OutcomeHpnPavInputRun[]
   hpnReviewedSeasons        OutcomeHpnReviewedSeasonUniverse[]
   privateValuationCaptureBindings OutcomePrivateValuationCaptureBinding[] @relation("PrivateValuationCaptureNormalization")
+  privateValuationHpnSourceAdmission OutcomePrivateValuationHpnSourceAdmission?
 
   @@unique([captureId, fieldMapId, decoderVersion, normalizerVersion], map: "outcome_provider_normalization_idempotency_key")
   @@unique([normalizationRunId, captureId], map: "outcome_provider_normalization_run_capture_key")
@@ -1317,6 +1319,7 @@ model OutcomeHpnProjectedFieldMap {
   reviewedResultSeasons OutcomeHpnReviewedSeasonUniverse[] @relation("OutcomeHpnReviewedResultFieldMap")
   reviewedPlayerSeasons OutcomeHpnReviewedSeasonUniverse[] @relation("OutcomeHpnReviewedPlayerFieldMap")
   pavInputRuns          OutcomeHpnPavInputRun[]
+  privateValuationHpnSourceAdmissions OutcomePrivateValuationHpnSourceAdmission[]
 
   @@index([environment, competition, provider, capabilityId, inputKind, validFromSeason, validThroughSeason], map: "outcome_hpn_projected_field_map_lookup_idx")
   @@map("outcome_hpn_projected_field_map")
@@ -5407,6 +5410,7 @@ model OutcomePrivateValuationDispatchRequest {
   attempts              OutcomePrivateValuationDispatchAttempt[]
   captureBindings       OutcomePrivateValuationCaptureBinding[]
   sourceAdmission       OutcomePrivateValuationSourceAdmission?
+  hpnSourceAdmissions OutcomePrivateValuationHpnSourceAdmission[]
   factualOutput         OutcomePrivateValuationFactualOutput?
 
   @@index([status, availableAt, scopeKey], map: "outcome_private_valuation_dispatch_due_idx")
@@ -5428,6 +5432,7 @@ model OutcomePrivateValuationDispatchAttempt {
   resultJson       Json?                                  @map("result_json")
   request          OutcomePrivateValuationDispatchRequest @relation(fields: [requestId], references: [requestId], onDelete: Restrict)
   captureBindings  OutcomePrivateValuationCaptureBinding[] @relation("PrivateValuationCaptureDispatchAttempt")
+  hpnSourceAdmissions OutcomePrivateValuationHpnSourceAdmission[]
 
   @@unique([requestId, attemptSequence], map: "outcome_private_valuation_dispatch_attempt_sequence")
   @@unique([requestId, attemptSequence, claimId], map: "outcome_private_valuation_dispatch_attempt_fence")
@@ -5454,6 +5459,7 @@ model OutcomePrivateValuationCaptureBinding {
   sourceCapture         OutcomeSourceCapture                       @relation("PrivateValuationCaptureSource", fields: [sourceCaptureId, sourceCaptureAttemptId, sourceSnapshotId], references: [captureId, attemptId, sourceSnapshotId], onDelete: Restrict)
   normalizationRun      OutcomeProviderNormalizationRun            @relation("PrivateValuationCaptureNormalization", fields: [normalizationRunId, sourceCaptureId], references: [normalizationRunId, captureId], onDelete: Restrict)
   sourceAdmission       OutcomePrivateValuationSourceAdmission?
+  hpnSourceAdmission OutcomePrivateValuationHpnSourceAdmission?
   factualOutput         OutcomePrivateValuationFactualOutput?
 
   @@unique([requestId, sourceRole], map: "outcome_private_valuation_capture_binding_request_role_key")
@@ -5481,6 +5487,31 @@ model OutcomePrivateValuationSourceAdmission {
 
   @@unique([captureBindingId, normalizationRunId], map: "outcome_private_valuation_source_admission_binding_run_key")
   @@map("outcome_private_valuation_source_admission")
+}
+
+model OutcomePrivateValuationHpnSourceAdmission {
+  admissionId         String                                 @id @map("admission_id") @outcomes.Text
+  requestId           String                                 @map("request_id") @outcomes.Text
+  sourceRole          String                                 @map("source_role") @outcomes.Text
+  dispatchClaimId     String                                 @map("dispatch_claim_id") @outcomes.Text
+  attemptSequence     Int                                    @map("attempt_sequence")
+  attemptNumber       Int                                    @map("attempt_number")
+  captureBindingId    String                                 @unique @map("capture_binding_id") @outcomes.Text
+  sourceCaptureId     String                                 @unique @map("source_capture_id") @outcomes.Text
+  normalizationRunId  String                                 @unique @map("normalization_run_id") @outcomes.Text
+  projectedFieldMapId String                                 @map("projected_field_map_id") @outcomes.Text
+  admittedAt          DateTime                               @map("admitted_at") @outcomes.Timestamptz(3)
+  admissionJson       Json                                   @map("admission_json")
+  request             OutcomePrivateValuationDispatchRequest @relation(fields: [requestId], references: [requestId], onDelete: Restrict)
+  dispatchAttempt     OutcomePrivateValuationDispatchAttempt @relation(fields: [requestId, attemptSequence, dispatchClaimId], references: [requestId, attemptSequence, claimId], onDelete: Restrict)
+  captureBinding      OutcomePrivateValuationCaptureBinding  @relation(fields: [captureBindingId], references: [bindingId], onDelete: Restrict)
+  sourceCapture       OutcomeSourceCapture                   @relation(fields: [sourceCaptureId], references: [captureId], onDelete: Restrict)
+  normalizationRun    OutcomeProviderNormalizationRun        @relation(fields: [normalizationRunId], references: [normalizationRunId], onDelete: Restrict)
+  projectedFieldMap   OutcomeHpnProjectedFieldMap            @relation(fields: [projectedFieldMapId], references: [fieldMapId], onDelete: Restrict)
+
+  @@unique([requestId, sourceRole], map: "outcome_private_valuation_hpn_source_admission_request_role_key")
+  @@index([projectedFieldMapId, admittedAt], map: "outcome_private_valuation_hpn_source_admission_map_idx")
+  @@map("outcome_private_valuation_hpn_source_admission")
 }
 
 model OutcomePrivateValuationFactualOutput {

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationCaptureBindingRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationCaptureBindingRepository.ts
@@ -5,12 +5,18 @@ import { z } from 'zod';
 import { canonicalizeAflTradeJson } from '../artifacts/contentAddress';
 import type { AflOutcomeSqlClient } from '../outcomes/postgresOutcomeReleaseRepository';
 import {
+  AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_V2_SCHEMA_VERSION,
   aflTradePrivateValuationCaptureSourceRoleSchema,
   getAflTradePrivateValuationCaptureSourceRole,
   parseAflTradePrivateValuationCaptureBinding,
   type AflTradePrivateValuationCaptureBinding,
   type AflTradePrivateValuationCaptureSourceRole,
 } from './privateValuationCaptureBinding';
+import {
+  aflTradePrivateValuationHpnSourceAdmissionSchema,
+  aflTradePrivateValuationHpnSourceRoleSchema,
+  type AflTradePrivateValuationHpnSourceAdmission,
+} from './privateValuationHpnSourceAdmission';
 import type { AflTradePrivateValuationCaptureBindingRepository } from './privateValuationRawDataCoordinator';
 import { aflTradePrivateValuationDispatchRequestSchema } from './privateValuationScheduling';
 
@@ -20,6 +26,18 @@ const leaseTokenSchema = z.string().regex(/^[a-f0-9]{64}$/);
 const normalizationRunIdSchema = z
   .string()
   .regex(/^provider-normalization-run:[a-f0-9]{64}$/);
+const projectedFieldMapIdSchema = z
+  .string()
+  .regex(/^hpn-pav-field-map:[a-f0-9]{64}$/);
+const factualOutputIdSchema = z
+  .string()
+  .regex(/^private-valuation-factual-output:[a-f0-9]{64}$/);
+const hpnAdmissionResultSchema = z
+  .object({
+    state: z.enum(['admitted', 'already_admitted']),
+    admission: aflTradePrivateValuationHpnSourceAdmissionSchema,
+  })
+  .strict();
 
 function sha256(value: string): string {
   return createHash('sha256').update(value, 'utf8').digest('hex');
@@ -104,5 +122,70 @@ export class PostgresAflTradePrivateValuationCaptureBindingRepository
       throw new TypeError('Accepted capture binding disagrees with its dispatch claim or source.');
     }
     return binding;
+  }
+
+  async admitHpnSource(input: {
+    readonly request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>;
+    readonly claim: { readonly claimId: string; readonly leaseToken: string };
+    readonly factualOutputId: string;
+    readonly binding: AflTradePrivateValuationCaptureBinding;
+    readonly projectedFieldMapId: string;
+  }): Promise<{
+    readonly state: 'admitted' | 'already_admitted';
+    readonly admission: AflTradePrivateValuationHpnSourceAdmission;
+  }> {
+    const request = aflTradePrivateValuationDispatchRequestSchema.parse(input.request);
+    const claimId = claimIdSchema.parse(input.claim.claimId);
+    const leaseToken = leaseTokenSchema.parse(input.claim.leaseToken);
+    const factualOutputId = factualOutputIdSchema.parse(input.factualOutputId);
+    const binding = requireExactRequest(
+      parseAflTradePrivateValuationCaptureBinding(input.binding),
+      request
+    );
+    if (
+      binding.content.schemaVersion !==
+      AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_V2_SCHEMA_VERSION
+    ) {
+      throw new TypeError('HPN source admission requires role-aware capture custody.');
+    }
+    const sourceRole = aflTradePrivateValuationHpnSourceRoleSchema.parse(
+      binding.content.sourceRole
+    );
+    const projectedFieldMapId = projectedFieldMapIdSchema.parse(
+      input.projectedFieldMapId
+    );
+    const result = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<{ readonly admission_result: unknown }>(
+        `SELECT admit_outcome_private_valuation_hpn_source($1,$2,$3,$4,$5,$6,$7)
+                AS admission_result`,
+        [
+          request.requestId,
+          claimId,
+          sha256(leaseToken),
+          factualOutputId,
+          sourceRole,
+          binding.bindingId,
+          projectedFieldMapId,
+        ]
+      );
+    });
+    if (result.rows.length !== 1) {
+      throw new TypeError('HPN source admission did not return one exact receipt.');
+    }
+    const admitted = hpnAdmissionResultSchema.parse(result.rows[0]?.admission_result);
+    if (
+      admitted.admission.content.requestId !== request.requestId ||
+      admitted.admission.content.dispatchClaimId !== binding.content.dispatchClaimId ||
+      admitted.admission.content.sourceRole !== sourceRole ||
+      admitted.admission.content.captureBindingId !== binding.bindingId ||
+      admitted.admission.content.sourceCaptureId !== binding.content.sourceCaptureId ||
+      admitted.admission.content.normalizationRunId !==
+        binding.content.normalizationRunId ||
+      admitted.admission.content.projectedFieldMapId !== projectedFieldMapId
+    ) {
+      throw new TypeError('HPN source admission disagrees with its dispatch source custody.');
+    }
+    return admitted;
   }
 }

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationHpnPreparation.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationHpnPreparation.ts
@@ -9,9 +9,13 @@ import {
 import { createLocalAflTradeOfficialAfl2026Authority } from '../development/localOfficialAfl2026Authority';
 import type { AflTradeHpnPavMethodAuthority } from '../modeling/hpnPavCalculationService';
 import { PostgresAflTradeHpnPavCalculationRepository } from '../modeling/postgresHpnPavCalculationRepository';
+import type { AflTradeHpnPavSeasonInputRequest } from '../modeling/hpnPavInputRepository';
 import { PostgresAflTradeHpnPavInputRepository } from '../modeling/postgresHpnPavInputRepository';
 import { PostgresAflTradeHpnProjectedFieldMapAuthority } from '../modeling/postgresHpnProjectedFieldMapAuthority';
-import type { AflOutcomeSqlClient } from '../outcomes/postgresOutcomeReleaseRepository';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../outcomes/postgresOutcomeReleaseRepository';
 import type { AflTradeFitzRoyCaptureCommand } from '../source/fitzRoyCaptureRuntime';
 import type { AflTradeFitzRoyFieldMap } from '../source/fitzRoyObservationContracts';
 import {
@@ -54,6 +58,7 @@ export type AflTradePrivateValuationHpnPreparationResult = Readonly<{
   inputSetId: string;
   calculationId: string;
   captureBindingIds: readonly string[];
+  sourceAdmissionIds: readonly string[];
   publicationEligible: false;
 }>;
 
@@ -100,6 +105,13 @@ function sourceLanes(seasonYear: number): readonly SourceLane[] {
 
 function sha256(value: string): string {
   return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function transactionClient(transaction: AflOutcomeSqlTransaction): AflOutcomeSqlClient {
+  return {
+    query: transaction.query.bind(transaction),
+    transaction: async (work) => work(transaction),
+  };
 }
 
 function requireExactLaneBinding(
@@ -198,6 +210,18 @@ export class PostgresAflTradePrivateValuationHpnPreparation {
     await new PostgresAflTradePrivateValuationScheduleRepository(this.client).heartbeat(claim);
   }
 
+  private async renewClaimInTransaction(
+    transaction: AflOutcomeSqlTransaction,
+    claim: z.infer<typeof claimSchema>
+  ): Promise<void> {
+    await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+    await transaction.query(`SELECT heartbeat_outcome_private_valuation_dispatch($1,$2)`, [
+      claim.claimId,
+      sha256(claim.leaseToken),
+    ]);
+    await transaction.query(`RESET ROLE`);
+  }
+
   async prepare(input: {
     readonly requestId: string;
     readonly claim: { readonly claimId: string; readonly leaseToken: string };
@@ -229,7 +253,10 @@ export class PostgresAflTradePrivateValuationHpnPreparation {
     }
 
     const fieldMapAuthority = new PostgresAflTradeHpnProjectedFieldMapAuthority(this.client);
-    const sources = [];
+    const captureBindingRepository =
+      new PostgresAflTradePrivateValuationCaptureBindingRepository(this.client);
+    const sources: AflTradeHpnPavSeasonInputRequest['sources'] = [];
+    const sourceAdmissions = [];
     for (let index = 0; index < lanes.length; index += 1) {
       const lane = lanes[index]!;
       const binding = bindings[index]!;
@@ -250,6 +277,14 @@ export class PostgresAflTradePrivateValuationHpnPreparation {
       if (fieldMap === null) {
         throw new TypeError(`No current reviewed HPN field map exists for ${lane.sourceRole}.`);
       }
+      const sourceAdmission = await captureBindingRepository.admitHpnSource({
+        request,
+        claim,
+        factualOutputId: factual.output.outputId,
+        binding,
+        projectedFieldMapId: fieldMap.fieldMapId,
+      });
+      sourceAdmissions.push(sourceAdmission);
       sources.push({
         normalizationRunId: binding.content.normalizationRunId,
         fieldMapId: fieldMap.fieldMapId,
@@ -258,41 +293,49 @@ export class PostgresAflTradePrivateValuationHpnPreparation {
       });
     }
 
-    await this.renewClaim(claim);
-    const inputSet = await new PostgresAflTradeHpnPavInputRepository(
-      this.client
-    ).buildAndPersistSeasonInputSet(
-      {
-        environment: 'non_production',
-        competition: 'AFLM',
-        seasonYear,
-        methodId,
-        factualRunId: factual.output.content.reconciliation.factualRunId,
-        effectiveThrough: await this.loadEffectiveThrough(
-          bindings.map(({ content }) => content.normalizationRunId)
-        ),
-        sources,
-      },
-      { environment: 'non_production' }
+    const effectiveThrough = await this.loadEffectiveThrough(
+      bindings.map(({ content }) => content.normalizationRunId)
     );
-    await this.renewClaim(claim);
-    const calculation = await new PostgresAflTradeHpnPavCalculationRepository(
-      this.client,
-      this.dependencies.methodAuthority
-    ).calculateAndPersist(
-      {
-        inputSetId: inputSet.inputSet.inputSetId,
-        environment: 'non_production',
-        competition: 'AFLM',
-        seasonYear,
-        methodId,
-      },
-      { environment: 'non_production' }
+    const { inputSet, calculation } = await this.client.transaction(
+      async (transaction) => {
+        await this.renewClaimInTransaction(transaction, claim);
+        const claimFencedClient = transactionClient(transaction);
+        const inputSet = await new PostgresAflTradeHpnPavInputRepository(
+          claimFencedClient
+        ).buildAndPersistSeasonInputSet(
+          {
+            environment: 'non_production',
+            competition: 'AFLM',
+            seasonYear,
+            methodId,
+            factualRunId: factual.output.content.reconciliation.factualRunId,
+            effectiveThrough,
+            sources,
+          },
+          { environment: 'non_production' }
+        );
+        const calculation = await new PostgresAflTradeHpnPavCalculationRepository(
+          claimFencedClient,
+          this.dependencies.methodAuthority
+        ).calculateAndPersist(
+          {
+            inputSetId: inputSet.inputSet.inputSetId,
+            environment: 'non_production',
+            competition: 'AFLM',
+            seasonYear,
+            methodId,
+          },
+          { environment: 'non_production' }
+        );
+        await this.renewClaimInTransaction(transaction, claim);
+        return { inputSet, calculation };
+      }
     );
 
     return {
       state:
         factual.state === 'already_prepared' &&
+        sourceAdmissions.every(({ state }) => state === 'already_admitted') &&
         inputSet.idempotentReplay &&
         calculation.idempotentReplay
           ? 'already_prepared'
@@ -302,6 +345,9 @@ export class PostgresAflTradePrivateValuationHpnPreparation {
       inputSetId: inputSet.inputSet.inputSetId,
       calculationId: calculation.calculation.calculationId,
       captureBindingIds: bindings.map(({ bindingId }) => bindingId),
+      sourceAdmissionIds: sourceAdmissions.map(
+        ({ admission }) => admission.admissionId
+      ),
       publicationEligible: false,
     };
   }

--- a/src/server/aflTradeIntelligence/valuation/privateValuationHpnSourceAdmission.ts
+++ b/src/server/aflTradeIntelligence/valuation/privateValuationHpnSourceAdmission.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  createAflTradeContentAddress,
+} from '../artifacts/contentAddress';
+import { AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID } from './automatedPrivateEvaluationPolicy';
+
+export const AFL_TRADE_PRIVATE_VALUATION_HPN_SOURCE_ADMISSION_SCHEMA_VERSION =
+  'afl-trade-private-valuation-hpn-source-admission/v1' as const;
+export const AFL_TRADE_PRIVATE_VALUATION_HPN_SOURCE_ADMISSION_LIMITATION =
+  'Non-production private HPN source admission only; it grants no factual, model-training, public-display, redistribution, publication, production, or activation authority.' as const;
+
+const instantSchema = z.string().datetime({ offset: true });
+
+export const aflTradePrivateValuationHpnSourceRoleSchema = z.enum([
+  'hpn_completed_results',
+  'hpn_primary_player_stats',
+  'hpn_corroborating_player_stats',
+]);
+
+export const aflTradePrivateValuationHpnSourceAdmissionContentSchema = z
+  .object({
+    schemaVersion: z.literal(
+      AFL_TRADE_PRIVATE_VALUATION_HPN_SOURCE_ADMISSION_SCHEMA_VERSION
+    ),
+    requestId: aflTradeContentAddressedIdSchema('private-valuation-dispatch'),
+    dispatchClaimId: aflTradeContentAddressedIdSchema(
+      'private-valuation-dispatch-claim'
+    ),
+    attemptSequence: z.number().int().positive(),
+    attemptNumber: z.number().int().min(1).max(3),
+    sourceRole: aflTradePrivateValuationHpnSourceRoleSchema,
+    captureBindingId: aflTradeContentAddressedIdSchema(
+      'private-valuation-capture-binding'
+    ),
+    sourceCaptureId: aflTradeContentAddressedIdSchema('source-capture'),
+    normalizationRunId: aflTradeContentAddressedIdSchema('provider-normalization-run'),
+    projectedFieldMapId: aflTradeContentAddressedIdSchema('hpn-pav-field-map'),
+    admittedAt: instantSchema,
+    principalId: z.literal(AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID),
+    environment: z.literal('non_production'),
+    publicationEligible: z.literal(false),
+    publicationProhibited: z.literal(true),
+    limitation: z.literal(AFL_TRADE_PRIVATE_VALUATION_HPN_SOURCE_ADMISSION_LIMITATION),
+  })
+  .strict()
+  .superRefine((content, context) => {
+    if (content.attemptNumber > content.attemptSequence) {
+      context.addIssue({
+        code: 'custom',
+        path: ['attemptNumber'],
+        message: 'The technical attempt number cannot exceed its dispatch claim sequence.',
+      });
+    }
+  });
+
+export const aflTradePrivateValuationHpnSourceAdmissionSchema = z
+  .object({
+    admissionId: aflTradeContentAddressedIdSchema(
+      'private-valuation-hpn-source-admission'
+    ),
+    content: aflTradePrivateValuationHpnSourceAdmissionContentSchema,
+  })
+  .strict()
+  .superRefine((admission, context) => {
+    addAflTradeContentAddressIssue(
+      'private-valuation-hpn-source-admission',
+      admission.admissionId,
+      admission.content,
+      context,
+      ['admissionId']
+    );
+  });
+
+export type AflTradePrivateValuationHpnSourceRole = z.infer<
+  typeof aflTradePrivateValuationHpnSourceRoleSchema
+>;
+export type AflTradePrivateValuationHpnSourceAdmission = z.infer<
+  typeof aflTradePrivateValuationHpnSourceAdmissionSchema
+>;
+
+export function createAflTradePrivateValuationHpnSourceAdmission(
+  input: Omit<
+    z.input<typeof aflTradePrivateValuationHpnSourceAdmissionContentSchema>,
+    | 'schemaVersion'
+    | 'principalId'
+    | 'environment'
+    | 'publicationEligible'
+    | 'publicationProhibited'
+    | 'limitation'
+  >
+): AflTradePrivateValuationHpnSourceAdmission {
+  const content = aflTradePrivateValuationHpnSourceAdmissionContentSchema.parse({
+    schemaVersion: AFL_TRADE_PRIVATE_VALUATION_HPN_SOURCE_ADMISSION_SCHEMA_VERSION,
+    ...input,
+    principalId: AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID,
+    environment: 'non_production',
+    publicationEligible: false,
+    publicationProhibited: true,
+    limitation: AFL_TRADE_PRIVATE_VALUATION_HPN_SOURCE_ADMISSION_LIMITATION,
+  });
+  return aflTradePrivateValuationHpnSourceAdmissionSchema.parse({
+    admissionId: createAflTradeContentAddress(
+      'private-valuation-hpn-source-admission',
+      content
+    ),
+    content,
+  });
+}
+
+export function parseAflTradePrivateValuationHpnSourceAdmission(
+  value: unknown
+): AflTradePrivateValuationHpnSourceAdmission {
+  return aflTradePrivateValuationHpnSourceAdmissionSchema.parse(value);
+}

--- a/tests/outcomes-integration/afl-hpn-pav-projected-input-postgres.test.ts
+++ b/tests/outcomes-integration/afl-hpn-pav-projected-input-postgres.test.ts
@@ -33,8 +33,11 @@ import {
   AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_LIMITATION,
   AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_V2_SCHEMA_VERSION,
   aflTradePrivateValuationCaptureBindingSchema,
+  type AflTradePrivateValuationCaptureBinding,
 } from '@/server/aflTradeIntelligence/valuation/privateValuationCaptureBinding';
 import { createAflTradePrivateValuationFactualOutput } from '@/server/aflTradeIntelligence/valuation/privateValuationFactualOutput';
+import { createAflTradePrivateValuationHpnSourceAdmission } from '@/server/aflTradeIntelligence/valuation/privateValuationHpnSourceAdmission';
+import { createAflTradePrivateValuationSourceAdmission } from '@/server/aflTradeIntelligence/valuation/privateValuationSourceAdmission';
 import { PostgresAflTradePrivateValuationHpnPreparation } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationHpnPreparation';
 import { PostgresAflTradePrivateValuationScheduleRepository } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationScheduling';
 import {
@@ -143,6 +146,15 @@ const reviewedCaptureSources = [
     authority: createLocalAflTradeAflTablesResultsAuthority(seasonYear),
   },
 ] as const satisfies readonly ReviewedCaptureSource[];
+
+let retainedBackdatedAdmissionFixture:
+  | Readonly<{
+      requestId: string;
+      originalClaimId: string;
+      binding: AflTradePrivateValuationCaptureBinding;
+      projected: ReturnType<typeof projection>;
+    }>
+  | undefined;
 
 const reviewedSourceArtifact = (suffix: string) =>
   createAflTradeCanonicalJsonArtifactRef({ sourceCapture: suffix }, fixtureAt);
@@ -534,7 +546,7 @@ async function seedSourceAndFactualAuthority(
            provider,dataset,dataset_version,access_mechanism,capability_id,competition,
            anchor_season_year,effective_at,captured_at,status,manifest_json)
          VALUES ($1,$2,$3,$4,'non_production',$5,$6,'fixture','fixture',$7,$8,$9,$10,$10,
-                 'approved',$11::jsonb)
+                 'staged',$11::jsonb)
          ON CONFLICT (capture_id) DO NOTHING`,
         [
           captureId,
@@ -1087,6 +1099,15 @@ async function retainHpnCaptureBindings(
   request: Awaited<ReturnType<typeof enqueueAndClaim>>['claim']['request'],
   claim: Awaited<ReturnType<typeof enqueueAndClaim>>['claim']
 ) {
+  const factualAdmission = createAflTradePrivateValuationSourceAdmission({
+    requestId: request.requestId,
+    captureBindingId: id('private-valuation-capture-binding', 'factual-input'),
+    sourceCaptureId: id('source-capture', 'factual-input'),
+    normalizationRunId: id('provider-normalization-run', 'factual-input'),
+    factBatchId: id('source-fact-batch', 'fixture'),
+    factualRunId: id('factual-reconciliation-run', 'projected-input'),
+    admittedAt: projectionAt,
+  });
   const bindings = lanes.map((lane) => {
     const sourceRights = lane.authority.capture.sourceRights;
     const content = {
@@ -1122,6 +1143,24 @@ async function retainHpnCaptureBindings(
     });
   });
   await client.transaction(async (transaction) => {
+    await transaction.query(`SET LOCAL session_replication_role='replica'`);
+    await transaction.query(
+      `INSERT INTO outcome_private_valuation_source_admission
+        (admission_id,request_id,capture_binding_id,source_capture_id,
+         normalization_run_id,fact_batch_id,factual_run_id,admitted_at,admission_json)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb)`,
+      [
+        factualAdmission.admissionId,
+        factualAdmission.content.requestId,
+        factualAdmission.content.captureBindingId,
+        factualAdmission.content.sourceCaptureId,
+        factualAdmission.content.normalizationRunId,
+        factualAdmission.content.factBatchId,
+        factualAdmission.content.factualRunId,
+        factualAdmission.content.admittedAt,
+        canonicalizeAflTradeJson(factualAdmission),
+      ]
+    );
     for (const binding of bindings) {
       if (
         binding.content.schemaVersion !==
@@ -1150,18 +1189,19 @@ async function retainHpnCaptureBindings(
         ]
       );
     }
+    await transaction.query(`SET LOCAL session_replication_role='origin'`);
   });
-  return bindings;
+  return { bindings, factualAdmission };
 }
 
-function factualOutput(requestId: string) {
+function factualOutput(requestId: string, sourceAdmissionId: string) {
   const factualRunId = id('factual-reconciliation-run', 'projected-input');
   return createAflTradePrivateValuationFactualOutput({
     requestId,
     valuationScopeKey: 'afl-men:2026-trades',
     captureBindingId: id('private-valuation-capture-binding', 'factual-input'),
-    sourceAdmissionId: id('private-valuation-source-admission', 'factual-input'),
-    normalizationRunId: id('provider-normalization-run', 'primary'),
+    sourceAdmissionId,
+    normalizationRunId: id('provider-normalization-run', 'factual-input'),
     factBatch: {
       batchId: id('source-fact-batch', 'fixture'),
       batchSha256: sha256('fixture'),
@@ -1188,6 +1228,42 @@ function factualOutput(requestId: string) {
       releaseSha256: sha256('fixture'),
     },
     preparedAt: projectionAt,
+  });
+}
+
+async function retainFactualOutput(
+  requestId: string,
+  output: ReturnType<typeof factualOutput>
+): Promise<void> {
+  await client.transaction(async (transaction) => {
+    await transaction.query(`SET LOCAL session_replication_role='replica'`);
+    await transaction.query(
+      `INSERT INTO outcome_private_valuation_factual_output
+        (output_id,request_id,capture_binding_id,source_admission_id,normalization_run_id,
+         fact_batch_id,factual_run_id,candidate_id,factual_release_id,prepared_at,output_json)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb)`,
+      [
+        output.outputId,
+        requestId,
+        output.content.captureBindingId,
+        output.content.sourceAdmissionId,
+        output.content.normalizationRunId,
+        output.content.factBatch.batchId,
+        output.content.reconciliation.factualRunId,
+        output.content.candidate.candidateId,
+        output.content.factualRelease.releaseId,
+        output.content.preparedAt,
+        canonicalizeAflTradeJson(output),
+      ]
+    );
+    for (const [index, batch] of output.content.spellMetricBatches.entries()) {
+      await transaction.query(
+        `INSERT INTO outcome_private_valuation_factual_output_spell_batch
+          (output_id,batch_id,ordinal) VALUES ($1,$2,$3)`,
+        [output.outputId, batch.batchId, index + 1]
+      );
+    }
+    await transaction.query(`SET LOCAL session_replication_role='origin'`);
   });
 }
 
@@ -1703,8 +1779,38 @@ describe.sequential('private valuation HPN preparation with projected authority 
       )
     );
     const { requestId, claim } = await enqueueAndClaim('projected-hpn-coordinator');
-    const bindings = await retainHpnCaptureBindings(claim.request, claim);
-    const output = factualOutput(requestId);
+    const { bindings, factualAdmission } = await retainHpnCaptureBindings(
+      claim.request,
+      claim
+    );
+    const schedule = new PostgresAflTradePrivateValuationScheduleRepository(client);
+    await schedule.reschedule({
+      claimId: claim.claimId,
+      leaseToken: claim.leaseToken,
+      state: 'retry_pending',
+    });
+    await client.query(`SELECT pg_sleep(5.05)`);
+    const recoveredClaim = await schedule.claim(
+      'system:weekly-valuation-coordinator',
+      requestId
+    );
+    if (recoveredClaim === null) {
+      throw new TypeError('The HPN coordinator fixture did not reclaim its dispatch.');
+    }
+    expect(recoveredClaim.claimId).not.toBe(claim.claimId);
+    const publicPointersBefore = await client.query<{
+      active_release: unknown;
+      active_publication: unknown;
+    }>(
+      `SELECT
+         (SELECT COALESCE(jsonb_agg(to_jsonb(active_release)
+                    ORDER BY active_release.scope_key),'[]'::jsonb)
+            FROM outcome_active_release active_release) AS active_release,
+         (SELECT COALESCE(jsonb_agg(to_jsonb(active_publication)
+                    ORDER BY active_publication.scope_key),'[]'::jsonb)
+            FROM outcome_valuation_active_publication active_publication) AS active_publication`
+    );
+    const output = factualOutput(requestId, factualAdmission.admissionId);
     const methodBytes = new TextEncoder().encode('<html>Disposable HPN method evidence</html>');
     const method = createAflTradeHpnPavMethod({
       sourceArtifact: createAflTradeByteArtifactRef(
@@ -1735,22 +1841,85 @@ describe.sequential('private valuation HPN preparation with projected authority 
     };
     const preparationInput = {
       requestId,
-      claim: { claimId: claim.claimId, leaseToken: claim.leaseToken },
-    };
-    const first = await new PostgresAflTradePrivateValuationHpnPreparation(client, {
-      factualPreparation: { prepare: async () => ({ state: 'prepared' as const, output }) },
-      methodId: method.methodId,
-      methodAuthority,
-      captureSource,
-    }).prepare(preparationInput);
-    const replay = await new PostgresAflTradePrivateValuationHpnPreparation(client, {
-      factualPreparation: {
-        prepare: async () => ({ state: 'already_prepared' as const, output }),
+      claim: {
+        claimId: recoveredClaim.claimId,
+        leaseToken: recoveredClaim.leaseToken,
       },
-      methodId: method.methodId,
-      methodAuthority,
-      captureSource,
-    }).prepare(preparationInput);
+    };
+    const missingOutputPreparation = new PostgresAflTradePrivateValuationHpnPreparation(
+      client,
+      {
+        factualPreparation: { prepare: async () => ({ state: 'prepared' as const, output }) },
+        methodId: method.methodId,
+        methodAuthority,
+        captureSource,
+      }
+    );
+    await expect(missingOutputPreparation.prepare(preparationInput)).rejects.toThrow(
+      'Private valuation HPN source admission lacks exact factual authority'
+    );
+    const beforeExactOutput = await client.query<{
+      inputs: number;
+      calculations: number;
+    }>(
+      `SELECT
+         (SELECT count(*)::integer FROM outcome_hpn_pav_input_set) AS inputs,
+         (SELECT count(*)::integer FROM outcome_hpn_pav_calculation) AS calculations`
+    );
+    expect(beforeExactOutput.rows).toEqual([{ inputs: 0, calculations: 0 }]);
+    await retainFactualOutput(requestId, output);
+    await client.query(
+      `CREATE FUNCTION hpn_calculation_failure_test() RETURNS trigger
+         LANGUAGE plpgsql AS $$
+       BEGIN
+         RAISE EXCEPTION 'HPN calculation persistence failed';
+       END $$`
+    );
+    await client.query(
+      `CREATE TRIGGER hpn_calculation_failure_test
+         BEFORE INSERT ON outcome_hpn_pav_calculation
+         FOR EACH ROW EXECUTE FUNCTION hpn_calculation_failure_test()`
+    );
+    try {
+      await expect(missingOutputPreparation.prepare(preparationInput)).rejects.toThrow(
+        'HPN calculation persistence failed'
+      );
+    } finally {
+      await client.query(
+        `DROP TRIGGER hpn_calculation_failure_test ON outcome_hpn_pav_calculation`
+      );
+      await client.query(`DROP FUNCTION hpn_calculation_failure_test()`);
+    }
+    const afterClaimLoss = await client.query<{
+      inputs: number;
+      calculations: number;
+    }>(
+      `SELECT
+         (SELECT count(*)::integer FROM outcome_hpn_pav_input_set) AS inputs,
+         (SELECT count(*)::integer FROM outcome_hpn_pav_calculation) AS calculations`
+    );
+    expect(afterClaimLoss.rows).toEqual([{ inputs: 0, calculations: 0 }]);
+    const concurrent = await Promise.all([
+      new PostgresAflTradePrivateValuationHpnPreparation(client, {
+        factualPreparation: { prepare: async () => ({ state: 'prepared' as const, output }) },
+        methodId: method.methodId,
+        methodAuthority,
+        captureSource,
+      }).prepare(preparationInput),
+      new PostgresAflTradePrivateValuationHpnPreparation(client, {
+        factualPreparation: {
+          prepare: async () => ({ state: 'already_prepared' as const, output }),
+        },
+        methodId: method.methodId,
+        methodAuthority,
+        captureSource,
+      }).prepare(preparationInput),
+    ]);
+    const first = concurrent.find(({ state }) => state === 'prepared');
+    const replay = concurrent.find(({ state }) => state === 'already_prepared');
+    if (!first || !replay) {
+      throw new TypeError('Concurrent HPN preparation did not converge on one retained result.');
+    }
 
     expect(first).toMatchObject({
       state: 'prepared',
@@ -1759,9 +1928,104 @@ describe.sequential('private valuation HPN preparation with projected authority 
       inputSetId: expect.stringMatching(/^hpn-pav-input-set:[a-f0-9]{64}$/),
       calculationId: expect.stringMatching(/^hpn-pav-season:[a-f0-9]{64}$/),
       captureBindingIds: bindings.map(({ bindingId }) => bindingId),
+      sourceAdmissionIds: [
+        expect.stringMatching(/^private-valuation-hpn-source-admission:[a-f0-9]{64}$/),
+        expect.stringMatching(/^private-valuation-hpn-source-admission:[a-f0-9]{64}$/),
+        expect.stringMatching(/^private-valuation-hpn-source-admission:[a-f0-9]{64}$/),
+      ],
       publicationEligible: false,
     });
     expect(replay).toEqual({ ...first, state: 'already_prepared' });
+    retainedBackdatedAdmissionFixture = {
+      requestId,
+      originalClaimId: claim.claimId,
+      binding: bindings[0]!,
+      projected: projections[0]!,
+    };
+    const retainedAdmissions = await client.query<{
+      dispatch_claim_id: string;
+      attempt_sequence: number;
+    }>(
+      `SELECT dispatch_claim_id,attempt_sequence
+         FROM outcome_private_valuation_hpn_source_admission
+        WHERE request_id=$1 ORDER BY source_role`,
+      [requestId]
+    );
+    expect(retainedAdmissions.rows).toEqual([
+      { dispatch_claim_id: claim.claimId, attempt_sequence: 1 },
+      { dispatch_claim_id: claim.claimId, attempt_sequence: 1 },
+      { dispatch_claim_id: claim.claimId, attempt_sequence: 1 },
+    ]);
+    const forgedAdmission = createAflTradePrivateValuationHpnSourceAdmission({
+      requestId,
+      dispatchClaimId: claim.claimId,
+      attemptSequence: 1,
+      attemptNumber: 1,
+      sourceRole: lanes[0]!.sourceRole,
+      captureBindingId: bindings[0]!.bindingId,
+      sourceCaptureId: bindings[1]!.content.sourceCaptureId,
+      normalizationRunId: bindings[1]!.content.normalizationRunId,
+      projectedFieldMapId: projections[0]!.projectedFieldMap!.fieldMapId,
+      admittedAt: projectionAt,
+    });
+    await expect(
+      client.query(
+        `INSERT INTO outcome_private_valuation_hpn_source_admission
+          (admission_id,request_id,source_role,dispatch_claim_id,attempt_sequence,
+           attempt_number,capture_binding_id,source_capture_id,normalization_run_id,
+           projected_field_map_id,admitted_at,admission_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
+        [
+          forgedAdmission.admissionId,
+          requestId,
+          forgedAdmission.content.sourceRole,
+          claim.claimId,
+          1,
+          1,
+          forgedAdmission.content.captureBindingId,
+          forgedAdmission.content.sourceCaptureId,
+          forgedAdmission.content.normalizationRunId,
+          forgedAdmission.content.projectedFieldMapId,
+          forgedAdmission.content.admittedAt,
+          canonicalizeAflTradeJson(forgedAdmission),
+        ]
+      )
+    ).rejects.toThrow('Private valuation HPN source admission custody is invalid');
+    const wrongMapAdmission = createAflTradePrivateValuationHpnSourceAdmission({
+      requestId,
+      dispatchClaimId: claim.claimId,
+      attemptSequence: 1,
+      attemptNumber: 1,
+      sourceRole: lanes[0]!.sourceRole,
+      captureBindingId: bindings[0]!.bindingId,
+      sourceCaptureId: bindings[0]!.content.sourceCaptureId,
+      normalizationRunId: bindings[0]!.content.normalizationRunId,
+      projectedFieldMapId: projections[1]!.projectedFieldMap!.fieldMapId,
+      admittedAt: projectionAt,
+    });
+    await expect(
+      client.query(
+        `INSERT INTO outcome_private_valuation_hpn_source_admission
+          (admission_id,request_id,source_role,dispatch_claim_id,attempt_sequence,
+           attempt_number,capture_binding_id,source_capture_id,normalization_run_id,
+           projected_field_map_id,admitted_at,admission_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
+        [
+          wrongMapAdmission.admissionId,
+          requestId,
+          wrongMapAdmission.content.sourceRole,
+          claim.claimId,
+          1,
+          1,
+          wrongMapAdmission.content.captureBindingId,
+          wrongMapAdmission.content.sourceCaptureId,
+          wrongMapAdmission.content.normalizationRunId,
+          wrongMapAdmission.content.projectedFieldMapId,
+          wrongMapAdmission.content.admittedAt,
+          canonicalizeAflTradeJson(wrongMapAdmission),
+        ]
+      )
+    ).rejects.toThrow('Private valuation HPN source admission custody is invalid');
     const stored = await client.query<{
       input_status: string;
       calculation_status: string;
@@ -1788,6 +2052,20 @@ describe.sequential('private valuation HPN preparation with projected authority 
         projected_maps: 3,
       },
     ]);
+    await expect(
+      client.query<{
+        active_release: unknown;
+        active_publication: unknown;
+      }>(
+        `SELECT
+           (SELECT COALESCE(jsonb_agg(to_jsonb(active_release)
+                      ORDER BY active_release.scope_key),'[]'::jsonb)
+              FROM outcome_active_release active_release) AS active_release,
+           (SELECT COALESCE(jsonb_agg(to_jsonb(active_publication)
+                      ORDER BY active_publication.scope_key),'[]'::jsonb)
+              FROM outcome_valuation_active_publication active_publication) AS active_publication`
+      )
+    ).resolves.toEqual(publicPointersBefore);
   });
 
   it('rejects a reviewed-evidence successor with duplicated members behind claimed 7/3 counts', async () => {
@@ -2229,4 +2507,75 @@ describe.sequential('private valuation HPN preparation with projected authority 
       })
     ).rejects.toThrow(/exact current source authority/i);
   }, 60_000);
+
+  it('rejects a backdated direct admission after its projected map is superseded', async () => {
+    const fixture = retainedBackdatedAdmissionFixture;
+    if (fixture === undefined) {
+      throw new TypeError('The backdated-admission fixture was not retained.');
+    }
+    const successorAt = '2026-08-22T00:00:00.000Z';
+    const rejectedDecision = createAflTradeHpnFieldMapReviewDecision({
+      candidate: fixture.projected.candidate,
+      candidateArtifact: fixture.projected.candidateArtifact,
+      sourceUseAssessment: fixture.projected.sourceUseAssessment,
+      sourceUseAssessmentArtifact: fixture.projected.sourceUseAssessmentArtifact,
+      decision: 'rejected',
+      reviewerId: 'projected-hpn-input-fixture-reviewer',
+      rationale: 'Supersede the disposable projection for a backdating regression.',
+      decidedAt: successorAt,
+    });
+    await new PostgresAflTradeHpnProjectedFieldMapAuthority(client).registerDecision({
+      candidate: fixture.projected.candidate,
+      candidateArtifact: fixture.projected.candidateArtifact,
+      sourceUseAssessment: fixture.projected.sourceUseAssessment,
+      sourceUseAssessmentArtifact: fixture.projected.sourceUseAssessmentArtifact,
+      reviewDecision: rejectedDecision,
+      decisionArtifact: createAflTradeCanonicalJsonArtifactRef(
+        rejectedDecision,
+        successorAt
+      ),
+    });
+    const binding = fixture.binding;
+    if (
+      binding.content.schemaVersion !==
+      AFL_TRADE_PRIVATE_VALUATION_CAPTURE_BINDING_V2_SCHEMA_VERSION
+    ) {
+      throw new TypeError('The backdated-admission fixture requires role-aware custody.');
+    }
+    const backdated = createAflTradePrivateValuationHpnSourceAdmission({
+      requestId: fixture.requestId,
+      dispatchClaimId: fixture.originalClaimId,
+      attemptSequence: binding.content.attemptSequence,
+      attemptNumber: binding.content.attemptNumber,
+      sourceRole: binding.content.sourceRole,
+      captureBindingId: binding.bindingId,
+      sourceCaptureId: binding.content.sourceCaptureId,
+      normalizationRunId: binding.content.normalizationRunId,
+      projectedFieldMapId: fixture.projected.projectedFieldMap!.fieldMapId,
+      admittedAt: projectionAt,
+    });
+    await expect(
+      client.query(
+        `INSERT INTO outcome_private_valuation_hpn_source_admission
+          (admission_id,request_id,source_role,dispatch_claim_id,attempt_sequence,
+           attempt_number,capture_binding_id,source_capture_id,normalization_run_id,
+           projected_field_map_id,admitted_at,admission_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
+        [
+          backdated.admissionId,
+          backdated.content.requestId,
+          backdated.content.sourceRole,
+          backdated.content.dispatchClaimId,
+          backdated.content.attemptSequence,
+          backdated.content.attemptNumber,
+          backdated.content.captureBindingId,
+          backdated.content.sourceCaptureId,
+          backdated.content.normalizationRunId,
+          backdated.content.projectedFieldMapId,
+          backdated.content.admittedAt,
+          canonicalizeAflTradeJson(backdated),
+        ]
+      )
+    ).rejects.toThrow('Private valuation HPN source admission custody is invalid');
+  });
 });

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1104,6 +1104,7 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0075_versioned_release_acquisition_spell_eligibility',
       '0076_role_aware_private_valuation_capture_binding',
       '0077_projected_hpn_pav_input_authority',
+      '0078_private_valuation_hpn_source_admission',
     ]);
 
     const tables = await query<{ table_name: string }>(

--- a/tests/unit/afl-trade-intelligence-private-valuation-hpn-preparation.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-hpn-preparation.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority';
 import { createLocalAflTradeOfficialAfl2026Authority } from '@/server/aflTradeIntelligence/development/localOfficialAfl2026Authority';
 import { createAflTradePrivateValuationFactualOutput } from '@/server/aflTradeIntelligence/valuation/privateValuationFactualOutput';
+import { createAflTradePrivateValuationHpnSourceAdmission } from '@/server/aflTradeIntelligence/valuation/privateValuationHpnSourceAdmission';
 import {
   aflTradePrivateValuationDispatchRequestSchema,
   createAflTradePrivateValuationDispatchRequestId,
@@ -42,6 +43,10 @@ const request = aflTradePrivateValuationDispatchRequestSchema.parse({
 });
 
 class PreparationSqlClient implements AflOutcomeSqlClient, AflOutcomeSqlTransaction {
+  readonly events: string[] = [];
+  heartbeatCount = 0;
+  failHeartbeatAt: number | undefined;
+
   constructor(private readonly retainedRequest = request) {}
 
   async transaction<T>(work: (transaction: AflOutcomeSqlTransaction) => Promise<T>): Promise<T> {
@@ -50,10 +55,17 @@ class PreparationSqlClient implements AflOutcomeSqlClient, AflOutcomeSqlTransact
 
   async query<Row>(sql: string): Promise<AflOutcomeSqlQueryResult<Row>> {
     if (sql.startsWith('SET LOCAL ROLE')) return this.result([]);
+    if (sql.startsWith('RESET ROLE')) return this.result([]);
     if (sql.includes('load_outcome_private_valuation_dispatch_request_for_claim')) {
+      this.events.push('claim-check');
       return this.result([{ request_json: this.retainedRequest }]);
     }
     if (sql.includes('heartbeat_outcome_private_valuation_dispatch')) {
+      this.heartbeatCount += 1;
+      this.events.push('heartbeat');
+      if (this.heartbeatCount === this.failHeartbeatAt) {
+        throw new Error('Private valuation dispatch claim was lost');
+      }
       return this.result([{ heartbeat_outcome_private_valuation_dispatch: null }]);
     }
     if (sql.includes('max(capture.captured_at)')) {
@@ -109,6 +121,7 @@ afterEach(() => {
 
 describe('private valuation HPN preparation', () => {
   it('composes three exact capture lanes into the existing HPN input and calculation owners', async () => {
+    const sqlClient = new PreparationSqlClient();
     const roles = [
       'hpn_completed_results',
       'hpn_primary_player_stats',
@@ -194,15 +207,54 @@ describe('private valuation HPN preparation', () => {
       }) as never);
     const buildInput = vi
       .spyOn(PostgresAflTradeHpnPavInputRepository.prototype, 'buildAndPersistSeasonInputSet')
-      .mockResolvedValue({
-        inputSet: { inputSetId: addressed('hpn-pav-input-set', 'input') } as never,
-        idempotentReplay: false,
+      .mockImplementation(async () => {
+        sqlClient.events.push('input');
+        return {
+          inputSet: { inputSetId: addressed('hpn-pav-input-set', 'input') } as never,
+          idempotentReplay: false,
+        };
+      });
+    const retainedAdmissions = new Map<
+      (typeof roles)[number],
+      ReturnType<typeof createAflTradePrivateValuationHpnSourceAdmission>
+    >();
+    const admitHpnSource = vi
+      .spyOn(
+        PostgresAflTradePrivateValuationCaptureBindingRepository.prototype,
+        'admitHpnSource'
+      )
+      .mockImplementation(async ({ binding, projectedFieldMapId }) => {
+        if (binding.content.schemaVersion !== 'afl-trade-private-valuation-capture-binding/v2') {
+          throw new TypeError('The unit fixture requires role-aware capture custody.');
+        }
+        const sourceRole = binding.content.sourceRole as (typeof roles)[number];
+        const retained = retainedAdmissions.get(sourceRole);
+        if (retained !== undefined) {
+          return { state: 'already_admitted', admission: retained };
+        }
+        const admission = createAflTradePrivateValuationHpnSourceAdmission({
+          requestId: request.requestId,
+          dispatchClaimId: claim.claimId,
+          attemptSequence: binding.content.attemptSequence,
+          attemptNumber: binding.content.attemptNumber,
+          sourceRole,
+          captureBindingId: binding.bindingId,
+          sourceCaptureId: binding.content.sourceCaptureId,
+          normalizationRunId: binding.content.normalizationRunId,
+          projectedFieldMapId,
+          admittedAt: '2026-08-12T00:04:00.000Z',
+        });
+        retainedAdmissions.set(sourceRole, admission);
+        return { state: 'admitted', admission };
       });
     const calculate = vi
       .spyOn(PostgresAflTradeHpnPavCalculationRepository.prototype, 'calculateAndPersist')
-      .mockResolvedValue({
-        calculation: { calculationId: addressed('hpn-pav-season', 'calculation') } as never,
-        idempotentReplay: false,
+      .mockImplementation(async () => {
+        sqlClient.events.push('calculation');
+        return {
+          calculation: { calculationId: addressed('hpn-pav-season', 'calculation') } as never,
+          idempotentReplay: false,
+        };
       });
     const captureSource = vi.fn(async ({ sourceRole }: { sourceRole: string }) => ({
       normalizationRunId: addressed('provider-normalization-run', sourceRole),
@@ -212,7 +264,7 @@ describe('private valuation HPN preparation', () => {
       .mockResolvedValueOnce({ state: 'prepared' as const, output: factualOutput() })
       .mockResolvedValue({ state: 'already_prepared' as const, output: factualOutput() });
     const preparation = new PostgresAflTradePrivateValuationHpnPreparation(
-      new PreparationSqlClient(),
+      sqlClient,
       {
         factualPreparation: { prepare: prepareFactual },
         methodId: addressed('hpn-pav-method', 'method'),
@@ -230,12 +282,22 @@ describe('private valuation HPN preparation', () => {
       captureBindingIds: roles.map((_role) =>
         expect.stringMatching(/^private-valuation-capture-binding:[a-f0-9]{64}$/u)
       ),
+      sourceAdmissionIds: roles.map((_role) =>
+        expect.stringMatching(/^private-valuation-hpn-source-admission:[a-f0-9]{64}$/u)
+      ),
       publicationEligible: false,
     });
     expect(loadBinding).toHaveBeenCalledTimes(3);
     expect(acceptBinding).toHaveBeenCalledTimes(3);
     expect(captureSource.mock.calls.map(([input]) => input.sourceRole)).toEqual(roles);
     expect(selectedMaps).toHaveBeenCalledTimes(3);
+    expect(admitHpnSource).toHaveBeenCalledTimes(3);
+    for (const [admissionInput] of admitHpnSource.mock.calls.slice(0, 3)) {
+      expect(admissionInput.factualOutputId).toBe(factualOutput().outputId);
+    }
+    expect(Math.max(...admitHpnSource.mock.invocationCallOrder)).toBeLessThan(
+      buildInput.mock.invocationCallOrder[0]!
+    );
     expect(buildInput).toHaveBeenCalledWith(
       expect.objectContaining({
         environment: 'non_production',
@@ -251,15 +313,37 @@ describe('private valuation HPN preparation', () => {
       { environment: 'non_production' }
     );
     expect(calculate).toHaveBeenCalledTimes(1);
+    expect(sqlClient.events.slice(-4)).toEqual([
+      'heartbeat',
+      'input',
+      'calculation',
+      'heartbeat',
+    ]);
 
-    buildInput.mockResolvedValue({
-      inputSet: { inputSetId: addressed('hpn-pav-input-set', 'input') } as never,
-      idempotentReplay: true,
+    buildInput.mockImplementation(async () => {
+      sqlClient.events.push('input');
+      return {
+        inputSet: { inputSetId: addressed('hpn-pav-input-set', 'input') } as never,
+        idempotentReplay: true,
+      };
     });
-    calculate.mockResolvedValue({
-      calculation: { calculationId: addressed('hpn-pav-season', 'calculation') } as never,
-      idempotentReplay: true,
+    calculate.mockImplementation(async () => {
+      sqlClient.events.push('calculation');
+      return {
+        calculation: { calculationId: addressed('hpn-pav-season', 'calculation') } as never,
+        idempotentReplay: true,
+      };
     });
+    sqlClient.failHeartbeatAt = sqlClient.heartbeatCount + 5;
+    await expect(
+      preparation.prepare({ requestId: request.requestId, claim })
+    ).rejects.toThrow('Private valuation dispatch claim was lost');
+    expect(sqlClient.events.slice(-3)).toEqual([
+      'input',
+      'calculation',
+      'heartbeat',
+    ]);
+    sqlClient.failHeartbeatAt = undefined;
     await expect(preparation.prepare({ requestId: request.requestId, claim })).resolves.toMatchObject({
       state: 'already_prepared',
       inputSetId: addressed('hpn-pav-input-set', 'input'),
@@ -267,6 +351,7 @@ describe('private valuation HPN preparation', () => {
     });
     expect(captureSource).toHaveBeenCalledTimes(3);
     expect(acceptBinding).toHaveBeenCalledTimes(3);
+    expect(admitHpnSource).toHaveBeenCalledTimes(9);
   });
 
   it('fails closed before HPN persistence when exact accepted source custody is missing', async () => {


### PR DESCRIPTION
## Summary

- require an exact retained private factual output before admitting an HPN source
- add immutable PostgreSQL admission receipts for three role-aware HPN lanes, including current decode, projected, review, and rights authority plus a database-owned staged-to-approved transition
- compose the existing HPN input and calculation repositories inside one claim-fenced transaction
- preserve public factual and publication pointers, and document the #563 to #564 runtime sequence

Closes #562

## Owning boundary and decisions

- PostgreSQL owns source admission and the status transition
- each receipt retains its original capture-binding claim ancestry, while callers must hold the current live request claim
- governed admission and the direct-insert trigger share one current-authority predicate
- the existing weekly worker remains unchanged because direct midpoint wiring would calculate from the old prepared-v3 head

## Verification

- `npm run docs:check`
- `npm run lint:ci`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run typecheck`
- `npm run test:unit` - 598 files, 3,756 tests passed
- `DATABASE_URL_TEST=file:<disposable-sqlite> npm run test:int` - 3 files, 3 tests passed
- `DATABASE_URL=file:<disposable-sqlite> npm run test:e2e` - 24 passed; two Firefox loading-timeout cases passed immediately on targeted retry and also passed in Chromium and WebKit
- `DATABASE_URL=file:<disposable-sqlite> NEXT_PUBLIC_FIREBASE_*=<non-secret-build-placeholders> npm run build`
- `npm run test:outcomes:int` - 29 files, 130 tests passed
- independent Standards and Deepening reviews - no remaining findings

## Impact and residual risk

- this changes non-production private valuation authority only
- no public factual-release, valuation-publication, or publication pointers change
- no scheduler or worker cutover is included; model execution remains #563 and prepared-v3, cohort, and runtime composition remains #564
- no deployment is expected from this migration and backend preparation seam

## Summary by Sourcery

Govern private HPN source admission by requiring exact retained factual authority, immutable role-aware receipts, and claim-fenced persistence before private calculation.

New Features:
- Add governed admission of the three role-specific HPN source lanes using immutable, content-addressed receipts tied to retained factual output and current reviewed authority.
- Expose HPN source admission results in private valuation preparation outputs.

Bug Fixes:
- Prevent HPN preparation from proceeding without the exact retained private factual output or current source, mapping, rights, and review authority.
- Reject stale, forged, backdated, or conflicting admissions and prevent unauthorized source-capture status changes.

Enhancements:
- Run source admission, HPN input persistence, and calculation within claim-fenced PostgreSQL transactions with heartbeat validation and atomic rollback.
- Preserve the existing public release and publication pointers while ensuring admissions remain limited to non-production private calculation authority.
- Document operational inspection, replay, lease handoff, and failure-handling behavior for HPN source admission.

Documentation:
- Update architecture and operations documentation with the governed HPN admission flow and runtime sequencing constraints.

Tests:
- Expand unit and PostgreSQL integration coverage for exact factual-output requirements, immutable admissions, concurrency convergence, claim loss rollback, stale authority rejection, and preservation of public pointers.

Chores:
- Add the PostgreSQL schema, migration, validation triggers, authority checks, and admission function for role-aware HPN source receipts.