### PR TITLE
Run and qualify one dispatch-bound private model pair

### DIFF
--- a/docs/architecture/afl-trade-intelligence.md
+++ b/docs/architecture/afl-trade-intelligence.md
@@ -1972,6 +1972,9 @@ and attempt rows through their owning PostgreSQL transactions; immutable artifac
 orphaned after a process failure but cannot acquire accepted authority. Concurrent requests may
 run for different scopes. Requests for the same scope claim serially; after the live claim ends, the
 next request can bind to and resume the same substantive operation without duplicating its components.
+The qualification transaction also binds its exact retained result to that substantive operation;
+failure to bind rolls back the qualification, Gate 3 records, work item, and current-pair advancement
+together.
 
 Acceptance also proves component ancestry rather than trusting the coordinator callback. The player
 component's admitted authorization must name the same request, substantive operation, claim attempt,

--- a/docs/architecture/afl-trade-intelligence.md
+++ b/docs/architecture/afl-trade-intelligence.md
@@ -1185,22 +1185,25 @@ Model execution is a second, separately durable seam. A registered
 set, executable intent, current Gate 2 decision, fresh Gate 0A model-training receipts and retained
 bytes for every dataset, protocol and runtime artifact are authenticated before one short-lived
 `afl-trade-model-run-authorization/v1` is issued. The start boundary also requires a distinct
-`afl-trade-model-run-operational-authorization/v1` receipt from a human operational principal. That
-receipt authorizes `execute_model_run` for one exact intent, dataset, admission, protocol and
-observation set; it cannot reuse the earlier dataset-materialization authorization or authorize a
-different attempt. The receipt must reference a separately retained and currently approved governed
-operator-authority evidence record whose environment, scope, competition, season coverage, principal,
-role and validity cover the exact admitted rows. The model-run writer may consume that trust root but
-cannot create or approve it. Database time owns both authorization windows and expiry.
+`afl-trade-model-run-operational-authorization/v1` receipt for one exact intent, dataset, admission,
+protocol and observation set; it cannot reuse the earlier dataset-materialization authorization or
+authorize a different attempt. The normal path requires a human operational principal and a separately
+retained, currently approved governed operator-authority evidence record whose environment, scope,
+competition, season coverage, principal, role and validity cover the exact admitted rows. The fixed
+non-production dispatch-bound private-valuation path instead derives operational authority from the
+current live dispatch claim and its exact retained factual and HPN input binding. Callers cannot select
+that policy principal, role, environment, execution mode or publication posture. The model-run writer
+may consume either authenticated trust root but cannot create or approve one. Database time owns both
+authorization windows and expiry.
 The authorization is unique per intent and consumed once before execution; the completed
 `afl-trade-model-run/v3` is append-only and binds the same dataset, admission, protocol, observation
 set, intent and authorization. PostgreSQL stores each immutable parent and enforces exact replay,
 current analytical authority, exact current Gate 2 artifacts, the complete admitted Gate 0A source
-set and request/use parity, their exclusive rights and revalidation deadlines, one governed human
+set and request/use parity, their exclusive rights and revalidation deadlines, one governed
 operational receipt, one authorization, one consumption and one completed run. A
 failure after consumption is persisted as an immutable failed run and may also raise an operational
 incident, but the same intent cannot be run again. A new attempt requires a new content-addressed
-intent and a new human operational receipt.
+intent and a new exact operational receipt from the applicable human or dispatch-bound policy path.
 
 This durable authority path remains private and unmounted. It authorizes no model merely because the
 records exist, and it does not fit coefficients, select a champion, issue Gate 3 approval, calculate a
@@ -1946,10 +1949,51 @@ activation authority. Missing or stale source custody, map approval, identity re
 factual-universe coverage, or method authority fails closed before downstream authority changes. The
 current public release pointer and publication Gates remain untouched.
 
+The next boundary composes the existing admitted player runner, governed pick execution, and governed
+qualification service for the exact factual output and finalized HPN calculation returned by that
+preparation. One content-addressed substantive operation excludes dispatch identity, trigger time,
+request identity, capture identity, and other fresh custody metadata. Different requests with the same
+factual values, HPN values, model targets, and qualification policy therefore converge on one model
+pair. PostgreSQL retains only two new bindings: immutable request-to-exact-input lineage and monotonic
+substantive-operation progress. It does not introduce another retry ledger, component-run store,
+qualification store, or current-pair pointer.
+
+The dispatch attempt remains the sole retry number and is capped at three by the scheduling boundary.
+A successful component is retained independently, so a transient failure of the other component does
+not rerun it. Deterministic, stale-authority, and unavailable outcomes return without blind retry.
+Restart reconstructs progress after either component, pair acceptance, or qualification; a failed
+qualification remains immutable evidence and cannot advance the existing current-pair authority.
+The dispatch terminal `already_current` means no authority change is required because the same or a
+newer qualified pair is already current; it never identifies an older retained qualification as the
+current pointer.
+Every operation or authority mutation is fenced by the request's current live claim. Dispatch-bound
+pick execution, component registration, and qualification/current-pair advancement hold the request
+and attempt rows through their owning PostgreSQL transactions; immutable artifact writes may be
+orphaned after a process failure but cannot acquire accepted authority. Concurrent requests may
+run for different scopes. Requests for the same scope claim serially; after the live claim ends, the
+next request can bind to and resume the same substantive operation without duplicating its components.
+
+Acceptance also proves component ancestry rather than trusting the coordinator callback. The player
+component's admitted authorization must name the same request, substantive operation, claim attempt,
+lease digest, factual output, HPN calculation, and substantive input digests. The governed pick
+execution uses the dispatch-bound v4 envelope with the same fields; retained v2/v3 executions remain
+valid for their existing flows but cannot satisfy this boundary. Qualification binding verifies the
+retained pair, outcome, scope, and the operation's exact content-addressed qualification policy.
+
+Automated player execution uses the admitted runner's existing rights, dataset, protocol, custody,
+and publication checks. The only new operational-authority branch is a fixed non-production local
+policy for `system:weekly-valuation-coordinator`; callers cannot select its principal, role,
+environment, execution mode, or publication posture. The human-authorized path remains unchanged.
+Operational authority recording and final run-authorization issuance independently recheck the live
+dispatch claim, attempt, lease window, and exact input binding, so a stale claimant cannot begin new
+model spend.
+Neither the exact-input loader nor either new binding reads or writes a public release or publication
+pointer.
+
 This is still not a complete new-game-data pipeline. The deployed weekly runner continues to consume
-whatever exact prepared-v3 head is current. Model observation rebuild, bounded model execution,
-automatic qualification handoff, and prepared-v3 activation still need to be composed after HPN
-preparation before the worker can run raw data through to recalculation without manual orchestration.
+whatever exact prepared-v3 head is current. Observation rebuild and prepared-v3 activation still need
+to be composed around this dispatch-bound model-pair coordinator before the worker can run raw data
+through to recalculation without manual orchestration.
 
 A structurally valid fixture report always retains `publicationReady: false` and the remaining
 external blockers: a real historical-data run, component-model calibration exit criteria, downstream

--- a/prisma/afl-trade-outcomes/migrations/0079_dispatch_bound_private_model_pair/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0079_dispatch_bound_private_model_pair/migration.sql
@@ -1091,7 +1091,7 @@ FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_valuation_model_operatio
 CREATE TRIGGER "outcome_private_valuation_model_operation_no_delete"
 BEFORE DELETE ON "outcome_private_valuation_model_operation"
 FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_valuation_dispatch_delete"();
-CREATE TRIGGER "outcome_private_valuation_model_request_binding_no_update_or_delete"
+CREATE TRIGGER "outcome_private_model_request_binding_no_write"
 BEFORE UPDATE OR DELETE ON "outcome_private_valuation_model_request_binding"
 FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_valuation_dispatch_delete"();
 

--- a/prisma/afl-trade-outcomes/migrations/0079_dispatch_bound_private_model_pair/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0079_dispatch_bound_private_model_pair/migration.sql
@@ -1,0 +1,1148 @@
+-- Bind exact private dispatch inputs to existing immutable model and qualification custody.
+-- Dispatch attempts remain the sole retry ledger.
+
+CREATE OR REPLACE FUNCTION "claim_outcome_private_valuation_dispatch"(
+  target_worker_id TEXT,target_lease_token_sha256 TEXT,target_lease_seconds INTEGER,
+  target_request_id TEXT DEFAULT NULL
+) RETURNS TABLE(request_id TEXT,request_json JSONB,claim_id TEXT,lease_expires_at TIMESTAMPTZ)
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  candidate "outcome_private_valuation_dispatch_request"%ROWTYPE;
+  trusted_at TIMESTAMPTZ(3):=date_trunc('milliseconds',clock_timestamp());
+  next_sequence INTEGER;
+  next_attempt INTEGER;
+  new_claim_id TEXT;
+  new_lease_expires_at TIMESTAMPTZ(3);
+BEGIN
+  IF target_worker_id IS NULL OR btrim(target_worker_id)='' OR length(target_worker_id)>240
+    OR target_lease_token_sha256 !~ '^[a-f0-9]{64}$'
+    OR target_lease_seconds NOT BETWEEN 5 AND 3600
+  THEN RAISE EXCEPTION 'Private valuation dispatch claim is malformed'; END IF;
+
+  LOOP
+    SELECT * INTO candidate FROM "outcome_private_valuation_dispatch_request" request
+     WHERE request."available_at"<=trusted_at
+       AND (request."status"='pending'
+         OR (request."status"='claimed' AND request."lease_expires_at"<trusted_at))
+       AND (target_request_id IS NULL OR request."request_id"=target_request_id)
+       AND NOT EXISTS (
+         SELECT 1 FROM "outcome_private_valuation_dispatch_request" live_request
+          WHERE live_request."scope_key"=request."scope_key"
+            AND live_request."request_id"<>request."request_id"
+            AND live_request."status"='claimed'
+            AND live_request."lease_expires_at">=trusted_at)
+     ORDER BY request."scheduled_for",request."request_id"
+     FOR UPDATE SKIP LOCKED LIMIT 1;
+    IF NOT FOUND THEN RETURN; END IF;
+
+    PERFORM pg_advisory_xact_lock(
+      hashtextextended('private-valuation-dispatch-scope:'||candidate."scope_key",0)
+    );
+    -- Judge both the row lease and scope ownership only after their locks are held.
+    trusted_at:=date_trunc('milliseconds',clock_timestamp());
+    IF EXISTS (
+      SELECT 1 FROM "outcome_private_valuation_dispatch_request" live_request
+       WHERE live_request."scope_key"=candidate."scope_key"
+         AND live_request."request_id"<>candidate."request_id"
+         AND live_request."status"='claimed'
+         AND live_request."lease_expires_at">=trusted_at
+    ) THEN RETURN; END IF;
+
+    IF candidate."status"='claimed' THEN
+      UPDATE "outcome_private_valuation_dispatch_attempt" expired_attempt SET
+        "finished_at"=trusted_at,"outcome"='lease_expired',
+        "result_json"=jsonb_build_object('state','lease_expired')
+       WHERE expired_attempt."claim_id"=candidate."claim_id"
+         AND expired_attempt."finished_at" IS NULL;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'Private valuation dispatch expired claim lacks attempt custody';
+      END IF;
+      IF candidate."transient_failure_count"+1>=3 THEN
+        UPDATE "outcome_private_valuation_dispatch_request" exhausted_request SET
+          "status"='completed',"completed_at"=trusted_at,
+          "result_json"=jsonb_build_object('state','exhausted'),
+          "transient_failure_count"="transient_failure_count"+1,
+          "claim_id"=NULL,"lease_token_sha256"=NULL,
+          "lease_expires_at"=NULL,"claimed_at"=NULL
+         WHERE exhausted_request."request_id"=candidate."request_id";
+        IF target_request_id IS NULL THEN CONTINUE; END IF;
+        RETURN;
+      END IF;
+      UPDATE "outcome_private_valuation_dispatch_request" retry_request SET
+        "status"='pending',"available_at"=trusted_at,
+        "transient_failure_count"="transient_failure_count"+1,
+        "claim_id"=NULL,"lease_token_sha256"=NULL,
+        "lease_expires_at"=NULL,"claimed_at"=NULL
+       WHERE retry_request."request_id"=candidate."request_id";
+      candidate."transient_failure_count":=candidate."transient_failure_count"+1;
+    END IF;
+    EXIT;
+  END LOOP;
+
+  next_sequence:=candidate."claim_sequence"+1;
+  next_attempt:=candidate."transient_failure_count"+1;
+  new_claim_id:="create_outcome_private_valuation_dispatch_claim_id"(
+    candidate."request_id",next_sequence,target_worker_id,target_lease_token_sha256);
+  new_lease_expires_at:=trusted_at+make_interval(secs=>target_lease_seconds);
+  INSERT INTO "outcome_private_valuation_dispatch_attempt"(
+    "claim_id","request_id","attempt_sequence","attempt_number","worker_id",
+    "lease_token_sha256","claimed_at","lease_expires_at","heartbeat_at"
+  ) VALUES (
+    new_claim_id,candidate."request_id",next_sequence,next_attempt,target_worker_id,
+    target_lease_token_sha256,trusted_at,new_lease_expires_at,trusted_at
+  );
+  UPDATE "outcome_private_valuation_dispatch_request" SET
+    "status"='claimed',"claim_sequence"=next_sequence,"claim_id"=new_claim_id,
+    "lease_token_sha256"=target_lease_token_sha256,"claimed_at"=trusted_at,
+    "lease_expires_at"=new_lease_expires_at,"completed_at"=NULL,"result_json"=NULL
+   WHERE "outcome_private_valuation_dispatch_request"."request_id"=candidate."request_id";
+  request_id:=candidate."request_id";
+  request_json:=candidate."request_json";
+  claim_id:=new_claim_id;
+  lease_expires_at:=new_lease_expires_at;
+  RETURN NEXT;
+END $$;
+
+ALTER TABLE "outcome_valuation_model_run_operational_authorization"
+  ALTER COLUMN "authority_evidence_id" DROP NOT NULL;
+
+DROP TRIGGER "outcome_valuation_model_run_operation_insert_guard"
+  ON "outcome_valuation_model_run_operational_authorization";
+
+CREATE OR REPLACE FUNCTION "validate_outcome_valuation_model_run_operation_insert"()
+RETURNS TRIGGER AS $$
+DECLARE
+  intent_row RECORD;
+  dataset_row RECORD;
+  authority_row RECORD;
+  content JSONB;
+  policy_owned BOOLEAN;
+  trusted_now TIMESTAMPTZ(3):=clock_timestamp();
+BEGIN
+  SELECT * INTO intent_row FROM "outcome_valuation_model_run_intent"
+   WHERE "intent_id"=NEW."intent_id" FOR SHARE;
+  SELECT * INTO dataset_row FROM "outcome_valuation_dataset_candidate"
+   WHERE "dataset_id"=NEW."dataset_id" FOR SHARE;
+  content:=NEW."receipt_json"->'content';
+  policy_owned:=COALESCE(
+    content->>'authorityBoundary'=
+      'policy_owned_local_private_valuation_for_one_exact_model_run_intent',
+    FALSE
+  );
+
+  IF policy_owned THEN
+    PERFORM "load_outcome_private_valuation_dispatch_request_for_claim"(
+      content->>'dispatchRequestId',
+      content->>'dispatchClaimId',
+      content->>'dispatchLeaseTokenSha256'
+    );
+  ELSE
+    PERFORM pg_advisory_xact_lock(hashtextextended(
+      'outcome-review-subject:governed_evidence_reference:' || NEW."authority_evidence_id", 0
+    ));
+    SELECT operational.*,evidence."environment" AS evidence_environment,
+           evidence."reference_sha256",evidence."approval_decision_id",
+           evidence."evidence_json"
+      INTO authority_row
+      FROM "outcome_operational_principal_authority" operational
+      JOIN "outcome_governed_evidence_reference" evidence
+        ON evidence."reference_id"=operational."authority_evidence_id"
+     WHERE operational."authority_evidence_id"=NEW."authority_evidence_id" FOR SHARE;
+  END IF;
+
+  IF NEW."receipt_id" <> 'architecture-operation-receipt:' ||
+       encode(sha256(convert_to(NEW."receipt_canonical_json",'UTF8')),'hex') OR
+     intent_row."intent_id" IS NULL OR dataset_row."dataset_id" IS NULL OR
+     NEW."environment"<>intent_row."environment" OR
+     NEW."dataset_id"<>intent_row."dataset_id" OR
+     NEW."admission_id"<>intent_row."admission_id" OR
+     NEW."protocol_id"<>intent_row."protocol_id" OR
+     NEW."observation_set_id"<>intent_row."observation_set_id" OR
+     NEW."authorized_at">intent_row."started_at" OR
+     NEW."authorized_at">trusted_now OR NEW."valid_through"<=trusted_now OR
+     NEW."receipt_json"->>'receiptId'<>NEW."receipt_id" OR
+     content->>'schemaVersion'<>'afl-trade-model-run-operational-authorization/v1' OR
+     content->>'operation'<>'execute_model_run' OR
+     content->'publicationEligible' IS DISTINCT FROM 'false'::JSONB OR
+     content->>'environment' IS DISTINCT FROM NEW."environment"::TEXT OR
+     content->>'runIntentId'<>NEW."intent_id" OR
+     content->>'datasetId'<>NEW."dataset_id" OR
+     content->>'datasetAdmissionId'<>NEW."admission_id" OR
+     content->>'modelProtocolId'<>NEW."protocol_id" OR
+     content->>'observationSetId'<>NEW."observation_set_id" OR
+     (content->>'authorizedAt')::TIMESTAMPTZ<>NEW."authorized_at" OR
+     (content->>'validThrough')::TIMESTAMPTZ<>NEW."valid_through" OR
+     content->>'principalRef'<>NEW."principal_ref" THEN
+    RAISE EXCEPTION 'Model-run operational authorization is invalid or misbound';
+  END IF;
+
+  IF policy_owned THEN
+    IF NEW."environment"<>'non_production' OR
+       NEW."authority_evidence_id" IS NOT NULL OR
+       content->>'executionMode'<>'local' OR
+       content->'publicationProhibited' IS DISTINCT FROM 'true'::JSONB OR
+       content->>'principalRef'<>'system:weekly-valuation-coordinator' OR
+       content->>'role'<>'afl_trade_private_evaluation_coordinator' OR
+       NOT EXISTS (
+         SELECT 1
+           FROM "outcome_private_valuation_model_request_binding" binding
+           JOIN "outcome_private_valuation_model_operation" operation
+             ON operation."operation_id"=binding."operation_id"
+           JOIN "outcome_private_valuation_dispatch_request" request
+             ON request."request_id"=binding."request_id"
+           JOIN "outcome_private_valuation_dispatch_attempt" attempt
+             ON attempt."claim_id"=request."claim_id"
+            AND attempt."request_id"=request."request_id"
+          WHERE binding."request_id"=content->>'dispatchRequestId'
+            AND binding."operation_id"=content->>'substantiveOperationId'
+            AND binding."factual_output_id"=content->>'factualOutputId'
+            AND binding."hpn_calculation_id"=content->>'hpnCalculationId'
+            AND operation."factual_values_sha256"=content->>'factualValuesSha256'
+            AND operation."hpn_values_sha256"=content->>'hpnValuesSha256'
+            AND request."status"='claimed'
+            AND request."claim_id"=content->>'dispatchClaimId'
+            AND request."lease_token_sha256"=
+              content->>'dispatchLeaseTokenSha256'
+            AND request."lease_expires_at">trusted_now
+            AND NEW."valid_through"<=request."lease_expires_at"
+            AND attempt."attempt_number"=
+              (content->>'dispatchAttemptNumber')::INTEGER
+            AND attempt."lease_token_sha256"=
+              content->>'dispatchLeaseTokenSha256'
+            AND attempt."lease_expires_at">trusted_now
+            AND NEW."valid_through"<=attempt."lease_expires_at"
+            AND attempt."finished_at" IS NULL
+       ) OR
+       intent_row."intent_json"->'content'->'job'->>'initiatedBy'<>
+         'system:weekly-valuation-coordinator' OR
+       intent_row."intent_json"->'content'->'job'->>'workerIdentity'<>
+         'system:weekly-valuation-coordinator'
+    THEN
+      RAISE EXCEPTION 'Model-run operational authorization is invalid or misbound';
+    END IF;
+  ELSE
+    IF content->>'authorityBoundary' IS DISTINCT FROM
+         'human_operational_authorization_for_one_exact_model_run_intent' OR
+       authority_row."authority_evidence_id" IS NULL OR
+       authority_row."principal_ref"<>NEW."principal_ref" OR
+       authority_row."role"<>'afl_trade_model_run_operator' OR
+       authority_row."scope_key"<>dataset_row."scope_key" OR
+       authority_row."provider"<>'statly_modeling' OR
+       authority_row."capability_id"<>'execute_model_run' OR
+       authority_row."competition"<>dataset_row."competition" OR
+       authority_row."evidence_environment"<>NEW."environment" OR
+       (authority_row."evidence_json"->>'validFrom')::TIMESTAMPTZ IS DISTINCT FROM
+         authority_row."valid_from" OR
+       (authority_row."evidence_json"->>'validThrough')::TIMESTAMPTZ IS DISTINCT FROM
+         authority_row."valid_through" OR
+       authority_row."valid_from">trusted_now OR
+       (authority_row."valid_through" IS NOT NULL AND
+         authority_row."valid_through"<=trusted_now) OR
+       (authority_row."valid_through" IS NOT NULL AND
+         NEW."valid_through">authority_row."valid_through") OR
+       EXISTS (SELECT 1 FROM "outcome_valuation_dataset_row" dataset_member
+         WHERE dataset_member."dataset_id"=NEW."dataset_id"
+           AND dataset_member."season_year" NOT BETWEEN
+             authority_row."valid_from_season" AND authority_row."valid_through_season") OR
+       EXISTS (SELECT 1 FROM "outcome_review_decision" successor
+         WHERE successor."supersedes_decision_id"=authority_row."approval_decision_id") OR
+       content->>'role'<>'afl_trade_model_run_operator' OR
+       content->'authorityEvidence'->>'id'<>NEW."authority_evidence_id" OR
+       content->'authorityEvidence'->>'sha256'<>authority_row."reference_sha256" OR
+       (NEW."environment"<>'test_fixture' AND
+         current_user<>'afl_trade_operational_authorization_registry_writer')
+    THEN
+      RAISE EXCEPTION 'Model-run operational authorization is invalid or misbound';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "outcome_valuation_model_run_operation_insert_guard"
+  BEFORE INSERT ON "outcome_valuation_model_run_operational_authorization"
+  FOR EACH ROW EXECUTE FUNCTION "validate_outcome_valuation_model_run_operation_insert"();
+
+CREATE OR REPLACE FUNCTION "validate_outcome_valuation_model_authorization_insert"() RETURNS TRIGGER AS $$
+DECLARE
+  intent_row RECORD;
+  observation_row RECORD;
+  protocol_row RECORD;
+  analytical_authority RECORD;
+  operational_authority RECORD;
+  operator_trust RECORD;
+  policy_owned BOOLEAN;
+  admission_row RECORD;
+  dataset_row RECORD;
+  admission_gate2 RECORD;
+  gate2 RECORD;
+  trusted_now TIMESTAMPTZ(3):=clock_timestamp();
+  current_revision INTEGER;
+  requested_receipt_count INTEGER;
+  current_receipt_count INTEGER;
+  required_proposal_count INTEGER;
+  covered_proposal_count INTEGER;
+BEGIN
+  SELECT * INTO intent_row FROM "outcome_valuation_model_run_intent"
+   WHERE "intent_id"=NEW."intent_id" FOR SHARE;
+  SELECT * INTO observation_row FROM "outcome_valuation_player_observation_set"
+   WHERE "observation_set_id"=intent_row."observation_set_id" FOR SHARE;
+  SELECT * INTO protocol_row FROM "outcome_valuation_model_protocol"
+   WHERE "protocol_id"=intent_row."protocol_id" FOR SHARE;
+  SELECT * INTO analytical_authority FROM "outcome_valuation_dataset_operation_authority"
+   WHERE "receipt_id"=protocol_row."analytical_authority_receipt_id" FOR SHARE;
+  SELECT * INTO operational_authority
+    FROM "outcome_valuation_model_run_operational_authorization"
+   WHERE "receipt_id"=NEW."operational_authorization_receipt_id" FOR SHARE;
+  policy_owned:=COALESCE(
+    operational_authority."receipt_json"->'content'->>'authorityBoundary'=
+      'policy_owned_local_private_valuation_for_one_exact_model_run_intent',
+    FALSE
+  );
+  IF policy_owned THEN
+    PERFORM "load_outcome_private_valuation_dispatch_request_for_claim"(
+      operational_authority."receipt_json"->'content'->>'dispatchRequestId',
+      operational_authority."receipt_json"->'content'->>'dispatchClaimId',
+      operational_authority."receipt_json"->'content'->>'dispatchLeaseTokenSha256'
+    );
+  ELSE
+    PERFORM pg_advisory_xact_lock(hashtextextended(
+      'outcome-review-subject:governed_evidence_reference:' ||
+        operational_authority."authority_evidence_id", 0
+    ));
+    SELECT operational.*,evidence."environment" AS evidence_environment,
+           evidence."reference_sha256",evidence."approval_decision_id",
+           evidence."evidence_json"
+      INTO operator_trust
+      FROM "outcome_operational_principal_authority" operational
+      JOIN "outcome_governed_evidence_reference" evidence
+        ON evidence."reference_id"=operational."authority_evidence_id"
+     WHERE operational."authority_evidence_id"=operational_authority."authority_evidence_id"
+     FOR SHARE;
+  END IF;
+  SELECT * INTO admission_row FROM "outcome_valuation_dataset_admission"
+   WHERE "admission_id"=intent_row."admission_id" FOR SHARE;
+  SELECT * INTO dataset_row FROM "outcome_valuation_dataset_candidate"
+   WHERE "dataset_id"=intent_row."dataset_id" FOR SHARE;
+  SELECT decision.* INTO admission_gate2
+    FROM "outcome_valuation_dataset_admission" admission
+    JOIN "outcome_gate_decision" decision ON decision."decision_id"=admission."gate2_decision_id"
+   WHERE admission."admission_id"=intent_row."admission_id" FOR SHARE OF admission,decision;
+  SELECT "revision" INTO current_revision FROM "outcome_gate_ledger_head"
+   WHERE "singleton_id"=1 FOR SHARE;
+  SELECT * INTO gate2 FROM "outcome_gate_decision"
+   WHERE "decision_id"=NEW."authorization_json"->'content'->>'gate2DecisionId' FOR SHARE;
+  SELECT jsonb_array_length(
+    NEW."authorization_json"->'content'->'modelTrainingEvaluationReceiptIds'
+  ) INTO requested_receipt_count;
+  SELECT count(*) INTO current_receipt_count
+    FROM jsonb_array_elements_text(
+      NEW."authorization_json"->'content'->'modelTrainingEvaluationReceiptIds'
+    ) requested("receipt_id")
+    JOIN "outcome_valuation_dataset_gate0_evaluation" receipt
+      ON receipt."receipt_id"=requested."receipt_id"
+    JOIN "outcome_gate_decision" decision ON decision."decision_id"=receipt."decision_id"
+    JOIN "outcome_source_rights_proposal" rights
+      ON rights."rights_artifact_id"=receipt."rights_artifact_id"
+    JOIN LATERAL jsonb_array_elements(
+      admission_row."admission_json"->'content'->'sourceRightsEvaluations'
+    ) required("evaluation")
+      ON required."evaluation"->>'proposalId'=receipt."rights_artifact_id"
+    JOIN "outcome_valuation_dataset_gate0_evaluation" admission_receipt
+      ON admission_receipt."receipt_id"=
+        required."evaluation"->>'admissionEvaluationReceiptId'
+   WHERE receipt."environment"=intent_row."environment"
+     AND receipt."operation_kind"='model_training'
+     AND receipt."evaluated_at"=intent_row."started_at"
+     AND receipt."recorded_at"=intent_row."started_at"
+     AND decision."gate"='gate_0a_permission_to_evaluate'
+     AND decision."state"='approved'
+     AND decision."effective_at"<=trusted_now
+     AND decision."revalidate_at">trusted_now
+     AND NEW."valid_through"<=decision."revalidate_at"
+     AND ((receipt."receipt_json"->'content'->'request') - 'evaluatedAt'::TEXT)
+       IS NOT DISTINCT FROM
+       ((admission_receipt."receipt_json"->'content'->'request') - 'evaluatedAt'::TEXT)
+     AND receipt."receipt_json"->'content'->'request'->'operations' ? 'model_training'
+     AND EXISTS (SELECT 1
+       FROM jsonb_array_elements(
+         receipt."receipt_json"->'content'->'request'->'fieldUses'
+       ) field_use WHERE field_use->>'use'='model_training')
+     AND NOT EXISTS (SELECT 1 FROM "outcome_gate_decision" successor
+       WHERE successor."supersedes_decision_id"=decision."decision_id")
+     AND (rights."content_json"->'content'->>'termsExpireAt' IS NULL OR
+       ((rights."content_json"->'content'->>'termsExpireAt')::TIMESTAMPTZ>trusted_now AND
+        NEW."valid_through"<=
+          (rights."content_json"->'content'->>'termsExpireAt')::TIMESTAMPTZ));
+  SELECT jsonb_array_length(
+    admission_row."admission_json"->'content'->'sourceRightsEvaluations'
+  ) INTO required_proposal_count;
+  SELECT count(*) INTO covered_proposal_count
+    FROM jsonb_array_elements(
+      admission_row."admission_json"->'content'->'sourceRightsEvaluations'
+    ) required("evaluation")
+   WHERE EXISTS (
+     SELECT 1
+       FROM jsonb_array_elements_text(
+         NEW."authorization_json"->'content'->'modelTrainingEvaluationReceiptIds'
+       ) requested("receipt_id")
+       JOIN "outcome_valuation_dataset_gate0_evaluation" receipt
+         ON receipt."receipt_id"=requested."receipt_id"
+      WHERE receipt."rights_artifact_id"=required."evaluation"->>'proposalId'
+   );
+  IF NEW."authorization_id" <> 'model-run-authorization:' ||
+       encode(sha256(convert_to(NEW."authorization_canonical_json",'UTF8')),'hex') OR
+     NEW."gate_ledger_revision"<>current_revision OR
+     NEW."authorized_at">trusted_now OR trusted_now>=NEW."valid_through" OR
+     trusted_now-intent_row."started_at">INTERVAL '5 seconds' OR
+     trusted_now<intent_row."started_at" OR
+     analytical_authority."authority_kind"<>'analytical_authority' OR
+     analytical_authority."environment"<>intent_row."environment" OR
+     analytical_authority."dataset_id"<>intent_row."dataset_id" OR
+     analytical_authority."authorized_at">trusted_now OR
+     analytical_authority."valid_through"<=trusted_now OR
+     NEW."valid_through">analytical_authority."valid_through" OR
+     operational_authority."receipt_id" IS NULL OR
+     operational_authority."intent_id"<>intent_row."intent_id" OR
+     operational_authority."environment"<>intent_row."environment" OR
+     operational_authority."dataset_id"<>intent_row."dataset_id" OR
+     operational_authority."admission_id"<>intent_row."admission_id" OR
+     operational_authority."protocol_id"<>intent_row."protocol_id" OR
+     operational_authority."observation_set_id"<>intent_row."observation_set_id" OR
+     operational_authority."authorized_at">intent_row."started_at" OR
+     operational_authority."authorized_at">trusted_now OR
+     operational_authority."valid_through"<=trusted_now OR
+     NEW."valid_through">operational_authority."valid_through" THEN
+    RAISE EXCEPTION 'Model-run authorization is invalid, stale, or misbound';
+  END IF;
+
+  IF policy_owned THEN
+    IF operational_authority."environment"<>'non_production' OR
+       operational_authority."authority_evidence_id" IS NOT NULL OR
+       operational_authority."principal_ref"<>'system:weekly-valuation-coordinator' OR
+       operational_authority."receipt_json"->'content'->>'role'<>
+         'afl_trade_private_evaluation_coordinator' OR
+       operational_authority."receipt_json"->'content'->>'executionMode'<>'local' OR
+       operational_authority."receipt_json"->'content'->'publicationProhibited'
+         IS DISTINCT FROM 'true'::JSONB OR
+       NOT EXISTS (
+         SELECT 1
+           FROM "outcome_private_valuation_model_request_binding" binding
+           JOIN "outcome_private_valuation_model_operation" operation
+             ON operation."operation_id"=binding."operation_id"
+           JOIN "outcome_private_valuation_dispatch_request" request
+             ON request."request_id"=binding."request_id"
+           JOIN "outcome_private_valuation_dispatch_attempt" attempt
+             ON attempt."claim_id"=request."claim_id"
+            AND attempt."request_id"=request."request_id"
+          WHERE binding."request_id"=
+              operational_authority."receipt_json"->'content'->>'dispatchRequestId'
+            AND binding."operation_id"=
+              operational_authority."receipt_json"->'content'->>'substantiveOperationId'
+            AND binding."factual_output_id"=
+              operational_authority."receipt_json"->'content'->>'factualOutputId'
+            AND binding."hpn_calculation_id"=
+              operational_authority."receipt_json"->'content'->>'hpnCalculationId'
+            AND operation."factual_values_sha256"=
+              operational_authority."receipt_json"->'content'->>'factualValuesSha256'
+            AND operation."hpn_values_sha256"=
+              operational_authority."receipt_json"->'content'->>'hpnValuesSha256'
+            AND request."status"='claimed'
+            AND request."claim_id"=
+              operational_authority."receipt_json"->'content'->>'dispatchClaimId'
+            AND request."lease_token_sha256"=
+              operational_authority."receipt_json"->'content'->>'dispatchLeaseTokenSha256'
+            AND request."lease_expires_at">trusted_now
+            AND NEW."valid_through"<=request."lease_expires_at"
+            AND attempt."attempt_number"=
+              (operational_authority."receipt_json"->'content'->>'dispatchAttemptNumber')::INTEGER
+            AND attempt."lease_token_sha256"=
+              operational_authority."receipt_json"->'content'->>'dispatchLeaseTokenSha256'
+            AND attempt."lease_expires_at">trusted_now
+            AND NEW."valid_through"<=attempt."lease_expires_at"
+            AND attempt."finished_at" IS NULL
+       )
+    THEN
+      RAISE EXCEPTION 'Model-run authorization is invalid, stale, or misbound';
+    END IF;
+  ELSE
+    IF operator_trust."authority_evidence_id" IS NULL OR
+       operator_trust."principal_ref"<>operational_authority."principal_ref" OR
+       operator_trust."role"<>'afl_trade_model_run_operator' OR
+       operator_trust."scope_key"<>dataset_row."scope_key" OR
+       operator_trust."provider"<>'statly_modeling' OR
+       operator_trust."capability_id"<>'execute_model_run' OR
+       operator_trust."competition"<>dataset_row."competition" OR
+       operator_trust."evidence_environment"<>intent_row."environment" OR
+       operator_trust."valid_from">trusted_now OR
+       (operator_trust."valid_through" IS NOT NULL AND
+         operator_trust."valid_through"<=trusted_now) OR
+       (operator_trust."valid_through" IS NOT NULL AND
+         NEW."valid_through">operator_trust."valid_through") OR
+       (operator_trust."evidence_json"->>'validFrom')::TIMESTAMPTZ IS DISTINCT FROM
+         operator_trust."valid_from" OR
+       (operator_trust."evidence_json"->>'validThrough')::TIMESTAMPTZ IS DISTINCT FROM
+         operator_trust."valid_through" OR
+       EXISTS (SELECT 1 FROM "outcome_valuation_dataset_row" dataset_member
+         WHERE dataset_member."dataset_id"=intent_row."dataset_id"
+           AND dataset_member."season_year" NOT BETWEEN
+             operator_trust."valid_from_season" AND operator_trust."valid_through_season") OR
+       EXISTS (SELECT 1 FROM "outcome_review_decision" successor
+         WHERE successor."supersedes_decision_id"=operator_trust."approval_decision_id")
+    THEN
+      RAISE EXCEPTION 'Model-run authorization is invalid, stale, or misbound';
+    END IF;
+  END IF;
+
+  IF gate2."gate"<>'gate_2_corpus_lineage' OR gate2."state"<>'approved' OR
+     gate2."environment"<>intent_row."environment" OR
+     gate2."decision_key"<>admission_gate2."decision_key" OR
+     gate2."decision_json"->'content'->'scope'->>'scopeKey'<>dataset_row."scope_key" OR
+     (SELECT count(*) FROM jsonb_array_elements(
+       gate2."decision_json"->'content'->'scope'->'dimensions') dimension
+       WHERE dimension->>'name'='scope'
+         AND dimension->'values'=jsonb_build_array(dataset_row."scope_key"))<>1 OR
+     (SELECT count(*) FROM jsonb_array_elements(
+       gate2."decision_json"->'content'->'scope'->'dimensions') dimension
+       WHERE dimension->>'name'='competition'
+         AND dimension->'values'=jsonb_build_array(dataset_row."competition"))<>1 OR
+     gate2."effective_at">trusted_now OR gate2."revalidate_at" IS NULL OR
+     gate2."revalidate_at"<=trusted_now OR
+     NEW."valid_through">gate2."revalidate_at" OR
+     EXISTS (SELECT 1 FROM "outcome_gate_decision" successor
+       WHERE successor."supersedes_decision_id"=gate2."decision_id") OR
+     jsonb_array_length(gate2."decision_json"->'content'->'affectedArtifacts')<>4 OR
+     NOT EXISTS (SELECT 1
+       FROM jsonb_array_elements(gate2."decision_json"->'content'->'affectedArtifacts') artifact
+      WHERE artifact->>'kind'='corpus_manifest'
+        AND artifact->>'artifactId'=admission_row."admission_json"->'content'->>'corpusId') OR
+     NOT EXISTS (SELECT 1
+       FROM jsonb_array_elements(gate2."decision_json"->'content'->'affectedArtifacts') artifact
+      WHERE artifact->>'kind'='corpus_factual_lineage'
+        AND artifact->>'artifactId'=
+          admission_row."admission_json"->'content'->>'corpusToCandidateLineageId') OR
+     NOT EXISTS (SELECT 1
+       FROM jsonb_array_elements(gate2."decision_json"->'content'->'affectedArtifacts') artifact
+      WHERE artifact->>'kind'='factual_release'
+        AND artifact->>'artifactId'=
+          admission_row."admission_json"->'content'->>'factualReleaseId') OR
+     NOT EXISTS (SELECT 1
+       FROM jsonb_array_elements(gate2."decision_json"->'content'->'affectedArtifacts') artifact
+      WHERE artifact->>'kind'='factual_release_candidate'
+        AND artifact->>'artifactId'=
+          admission_row."admission_json"->'content'->>'factualCandidateId') OR
+     requested_receipt_count<1 OR requested_receipt_count<>current_receipt_count OR
+     required_proposal_count<1 OR required_proposal_count<>covered_proposal_count OR
+     required_proposal_count<>requested_receipt_count OR
+     EXISTS (
+       SELECT 1
+         FROM jsonb_array_elements_text(
+           NEW."authorization_json"->'content'->'modelTrainingEvaluationReceiptIds'
+         ) requested("receipt_id")
+         JOIN "outcome_valuation_dataset_gate0_evaluation" receipt
+           ON receipt."receipt_id"=requested."receipt_id"
+        WHERE NOT EXISTS (
+          SELECT 1
+            FROM jsonb_array_elements(
+              admission_row."admission_json"->'content'->'sourceRightsEvaluations'
+            ) required("evaluation")
+           WHERE required."evaluation"->>'proposalId'=receipt."rights_artifact_id"
+        )
+     ) OR
+     NEW."authorization_json"->>'authorizationId'<>NEW."authorization_id" OR
+     NEW."authorization_json"->'content'->>'schemaVersion'<>
+       'afl-trade-model-run-authorization/v1' OR
+     NEW."authorization_json"->'content'->>'authorityBoundary' IS DISTINCT FROM
+       'model_run_start_authority_no_grade_publication_or_fantasy_ownership' OR
+     NEW."authorization_json"->'content'->>'publicationEligible'<>'false' OR
+     NEW."authorization_json"->'content'->>'runIntentId'<>NEW."intent_id" OR
+     (NEW."authorization_json"->'content'->>'gateLedgerRevision')::INTEGER<>
+       NEW."gate_ledger_revision" OR
+     NEW."authorization_json"->'content'->>'environment' IS DISTINCT FROM
+       intent_row."environment"::TEXT OR
+     NEW."authorization_json"->'content'->>'datasetId' IS DISTINCT FROM intent_row."dataset_id" OR
+     NEW."authorization_json"->'content'->>'datasetAdmissionId' IS DISTINCT FROM
+       intent_row."admission_id" OR
+     NEW."authorization_json"->'content'->>'modelProtocolId' IS DISTINCT FROM
+       intent_row."protocol_id" OR
+     NEW."authorization_json"->'content'->>'observationSetId' IS DISTINCT FROM
+       intent_row."observation_set_id" OR
+     NEW."authorization_json"->'content'->>'operationalAuthorizationReceiptId' IS DISTINCT FROM
+       operational_authority."receipt_id" OR
+     NEW."authorization_json"->'content'->>'datasetRowSetSha256' IS DISTINCT FROM
+       observation_row."dataset_row_set_sha256" OR
+     NEW."authorization_json"->'content'->'modelTrainingEvaluationReceiptIds' IS DISTINCT FROM
+       intent_row."intent_json"->'content'->'modelTrainingEvaluationReceiptIds' OR
+     (NEW."authorization_json"->'content'->>'authorizedAt')::TIMESTAMPTZ<>NEW."authorized_at" OR
+     (NEW."authorization_json"->'content'->>'validThrough')::TIMESTAMPTZ<>NEW."valid_through" THEN
+    RAISE EXCEPTION 'Model-run authorization is invalid, stale, or misbound';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Preserve the existing governed pick and qualification validators while admitting only the
+-- dispatch-bound v4 successor. The surrounding ancestry and evidence checks remain unchanged.
+DO $patch_governed_pick_v4$
+DECLARE
+  current_definition TEXT;
+  updated_definition TEXT;
+  old_pick_state TEXT :=
+    $old$content->>'schemaVersion'='afl-trade-pick-pav-model-execution/v3'$old$;
+  new_pick_state TEXT := $new$content->>'schemaVersion' IN (
+       'afl-trade-pick-pav-model-execution/v3',
+       'afl-trade-pick-pav-model-execution/v4'
+     )$new$;
+  old_evidence_state TEXT := $old$execution_content->>'schemaVersion' IS DISTINCT FROM
+         'afl-trade-pick-pav-model-execution/v3'$old$;
+  new_evidence_state TEXT := $new$execution_content->>'schemaVersion' NOT IN (
+         'afl-trade-pick-pav-model-execution/v3',
+         'afl-trade-pick-pav-model-execution/v4'
+       )$new$;
+BEGIN
+  SELECT pg_get_functiondef(
+    'validate_outcome_governed_pick_pav_model_execution_insert()'::regprocedure
+  ) INTO current_definition;
+  updated_definition:=replace(current_definition,old_pick_state,new_pick_state);
+  IF updated_definition=current_definition THEN
+    RAISE EXCEPTION 'Expected governed pick v3 validator was not found';
+  END IF;
+  EXECUTE updated_definition;
+
+  SELECT pg_get_functiondef(
+    'validate_outcome_governed_component_validation_evidence()'::regprocedure
+  ) INTO current_definition;
+  updated_definition:=replace(current_definition,old_evidence_state,new_evidence_state);
+  IF updated_definition=current_definition THEN
+    RAISE EXCEPTION 'Expected governed pick qualification evidence validator was not found';
+  END IF;
+  EXECUTE updated_definition;
+END;
+$patch_governed_pick_v4$;
+
+
+CREATE TABLE "outcome_private_valuation_model_operation" (
+  "operation_id" TEXT PRIMARY KEY,
+  "scope_key" TEXT NOT NULL,
+  "factual_values_sha256" CHAR(64) NOT NULL,
+  "hpn_values_sha256" CHAR(64) NOT NULL,
+  "hpn_method_id" TEXT NOT NULL
+    REFERENCES "outcome_hpn_pav_method"("method_id") ON DELETE RESTRICT,
+  "player_model_id" TEXT NOT NULL,
+  "player_model_version" TEXT NOT NULL,
+  "player_protocol_id" TEXT NOT NULL,
+  "player_dataset_id" TEXT NOT NULL,
+  "player_dataset_admission_id" TEXT NOT NULL,
+  "pick_protocol_id" TEXT NOT NULL,
+  "pick_dataset_id" TEXT NOT NULL,
+  "pick_dataset_admission_id" TEXT NOT NULL,
+  "pick_policy_id" TEXT NOT NULL,
+  "qualification_policy_id" TEXT NOT NULL,
+  "operation_canonical_json" TEXT NOT NULL,
+  "operation_json" JSONB NOT NULL,
+  "player_run_id" TEXT
+    REFERENCES "outcome_governed_valuation_component_run"("run_id") ON DELETE RESTRICT,
+  "player_claim_id" TEXT
+    REFERENCES "outcome_private_valuation_dispatch_attempt"("claim_id") ON DELETE RESTRICT,
+  "player_attempt_number" INTEGER CHECK ("player_attempt_number" BETWEEN 1 AND 3),
+  "player_accepted_at" TIMESTAMPTZ(3),
+  "pick_run_id" TEXT
+    REFERENCES "outcome_governed_valuation_component_run"("run_id") ON DELETE RESTRICT,
+  "pick_claim_id" TEXT
+    REFERENCES "outcome_private_valuation_dispatch_attempt"("claim_id") ON DELETE RESTRICT,
+  "pick_attempt_number" INTEGER CHECK ("pick_attempt_number" BETWEEN 1 AND 3),
+  "pick_accepted_at" TIMESTAMPTZ(3),
+  "pair_accepted_at" TIMESTAMPTZ(3),
+  "qualification_id" TEXT
+    REFERENCES "outcome_governed_valuation_model_qualification"("qualification_id")
+    ON DELETE RESTRICT,
+  "qualification_outcome" TEXT CHECK ("qualification_outcome" IN ('qualified','failed')),
+  "qualification_claim_id" TEXT
+    REFERENCES "outcome_private_valuation_dispatch_attempt"("claim_id") ON DELETE RESTRICT,
+  "qualification_bound_at" TIMESTAMPTZ(3),
+  "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT "outcome_private_valuation_model_operation_id_check" CHECK (
+    "operation_id" ~ '^private-valuation-model-operation:[a-f0-9]{64}$'
+  ),
+  CONSTRAINT "outcome_private_valuation_model_operation_component_shape" CHECK (
+    ("player_run_id" IS NULL)=("player_claim_id" IS NULL AND
+      "player_attempt_number" IS NULL AND "player_accepted_at" IS NULL)
+    AND ("pick_run_id" IS NULL)=("pick_claim_id" IS NULL AND
+      "pick_attempt_number" IS NULL AND "pick_accepted_at" IS NULL)
+    AND ("pair_accepted_at" IS NULL OR
+      ("player_run_id" IS NOT NULL AND "pick_run_id" IS NOT NULL))
+    AND ("qualification_id" IS NULL)=("qualification_outcome" IS NULL AND
+      "qualification_claim_id" IS NULL AND "qualification_bound_at" IS NULL)
+    AND ("qualification_id" IS NULL OR "pair_accepted_at" IS NOT NULL)
+  )
+);
+
+CREATE TABLE "outcome_private_valuation_model_request_binding" (
+  "request_id" TEXT PRIMARY KEY
+    REFERENCES "outcome_private_valuation_dispatch_request"("request_id") ON DELETE RESTRICT,
+  "operation_id" TEXT NOT NULL
+    REFERENCES "outcome_private_valuation_model_operation"("operation_id") ON DELETE RESTRICT,
+  "factual_output_id" TEXT NOT NULL
+    REFERENCES "outcome_private_valuation_factual_output"("output_id") ON DELETE RESTRICT,
+  "hpn_calculation_id" TEXT NOT NULL
+    REFERENCES "outcome_hpn_pav_calculation"("calculation_id") ON DELETE RESTRICT,
+  "claim_id" TEXT NOT NULL
+    REFERENCES "outcome_private_valuation_dispatch_attempt"("claim_id") ON DELETE RESTRICT,
+  "attempt_number" INTEGER NOT NULL CHECK ("attempt_number" BETWEEN 1 AND 3),
+  "bound_at" TIMESTAMPTZ(3) NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT "outcome_private_model_request_operation_key"
+    UNIQUE ("request_id","operation_id"),
+  CONSTRAINT "outcome_private_model_request_input_key"
+    UNIQUE ("request_id","factual_output_id","hpn_calculation_id")
+);
+
+CREATE INDEX "outcome_private_valuation_model_request_operation_idx"
+  ON "outcome_private_valuation_model_request_binding"("operation_id","request_id");
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_valuation_model_operation_insert"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE content JSONB:=NEW."operation_json"->'content';
+BEGIN
+  IF current_user<>'afl_trade_private_evaluation_coordinator'
+    OR NEW."operation_id"<>'private-valuation-model-operation:' ||
+      encode(sha256(convert_to(NEW."operation_canonical_json",'UTF8')),'hex')
+    OR NEW."operation_json"->>'operationId'<>NEW."operation_id"
+    OR content->>'schemaVersion'<>'afl-trade-private-valuation-model-operation/v1'
+    OR content->>'scopeKey'<>NEW."scope_key"
+    OR content->>'factualValuesSha256'<>NEW."factual_values_sha256"
+    OR content->>'hpnValuesSha256'<>NEW."hpn_values_sha256"
+    OR content->>'hpnMethodId'<>NEW."hpn_method_id"
+    OR content->'player'->>'modelId'<>NEW."player_model_id"
+    OR content->'player'->>'modelVersion'<>NEW."player_model_version"
+    OR content->'player'->>'protocolId'<>NEW."player_protocol_id"
+    OR content->'player'->>'datasetId'<>NEW."player_dataset_id"
+    OR content->'player'->>'datasetAdmissionId'<>NEW."player_dataset_admission_id"
+    OR content->'pick'->>'protocolId'<>NEW."pick_protocol_id"
+    OR content->'pick'->>'datasetId'<>NEW."pick_dataset_id"
+    OR content->'pick'->>'datasetAdmissionId'<>NEW."pick_dataset_admission_id"
+    OR content->'pick'->>'policyId'<>NEW."pick_policy_id"
+    OR content->>'qualificationPolicyId'<>NEW."qualification_policy_id"
+    OR NEW."player_run_id" IS NOT NULL OR NEW."pick_run_id" IS NOT NULL
+    OR NEW."pair_accepted_at" IS NOT NULL OR NEW."qualification_id" IS NOT NULL
+  THEN RAISE EXCEPTION 'Private valuation substantive model operation is invalid'; END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_private_valuation_model_operation_insert_guard"
+BEFORE INSERT ON "outcome_private_valuation_model_operation"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_valuation_model_operation_insert"();
+
+CREATE OR REPLACE FUNCTION "outcome_private_valuation_hpn_substantive_sha256"(
+  calculation_json JSONB
+) RETURNS TEXT LANGUAGE sql IMMUTABLE STRICT AS $$
+  WITH stable AS (
+    SELECT (calculation_json->'content') - ARRAY[
+      'effectiveThrough','calculatedAt','inputSetId','inputSetSha256','factualRunId',
+      'factualInputSetSha256','primaryProviders','corroboratingProviders','resultSourceRowIds'
+    ]::TEXT[] AS value
+  ), players AS (
+    SELECT COALESCE(
+      jsonb_agg(
+        (player.value - 'spellVersionId' - 'source') ||
+          jsonb_build_object('source',(player.value->'source') - 'sourceRowIds')
+        ORDER BY player.ordinality
+      ),
+      '[]'::JSONB
+    ) AS value
+      FROM stable
+      LEFT JOIN LATERAL jsonb_array_elements(stable.value->'players')
+        WITH ORDINALITY AS player(value,ordinality) ON TRUE
+     WHERE player.value IS NOT NULL
+  ), substantive AS (
+    SELECT (stable.value - 'players') || jsonb_build_object('players',players.value) AS value
+      FROM stable CROSS JOIN players
+  )
+  SELECT encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(substantive.value),'UTF8'
+  )),'hex') FROM substantive
+$$;
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_valuation_model_request_binding"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE request RECORD; attempt RECORD; operation RECORD; factual RECORD; calculation RECORD;
+BEGIN
+  SELECT * INTO request FROM "outcome_private_valuation_dispatch_request"
+   WHERE "request_id"=NEW."request_id";
+  SELECT * INTO attempt FROM "outcome_private_valuation_dispatch_attempt"
+   WHERE "claim_id"=NEW."claim_id";
+  SELECT * INTO operation FROM "outcome_private_valuation_model_operation"
+   WHERE "operation_id"=NEW."operation_id";
+  SELECT * INTO factual FROM "outcome_private_valuation_factual_output"
+   WHERE "output_id"=NEW."factual_output_id";
+  SELECT * INTO calculation FROM "outcome_hpn_pav_calculation"
+   WHERE "calculation_id"=NEW."hpn_calculation_id";
+  IF current_user<>'afl_trade_private_evaluation_coordinator'
+    OR request."status"<>'claimed' OR request."claim_id"<>NEW."claim_id"
+    OR request."lease_expires_at"<clock_timestamp()
+    OR attempt."request_id"<>NEW."request_id" OR attempt."finished_at" IS NOT NULL
+    OR attempt."attempt_number"<>NEW."attempt_number"
+    OR operation."operation_id" IS NULL OR operation."scope_key"<>request."scope_key"
+    OR factual."output_id" IS NULL OR factual."request_id"<>NEW."request_id"
+    OR operation."factual_values_sha256"<>
+      factual."output_json"->'content'->'candidate'->>'memberSetSha256'
+    OR calculation."status"<>'finalized' OR calculation."finalized_at" IS NULL
+    OR operation."hpn_method_id"<>calculation."method_id"
+    OR operation."hpn_values_sha256"<>
+      "outcome_private_valuation_hpn_substantive_sha256"(calculation."calculation_json")
+    OR calculation."calculation_json"->'content'->>'factualRunId'<>
+      factual."factual_run_id"
+  THEN RAISE EXCEPTION 'Private valuation model input lacks exact live dispatch custody'; END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_private_valuation_model_request_binding_guard"
+BEFORE INSERT ON "outcome_private_valuation_model_request_binding"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_valuation_model_request_binding"();
+
+CREATE OR REPLACE FUNCTION "fence_outcome_dispatch_bound_pick_execution"()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE content JSONB:=NEW."execution_json"->'content';
+BEGIN
+  IF content->>'schemaVersion'='afl-trade-pick-pav-model-execution/v4' THEN
+    PERFORM "load_outcome_private_valuation_dispatch_request_for_claim"(
+      content->'privateInput'->>'requestId',
+      content->'privateInput'->>'claimId',
+      content->'privateInput'->>'leaseTokenSha256'
+    );
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_dispatch_bound_pick_execution_claim_fence"
+BEFORE INSERT ON "outcome_governed_pick_pav_model_execution"
+FOR EACH ROW EXECUTE FUNCTION "fence_outcome_dispatch_bound_pick_execution"();
+
+CREATE OR REPLACE FUNCTION "fence_outcome_dispatch_bound_component"()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE execution_content JSONB;
+BEGIN
+  IF NEW."native_execution_kind"='governed_pick_pav_model_execution' THEN
+    SELECT "execution_json"->'content' INTO execution_content
+      FROM "outcome_governed_pick_pav_model_execution"
+     WHERE "execution_id"=NEW."native_execution_id";
+    IF execution_content->>'schemaVersion'='afl-trade-pick-pav-model-execution/v4' THEN
+      PERFORM "load_outcome_private_valuation_dispatch_request_for_claim"(
+        execution_content->'privateInput'->>'requestId',
+        execution_content->'privateInput'->>'claimId',
+        execution_content->'privateInput'->>'leaseTokenSha256'
+      );
+    END IF;
+  ELSIF NEW."native_execution_kind"='admitted_player_model_run' THEN
+    SELECT operational."receipt_json"->'content' INTO execution_content
+      FROM "outcome_valuation_model_run" native_run
+      JOIN "outcome_valuation_model_run_authorization" run_authorization
+        ON run_authorization."authorization_id"=native_run."authorization_id"
+      JOIN "outcome_valuation_model_run_operational_authorization" operational
+        ON operational."receipt_id"=run_authorization."operational_authorization_receipt_id"
+     WHERE native_run."run_id"=NEW."native_execution_id";
+    IF execution_content->>'authorityBoundary'=
+      'policy_owned_local_private_valuation_for_one_exact_model_run_intent'
+    THEN
+      PERFORM "load_outcome_private_valuation_dispatch_request_for_claim"(
+        execution_content->>'dispatchRequestId',
+        execution_content->>'dispatchClaimId',
+        execution_content->>'dispatchLeaseTokenSha256'
+      );
+    END IF;
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_dispatch_bound_component_claim_fence"
+BEFORE INSERT ON "outcome_governed_valuation_component_run"
+FOR EACH ROW EXECUTE FUNCTION "fence_outcome_dispatch_bound_component"();
+
+CREATE OR REPLACE FUNCTION "fence_outcome_dispatch_bound_model_qualification"()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  dispatch_operation_exists BOOLEAN;
+  target_request_id TEXT:=current_setting('statly.private_valuation_request_id',true);
+  target_claim_id TEXT:=current_setting('statly.private_valuation_claim_id',true);
+  target_lease_sha256 TEXT:=current_setting('statly.private_valuation_lease_sha256',true);
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM "outcome_private_valuation_model_operation" operation
+     WHERE operation."player_run_id"=NEW."player_run_id"
+       AND operation."pick_run_id"=NEW."pick_run_id"
+       AND operation."pair_accepted_at" IS NOT NULL
+  ) INTO dispatch_operation_exists;
+  IF dispatch_operation_exists THEN
+    IF target_request_id IS NULL OR target_claim_id IS NULL OR target_lease_sha256 IS NULL
+      OR NOT EXISTS (
+        SELECT 1 FROM "outcome_private_valuation_model_operation" operation
+        JOIN "outcome_private_valuation_model_request_binding" binding
+          ON binding."operation_id"=operation."operation_id"
+        WHERE binding."request_id"=target_request_id
+          AND operation."scope_key"=NEW."scope_key"
+          AND operation."player_run_id"=NEW."player_run_id"
+          AND operation."pick_run_id"=NEW."pick_run_id"
+          AND operation."pair_accepted_at" IS NOT NULL
+          AND operation."qualification_policy_id"=
+            NEW."qualification_json"->'content'->'policy'->>'policyVersion'
+      )
+    THEN
+      RAISE EXCEPTION 'Dispatch-bound model qualification lost its live claim fence';
+    END IF;
+    PERFORM "load_outcome_private_valuation_dispatch_request_for_claim"(
+      target_request_id,target_claim_id,target_lease_sha256
+    );
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_dispatch_bound_model_qualification_claim_fence"
+BEFORE INSERT ON "outcome_governed_valuation_model_qualification"
+FOR EACH ROW EXECUTE FUNCTION "fence_outcome_dispatch_bound_model_qualification"();
+
+DO $paths$ BEGIN
+  EXECUTE format(
+    'ALTER FUNCTION %I.claim_outcome_private_valuation_dispatch(TEXT,TEXT,INTEGER,TEXT) SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+  EXECUTE format(
+    'ALTER FUNCTION %I.fence_outcome_dispatch_bound_pick_execution() SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+  EXECUTE format(
+    'ALTER FUNCTION %I.fence_outcome_dispatch_bound_component() SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+  EXECUTE format(
+    'ALTER FUNCTION %I.fence_outcome_dispatch_bound_model_qualification() SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema());
+END $paths$;
+
+CREATE OR REPLACE FUNCTION "validate_outcome_private_valuation_model_operation_update"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE player RECORD; pick RECORD; qualification RECORD;
+BEGIN
+  IF current_user<>'afl_trade_private_evaluation_coordinator'
+    OR NEW."operation_id"<>OLD."operation_id"
+    OR (to_jsonb(NEW)-ARRAY[
+      'player_run_id','player_claim_id','player_attempt_number','player_accepted_at',
+      'pick_run_id','pick_claim_id','pick_attempt_number','pick_accepted_at',
+      'pair_accepted_at','qualification_id','qualification_outcome',
+      'qualification_claim_id','qualification_bound_at'
+    ]) IS DISTINCT FROM (to_jsonb(OLD)-ARRAY[
+      'player_run_id','player_claim_id','player_attempt_number','player_accepted_at',
+      'pick_run_id','pick_claim_id','pick_attempt_number','pick_accepted_at',
+      'pair_accepted_at','qualification_id','qualification_outcome',
+      'qualification_claim_id','qualification_bound_at'
+    ])
+    OR (OLD."player_run_id" IS NOT NULL AND (
+      NEW."player_run_id" IS DISTINCT FROM OLD."player_run_id"
+      OR NEW."player_claim_id" IS DISTINCT FROM OLD."player_claim_id"
+      OR NEW."player_attempt_number" IS DISTINCT FROM OLD."player_attempt_number"
+      OR NEW."player_accepted_at" IS DISTINCT FROM OLD."player_accepted_at"))
+    OR (OLD."pick_run_id" IS NOT NULL AND (
+      NEW."pick_run_id" IS DISTINCT FROM OLD."pick_run_id"
+      OR NEW."pick_claim_id" IS DISTINCT FROM OLD."pick_claim_id"
+      OR NEW."pick_attempt_number" IS DISTINCT FROM OLD."pick_attempt_number"
+      OR NEW."pick_accepted_at" IS DISTINCT FROM OLD."pick_accepted_at"))
+    OR (OLD."pair_accepted_at" IS NOT NULL AND NEW."pair_accepted_at" IS DISTINCT FROM OLD."pair_accepted_at")
+    OR (OLD."qualification_id" IS NOT NULL AND (
+      NEW."qualification_id" IS DISTINCT FROM OLD."qualification_id"
+      OR NEW."qualification_outcome" IS DISTINCT FROM OLD."qualification_outcome"
+      OR NEW."qualification_claim_id" IS DISTINCT FROM OLD."qualification_claim_id"
+      OR NEW."qualification_bound_at" IS DISTINCT FROM OLD."qualification_bound_at"))
+  THEN RAISE EXCEPTION 'Private valuation model operation is immutable after acceptance'; END IF;
+
+  IF OLD."player_run_id" IS NULL AND NEW."player_run_id" IS NOT NULL THEN
+    SELECT * INTO player FROM "outcome_governed_valuation_component_run"
+     WHERE "run_id"=NEW."player_run_id";
+    IF player."role"<>'player_contribution_and_availability'
+      OR player."protocol_id"<>NEW."player_protocol_id"
+      OR player."dataset_id"<>NEW."player_dataset_id"
+      OR player."dataset_admission_id"<>NEW."player_dataset_admission_id"
+      OR NOT EXISTS (
+        SELECT 1 FROM "outcome_valuation_model_run" native_run
+        JOIN "outcome_valuation_model_run_intent" native_intent
+          ON native_intent."intent_id"=native_run."intent_id"
+        JOIN "outcome_valuation_model_run_authorization" native_authorization
+          ON native_authorization."authorization_id"=native_run."authorization_id"
+        JOIN "outcome_valuation_model_run_operational_authorization" operational
+          ON operational."receipt_id"=
+            native_authorization."operational_authorization_receipt_id"
+        JOIN "outcome_private_valuation_model_request_binding" binding
+          ON binding."operation_id"=NEW."operation_id"
+        JOIN "outcome_private_valuation_dispatch_request" bound_request
+          ON bound_request."request_id"=binding."request_id"
+        WHERE native_run."run_id"=player."native_execution_id"
+          AND native_intent."intent_json"->'content'->>'modelId'=
+            NEW."player_model_id"
+          AND native_intent."intent_json"->'content'->>'modelVersion'=
+            NEW."player_model_version"
+          AND operational."receipt_json"->'content'->>'authorityBoundary'=
+            'policy_owned_local_private_valuation_for_one_exact_model_run_intent'
+          AND operational."receipt_json"->'content'->>'dispatchRequestId'=
+            binding."request_id"
+          AND operational."receipt_json"->'content'->>'substantiveOperationId'=
+            NEW."operation_id"
+          AND operational."receipt_json"->'content'->>'dispatchClaimId'=
+            NEW."player_claim_id"
+          AND operational."receipt_json"->'content'->>'dispatchLeaseTokenSha256'=
+            bound_request."lease_token_sha256"
+          AND (operational."receipt_json"->'content'->>'dispatchAttemptNumber')::INTEGER=
+            NEW."player_attempt_number"
+          AND operational."receipt_json"->'content'->>'factualOutputId'=
+            binding."factual_output_id"
+          AND operational."receipt_json"->'content'->>'hpnCalculationId'=
+            binding."hpn_calculation_id"
+          AND operational."receipt_json"->'content'->>'factualValuesSha256'=
+            NEW."factual_values_sha256"
+          AND operational."receipt_json"->'content'->>'hpnValuesSha256'=
+            NEW."hpn_values_sha256")
+      OR NOT EXISTS (
+        SELECT 1 FROM "outcome_private_valuation_model_request_binding" binding
+        JOIN "outcome_private_valuation_dispatch_request" request
+          ON request."request_id"=binding."request_id"
+        JOIN "outcome_private_valuation_dispatch_attempt" attempt
+          ON attempt."claim_id"=NEW."player_claim_id"
+         AND attempt."request_id"=request."request_id"
+        WHERE binding."operation_id"=NEW."operation_id"
+          AND request."status"='claimed' AND request."claim_id"=NEW."player_claim_id"
+          AND request."lease_expires_at">=clock_timestamp()
+          AND attempt."attempt_number"=NEW."player_attempt_number"
+          AND attempt."finished_at" IS NULL)
+    THEN RAISE EXCEPTION 'Accepted private player output has wrong ancestry'; END IF;
+  END IF;
+  IF OLD."pick_run_id" IS NULL AND NEW."pick_run_id" IS NOT NULL THEN
+    SELECT * INTO pick FROM "outcome_governed_valuation_component_run"
+     WHERE "run_id"=NEW."pick_run_id";
+    IF pick."role"<>'draft_pick_and_future_pick_distribution'
+      OR pick."protocol_id"<>NEW."pick_protocol_id"
+      OR pick."dataset_id"<>NEW."pick_dataset_id"
+      OR pick."dataset_admission_id"<>NEW."pick_dataset_admission_id"
+      OR NOT EXISTS (
+        SELECT 1 FROM "outcome_governed_pick_pav_model_execution" native_execution
+        JOIN "outcome_private_valuation_model_request_binding" binding
+          ON binding."operation_id"=NEW."operation_id"
+        JOIN "outcome_private_valuation_dispatch_request" bound_request
+          ON bound_request."request_id"=binding."request_id"
+        WHERE native_execution."execution_id"=pick."native_execution_id"
+          AND native_execution."execution_json"->'content'->>'policyId'=
+            NEW."pick_policy_id"
+          AND native_execution."execution_json"->'content'->>'schemaVersion'=
+            'afl-trade-pick-pav-model-execution/v4'
+          AND native_execution."execution_json"->'content'->'privateInput'->>'requestId'=
+            binding."request_id"
+          AND native_execution."execution_json"->'content'->'privateInput'->>'operationId'=
+            NEW."operation_id"
+          AND native_execution."execution_json"->'content'->'privateInput'->>'claimId'=
+            NEW."pick_claim_id"
+          AND native_execution."execution_json"->'content'->'privateInput'->>'leaseTokenSha256'=
+            bound_request."lease_token_sha256"
+          AND (native_execution."execution_json"->'content'->'privateInput'->>'attemptNumber')::INTEGER=
+            NEW."pick_attempt_number"
+          AND native_execution."execution_json"->'content'->'privateInput'->>'factualOutputId'=
+            binding."factual_output_id"
+          AND native_execution."execution_json"->'content'->'privateInput'->>'hpnCalculationId'=
+            binding."hpn_calculation_id"
+          AND native_execution."execution_json"->'content'->'privateInput'->>'factualValuesSha256'=
+            NEW."factual_values_sha256"
+          AND native_execution."execution_json"->'content'->'privateInput'->>'hpnValuesSha256'=
+            NEW."hpn_values_sha256")
+      OR NOT EXISTS (
+        SELECT 1 FROM "outcome_private_valuation_model_request_binding" binding
+        JOIN "outcome_private_valuation_dispatch_request" request
+          ON request."request_id"=binding."request_id"
+        JOIN "outcome_private_valuation_dispatch_attempt" attempt
+          ON attempt."claim_id"=NEW."pick_claim_id"
+         AND attempt."request_id"=request."request_id"
+        WHERE binding."operation_id"=NEW."operation_id"
+          AND request."status"='claimed' AND request."claim_id"=NEW."pick_claim_id"
+          AND request."lease_expires_at">=clock_timestamp()
+          AND attempt."attempt_number"=NEW."pick_attempt_number"
+          AND attempt."finished_at" IS NULL)
+    THEN RAISE EXCEPTION 'Accepted private pick output has wrong ancestry'; END IF;
+  END IF;
+  IF OLD."qualification_id" IS NULL AND NEW."qualification_id" IS NOT NULL THEN
+    SELECT * INTO qualification FROM "outcome_governed_valuation_model_qualification"
+     WHERE "qualification_id"=NEW."qualification_id";
+    IF qualification."scope_key"<>NEW."scope_key"
+      OR qualification."player_run_id"<>NEW."player_run_id"
+      OR qualification."pick_run_id"<>NEW."pick_run_id"
+      OR qualification."outcome"<>NEW."qualification_outcome"
+      OR qualification."qualification_json"->'content'->'policy'->>'policyVersion'<>
+        NEW."qualification_policy_id"
+      OR NOT EXISTS (
+        SELECT 1 FROM "outcome_private_valuation_model_request_binding" binding
+        JOIN "outcome_private_valuation_dispatch_request" request
+          ON request."request_id"=binding."request_id"
+        JOIN "outcome_private_valuation_dispatch_attempt" attempt
+          ON attempt."claim_id"=NEW."qualification_claim_id"
+         AND attempt."request_id"=request."request_id"
+        WHERE binding."operation_id"=NEW."operation_id"
+          AND request."status"='claimed'
+          AND request."claim_id"=NEW."qualification_claim_id"
+          AND request."lease_expires_at">=clock_timestamp()
+          AND attempt."finished_at" IS NULL)
+    THEN RAISE EXCEPTION 'Private model qualification has wrong accepted pair'; END IF;
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_private_valuation_model_operation_update_guard"
+BEFORE UPDATE ON "outcome_private_valuation_model_operation"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_private_valuation_model_operation_update"();
+
+CREATE TRIGGER "outcome_private_valuation_model_operation_no_delete"
+BEFORE DELETE ON "outcome_private_valuation_model_operation"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_valuation_dispatch_delete"();
+CREATE TRIGGER "outcome_private_valuation_model_request_binding_no_update_or_delete"
+BEFORE UPDATE OR DELETE ON "outcome_private_valuation_model_request_binding"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_private_valuation_dispatch_delete"();
+
+ALTER TABLE "outcome_private_valuation_model_operation"
+  OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER TABLE "outcome_private_valuation_model_request_binding"
+  OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "validate_outcome_valuation_model_run_operation_insert"()
+  OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "validate_outcome_private_valuation_model_request_binding"()
+  OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "validate_outcome_private_valuation_model_operation_insert"()
+  OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "outcome_private_valuation_hpn_substantive_sha256"(JSONB)
+  OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "validate_outcome_private_valuation_model_operation_update"()
+  OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "fence_outcome_dispatch_bound_pick_execution"()
+  OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "fence_outcome_dispatch_bound_component"()
+  OWNER TO afl_trade_private_valuation_scheduler_owner;
+ALTER FUNCTION "fence_outcome_dispatch_bound_model_qualification"()
+  OWNER TO afl_trade_private_valuation_scheduler_owner;
+
+REVOKE ALL ON FUNCTION "fence_outcome_dispatch_bound_pick_execution"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "fence_outcome_dispatch_bound_component"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "fence_outcome_dispatch_bound_model_qualification"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "outcome_private_valuation_hpn_substantive_sha256"(JSONB) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "outcome_private_valuation_hpn_substantive_sha256"(JSONB)
+  TO afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_governed_pick_pav_model_execution",
+  "outcome_valuation_model_run",
+  "outcome_valuation_model_run_authorization",
+  "outcome_valuation_model_run_operational_authorization"
+  TO afl_trade_private_valuation_scheduler_owner;
+
+REVOKE ALL ON "outcome_private_valuation_model_operation",
+  "outcome_private_valuation_model_request_binding" FROM PUBLIC;
+GRANT SELECT,INSERT,UPDATE ON "outcome_private_valuation_model_operation"
+  TO afl_trade_private_evaluation_coordinator;
+GRANT SELECT,INSERT ON "outcome_private_valuation_model_request_binding"
+  TO afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_private_valuation_dispatch_request",
+  "outcome_private_valuation_dispatch_attempt",
+  "outcome_private_valuation_factual_output",
+  "outcome_hpn_pav_calculation",
+  "outcome_governed_valuation_component_run",
+  "outcome_valuation_model_run",
+  "outcome_valuation_model_run_intent",
+  "outcome_valuation_model_run_authorization",
+  "outcome_valuation_model_run_operational_authorization",
+  "outcome_governed_pick_pav_model_execution",
+  "outcome_governed_valuation_model_qualification"
+  TO afl_trade_private_evaluation_coordinator;

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -4144,7 +4144,7 @@ model OutcomeValuationModelRunOperationalAuthorization {
   authorizedAt         DateTime                               @map("authorized_at") @outcomes.Timestamptz(3)
   validThrough         DateTime                               @map("valid_through") @outcomes.Timestamptz(3)
   principalRef         String                                 @map("principal_ref")
-  authorityEvidenceId  String                                 @map("authority_evidence_id")
+  authorityEvidenceId  String?                                @map("authority_evidence_id")
   receiptCanonicalJson String                                 @map("receipt_canonical_json") @outcomes.Text
   receiptJson          Json                                   @map("receipt_json")
   registeredAt         DateTime                               @default(dbgenerated("clock_timestamp()")) @map("registered_at") @outcomes.Timestamptz(3)
@@ -4154,7 +4154,7 @@ model OutcomeValuationModelRunOperationalAuthorization {
   admission            OutcomeValuationDatasetAdmission       @relation(fields: [admissionId], references: [admissionId], onDelete: Restrict)
   protocol             OutcomeValuationModelProtocol          @relation(fields: [protocolId], references: [protocolId], onDelete: Restrict)
   observationSet       OutcomeValuationPlayerObservationSet   @relation(fields: [observationSetId], references: [observationSetId], onDelete: Restrict)
-  authorityEvidence    OutcomeOperationalPrincipalAuthority   @relation(fields: [authorityEvidenceId], references: [authorityEvidenceId], onDelete: Restrict)
+  authorityEvidence    OutcomeOperationalPrincipalAuthority?  @relation(fields: [authorityEvidenceId], references: [authorityEvidenceId], onDelete: Restrict)
   runAuthorization     OutcomeValuationModelRunAuthorization?
 
   @@unique([datasetId, admissionId, protocolId, observationSetId, intentId], map: "outcome_valuation_model_run_operation_ancestry_key")
@@ -5438,6 +5438,59 @@ model OutcomePrivateValuationDispatchAttempt {
   @@unique([requestId, attemptSequence, claimId], map: "outcome_private_valuation_dispatch_attempt_fence")
   @@index([requestId, attemptSequence], map: "outcome_private_valuation_dispatch_attempt_request_idx")
   @@map("outcome_private_valuation_dispatch_attempt")
+}
+
+model OutcomePrivateValuationModelOperation {
+  operationId             String    @id @map("operation_id") @outcomes.Text
+  scopeKey                String    @map("scope_key") @outcomes.Text
+  factualValuesSha256     String    @map("factual_values_sha256") @outcomes.Char(64)
+  hpnValuesSha256         String    @map("hpn_values_sha256") @outcomes.Char(64)
+  hpnMethodId             String    @map("hpn_method_id") @outcomes.Text
+  playerModelId           String    @map("player_model_id") @outcomes.Text
+  playerModelVersion      String    @map("player_model_version") @outcomes.Text
+  playerProtocolId        String    @map("player_protocol_id") @outcomes.Text
+  playerDatasetId         String    @map("player_dataset_id") @outcomes.Text
+  playerDatasetAdmissionId String   @map("player_dataset_admission_id") @outcomes.Text
+  pickProtocolId          String    @map("pick_protocol_id") @outcomes.Text
+  pickDatasetId           String    @map("pick_dataset_id") @outcomes.Text
+  pickDatasetAdmissionId  String    @map("pick_dataset_admission_id") @outcomes.Text
+  pickPolicyId            String    @map("pick_policy_id") @outcomes.Text
+  qualificationPolicyId   String    @map("qualification_policy_id") @outcomes.Text
+  operationCanonicalJson String    @map("operation_canonical_json") @outcomes.Text
+  operationJson          Json      @map("operation_json")
+  playerRunId            String?   @map("player_run_id") @outcomes.Text
+  playerClaimId          String?   @map("player_claim_id") @outcomes.Text
+  playerAttemptNumber    Int?      @map("player_attempt_number")
+  playerAcceptedAt       DateTime? @map("player_accepted_at") @outcomes.Timestamptz(3)
+  pickRunId              String?   @map("pick_run_id") @outcomes.Text
+  pickClaimId            String?   @map("pick_claim_id") @outcomes.Text
+  pickAttemptNumber      Int?      @map("pick_attempt_number")
+  pickAcceptedAt         DateTime? @map("pick_accepted_at") @outcomes.Timestamptz(3)
+  pairAcceptedAt         DateTime? @map("pair_accepted_at") @outcomes.Timestamptz(3)
+  qualificationId       String?   @map("qualification_id") @outcomes.Text
+  qualificationOutcome  String?   @map("qualification_outcome") @outcomes.Text
+  qualificationClaimId  String?   @map("qualification_claim_id") @outcomes.Text
+  qualificationBoundAt  DateTime? @map("qualification_bound_at") @outcomes.Timestamptz(3)
+  createdAt              DateTime  @default(dbgenerated("clock_timestamp()")) @map("created_at") @outcomes.Timestamptz(3)
+  requestBindings        OutcomePrivateValuationModelRequestBinding[]
+
+  @@map("outcome_private_valuation_model_operation")
+}
+
+model OutcomePrivateValuationModelRequestBinding {
+  requestId        String   @id @map("request_id") @outcomes.Text
+  operationId      String   @map("operation_id") @outcomes.Text
+  factualOutputId  String   @map("factual_output_id") @outcomes.Text
+  hpnCalculationId String   @map("hpn_calculation_id") @outcomes.Text
+  claimId          String   @map("claim_id") @outcomes.Text
+  attemptNumber    Int      @map("attempt_number")
+  boundAt          DateTime @default(dbgenerated("clock_timestamp()")) @map("bound_at") @outcomes.Timestamptz(3)
+  operation        OutcomePrivateValuationModelOperation @relation(fields: [operationId], references: [operationId], onDelete: Restrict)
+
+  @@unique([requestId, operationId], map: "outcome_private_model_request_operation_key")
+  @@unique([requestId, factualOutputId, hpnCalculationId], map: "outcome_private_model_request_input_key")
+  @@index([operationId, requestId], map: "outcome_private_valuation_model_request_operation_idx")
+  @@map("outcome_private_valuation_model_request_binding")
 }
 
 model OutcomePrivateValuationCaptureBinding {

--- a/src/server/aflTradeIntelligence/modeling/admittedModelRunAuthority.ts
+++ b/src/server/aflTradeIntelligence/modeling/admittedModelRunAuthority.ts
@@ -47,6 +47,7 @@ import {
   type AflTradeAcquisitionSpellMetric,
   aflTradeAcquisitionSpellMetricSchema,
 } from '../outcomes/acquisitionSpellMetricContracts';
+import { AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID } from '../valuation/automatedPrivateEvaluationPolicy';
 
 const utcInstantSchema = z.iso.datetime({ offset: true });
 
@@ -56,7 +57,7 @@ export const AFL_TRADE_MODEL_RUN_AUTHORIZATION_SCHEMA_VERSION =
 export const AFL_TRADE_MODEL_RUN_OPERATIONAL_AUTHORIZATION_SCHEMA_VERSION =
   'afl-trade-model-run-operational-authorization/v1' as const;
 
-const modelRunOperationalAuthorizationContentSchema = z
+const humanModelRunOperationalAuthorizationContentSchema = z
   .object({
     schemaVersion: z.literal(AFL_TRADE_MODEL_RUN_OPERATIONAL_AUTHORIZATION_SCHEMA_VERSION),
     operation: z.literal('execute_model_run'),
@@ -100,6 +101,52 @@ const modelRunOperationalAuthorizationContentSchema = z
     }
   });
 
+const privateValuationModelRunOperationalAuthorizationContentSchema = z
+  .object({
+    schemaVersion: z.literal(AFL_TRADE_MODEL_RUN_OPERATIONAL_AUTHORIZATION_SCHEMA_VERSION),
+    operation: z.literal('execute_model_run'),
+    authorityBoundary: z.literal(
+      'policy_owned_local_private_valuation_for_one_exact_model_run_intent'
+    ),
+    publicationEligible: z.literal(false),
+    publicationProhibited: z.literal(true),
+    environment: z.literal('non_production'),
+    executionMode: z.literal('local'),
+    runIntentId: aflTradeContentAddressedIdSchema('model-run-intent'),
+    datasetId: aflTradeContentAddressedIdSchema('dataset'),
+    datasetAdmissionId: aflTradeContentAddressedIdSchema('dataset-admission'),
+    modelProtocolId: aflTradeContentAddressedIdSchema('model-protocol'),
+    observationSetId: aflTradeContentAddressedIdSchema('player-observation-set'),
+    dispatchRequestId: aflTradeContentAddressedIdSchema('private-valuation-dispatch'),
+    substantiveOperationId: aflTradeContentAddressedIdSchema('private-valuation-model-operation'),
+    dispatchClaimId: aflTradeContentAddressedIdSchema('private-valuation-dispatch-claim'),
+    dispatchAttemptNumber: z.number().int().min(1).max(3),
+    dispatchLeaseTokenSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+    factualOutputId: aflTradeContentAddressedIdSchema('private-valuation-factual-output'),
+    hpnCalculationId: aflTradeContentAddressedIdSchema('hpn-pav-season'),
+    factualValuesSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+    hpnValuesSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+    authorizedAt: utcInstantSchema,
+    validThrough: utcInstantSchema,
+    principalRef: z.literal(AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID),
+    role: z.literal('afl_trade_private_evaluation_coordinator'),
+  })
+  .strict()
+  .superRefine((authorization, context) => {
+    if (Date.parse(authorization.validThrough) <= Date.parse(authorization.authorizedAt)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['validThrough'],
+        message: 'Operational authorization requires a bounded positive execution window.',
+      });
+    }
+  });
+
+const modelRunOperationalAuthorizationContentSchema = z.discriminatedUnion('authorityBoundary', [
+  humanModelRunOperationalAuthorizationContentSchema,
+  privateValuationModelRunOperationalAuthorizationContentSchema,
+]);
+
 export const aflTradeModelRunOperationalAuthorizationSchema = z
   .object({
     receiptId: aflTradeContentAddressedIdSchema('architecture-operation-receipt'),
@@ -119,19 +166,55 @@ export const aflTradeModelRunOperationalAuthorizationSchema = z
 export type AflTradeModelRunOperationalAuthorization = z.infer<
   typeof aflTradeModelRunOperationalAuthorizationSchema
 >;
+export type AflTradeHumanModelRunOperationalAuthorization = Readonly<{
+  receiptId: string;
+  content: z.infer<typeof humanModelRunOperationalAuthorizationContentSchema>;
+}>;
 
 export function createAflTradeModelRunOperationalAuthorization(
   input: Omit<
-    z.input<typeof modelRunOperationalAuthorizationContentSchema>,
+    z.input<typeof humanModelRunOperationalAuthorizationContentSchema>,
     'schemaVersion' | 'operation' | 'authorityBoundary' | 'publicationEligible'
   >
-): AflTradeModelRunOperationalAuthorization {
-  const content = modelRunOperationalAuthorizationContentSchema.parse({
+): AflTradeHumanModelRunOperationalAuthorization {
+  const content = humanModelRunOperationalAuthorizationContentSchema.parse({
     ...input,
     schemaVersion: AFL_TRADE_MODEL_RUN_OPERATIONAL_AUTHORIZATION_SCHEMA_VERSION,
     operation: 'execute_model_run',
     authorityBoundary: 'human_operational_authorization_for_one_exact_model_run_intent',
     publicationEligible: false,
+  });
+  return {
+    receiptId: createAflTradeContentAddress('architecture-operation-receipt', content),
+    content,
+  };
+}
+
+export function createAflTradePrivateValuationModelRunOperationalAuthorization(
+  input: Omit<
+    z.input<typeof privateValuationModelRunOperationalAuthorizationContentSchema>,
+    | 'schemaVersion'
+    | 'operation'
+    | 'authorityBoundary'
+    | 'publicationEligible'
+    | 'publicationProhibited'
+    | 'environment'
+    | 'executionMode'
+    | 'principalRef'
+    | 'role'
+  >
+): AflTradeModelRunOperationalAuthorization {
+  const content = privateValuationModelRunOperationalAuthorizationContentSchema.parse({
+    ...input,
+    schemaVersion: AFL_TRADE_MODEL_RUN_OPERATIONAL_AUTHORIZATION_SCHEMA_VERSION,
+    operation: 'execute_model_run',
+    authorityBoundary: 'policy_owned_local_private_valuation_for_one_exact_model_run_intent',
+    publicationEligible: false,
+    publicationProhibited: true,
+    environment: 'non_production',
+    executionMode: 'local',
+    principalRef: AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID,
+    role: 'afl_trade_private_evaluation_coordinator',
   });
   return aflTradeModelRunOperationalAuthorizationSchema.parse({
     receiptId: createAflTradeContentAddress('architecture-operation-receipt', content),
@@ -463,7 +546,7 @@ function operationalAuthorizationIsCurrent(
   evaluatedAt: string
 ): boolean {
   const content = authorization.content;
-  return (
+  const exactIntent =
     content.environment === intent.content.environment &&
     content.runIntentId === intent.intentId &&
     content.datasetId === intent.content.datasetId &&
@@ -471,8 +554,13 @@ function operationalAuthorizationIsCurrent(
     content.modelProtocolId === intent.content.modelProtocolId &&
     content.observationSetId === intent.content.observationSetId &&
     Date.parse(content.authorizedAt) <= Date.parse(intent.content.startedAt) &&
-    Date.parse(content.validThrough) > Date.parse(evaluatedAt)
-  );
+    Date.parse(content.validThrough) > Date.parse(evaluatedAt);
+  if (!exactIntent) return false;
+  return content.authorityBoundary ===
+    'human_operational_authorization_for_one_exact_model_run_intent'
+    ? true
+    : intent.content.job.initiatedBy === AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID &&
+        intent.content.job.workerIdentity === AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID;
 }
 
 function intentMatchesProtocol(

--- a/src/server/aflTradeIntelligence/modeling/governedPickPavModelExecution.ts
+++ b/src/server/aflTradeIntelligence/modeling/governedPickPavModelExecution.ts
@@ -62,93 +62,93 @@ function refineGovernedExecution(
   execution: z.infer<typeof sharedGovernedExecutionContentSchema>,
   context: z.RefinementCtx
 ) {
-    const observationSet = execution.observationSet;
-    if (
-      execution.observationSetId !== observationSet.observationSetId ||
-      execution.observationSetSha256 !== observationSet.content.observationSetSha256 ||
-      observationSet.content.environment !== 'non_production' ||
-      execution.competition !== observationSet.content.competition ||
-      execution.releaseId !== observationSet.content.releaseId ||
-      execution.policyId !== observationSet.content.policy.policyId ||
-      execution.methodId !== observationSet.content.policy.content.methodId ||
-      execution.valueUnit !== observationSet.content.policy.content.outcomeValueUnit
-    ) {
-      context.addIssue({
-        code: 'custom',
-        path: ['observationSet'],
-        message: 'Governed pick execution ancestry must match one non-production observation set.',
-      });
-      return;
-    }
+  const observationSet = execution.observationSet;
+  if (
+    execution.observationSetId !== observationSet.observationSetId ||
+    execution.observationSetSha256 !== observationSet.content.observationSetSha256 ||
+    observationSet.content.environment !== 'non_production' ||
+    execution.competition !== observationSet.content.competition ||
+    execution.releaseId !== observationSet.content.releaseId ||
+    execution.policyId !== observationSet.content.policy.policyId ||
+    execution.methodId !== observationSet.content.policy.content.methodId ||
+    execution.valueUnit !== observationSet.content.policy.content.outcomeValueUnit
+  ) {
+    context.addIssue({
+      code: 'custom',
+      path: ['observationSet'],
+      message: 'Governed pick execution ancestry must match one non-production observation set.',
+    });
+    return;
+  }
 
-    const evidenceArtifacts = [
-      execution.datasetArtifact,
-      execution.datasetAdmissionArtifact,
-      execution.protocolArtifact,
-    ];
-    if (
-      new Set(evidenceArtifacts.map(({ artifactId }) => artifactId)).size !==
-        evidenceArtifacts.length ||
-      evidenceArtifacts.some(
-        ({ createdAt }) => Date.parse(createdAt) > Date.parse(execution.completedAt)
-      )
-    ) {
-      context.addIssue({
-        code: 'custom',
-        path: ['datasetArtifact'],
-        message: 'Governed pick execution requires distinct authority artifacts retained in time.',
-      });
-      return;
-    }
+  const evidenceArtifacts = [
+    execution.datasetArtifact,
+    execution.datasetAdmissionArtifact,
+    execution.protocolArtifact,
+  ];
+  if (
+    new Set(evidenceArtifacts.map(({ artifactId }) => artifactId)).size !==
+      evidenceArtifacts.length ||
+    evidenceArtifacts.some(
+      ({ createdAt }) => Date.parse(createdAt) > Date.parse(execution.completedAt)
+    )
+  ) {
+    context.addIssue({
+      code: 'custom',
+      path: ['datasetArtifact'],
+      message: 'Governed pick execution requires distinct authority artifacts retained in time.',
+    });
+    return;
+  }
 
-    const createdAt = Date.parse(observationSet.content.createdAt);
-    const finalTestEvaluationStartedAt = Date.parse(execution.finalTestEvaluationStartedAt);
-    const completedAt = Date.parse(execution.completedAt);
-    if (
-      finalTestEvaluationStartedAt < createdAt ||
-      completedAt < finalTestEvaluationStartedAt ||
-      execution.validationConfig.evaluatedAt !== execution.finalTestEvaluationStartedAt
-    ) {
-      context.addIssue({
-        code: 'custom',
-        path: ['finalTestEvaluationStartedAt'],
-        message: 'Governed final-test evaluation chronology is invalid.',
-      });
-      return;
-    }
+  const createdAt = Date.parse(observationSet.content.createdAt);
+  const finalTestEvaluationStartedAt = Date.parse(execution.finalTestEvaluationStartedAt);
+  const completedAt = Date.parse(execution.completedAt);
+  if (
+    finalTestEvaluationStartedAt < createdAt ||
+    completedAt < finalTestEvaluationStartedAt ||
+    execution.validationConfig.evaluatedAt !== execution.finalTestEvaluationStartedAt
+  ) {
+    context.addIssue({
+      code: 'custom',
+      path: ['finalTestEvaluationStartedAt'],
+      message: 'Governed final-test evaluation chronology is invalid.',
+    });
+    return;
+  }
 
-    try {
-      const expectedBenchmark = fitAflTradePickPavDistributionBenchmark(
-        observationSet,
-        execution.benchmarkConfig
-      );
-      const expectedReport = validateAflTradePickPavDistributionBenchmark(
-        observationSet,
-        expectedBenchmark,
-        execution.validationConfig
-      );
-      if (
-        canonicalizeAflTradeJson(expectedBenchmark) !==
-          canonicalizeAflTradeJson(execution.benchmark) ||
-        canonicalizeAflTradeJson(expectedReport) !==
-          canonicalizeAflTradeJson(execution.validationReport)
-      ) {
-        context.addIssue({
-          code: 'custom',
-          path: ['benchmark'],
-          message: 'Governed pick execution must retain its exactly re-derived model outputs.',
-        });
-      }
-    } catch (error) {
+  try {
+    const expectedBenchmark = fitAflTradePickPavDistributionBenchmark(
+      observationSet,
+      execution.benchmarkConfig
+    );
+    const expectedReport = validateAflTradePickPavDistributionBenchmark(
+      observationSet,
+      expectedBenchmark,
+      execution.validationConfig
+    );
+    if (
+      canonicalizeAflTradeJson(expectedBenchmark) !==
+        canonicalizeAflTradeJson(execution.benchmark) ||
+      canonicalizeAflTradeJson(expectedReport) !==
+        canonicalizeAflTradeJson(execution.validationReport)
+    ) {
       context.addIssue({
         code: 'custom',
         path: ['benchmark'],
-        message:
-          error instanceof Error
-            ? error.message
-            : 'Governed pick execution outputs could not be re-derived.',
+        message: 'Governed pick execution must retain its exactly re-derived model outputs.',
       });
     }
+  } catch (error) {
+    context.addIssue({
+      code: 'custom',
+      path: ['benchmark'],
+      message:
+        error instanceof Error
+          ? error.message
+          : 'Governed pick execution outputs could not be re-derived.',
+    });
+  }
 }
 
 const legacyGovernedExecutionContentSchema = sharedGovernedExecutionContentSchema
@@ -171,10 +171,39 @@ const governedExecutionContentSchema = sharedGovernedExecutionContentSchema
   .strict()
   .superRefine(refineGovernedExecution);
 
+const dispatchBoundPrivateInputSchema = z
+  .object({
+    requestId: aflTradeContentAddressedIdSchema('private-valuation-dispatch'),
+    operationId: aflTradeContentAddressedIdSchema('private-valuation-model-operation'),
+    claimId: aflTradeContentAddressedIdSchema('private-valuation-dispatch-claim'),
+    attemptNumber: z.number().int().min(1).max(3),
+    leaseTokenSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+    factualOutputId: aflTradeContentAddressedIdSchema('private-valuation-factual-output'),
+    hpnCalculationId: aflTradeContentAddressedIdSchema('hpn-pav-season'),
+    factualValuesSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+    hpnValuesSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+  })
+  .strict();
+
+const dispatchBoundGovernedExecutionContentSchema = sharedGovernedExecutionContentSchema
+  .extend({
+    schemaVersion: z.literal('afl-trade-pick-pav-model-execution/v4'),
+    authorityBoundary: z.literal(AUTHORITY_BOUNDARY),
+    qualificationStatus: z.literal('automated_qualification_pending'),
+    privateInput: dispatchBoundPrivateInputSchema,
+    limitation: z.literal(LIMITATION),
+  })
+  .strict()
+  .superRefine(refineGovernedExecution);
+
 export const governedAflTradePickPavModelExecutionSchema = z
   .object({
     executionId: aflTradeContentAddressedIdSchema('pick-pav-model-execution'),
-    content: z.union([legacyGovernedExecutionContentSchema, governedExecutionContentSchema]),
+    content: z.union([
+      legacyGovernedExecutionContentSchema,
+      governedExecutionContentSchema,
+      dispatchBoundGovernedExecutionContentSchema,
+    ]),
   })
   .strict()
   .superRefine((execution, context) => {
@@ -226,6 +255,51 @@ export function createGovernedAflTradePickPavModelExecution(input: {
     validationConfig: input.outputs.validationConfig,
     benchmark: input.outputs.benchmark,
     validationReport: input.outputs.validationReport,
+    limitation: LIMITATION,
+  });
+  return governedAflTradePickPavModelExecutionSchema.parse({
+    executionId: createAflTradeContentAddress('pick-pav-model-execution', content),
+    content,
+  });
+}
+
+export function createDispatchBoundGovernedAflTradePickPavModelExecution(input: {
+  readonly outputs: ReturnType<typeof computeAflTradePickPavModelExecutionOutputs>;
+  readonly completedAt: string;
+  readonly authority: Readonly<{
+    datasetId: string;
+    datasetArtifact: z.input<typeof aflTradeArtifactRefSchema>;
+    datasetAdmissionId: string;
+    datasetAdmissionArtifact: z.input<typeof aflTradeArtifactRefSchema>;
+    datasetAdmissionGateLedgerRevision: number;
+    protocolId: string;
+    protocolArtifact: z.input<typeof aflTradeArtifactRefSchema>;
+  }>;
+  readonly privateInput: z.input<typeof dispatchBoundPrivateInputSchema>;
+}): GovernedAflTradePickPavModelExecution {
+  const observationSet = aflTradePickPavObservationSetSchema.parse(input.outputs.observationSet);
+  const content = dispatchBoundGovernedExecutionContentSchema.parse({
+    schemaVersion: 'afl-trade-pick-pav-model-execution/v4',
+    authorityBoundary: AUTHORITY_BOUNDARY,
+    publicationEligible: false,
+    qualificationStatus: 'automated_qualification_pending',
+    environment: 'non_production',
+    competition: observationSet.content.competition,
+    ...input.authority,
+    observationSetId: observationSet.observationSetId,
+    observationSetSha256: observationSet.content.observationSetSha256,
+    releaseId: observationSet.content.releaseId,
+    policyId: observationSet.content.policy.policyId,
+    methodId: observationSet.content.policy.content.methodId,
+    valueUnit: observationSet.content.policy.content.outcomeValueUnit,
+    finalTestEvaluationStartedAt: input.outputs.validationConfig.evaluatedAt,
+    completedAt: input.completedAt,
+    observationSet,
+    benchmarkConfig: input.outputs.benchmarkConfig,
+    validationConfig: input.outputs.validationConfig,
+    benchmark: input.outputs.benchmark,
+    validationReport: input.outputs.validationReport,
+    privateInput: input.privateInput,
     limitation: LIMITATION,
   });
   return governedAflTradePickPavModelExecutionSchema.parse({

--- a/src/server/aflTradeIntelligence/modeling/governedPickPavModelExecution.ts
+++ b/src/server/aflTradeIntelligence/modeling/governedPickPavModelExecution.ts
@@ -220,7 +220,7 @@ export type GovernedAflTradePickPavModelExecution = z.infer<
   typeof governedAflTradePickPavModelExecutionSchema
 >;
 
-export function createGovernedAflTradePickPavModelExecution(input: {
+type GovernedExecutionFactoryInput = Readonly<{
   readonly outputs: ReturnType<typeof computeAflTradePickPavModelExecutionOutputs>;
   readonly completedAt: string;
   readonly authority: Readonly<{
@@ -232,10 +232,11 @@ export function createGovernedAflTradePickPavModelExecution(input: {
     protocolId: string;
     protocolArtifact: z.input<typeof aflTradeArtifactRefSchema>;
   }>;
-}): GovernedAflTradePickPavModelExecution {
+}>;
+
+function sharedGovernedExecutionContent(input: GovernedExecutionFactoryInput) {
   const observationSet = aflTradePickPavObservationSetSchema.parse(input.outputs.observationSet);
-  const content = governedExecutionContentSchema.parse({
-    schemaVersion: 'afl-trade-pick-pav-model-execution/v3',
+  return {
     authorityBoundary: AUTHORITY_BOUNDARY,
     publicationEligible: false,
     qualificationStatus: 'automated_qualification_pending',
@@ -256,6 +257,15 @@ export function createGovernedAflTradePickPavModelExecution(input: {
     benchmark: input.outputs.benchmark,
     validationReport: input.outputs.validationReport,
     limitation: LIMITATION,
+  } as const;
+}
+
+export function createGovernedAflTradePickPavModelExecution(
+  input: GovernedExecutionFactoryInput
+): GovernedAflTradePickPavModelExecution {
+  const content = governedExecutionContentSchema.parse({
+    schemaVersion: 'afl-trade-pick-pav-model-execution/v3',
+    ...sharedGovernedExecutionContent(input),
   });
   return governedAflTradePickPavModelExecutionSchema.parse({
     executionId: createAflTradeContentAddress('pick-pav-model-execution', content),
@@ -263,44 +273,15 @@ export function createGovernedAflTradePickPavModelExecution(input: {
   });
 }
 
-export function createDispatchBoundGovernedAflTradePickPavModelExecution(input: {
-  readonly outputs: ReturnType<typeof computeAflTradePickPavModelExecutionOutputs>;
-  readonly completedAt: string;
-  readonly authority: Readonly<{
-    datasetId: string;
-    datasetArtifact: z.input<typeof aflTradeArtifactRefSchema>;
-    datasetAdmissionId: string;
-    datasetAdmissionArtifact: z.input<typeof aflTradeArtifactRefSchema>;
-    datasetAdmissionGateLedgerRevision: number;
-    protocolId: string;
-    protocolArtifact: z.input<typeof aflTradeArtifactRefSchema>;
-  }>;
-  readonly privateInput: z.input<typeof dispatchBoundPrivateInputSchema>;
-}): GovernedAflTradePickPavModelExecution {
-  const observationSet = aflTradePickPavObservationSetSchema.parse(input.outputs.observationSet);
+export function createDispatchBoundGovernedAflTradePickPavModelExecution(
+  input: GovernedExecutionFactoryInput & {
+    readonly privateInput: z.input<typeof dispatchBoundPrivateInputSchema>;
+  }
+): GovernedAflTradePickPavModelExecution {
   const content = dispatchBoundGovernedExecutionContentSchema.parse({
     schemaVersion: 'afl-trade-pick-pav-model-execution/v4',
-    authorityBoundary: AUTHORITY_BOUNDARY,
-    publicationEligible: false,
-    qualificationStatus: 'automated_qualification_pending',
-    environment: 'non_production',
-    competition: observationSet.content.competition,
-    ...input.authority,
-    observationSetId: observationSet.observationSetId,
-    observationSetSha256: observationSet.content.observationSetSha256,
-    releaseId: observationSet.content.releaseId,
-    policyId: observationSet.content.policy.policyId,
-    methodId: observationSet.content.policy.content.methodId,
-    valueUnit: observationSet.content.policy.content.outcomeValueUnit,
-    finalTestEvaluationStartedAt: input.outputs.validationConfig.evaluatedAt,
-    completedAt: input.completedAt,
-    observationSet,
-    benchmarkConfig: input.outputs.benchmarkConfig,
-    validationConfig: input.outputs.validationConfig,
-    benchmark: input.outputs.benchmark,
-    validationReport: input.outputs.validationReport,
+    ...sharedGovernedExecutionContent(input),
     privateInput: input.privateInput,
-    limitation: LIMITATION,
   });
   return governedAflTradePickPavModelExecutionSchema.parse({
     executionId: createAflTradeContentAddress('pick-pav-model-execution', content),

--- a/src/server/aflTradeIntelligence/modeling/postgresAdmittedModelRunAuthority.ts
+++ b/src/server/aflTradeIntelligence/modeling/postgresAdmittedModelRunAuthority.ts
@@ -245,6 +245,11 @@ export class PostgresAflTradeAdmittedModelRunAuthority
     const operationalAuthorization = aflTradeModelRunOperationalAuthorizationSchema.parse(
       unparsed.operationalAuthorization
     );
+    const operationalAuthorityEvidenceId =
+      operationalAuthorization.content.authorityBoundary ===
+      'human_operational_authorization_for_one_exact_model_run_intent'
+        ? operationalAuthorization.content.authorityEvidence.id
+        : null;
     const runStartReceipts = unparsed.runStartEvaluationReceipts.map((receipt) =>
       aflTradeGate0AReceiptSchema.parse(receipt)
     );
@@ -278,7 +283,9 @@ export class PostgresAflTradeAdmittedModelRunAuthority
         `valuation-model-protocol:${protocol.protocolId}`,
         `valuation-model-intent:${intent.intentId}`,
         `valuation-model-operation:${operationalAuthorization.receiptId}`,
-        `operational-authority:${operationalAuthorization.content.authorityEvidence.id}`,
+        ...(operationalAuthorityEvidenceId === null
+          ? []
+          : [`operational-authority:${operationalAuthorityEvidenceId}`]),
       ]);
       const admissionResult = await transaction.query<AdmissionRow>(
         `SELECT admission.admission_json,admission.analytical_authority_receipt_id,
@@ -388,7 +395,7 @@ export class PostgresAflTradeAdmittedModelRunAuthority
           operationalAuthorization.content.authorizedAt,
           operationalAuthorization.content.validThrough,
           operationalAuthorization.content.principalRef,
-          operationalAuthorization.content.authorityEvidence.id,
+          operationalAuthorityEvidenceId,
           canonicalizeAflTradeJson(operationalAuthorization.content),
           canonicalizeAflTradeJson(operationalAuthorization),
         ],

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
@@ -636,7 +636,14 @@ export class PostgresGovernedValuationModelQualificationRepository {
   }
 
   async register(
-    input: QualificationRegistrationInput
+    input: QualificationRegistrationInput,
+    options?: Readonly<{
+      dispatchClaimFence?: Readonly<{
+        requestId: string;
+        claimId: string;
+        leaseTokenSha256: string;
+      }>;
+    }>
   ): Promise<GovernedValuationModelQualificationRegistrationResult> {
     const qualification = governedValuationModelQualificationSchema.parse(input.qualification);
     if (
@@ -654,13 +661,28 @@ export class PostgresGovernedValuationModelQualificationRepository {
       qualification,
       qualificationArtifact: input.qualificationArtifact,
     });
-    return this.dependencies.client.transaction((transaction) =>
-      registerQualificationWithinTransaction(
+    return this.dependencies.client.transaction(async (transaction) => {
+      if (options?.dispatchClaimFence !== undefined) {
+        const fence = options.dispatchClaimFence;
+        await transaction.query(
+          `SELECT set_config('statly.private_valuation_request_id',$1,true),
+                  set_config('statly.private_valuation_claim_id',$2,true),
+                  set_config('statly.private_valuation_lease_sha256',$3,true)`,
+          [fence.requestId, fence.claimId, fence.leaseTokenSha256]
+        );
+        await transaction.query('SET LOCAL ROLE afl_trade_private_evaluation_coordinator');
+        await transaction.query(
+          `SELECT load_outcome_private_valuation_dispatch_request_for_claim($1,$2,$3)`,
+          [fence.requestId, fence.claimId, fence.leaseTokenSha256]
+        );
+        await transaction.query('RESET ROLE');
+      }
+      return registerQualificationWithinTransaction(
         transaction,
         { ...input, qualification },
         nativeEvidence
-      )
-    );
+      );
+    });
   }
 
   loadCurrent(scopeKey: string): Promise<GovernedCurrentValuationModelPair | null> {

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
@@ -675,7 +675,7 @@ export class PostgresGovernedValuationModelQualificationRepository {
           `SELECT load_outcome_private_valuation_dispatch_request_for_claim($1,$2,$3)`,
           [fence.requestId, fence.claimId, fence.leaseTokenSha256]
         );
-        await transaction.query('RESET ROLE');
+        await transaction.query('SET LOCAL ROLE NONE');
       }
       const result = await registerQualificationWithinTransaction(
         transaction,

--- a/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
+++ b/src/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationModelQualificationRepository.ts
@@ -662,8 +662,8 @@ export class PostgresGovernedValuationModelQualificationRepository {
       qualificationArtifact: input.qualificationArtifact,
     });
     return this.dependencies.client.transaction(async (transaction) => {
-      if (options?.dispatchClaimFence !== undefined) {
-        const fence = options.dispatchClaimFence;
+      const fence = options?.dispatchClaimFence;
+      if (fence !== undefined) {
         await transaction.query(
           `SELECT set_config('statly.private_valuation_request_id',$1,true),
                   set_config('statly.private_valuation_claim_id',$2,true),
@@ -677,11 +677,57 @@ export class PostgresGovernedValuationModelQualificationRepository {
         );
         await transaction.query('RESET ROLE');
       }
-      return registerQualificationWithinTransaction(
+      const result = await registerQualificationWithinTransaction(
         transaction,
         { ...input, qualification },
         nativeEvidence
       );
+      if (fence !== undefined) {
+        await transaction.query('SET LOCAL ROLE afl_trade_private_evaluation_coordinator');
+        const bound = await transaction.query(
+          `UPDATE outcome_private_valuation_model_operation operation SET
+             qualification_id=coalesce(operation.qualification_id,$3),
+             qualification_outcome=coalesce(operation.qualification_outcome,$4),
+             qualification_claim_id=coalesce(operation.qualification_claim_id,$2),
+             qualification_bound_at=coalesce(
+               operation.qualification_bound_at,
+               date_trunc('milliseconds',clock_timestamp())
+             )
+           FROM outcome_private_valuation_model_request_binding binding
+           WHERE binding.request_id=$1
+             AND binding.claim_id=$2
+             AND binding.operation_id=operation.operation_id
+             AND operation.scope_key=$5
+             AND operation.player_run_id=$6
+             AND operation.pick_run_id=$7
+             AND operation.pair_accepted_at IS NOT NULL
+             AND (
+               operation.qualification_id IS NULL
+               OR (
+                 operation.qualification_id=$3
+                 AND operation.qualification_outcome=$4
+                 AND operation.qualification_claim_id=$2
+               )
+             )`,
+          [
+            fence.requestId,
+            fence.claimId,
+            qualification.qualificationId,
+            qualification.content.outcome,
+            qualification.content.scopeKey,
+            qualification.content.player.runId,
+            qualification.content.pick.runId,
+          ]
+        );
+        await transaction.query('RESET ROLE');
+        if (bound.rowCount !== 1) {
+          throw new GovernedValuationModelQualificationRepositoryError(
+            'INTEGRITY_MISMATCH',
+            'Dispatch-bound qualification did not bind to its exact accepted operation.'
+          );
+        }
+      }
+      return result;
     });
   }
 

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationModelPair.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateValuationModelPair.ts
@@ -1,0 +1,731 @@
+import { createHash } from 'node:crypto';
+
+import { z } from 'zod';
+
+import type { AflTradeArtifactRef } from '../artifacts/artifactReference';
+import { canonicalizeAflTradeJson } from '../artifacts/contentAddress';
+import type { AflTradeModelRunManifestV3 } from '../artifacts/modelRunManifest';
+import {
+  AflTradeAdmittedModelRunner,
+  createAflTradePrivateValuationModelRunOperationalAuthorization,
+} from '../modeling/admittedModelRunAuthority';
+import type { AflTradeModelRunPreparation } from '../modeling/postgresAdmittedModelRunAuthority';
+import {
+  createDispatchBoundGovernedAflTradePickPavModelExecution,
+  type GovernedAflTradePickPavModelExecution,
+} from '../modeling/governedPickPavModelExecution';
+import type { PostgresGovernedPickPavModelExecutionRepository } from '../modeling/postgresGovernedPickPavModelExecutionRepository';
+import { aflTradeFinalizedHpnPavCalculationSchema } from '../modeling/hpnPavCalculationService';
+import type {
+  AflOutcomeSqlClient,
+  AflOutcomeSqlTransaction,
+} from '../outcomes/postgresOutcomeReleaseRepository';
+import {
+  createAflTradePrivateValuationModelOperation,
+  createAflTradePrivateValuationModelPairCoordinator,
+  type AflTradePrivateValuationModelOperation,
+  type AflTradePrivateValuationModelOperationState,
+  type AflTradePrivateValuationModelPairExactInput,
+  type AflTradePrivateValuationModelPairRepository,
+} from './privateValuationModelPair';
+import {
+  parseAflTradePrivateValuationFactualOutput,
+  type AflTradePrivateValuationFactualOutput,
+} from './privateValuationFactualOutput';
+import type { AflTradePrivateValuationHpnPreparationResult } from './postgresPrivateValuationHpnPreparation';
+import {
+  createGovernedValuationComponentRunManifest,
+  type GovernedValuationComponentRunManifest,
+} from './internal/governedValuationComponentRunManifest';
+import {
+  createGovernedValuationModelQualification,
+  type GovernedValuationModelQualification,
+} from './internal/governedValuationModelQualification';
+import type { PostgresGovernedValuationComponentRunRepository } from './internal/postgresGovernedValuationComponentRunRepository';
+import type { PostgresGovernedValuationModelQualificationRepository } from './internal/postgresGovernedValuationModelQualificationRepository';
+
+const EXECUTION_DATABASE_ROLE = 'afl_trade_private_evaluation_coordinator';
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/u);
+
+interface OperationRow {
+  readonly operation_json: unknown;
+  readonly player_run_id: string | null;
+  readonly pick_run_id: string | null;
+  readonly pair_accepted_at: Date | string | null;
+  readonly qualification_id: string | null;
+  readonly qualification_outcome: 'qualified' | 'failed' | null;
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function operationForExactInput(
+  exactInput: AflTradePrivateValuationModelPairExactInput
+): AflTradePrivateValuationModelOperation {
+  return createAflTradePrivateValuationModelOperation({
+    scopeKey: exactInput.scopeKey,
+    ...exactInput.substantive,
+  });
+}
+
+async function loadState(
+  client: Pick<AflOutcomeSqlClient, 'query'>,
+  operationId: string,
+  attemptNumber: number
+): Promise<AflTradePrivateValuationModelOperationState> {
+  const result = await client.query<OperationRow>(
+    `SELECT operation_json,player_run_id,pick_run_id,pair_accepted_at,
+            qualification_id,qualification_outcome
+       FROM outcome_private_valuation_model_operation WHERE operation_id=$1`,
+    [operationId]
+  );
+  if (result.rows.length !== 1) {
+    throw new TypeError('Private valuation model operation was not retained exactly once.');
+  }
+  const row = result.rows[0]!;
+  return {
+    operation: row.operation_json as AflTradePrivateValuationModelOperation,
+    attemptNumber: z.number().int().min(1).max(3).parse(attemptNumber),
+    playerRunId: row.player_run_id,
+    pickRunId: row.pick_run_id,
+    pairAccepted: row.pair_accepted_at !== null,
+    qualificationId: row.qualification_id,
+    qualificationOutcome: row.qualification_outcome,
+  };
+}
+
+async function requireLiveOperationClaim(
+  transaction: AflOutcomeSqlTransaction,
+  input: { readonly operationId: string; readonly claimId: string; readonly leaseToken: string }
+): Promise<number> {
+  const result = await transaction.query<{
+    readonly request_id: string;
+    readonly attempt_number: number;
+  }>(
+    `SELECT binding.request_id,attempt.attempt_number
+       FROM outcome_private_valuation_model_request_binding binding
+       JOIN outcome_private_valuation_dispatch_request request
+         ON request.request_id=binding.request_id AND request.claim_id=$2
+       JOIN outcome_private_valuation_dispatch_attempt attempt
+         ON attempt.claim_id=request.claim_id AND attempt.finished_at IS NULL
+      WHERE binding.operation_id=$1
+      ORDER BY binding.request_id LIMIT 1`,
+    [input.operationId, input.claimId]
+  );
+  const row = result.rows[0];
+  if (row === undefined) throw new TypeError('Private valuation model operation lost its claim.');
+  await transaction.query(
+    `SELECT load_outcome_private_valuation_dispatch_request_for_claim($1,$2,$3)`,
+    [row.request_id, input.claimId, sha256(input.leaseToken)]
+  );
+  await transaction.query(`SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, [
+    `private-valuation-model-operation:${input.operationId}`,
+  ]);
+  return row.attempt_number;
+}
+
+export class PostgresAflTradePrivateValuationModelPairRepository implements AflTradePrivateValuationModelPairRepository {
+  constructor(private readonly client: AflOutcomeSqlClient) {}
+
+  async bindInput(input: {
+    readonly exactInput: AflTradePrivateValuationModelPairExactInput;
+    readonly claim: { readonly claimId: string; readonly leaseToken: string };
+  }): Promise<AflTradePrivateValuationModelOperationState> {
+    const operation = operationForExactInput(input.exactInput);
+    return this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      await transaction.query(
+        `SELECT load_outcome_private_valuation_dispatch_request_for_claim($1,$2,$3)`,
+        [input.exactInput.requestId, input.claim.claimId, sha256(input.claim.leaseToken)]
+      );
+      const attempt = await transaction.query<{ readonly attempt_number: number }>(
+        `SELECT attempt_number FROM outcome_private_valuation_dispatch_attempt
+          WHERE claim_id=$1 AND request_id=$2 AND finished_at IS NULL`,
+        [input.claim.claimId, input.exactInput.requestId]
+      );
+      const attemptNumber = attempt.rows[0]?.attempt_number;
+      if (attemptNumber === undefined) throw new TypeError('Dispatch attempt custody is missing.');
+      const content = operation.content;
+      await transaction.query(
+        `INSERT INTO outcome_private_valuation_model_operation
+          (operation_id,scope_key,factual_values_sha256,hpn_values_sha256,hpn_method_id,
+           player_model_id,player_model_version,player_protocol_id,player_dataset_id,
+           player_dataset_admission_id,pick_protocol_id,pick_dataset_id,
+           pick_dataset_admission_id,pick_policy_id,qualification_policy_id,
+           operation_canonical_json,operation_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17::jsonb)
+         ON CONFLICT (operation_id) DO NOTHING`,
+        [
+          operation.operationId,
+          content.scopeKey,
+          content.factualValuesSha256,
+          content.hpnValuesSha256,
+          content.hpnMethodId,
+          content.player.modelId,
+          content.player.modelVersion,
+          content.player.protocolId,
+          content.player.datasetId,
+          content.player.datasetAdmissionId,
+          content.pick.protocolId,
+          content.pick.datasetId,
+          content.pick.datasetAdmissionId,
+          content.pick.policyId,
+          content.qualificationPolicyId,
+          canonicalizeAflTradeJson(content),
+          canonicalizeAflTradeJson(operation),
+        ]
+      );
+      const retained = await transaction.query<{ readonly operation_json: unknown }>(
+        `SELECT operation_json FROM outcome_private_valuation_model_operation
+          WHERE operation_id=$1 FOR SHARE`,
+        [operation.operationId]
+      );
+      if (
+        canonicalizeAflTradeJson(retained.rows[0]?.operation_json) !==
+        canonicalizeAflTradeJson(operation)
+      ) {
+        throw new TypeError('Substantive model operation conflicts with retained custody.');
+      }
+      await transaction.query(
+        `INSERT INTO outcome_private_valuation_model_request_binding
+          (request_id,operation_id,factual_output_id,hpn_calculation_id,claim_id,attempt_number)
+         VALUES ($1,$2,$3,$4,$5,$6) ON CONFLICT (request_id) DO NOTHING`,
+        [
+          input.exactInput.requestId,
+          operation.operationId,
+          input.exactInput.factualOutputId,
+          input.exactInput.hpnCalculationId,
+          input.claim.claimId,
+          attemptNumber,
+        ]
+      );
+      const binding = await transaction.query<{
+        readonly operation_id: string;
+        readonly factual_output_id: string;
+        readonly hpn_calculation_id: string;
+      }>(
+        `SELECT operation_id,factual_output_id,hpn_calculation_id
+           FROM outcome_private_valuation_model_request_binding WHERE request_id=$1`,
+        [input.exactInput.requestId]
+      );
+      const row = binding.rows[0];
+      if (
+        row?.operation_id !== operation.operationId ||
+        row.factual_output_id !== input.exactInput.factualOutputId ||
+        row.hpn_calculation_id !== input.exactInput.hpnCalculationId
+      ) {
+        throw new TypeError('Dispatch model input conflicts with retained exact lineage.');
+      }
+      return loadState(transaction, operation.operationId, attemptNumber);
+    });
+  }
+
+  async acceptComponent(input: {
+    readonly operationId: string;
+    readonly role: 'player' | 'pick';
+    readonly runId: string;
+    readonly claim: { readonly claimId: string; readonly leaseToken: string };
+  }): Promise<AflTradePrivateValuationModelOperationState> {
+    return this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      const attemptNumber = await requireLiveOperationClaim(transaction, {
+        operationId: input.operationId,
+        claimId: input.claim.claimId,
+        leaseToken: input.claim.leaseToken,
+      });
+      const prefix = input.role === 'player' ? 'player' : 'pick';
+      await transaction.query(
+        `UPDATE outcome_private_valuation_model_operation SET
+           ${prefix}_run_id=coalesce(${prefix}_run_id,$2),
+           ${prefix}_claim_id=coalesce(${prefix}_claim_id,$3),
+           ${prefix}_attempt_number=coalesce(${prefix}_attempt_number,$4),
+           ${prefix}_accepted_at=coalesce(${prefix}_accepted_at,date_trunc('milliseconds',clock_timestamp()))
+         WHERE operation_id=$1`,
+        [input.operationId, input.runId, input.claim.claimId, attemptNumber]
+      );
+      return loadState(transaction, input.operationId, attemptNumber);
+    });
+  }
+
+  async acceptPair(input: {
+    readonly operationId: string;
+    readonly playerRunId: string;
+    readonly pickRunId: string;
+    readonly claim: { readonly claimId: string; readonly leaseToken: string };
+  }): Promise<AflTradePrivateValuationModelOperationState> {
+    return this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      const attemptNumber = await requireLiveOperationClaim(transaction, {
+        operationId: input.operationId,
+        claimId: input.claim.claimId,
+        leaseToken: input.claim.leaseToken,
+      });
+      await transaction.query(
+        `UPDATE outcome_private_valuation_model_operation SET
+           pair_accepted_at=coalesce(pair_accepted_at,date_trunc('milliseconds',clock_timestamp()))
+         WHERE operation_id=$1 AND player_run_id=$2 AND pick_run_id=$3`,
+        [input.operationId, input.playerRunId, input.pickRunId]
+      );
+      return loadState(transaction, input.operationId, attemptNumber);
+    });
+  }
+
+  async bindQualification(input: {
+    readonly operationId: string;
+    readonly qualificationId: string;
+    readonly outcome: 'qualified' | 'failed';
+    readonly claim: { readonly claimId: string; readonly leaseToken: string };
+  }): Promise<AflTradePrivateValuationModelOperationState> {
+    return this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      const attemptNumber = await requireLiveOperationClaim(transaction, {
+        operationId: input.operationId,
+        claimId: input.claim.claimId,
+        leaseToken: input.claim.leaseToken,
+      });
+      await transaction.query(
+        `UPDATE outcome_private_valuation_model_operation SET
+           qualification_id=coalesce(qualification_id,$2),
+           qualification_outcome=coalesce(qualification_outcome,$3),
+           qualification_claim_id=coalesce(qualification_claim_id,$4),
+           qualification_bound_at=coalesce(qualification_bound_at,date_trunc('milliseconds',clock_timestamp()))
+         WHERE operation_id=$1 AND pair_accepted_at IS NOT NULL`,
+        [input.operationId, input.qualificationId, input.outcome, input.claim.claimId]
+      );
+      return loadState(transaction, input.operationId, attemptNumber);
+    });
+  }
+}
+
+export async function loadAflTradePrivateValuationModelPairExactInput(input: {
+  readonly client: AflOutcomeSqlClient;
+  readonly prepared: AflTradePrivateValuationHpnPreparationResult;
+  readonly targets: {
+    readonly player: {
+      readonly modelId: string;
+      readonly modelVersion: string;
+      readonly protocolId: string;
+      readonly datasetId: string;
+      readonly datasetAdmissionId: string;
+    };
+    readonly pick: {
+      readonly protocolId: string;
+      readonly datasetId: string;
+      readonly datasetAdmissionId: string;
+      readonly policyId: string;
+    };
+    readonly qualificationPolicyId: string;
+  };
+}): Promise<AflTradePrivateValuationModelPairExactInput> {
+  const result = await input.client.query<{
+    readonly scope_key: string;
+    readonly output_json: unknown;
+    readonly calculation_json: unknown;
+    readonly hpn_values_sha256: string;
+  }>(
+    `SELECT request.scope_key,factual.output_json,calculation.calculation_json,
+            outcome_private_valuation_hpn_substantive_sha256(
+              calculation.calculation_json
+            ) AS hpn_values_sha256
+       FROM outcome_private_valuation_factual_output factual
+       JOIN outcome_private_valuation_dispatch_request request
+         ON request.request_id=factual.request_id
+       JOIN outcome_hpn_pav_calculation calculation
+         ON calculation.calculation_id=$3 AND calculation.status='finalized'
+      WHERE factual.request_id=$1 AND factual.output_id=$2
+        AND calculation.calculation_json->'content'->>'factualRunId'=factual.factual_run_id`,
+    [input.prepared.requestId, input.prepared.factualOutputId, input.prepared.calculationId]
+  );
+  if (result.rows.length !== 1) {
+    throw new TypeError('Exact private factual and HPN model input is unavailable.');
+  }
+  const row = result.rows[0]!;
+  const factual: AflTradePrivateValuationFactualOutput = parseAflTradePrivateValuationFactualOutput(
+    row.output_json
+  );
+  const calculation = aflTradeFinalizedHpnPavCalculationSchema.parse(row.calculation_json);
+  const hpnValuesSha256 = sha256Schema.parse(row.hpn_values_sha256);
+  return {
+    requestId: input.prepared.requestId,
+    scopeKey: row.scope_key,
+    factualOutputId: factual.outputId,
+    hpnCalculationId: calculation.calculationId,
+    substantive: {
+      factualValuesSha256: factual.content.candidate.memberSetSha256,
+      hpnValuesSha256,
+      hpnMethodId: calculation.content.methodId,
+      player: input.targets.player,
+      pick: input.targets.pick,
+      qualificationPolicyId: input.targets.qualificationPolicyId,
+    },
+  };
+}
+
+export function createPostgresAflTradePrivateValuationModelPairCoordinator(input: {
+  readonly client: AflOutcomeSqlClient;
+  readonly hpnPreparation: {
+    prepare(value: {
+      readonly requestId: string;
+      readonly claim: { readonly claimId: string; readonly leaseToken: string };
+    }): Promise<AflTradePrivateValuationHpnPreparationResult>;
+  };
+  readonly targets: Parameters<
+    typeof loadAflTradePrivateValuationModelPairExactInput
+  >[0]['targets'];
+  readonly playerExecutor: Readonly<{
+    execute: Parameters<
+      typeof createAflTradePrivateValuationModelPairCoordinator
+    >[0]['executePlayer'];
+  }>;
+  readonly pickExecutor: Readonly<{
+    execute: Parameters<
+      typeof createAflTradePrivateValuationModelPairCoordinator
+    >[0]['executePick'];
+  }>;
+  readonly qualificationRegistrar: Readonly<{
+    register: Parameters<typeof createAflTradePrivateValuationModelPairCoordinator>[0]['qualify'];
+  }>;
+}) {
+  return createAflTradePrivateValuationModelPairCoordinator({
+    repository: new PostgresAflTradePrivateValuationModelPairRepository(input.client),
+    prepareExactInput: async (request) =>
+      loadAflTradePrivateValuationModelPairExactInput({
+        client: input.client,
+        prepared: await input.hpnPreparation.prepare(request),
+        targets: input.targets,
+      }),
+    executePlayer: (request) => input.playerExecutor.execute(request),
+    executePick: (request) => input.pickExecutor.execute(request),
+    qualify: (request) => input.qualificationRegistrar.register(request),
+  });
+}
+
+export function createPostgresAflTradePrivateValuationModelPairDispatchRunner(
+  input: Parameters<typeof createPostgresAflTradePrivateValuationModelPairCoordinator>[0] & {
+    readonly repairCurrent: (
+      scopeKey: string,
+      reason: string,
+      repairOperationId: string
+    ) => Promise<unknown>;
+  }
+) {
+  const coordinator = createPostgresAflTradePrivateValuationModelPairCoordinator(input);
+  return {
+    async run(value: {
+      readonly request: { readonly requestId: string };
+      readonly claim: { readonly claimId: string; readonly leaseToken: string };
+    }) {
+      const result = await coordinator.prepare({
+        requestId: value.request.requestId,
+        claim: value.claim,
+      });
+      switch (result.state) {
+        case 'qualified':
+          return { ...result, state: 'activated' as const };
+        case 'already_qualified':
+          return { state: 'already_current' as const };
+        case 'qualification_failed':
+        case 'deterministic_failure':
+          return { ...result, state: 'unexpected_failure' as const };
+        default:
+          return result;
+      }
+    },
+    repairCurrent: input.repairCurrent,
+  };
+}
+
+type PlayerExecutorInput = Parameters<
+  typeof createAflTradePrivateValuationModelPairCoordinator
+>[0]['executePlayer'] extends (input: infer Input) => unknown
+  ? Input
+  : never;
+
+type PlayerPreparation = Omit<AflTradeModelRunPreparation, 'operationalAuthorization'> &
+  Readonly<{ validThrough: string }>;
+
+const STALE_PLAYER_AUTHORITY_CODES = new Set([
+  'ancestry_mismatch',
+  'observation_set_mismatch',
+  'gate2_not_current',
+  'rights_not_current',
+  'operational_authorization_invalid',
+]);
+const TRANSIENT_PLAYER_AUTHORITY_CODES = new Set([
+  'evidence_unavailable',
+  'authorization_unavailable',
+  'authorization_not_consumable',
+  'execution_failure_unrecorded',
+  'run_persistence_failed',
+]);
+const STALE_DISPATCH_ADAPTER_ERROR_CODES = new Set(['STALE_GATE_LEDGER', 'STALE_CURRENT_PAIR']);
+const TRANSIENT_DISPATCH_ADAPTER_ERROR_CODES = new Set([
+  'STORAGE_UNAVAILABLE',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  '40001',
+  '40P01',
+  '57P01',
+]);
+
+function classifiedDispatchAdapterFailure(error: unknown) {
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error ? String(error.code) : null;
+  const reason = error instanceof Error ? error.message : 'Private model adapter failed.';
+  if (code !== null && STALE_DISPATCH_ADAPTER_ERROR_CODES.has(code)) {
+    return { state: 'stale_authority' as const, reason };
+  }
+  if (
+    code !== null &&
+    (TRANSIENT_DISPATCH_ADAPTER_ERROR_CODES.has(code) || code.startsWith('08'))
+  ) {
+    return { state: 'transient_failure' as const, reason };
+  }
+  return { state: 'deterministic_failure' as const, reason };
+}
+
+export function createAflTradeDispatchBoundAdmittedPlayerExecutor(input: {
+  readonly admittedRunner: Pick<AflTradeAdmittedModelRunner, 'run'>;
+  readonly authorityPreparation: Readonly<{
+    prepare(value: AflTradeModelRunPreparation): Promise<void>;
+  }>;
+  readonly prepareRun: (value: PlayerExecutorInput) => Promise<PlayerPreparation>;
+  readonly registerComponent: (value: {
+    readonly run: AflTradeModelRunManifestV3;
+    readonly execution: PlayerExecutorInput;
+  }) => Promise<{ readonly runId: string }>;
+}) {
+  return {
+    async execute(execution: PlayerExecutorInput) {
+      try {
+        const prepared = await input.prepareRun(execution);
+        const intent = prepared.intent;
+        const operationalAuthorization =
+          createAflTradePrivateValuationModelRunOperationalAuthorization({
+            runIntentId: intent.intentId,
+            datasetId: intent.content.datasetId,
+            datasetAdmissionId: intent.content.datasetAdmissionId,
+            modelProtocolId: intent.content.modelProtocolId,
+            observationSetId: intent.content.observationSetId,
+            dispatchRequestId: execution.exactInput.requestId,
+            substantiveOperationId: execution.operation.operationId,
+            dispatchClaimId: execution.claim.claimId,
+            dispatchAttemptNumber: execution.attemptNumber,
+            dispatchLeaseTokenSha256: sha256(execution.claim.leaseToken),
+            factualOutputId: execution.exactInput.factualOutputId,
+            hpnCalculationId: execution.exactInput.hpnCalculationId,
+            factualValuesSha256: execution.exactInput.substantive.factualValuesSha256,
+            hpnValuesSha256: execution.exactInput.substantive.hpnValuesSha256,
+            authorizedAt: intent.content.startedAt,
+            validThrough: prepared.validThrough,
+          });
+        await input.authorityPreparation.prepare({
+          protocol: prepared.protocol,
+          observationSet: prepared.observationSet,
+          intent,
+          operationalAuthorization,
+          runStartEvaluationReceipts: prepared.runStartEvaluationReceipts,
+        });
+        const result = await input.admittedRunner.run({ intent, protocol: prepared.protocol });
+        if (result.status === 'completed') {
+          const retained = await input.registerComponent({ run: result.run, execution });
+          return { state: 'completed' as const, runId: retained.runId };
+        }
+        if (result.status === 'persistence_failed') {
+          return {
+            state: 'transient_failure' as const,
+            reason: result.blockers[0].message,
+          };
+        }
+        const blocker = result.blockers[0];
+        if (blocker === undefined) {
+          return { state: 'deterministic_failure' as const, reason: 'Player run was blocked.' };
+        }
+        if (STALE_PLAYER_AUTHORITY_CODES.has(blocker.code)) {
+          return { state: 'stale_authority' as const, reason: blocker.message };
+        }
+        if (TRANSIENT_PLAYER_AUTHORITY_CODES.has(blocker.code)) {
+          return { state: 'transient_failure' as const, reason: blocker.message };
+        }
+        return { state: 'deterministic_failure' as const, reason: blocker.message };
+      } catch (error) {
+        return classifiedDispatchAdapterFailure(error);
+      }
+    },
+  };
+}
+
+type PickExecutorInput = Parameters<
+  typeof createAflTradePrivateValuationModelPairCoordinator
+>[0]['executePick'] extends (input: infer Input) => unknown
+  ? Input
+  : never;
+
+type DispatchBoundPickPreparation = Omit<
+  Parameters<typeof createDispatchBoundGovernedAflTradePickPavModelExecution>[0],
+  'privateInput'
+> &
+  Readonly<{ registeredAt: string }>;
+
+type RetainCanonicalArtifact = (input: {
+  readonly document:
+    | GovernedAflTradePickPavModelExecution
+    | GovernedValuationComponentRunManifest
+    | GovernedValuationModelQualification;
+  readonly createdAt: string;
+}) => Promise<AflTradeArtifactRef>;
+
+export function createAflTradeDispatchBoundGovernedPickExecutor(input: {
+  readonly runModel: (execution: PickExecutorInput) => Promise<DispatchBoundPickPreparation>;
+  readonly retainArtifact: RetainCanonicalArtifact;
+  readonly executionRepository: Pick<PostgresGovernedPickPavModelExecutionRepository, 'register'>;
+  readonly componentRepository: Pick<PostgresGovernedValuationComponentRunRepository, 'register'>;
+}) {
+  return {
+    async execute(execution: PickExecutorInput) {
+      try {
+        const prepared = await input.runModel(execution);
+        const governedExecution = createDispatchBoundGovernedAflTradePickPavModelExecution({
+          outputs: prepared.outputs,
+          completedAt: prepared.completedAt,
+          authority: prepared.authority,
+          privateInput: {
+            requestId: execution.exactInput.requestId,
+            operationId: execution.operation.operationId,
+            claimId: execution.claim.claimId,
+            attemptNumber: execution.attemptNumber,
+            leaseTokenSha256: sha256(execution.claim.leaseToken),
+            factualOutputId: execution.exactInput.factualOutputId,
+            hpnCalculationId: execution.exactInput.hpnCalculationId,
+            factualValuesSha256: execution.exactInput.substantive.factualValuesSha256,
+            hpnValuesSha256: execution.exactInput.substantive.hpnValuesSha256,
+          },
+        });
+        if (
+          governedExecution.content.policyId !== execution.operation.content.pick.policyId ||
+          governedExecution.content.protocolId !== execution.operation.content.pick.protocolId ||
+          governedExecution.content.datasetId !== execution.operation.content.pick.datasetId ||
+          governedExecution.content.datasetAdmissionId !==
+            execution.operation.content.pick.datasetAdmissionId
+        ) {
+          return {
+            state: 'deterministic_failure' as const,
+            reason: 'Pick execution does not match the substantive operation target.',
+          };
+        }
+        const executionArtifact = await input.retainArtifact({
+          document: governedExecution,
+          createdAt: prepared.completedAt,
+        });
+        const retainedExecution = await input.executionRepository.register({
+          execution: governedExecution,
+          artifact: executionArtifact,
+        });
+        const content = retainedExecution.execution.content;
+        const manifest = createGovernedValuationComponentRunManifest({
+          environment: 'non_production',
+          role: 'draft_pick_and_future_pick_distribution',
+          nativeExecution: {
+            kind: 'governed_pick_pav_model_execution',
+            executionId: retainedExecution.execution.executionId,
+            artifact: retainedExecution.artifact,
+          },
+          protocolId: content.protocolId,
+          protocolArtifact: content.protocolArtifact,
+          datasetId: content.datasetId,
+          datasetArtifact: content.datasetArtifact,
+          datasetAdmissionId: content.datasetAdmissionId,
+          datasetAdmissionArtifact: content.datasetAdmissionArtifact,
+          datasetAdmissionGateLedgerRevision: content.datasetAdmissionGateLedgerRevision,
+          registeredAt: prepared.registeredAt,
+        });
+        const manifestArtifact = await input.retainArtifact({
+          document: manifest,
+          createdAt: prepared.registeredAt,
+        });
+        const retainedComponent = await input.componentRepository.register({
+          manifest,
+          artifact: manifestArtifact,
+        });
+        return { state: 'completed' as const, runId: retainedComponent.manifest.runId };
+      } catch (error) {
+        return classifiedDispatchAdapterFailure(error);
+      }
+    },
+  };
+}
+
+type QualificationExecutorInput = Parameters<
+  typeof createAflTradePrivateValuationModelPairCoordinator
+>[0]['qualify'] extends (input: infer Input) => unknown
+  ? Input
+  : never;
+type QualificationInput = Parameters<typeof createGovernedValuationModelQualification>[0];
+type QualificationRegistration = Parameters<
+  PostgresGovernedValuationModelQualificationRepository['register']
+>[0];
+
+export function createAflTradeDispatchBoundQualificationRegistrar(input: {
+  readonly prepareQualification: (
+    execution: QualificationExecutorInput
+  ) => Promise<QualificationInput>;
+  readonly retainArtifact: RetainCanonicalArtifact;
+  readonly prepareRegistration: (input: {
+    readonly execution: QualificationExecutorInput;
+    readonly qualification: GovernedValuationModelQualification;
+    readonly qualificationArtifact: AflTradeArtifactRef;
+  }) => Promise<Omit<QualificationRegistration, 'qualification' | 'qualificationArtifact'>>;
+  readonly repository: Pick<PostgresGovernedValuationModelQualificationRepository, 'register'>;
+}) {
+  return {
+    async register(execution: QualificationExecutorInput) {
+      try {
+        const prepared = await input.prepareQualification(execution);
+        if (
+          prepared.scopeKey !== execution.operation.content.scopeKey ||
+          prepared.policy.policyVersion !== execution.operation.content.qualificationPolicyId ||
+          prepared.components.player.runId !== execution.playerRunId ||
+          prepared.components.pick.runId !== execution.pickRunId
+        ) {
+          throw new TypeError(
+            'Qualification input does not match the accepted dispatch-bound pair and policy.'
+          );
+        }
+        const qualification = createGovernedValuationModelQualification(prepared);
+        const qualificationArtifact = await input.retainArtifact({
+          document: qualification,
+          createdAt: qualification.content.evaluatedAt,
+        });
+        const registration = await input.prepareRegistration({
+          execution,
+          qualification,
+          qualificationArtifact,
+        });
+        await input.repository.register(
+          {
+            qualification,
+            qualificationArtifact,
+            ...registration,
+          },
+          {
+            dispatchClaimFence: {
+              requestId: execution.exactInput.requestId,
+              claimId: execution.claim.claimId,
+              leaseTokenSha256: sha256(execution.claim.leaseToken),
+            },
+          }
+        );
+        return {
+          qualificationId: qualification.qualificationId,
+          outcome: qualification.content.outcome,
+        };
+      } catch (error) {
+        return classifiedDispatchAdapterFailure(error);
+      }
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/privateValuationModelPair.ts
+++ b/src/server/aflTradeIntelligence/valuation/privateValuationModelPair.ts
@@ -181,6 +181,31 @@ function parseState(
   };
 }
 
+function requireExactAcceptedPair(
+  state: AflTradePrivateValuationModelOperationState,
+  playerRunId: string,
+  pickRunId: string
+): void {
+  if (!state.pairAccepted || state.playerRunId !== playerRunId || state.pickRunId !== pickRunId) {
+    throw new TypeError('Private valuation pair was not accepted with the exact retained runs.');
+  }
+}
+
+function requireExactBoundQualification(
+  state: AflTradePrivateValuationModelOperationState,
+  qualification: Readonly<{ qualificationId: string; outcome: 'qualified' | 'failed' }>
+): string {
+  if (
+    state.qualificationId !== qualification.qualificationId ||
+    state.qualificationOutcome !== qualification.outcome
+  ) {
+    throw new TypeError(
+      'Private valuation qualification was not bound to the accepted pair exactly once.'
+    );
+  }
+  return state.qualificationId;
+}
+
 export function createAflTradePrivateValuationModelPairCoordinator(dependencies: {
   readonly prepareExactInput: (input: {
     readonly requestId: string;
@@ -278,15 +303,7 @@ export function createAflTradePrivateValuationModelPairCoordinator(dependencies:
           })
         );
       }
-      if (
-        !state.pairAccepted ||
-        state.playerRunId !== playerRunId ||
-        state.pickRunId !== pickRunId
-      ) {
-        throw new TypeError(
-          'Private valuation pair was not accepted with the exact retained runs.'
-        );
-      }
+      requireExactAcceptedPair(state, playerRunId, pickRunId);
       const qualificationExecution = await dependencies.qualify({
         exactInput,
         operation: state.operation,
@@ -317,14 +334,7 @@ export function createAflTradePrivateValuationModelPairCoordinator(dependencies:
           claim,
         })
       );
-      if (
-        state.qualificationId !== qualification.qualificationId ||
-        state.qualificationOutcome !== qualification.outcome
-      ) {
-        throw new TypeError(
-          'Private valuation qualification was not bound to the accepted pair exactly once.'
-        );
-      }
+      const qualificationId = requireExactBoundQualification(state, qualification);
       return {
         state:
           state.qualificationOutcome === 'qualified'
@@ -332,7 +342,7 @@ export function createAflTradePrivateValuationModelPairCoordinator(dependencies:
             : ('qualification_failed' as const),
         operationId,
         attemptNumber: state.attemptNumber,
-        qualificationId: state.qualificationId,
+        qualificationId,
       };
     },
   };

--- a/src/server/aflTradeIntelligence/valuation/privateValuationModelPair.ts
+++ b/src/server/aflTradeIntelligence/valuation/privateValuationModelPair.ts
@@ -278,6 +278,15 @@ export function createAflTradePrivateValuationModelPairCoordinator(dependencies:
           })
         );
       }
+      if (
+        !state.pairAccepted ||
+        state.playerRunId !== playerRunId ||
+        state.pickRunId !== pickRunId
+      ) {
+        throw new TypeError(
+          'Private valuation pair was not accepted with the exact retained runs.'
+        );
+      }
       const qualificationExecution = await dependencies.qualify({
         exactInput,
         operation: state.operation,
@@ -308,6 +317,14 @@ export function createAflTradePrivateValuationModelPairCoordinator(dependencies:
           claim,
         })
       );
+      if (
+        state.qualificationId !== qualification.qualificationId ||
+        state.qualificationOutcome !== qualification.outcome
+      ) {
+        throw new TypeError(
+          'Private valuation qualification was not bound to the accepted pair exactly once.'
+        );
+      }
       return {
         state:
           state.qualificationOutcome === 'qualified'
@@ -315,7 +332,7 @@ export function createAflTradePrivateValuationModelPairCoordinator(dependencies:
             : ('qualification_failed' as const),
         operationId,
         attemptNumber: state.attemptNumber,
-        qualificationId: state.qualificationId!,
+        qualificationId: state.qualificationId,
       };
     },
   };

--- a/src/server/aflTradeIntelligence/valuation/privateValuationModelPair.ts
+++ b/src/server/aflTradeIntelligence/valuation/privateValuationModelPair.ts
@@ -1,0 +1,322 @@
+import { z } from 'zod';
+
+import {
+  addAflTradeContentAddressIssue,
+  aflTradeContentAddressedIdSchema,
+  aflTradeSha256Schema,
+  createAflTradeContentAddress,
+} from '../artifacts/contentAddress';
+
+const boundedIdSchema = z.string().trim().min(1).max(400);
+const claimSchema = z
+  .object({
+    claimId: aflTradeContentAddressedIdSchema('private-valuation-dispatch-claim'),
+    leaseToken: aflTradeSha256Schema,
+  })
+  .strict();
+const modelTargetSchema = z
+  .object({
+    modelId: boundedIdSchema,
+    modelVersion: boundedIdSchema,
+    protocolId: aflTradeContentAddressedIdSchema('model-protocol'),
+    datasetId: aflTradeContentAddressedIdSchema('dataset'),
+    datasetAdmissionId: aflTradeContentAddressedIdSchema('dataset-admission'),
+  })
+  .strict();
+const pickModelTargetSchema = modelTargetSchema
+  .omit({ modelId: true, modelVersion: true })
+  .extend({ policyId: aflTradeContentAddressedIdSchema('pick-pav-policy') })
+  .strict();
+
+export const aflTradePrivateValuationModelOperationContentSchema = z
+  .object({
+    schemaVersion: z.literal('afl-trade-private-valuation-model-operation/v1'),
+    scopeKey: boundedIdSchema,
+    factualValuesSha256: aflTradeSha256Schema,
+    hpnValuesSha256: aflTradeSha256Schema,
+    hpnMethodId: aflTradeContentAddressedIdSchema('hpn-pav-method'),
+    player: modelTargetSchema,
+    pick: pickModelTargetSchema,
+    qualificationPolicyId: aflTradeContentAddressedIdSchema('model-qualification-policy'),
+  })
+  .strict();
+
+export const aflTradePrivateValuationModelOperationSchema = z
+  .object({
+    operationId: aflTradeContentAddressedIdSchema('private-valuation-model-operation'),
+    content: aflTradePrivateValuationModelOperationContentSchema,
+  })
+  .strict()
+  .superRefine((operation, context) => {
+    addAflTradeContentAddressIssue(
+      'private-valuation-model-operation',
+      operation.operationId,
+      operation.content,
+      context,
+      ['operationId']
+    );
+  });
+
+export type AflTradePrivateValuationModelOperation = z.infer<
+  typeof aflTradePrivateValuationModelOperationSchema
+>;
+
+export function createAflTradePrivateValuationModelOperation(
+  input: Omit<z.input<typeof aflTradePrivateValuationModelOperationContentSchema>, 'schemaVersion'>
+): AflTradePrivateValuationModelOperation {
+  const content = aflTradePrivateValuationModelOperationContentSchema.parse({
+    schemaVersion: 'afl-trade-private-valuation-model-operation/v1',
+    ...input,
+  });
+  return aflTradePrivateValuationModelOperationSchema.parse({
+    operationId: createAflTradeContentAddress('private-valuation-model-operation', content),
+    content,
+  });
+}
+
+const substantiveInputSchema = aflTradePrivateValuationModelOperationContentSchema.omit({
+  schemaVersion: true,
+  scopeKey: true,
+});
+
+export const aflTradePrivateValuationModelPairExactInputSchema = z
+  .object({
+    requestId: aflTradeContentAddressedIdSchema('private-valuation-dispatch'),
+    scopeKey: boundedIdSchema,
+    factualOutputId: aflTradeContentAddressedIdSchema('private-valuation-factual-output'),
+    hpnCalculationId: aflTradeContentAddressedIdSchema('hpn-pav-season'),
+    substantive: substantiveInputSchema,
+  })
+  .strict();
+
+export type AflTradePrivateValuationModelPairExactInput = z.infer<
+  typeof aflTradePrivateValuationModelPairExactInputSchema
+>;
+
+export interface AflTradePrivateValuationModelOperationState {
+  readonly operation: AflTradePrivateValuationModelOperation;
+  readonly attemptNumber: number;
+  readonly playerRunId: string | null;
+  readonly pickRunId: string | null;
+  readonly pairAccepted: boolean;
+  readonly qualificationId: string | null;
+  readonly qualificationOutcome: 'qualified' | 'failed' | null;
+}
+
+type Claim = z.infer<typeof claimSchema>;
+
+export interface AflTradePrivateValuationModelPairRepository {
+  bindInput(input: {
+    readonly exactInput: AflTradePrivateValuationModelPairExactInput;
+    readonly claim: Claim;
+  }): Promise<AflTradePrivateValuationModelOperationState>;
+  acceptComponent(input: {
+    readonly operationId: string;
+    readonly role: 'player' | 'pick';
+    readonly runId: string;
+    readonly claim: Claim;
+  }): Promise<AflTradePrivateValuationModelOperationState>;
+  acceptPair(input: {
+    readonly operationId: string;
+    readonly playerRunId: string;
+    readonly pickRunId: string;
+    readonly claim: Claim;
+  }): Promise<AflTradePrivateValuationModelOperationState>;
+  bindQualification(input: {
+    readonly operationId: string;
+    readonly qualificationId: string;
+    readonly outcome: 'qualified' | 'failed';
+    readonly claim: Claim;
+  }): Promise<AflTradePrivateValuationModelOperationState>;
+}
+
+type ComponentExecutionResult =
+  | Readonly<{ state: 'completed'; runId: string }>
+  | Readonly<{
+      state: 'transient_failure' | 'deterministic_failure' | 'stale_authority';
+      reason: string;
+    }>;
+type QualificationExecutionResult =
+  | Readonly<{
+      qualificationId: string;
+      outcome: 'qualified' | 'failed';
+    }>
+  | Readonly<{
+      state: 'transient_failure' | 'deterministic_failure' | 'stale_authority';
+      reason: string;
+    }>;
+
+function parseState(
+  state: AflTradePrivateValuationModelOperationState
+): AflTradePrivateValuationModelOperationState {
+  const operation = aflTradePrivateValuationModelOperationSchema.parse(state.operation);
+  const attemptNumber = z.number().int().min(1).max(3).parse(state.attemptNumber);
+  const playerRunId = z
+    .union([aflTradeContentAddressedIdSchema('model-run'), z.null()])
+    .parse(state.playerRunId);
+  const pickRunId = z
+    .union([aflTradeContentAddressedIdSchema('model-run'), z.null()])
+    .parse(state.pickRunId);
+  const qualificationId = z
+    .union([aflTradeContentAddressedIdSchema('model-qualification'), z.null()])
+    .parse(state.qualificationId);
+  const qualificationOutcome = z
+    .union([z.enum(['qualified', 'failed']), z.null()])
+    .parse(state.qualificationOutcome);
+  if (
+    (state.pairAccepted && (playerRunId === null || pickRunId === null)) ||
+    (qualificationId === null) !== (qualificationOutcome === null) ||
+    (qualificationId !== null && !state.pairAccepted)
+  ) {
+    throw new TypeError('Private valuation model-pair custody is inconsistent.');
+  }
+  return {
+    operation,
+    attemptNumber,
+    playerRunId,
+    pickRunId,
+    pairAccepted: state.pairAccepted,
+    qualificationId,
+    qualificationOutcome,
+  };
+}
+
+export function createAflTradePrivateValuationModelPairCoordinator(dependencies: {
+  readonly prepareExactInput: (input: {
+    readonly requestId: string;
+    readonly claim: Claim;
+  }) => Promise<AflTradePrivateValuationModelPairExactInput>;
+  readonly repository: AflTradePrivateValuationModelPairRepository;
+  readonly executePlayer: (input: {
+    readonly exactInput: AflTradePrivateValuationModelPairExactInput;
+    readonly operation: AflTradePrivateValuationModelOperation;
+    readonly attemptNumber: number;
+    readonly claim: Claim;
+  }) => Promise<ComponentExecutionResult>;
+  readonly executePick: (input: {
+    readonly exactInput: AflTradePrivateValuationModelPairExactInput;
+    readonly operation: AflTradePrivateValuationModelOperation;
+    readonly attemptNumber: number;
+    readonly claim: Claim;
+  }) => Promise<ComponentExecutionResult>;
+  readonly qualify: (input: {
+    readonly exactInput: AflTradePrivateValuationModelPairExactInput;
+    readonly operation: AflTradePrivateValuationModelOperation;
+    readonly playerRunId: string;
+    readonly pickRunId: string;
+    readonly claim: Claim;
+  }) => Promise<QualificationExecutionResult>;
+}) {
+  return {
+    async prepare(input: { readonly requestId: string; readonly claim: Claim }) {
+      const requestId = aflTradeContentAddressedIdSchema('private-valuation-dispatch').parse(
+        input.requestId
+      );
+      const claim = claimSchema.parse(input.claim);
+      const exactInput = aflTradePrivateValuationModelPairExactInputSchema.parse(
+        await dependencies.prepareExactInput({ requestId, claim })
+      );
+      if (exactInput.requestId !== requestId) {
+        throw new TypeError('Private model input belongs to another dispatch request.');
+      }
+      let state = parseState(await dependencies.repository.bindInput({ exactInput, claim }));
+      const operationId = state.operation.operationId;
+      if (state.qualificationId !== null) {
+        return {
+          state:
+            state.qualificationOutcome === 'qualified'
+              ? ('already_qualified' as const)
+              : ('qualification_failed' as const),
+          operationId,
+          attemptNumber: state.attemptNumber,
+          qualificationId: state.qualificationId,
+        };
+      }
+
+      for (const role of ['player', 'pick'] as const) {
+        const retainedRunId = role === 'player' ? state.playerRunId : state.pickRunId;
+        if (retainedRunId !== null) continue;
+        const execution = await (
+          role === 'player' ? dependencies.executePlayer : dependencies.executePick
+        )({
+          exactInput,
+          operation: state.operation,
+          attemptNumber: state.attemptNumber,
+          claim,
+        });
+        if (execution.state !== 'completed') {
+          return {
+            state: execution.state,
+            operationId,
+            attemptNumber: state.attemptNumber,
+            reason: execution.reason,
+          };
+        }
+        const runId = aflTradeContentAddressedIdSchema('model-run').parse(execution.runId);
+        state = parseState(
+          await dependencies.repository.acceptComponent({
+            operationId,
+            role,
+            runId,
+            claim,
+          })
+        );
+      }
+
+      if (state.playerRunId === null || state.pickRunId === null) {
+        throw new TypeError('Private valuation pair is missing a retained component.');
+      }
+      const playerRunId = state.playerRunId;
+      const pickRunId = state.pickRunId;
+      if (!state.pairAccepted) {
+        state = parseState(
+          await dependencies.repository.acceptPair({
+            operationId,
+            playerRunId,
+            pickRunId,
+            claim,
+          })
+        );
+      }
+      const qualificationExecution = await dependencies.qualify({
+        exactInput,
+        operation: state.operation,
+        playerRunId,
+        pickRunId,
+        claim,
+      });
+      if ('state' in qualificationExecution) {
+        return {
+          state: qualificationExecution.state,
+          operationId,
+          attemptNumber: state.attemptNumber,
+          reason: qualificationExecution.reason,
+        };
+      }
+      const qualification = z
+        .object({
+          qualificationId: aflTradeContentAddressedIdSchema('model-qualification'),
+          outcome: z.enum(['qualified', 'failed']),
+        })
+        .strict()
+        .parse(qualificationExecution);
+      state = parseState(
+        await dependencies.repository.bindQualification({
+          operationId,
+          qualificationId: qualification.qualificationId,
+          outcome: qualification.outcome,
+          claim,
+        })
+      );
+      return {
+        state:
+          state.qualificationOutcome === 'qualified'
+            ? ('qualified' as const)
+            : ('qualification_failed' as const),
+        operationId,
+        attemptNumber: state.attemptNumber,
+        qualificationId: state.qualificationId!,
+      };
+    },
+  };
+}

--- a/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
+++ b/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
@@ -20,6 +20,7 @@ import { aflTradePlayerValidationReportSchema } from '@/server/aflTradeIntellige
 import { createGovernedValuationComponentRunManifest } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationComponentRunManifest';
 import { loadGovernedNativeComponentValidationReport } from '@/server/aflTradeIntelligence/valuation/internal/governedNativeComponentExecution';
 import { PostgresGovernedValuationComponentRunRepository } from '@/server/aflTradeIntelligence/valuation/internal/postgresGovernedValuationComponentRunRepository';
+import { createAflTradePrivateValuationModelOperation } from '@/server/aflTradeIntelligence/valuation/privateValuationModelPair';
 import {
   GovernedValuationModelQualificationRepositoryError,
   PostgresGovernedValuationModelQualificationRepository,
@@ -1458,5 +1459,189 @@ describe('governed model qualification PostgreSQL registry', () => {
       [stale.qualification.qualificationId]
     );
     expect(rolledBack.rowCount).toBe(0);
+
+    const fencedBase = await qualificationFixture(runs, 'dispatch-fence', true);
+    const fencedContent = {
+      ...fencedBase.qualification.content,
+      scopeKey: 'afl-men:2026-dispatch-fence',
+    };
+    const fencedQualification = {
+      qualificationId: createAflTradeContentAddress('model-qualification', fencedContent),
+      content: fencedContent,
+    };
+    const fencedQualificationArtifact = await retain(fencedQualification, evaluatedAt);
+    const fencedGates = createGovernedValuationModelQualificationGateRecords({
+      qualification: fencedQualification,
+      qualificationArtifact: fencedQualificationArtifact,
+      decidedAt: '2026-08-21T09:20:00.000Z',
+      automationPrincipal: 'statly-model-qualification-agent',
+      accountableOwner: 'statly-model-owner',
+      versions: { player: 1, pick: 1 },
+      supersedes: { player: null, pick: null },
+    });
+    const fenced = {
+      qualification: fencedQualification,
+      qualificationArtifact: fencedQualificationArtifact,
+      expectedGateLedgerRevision: 2,
+      expectedCurrentRevision: 0,
+      gateRecords: fencedGates,
+    };
+    const dispatchRequestId = createAflTradeContentAddress(
+      'private-valuation-dispatch',
+      'qualification-fence-request'
+    );
+    const dispatchClaimId = createAflTradeContentAddress(
+      'private-valuation-dispatch-claim',
+      'qualification-fence-claim'
+    );
+    const dispatchLeaseTokenSha256 = 'c'.repeat(64);
+    const dispatchOperation = createAflTradePrivateValuationModelOperation({
+      scopeKey: fenced.qualification.content.scopeKey,
+      factualValuesSha256: 'd'.repeat(64),
+      hpnValuesSha256: 'e'.repeat(64),
+      hpnMethodId: createAflTradeContentAddress('hpn-pav-method', 'qualification-fence'),
+      player: {
+        modelId: runs.playerNativeExecution.content.modelId,
+        modelVersion: runs.playerNativeExecution.content.modelVersion,
+        protocolId: runs.player.content.protocolId,
+        datasetId: runs.player.content.datasetId,
+        datasetAdmissionId: runs.player.content.datasetAdmissionId,
+      },
+      pick: {
+        protocolId: runs.pick.content.protocolId,
+        datasetId: runs.pick.content.datasetId,
+        datasetAdmissionId: runs.pick.content.datasetAdmissionId,
+        policyId: createAflTradeContentAddress('pick-pav-policy', 'qualification-fence'),
+      },
+      qualificationPolicyId: fenced.qualification.content.policy.policyVersion,
+    });
+    const dispatchClock = await pool.query<{ trusted_now: Date }>(
+      'SELECT clock_timestamp() AS trusted_now'
+    );
+    const trustedNow = dispatchClock.rows[0]!.trusted_now;
+    const expiredAt = new Date(trustedNow.getTime() - 1_000);
+    const claimedAt = new Date(trustedNow.getTime() - 10_000);
+    const liveThrough = new Date(trustedNow.getTime() + 300_000);
+    const dispatchSeed = await pool.connect();
+    try {
+      await dispatchSeed.query('BEGIN');
+      await dispatchSeed.query(`SET LOCAL session_replication_role='replica'`);
+      await dispatchSeed.query(
+        `INSERT INTO outcome_private_valuation_dispatch_request
+          (request_id,scope_key,trigger_kind,scheduled_for,authority_key,status,available_at,
+           claim_id,lease_token_sha256,lease_expires_at,claimed_at,request_json,claim_sequence)
+         VALUES ($1,$2,'ad_hoc',$3,'qualification-fence','claimed',$3,$4,$5,$6,$6,'{}'::jsonb,1)`,
+        [
+          dispatchRequestId,
+          fenced.qualification.content.scopeKey,
+          claimedAt,
+          dispatchClaimId,
+          dispatchLeaseTokenSha256,
+          expiredAt,
+        ]
+      );
+      await dispatchSeed.query(
+        `INSERT INTO outcome_private_valuation_dispatch_attempt
+          (claim_id,request_id,attempt_sequence,attempt_number,worker_id,lease_token_sha256,
+           claimed_at,lease_expires_at,heartbeat_at)
+         VALUES ($1,$2,1,1,'system:weekly-valuation-coordinator',$3,$4,$5,$4)`,
+        [dispatchClaimId, dispatchRequestId, dispatchLeaseTokenSha256, claimedAt, expiredAt]
+      );
+      await dispatchSeed.query(
+        `INSERT INTO outcome_private_valuation_model_operation
+          (operation_id,scope_key,factual_values_sha256,hpn_values_sha256,hpn_method_id,
+           player_model_id,player_model_version,player_protocol_id,player_dataset_id,
+           player_dataset_admission_id,pick_protocol_id,pick_dataset_id,
+           pick_dataset_admission_id,pick_policy_id,qualification_policy_id,
+           player_run_id,player_claim_id,player_attempt_number,player_accepted_at,
+           pick_run_id,pick_claim_id,pick_attempt_number,pick_accepted_at,pair_accepted_at,
+           operation_canonical_json,operation_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,1,$18,
+                 $19,$20,1,$21,$21,$22,$23::jsonb)`,
+        [
+          dispatchOperation.operationId,
+          dispatchOperation.content.scopeKey,
+          dispatchOperation.content.factualValuesSha256,
+          dispatchOperation.content.hpnValuesSha256,
+          dispatchOperation.content.hpnMethodId,
+          dispatchOperation.content.player.modelId,
+          dispatchOperation.content.player.modelVersion,
+          dispatchOperation.content.player.protocolId,
+          dispatchOperation.content.player.datasetId,
+          dispatchOperation.content.player.datasetAdmissionId,
+          dispatchOperation.content.pick.protocolId,
+          dispatchOperation.content.pick.datasetId,
+          dispatchOperation.content.pick.datasetAdmissionId,
+          dispatchOperation.content.pick.policyId,
+          dispatchOperation.content.qualificationPolicyId,
+          runs.player.runId,
+          dispatchClaimId,
+          evaluatedAt,
+          runs.pick.runId,
+          dispatchClaimId,
+          evaluatedAt,
+          canonicalizeAflTradeJson(dispatchOperation.content),
+          canonicalizeAflTradeJson(dispatchOperation),
+        ]
+      );
+      await dispatchSeed.query(
+        `INSERT INTO outcome_private_valuation_model_request_binding
+          (request_id,operation_id,factual_output_id,hpn_calculation_id,claim_id,attempt_number)
+         VALUES ($1,$2,$3,$4,$5,1)`,
+        [
+          dispatchRequestId,
+          dispatchOperation.operationId,
+          createAflTradeContentAddress('private-valuation-factual-output', 'qualification-fence'),
+          createAflTradeContentAddress('hpn-pav-season', 'qualification-fence'),
+          dispatchClaimId,
+        ]
+      );
+      await dispatchSeed.query('COMMIT');
+    } catch (error) {
+      await dispatchSeed.query('ROLLBACK');
+      throw error;
+    } finally {
+      dispatchSeed.release();
+    }
+    const dispatchClaimFence = {
+      requestId: dispatchRequestId,
+      claimId: dispatchClaimId,
+      leaseTokenSha256: dispatchLeaseTokenSha256,
+    };
+    await expect(repository.register(fenced, { dispatchClaimFence })).rejects.toThrow(
+      'lost its live claim fence'
+    );
+    const revivedClaim = await pool.connect();
+    try {
+      await revivedClaim.query('BEGIN');
+      await revivedClaim.query(`SET LOCAL session_replication_role='replica'`);
+      await revivedClaim.query(
+        `UPDATE outcome_private_valuation_dispatch_request
+            SET lease_expires_at=$2
+          WHERE request_id=$1`,
+        [dispatchRequestId, liveThrough]
+      );
+      await revivedClaim.query(
+        `UPDATE outcome_private_valuation_dispatch_attempt
+            SET lease_expires_at=$2
+          WHERE claim_id=$1`,
+        [dispatchClaimId, liveThrough]
+      );
+      await revivedClaim.query('COMMIT');
+    } catch (error) {
+      await revivedClaim.query('ROLLBACK');
+      throw error;
+    } finally {
+      revivedClaim.release();
+    }
+    await expect(repository.register(fenced, { dispatchClaimFence })).resolves.toMatchObject({
+      status: 'advanced',
+      idempotentReplay: false,
+      current: {
+        scopeKey: fencedQualification.content.scopeKey,
+        revision: 1,
+        qualificationId: fencedQualification.qualificationId,
+      },
+    });
   }, 120_000);
 });

--- a/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
+++ b/tests/outcomes-integration/afl-governed-model-qualification-postgres.test.ts
@@ -1627,12 +1627,52 @@ describe('governed model qualification PostgreSQL registry', () => {
           WHERE claim_id=$1`,
         [dispatchClaimId, liveThrough]
       );
+      await revivedClaim.query(
+        `UPDATE outcome_private_valuation_model_operation
+            SET pair_accepted_at=NULL
+          WHERE operation_id=$1`,
+        [dispatchOperation.operationId]
+      );
       await revivedClaim.query('COMMIT');
     } catch (error) {
       await revivedClaim.query('ROLLBACK');
       throw error;
     } finally {
       revivedClaim.release();
+    }
+    await expect(repository.register(fenced, { dispatchClaimFence })).rejects.toThrow(
+      'did not bind to its exact accepted operation'
+    );
+    await expect(
+      pool.query(
+        `SELECT
+           (SELECT count(*)::int
+              FROM outcome_governed_valuation_model_qualification
+             WHERE qualification_id=$1) AS qualification_count,
+           (SELECT count(*)::int
+              FROM outcome_current_governed_valuation_model_pair
+             WHERE scope_key=$2) AS current_pair_count`,
+        [fencedQualification.qualificationId, fencedQualification.content.scopeKey]
+      )
+    ).resolves.toMatchObject({
+      rows: [{ qualification_count: 0, current_pair_count: 0 }],
+    });
+    const restoredPair = await pool.connect();
+    try {
+      await restoredPair.query('BEGIN');
+      await restoredPair.query(`SET LOCAL session_replication_role='replica'`);
+      await restoredPair.query(
+        `UPDATE outcome_private_valuation_model_operation
+            SET pair_accepted_at=$2
+          WHERE operation_id=$1`,
+        [dispatchOperation.operationId, evaluatedAt]
+      );
+      await restoredPair.query('COMMIT');
+    } catch (error) {
+      await restoredPair.query('ROLLBACK');
+      throw error;
+    } finally {
+      restoredPair.release();
     }
     await expect(repository.register(fenced, { dispatchClaimFence })).resolves.toMatchObject({
       status: 'advanced',
@@ -1642,6 +1682,24 @@ describe('governed model qualification PostgreSQL registry', () => {
         revision: 1,
         qualificationId: fencedQualification.qualificationId,
       },
+    });
+    await expect(
+      pool.query(
+        `SELECT qualification_id,qualification_outcome,qualification_claim_id,
+                qualification_bound_at
+           FROM outcome_private_valuation_model_operation
+          WHERE operation_id=$1`,
+        [dispatchOperation.operationId]
+      )
+    ).resolves.toMatchObject({
+      rows: [
+        {
+          qualification_id: fencedQualification.qualificationId,
+          qualification_outcome: 'qualified',
+          qualification_claim_id: dispatchClaimId,
+          qualification_bound_at: expect.any(Date),
+        },
+      ],
     });
   }, 120_000);
 });

--- a/tests/outcomes-integration/afl-model-run-authority-postgres.test.ts
+++ b/tests/outcomes-integration/afl-model-run-authority-postgres.test.ts
@@ -1005,7 +1005,7 @@ describe('durable PostgreSQL model-run authority', () => {
         });
       await policyClient.query('SAVEPOINT stale_policy_input');
       await expect(insertPolicyOperationalAuthorization(staleInputAuthorization)).rejects.toThrow(
-        /input|ancestry|invalid/i
+        'Model-run operational authorization is invalid or misbound'
       );
       await policyClient.query('ROLLBACK TO SAVEPOINT stale_policy_input');
 
@@ -1024,7 +1024,9 @@ describe('durable PostgreSQL model-run authority', () => {
         [policyClaimId, expiredClaimedAt, expiredLeaseAt]
       );
       await policyClient.query(`SET LOCAL session_replication_role='origin'`);
-      await expect(insertPolicyOperationalAuthorization()).rejects.toThrow(/claim|invalid/i);
+      await expect(insertPolicyOperationalAuthorization()).rejects.toThrow(
+        'Private valuation dispatch request lookup lost its live claim fence'
+      );
       await policyClient.query('ROLLBACK TO SAVEPOINT expired_policy_claim');
       await policyClient.query(`SET LOCAL session_replication_role='origin'`);
       await expect(insertPolicyOperationalAuthorization()).resolves.toMatchObject({ rowCount: 1 });
@@ -1085,7 +1087,9 @@ describe('durable PostgreSQL model-run authority', () => {
         [policyRequestId, replacementClaimId, hash('0')]
       );
       await policyClient.query(`SET LOCAL session_replication_role='origin'`);
-      await expect(insertPolicyAuthorization()).rejects.toThrow(/claim|stale|misbound/i);
+      await expect(insertPolicyAuthorization()).rejects.toThrow(
+        'Private valuation dispatch request lookup lost its live claim fence'
+      );
       await policyClient.query('ROLLBACK TO SAVEPOINT reclaimed_policy_claim');
       await policyClient.query(`SET LOCAL session_replication_role='origin'`);
       await expect(insertPolicyAuthorization()).resolves.toMatchObject({ rowCount: 1 });

--- a/tests/outcomes-integration/afl-model-run-authority-postgres.test.ts
+++ b/tests/outcomes-integration/afl-model-run-authority-postgres.test.ts
@@ -5,9 +5,13 @@ import {
   canonicalizeAflTradeJson,
   createAflTradeContentAddress,
 } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
-import { createAflTradeModelRunOperationalAuthorization } from '@/server/aflTradeIntelligence/modeling/admittedModelRunAuthority';
+import {
+  createAflTradeModelRunOperationalAuthorization,
+  createAflTradePrivateValuationModelRunOperationalAuthorization,
+} from '@/server/aflTradeIntelligence/modeling/admittedModelRunAuthority';
 import { PostgresAflTradeAdmittedModelRunAuthority } from '@/server/aflTradeIntelligence/modeling/postgresAdmittedModelRunAuthority';
 import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import { createAflTradePrivateValuationModelOperation } from '@/server/aflTradeIntelligence/valuation/privateValuationModelPair';
 import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
 
 const databaseUrl =
@@ -496,6 +500,38 @@ describe('durable PostgreSQL model-run authority', () => {
       role: 'afl_trade_model_run_operator',
       authorityEvidence: { id: operatorAuthorityEvidenceId, sha256: hash('e') },
     });
+    const { authorityBoundary: _authorityBoundary, ...boundarylessContent } =
+      operationalAuthorization.content;
+    const boundarylessReceiptId = createAflTradeContentAddress(
+      'architecture-operation-receipt',
+      boundarylessContent
+    );
+    await expect(
+      outcomesPool.query(
+        `INSERT INTO outcome_valuation_model_run_operational_authorization
+         (receipt_id,intent_id,environment,dataset_id,admission_id,protocol_id,observation_set_id,
+           authorized_at,valid_through,principal_ref,authority_evidence_id,
+           receipt_canonical_json,receipt_json)
+         VALUES ($1,$2,'test_fixture',$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)`,
+        [
+          boundarylessReceiptId,
+          intentId,
+          datasetId,
+          admissionId,
+          protocolId,
+          observationSetId,
+          startedAt,
+          validThrough,
+          operationalAuthorization.content.principalRef,
+          operationalAuthorization.content.authorityEvidence.id,
+          canonicalizeAflTradeJson(boundarylessContent),
+          canonicalizeAflTradeJson({
+            receiptId: boundarylessReceiptId,
+            content: boundarylessContent,
+          }),
+        ]
+      )
+    ).rejects.toThrow('Model-run operational authorization is invalid or misbound');
     await outcomesPool.query(
       `INSERT INTO outcome_valuation_model_run_operational_authorization
         (receipt_id,intent_id,environment,dataset_id,admission_id,protocol_id,observation_set_id,
@@ -719,5 +755,346 @@ describe('durable PostgreSQL model-run authority', () => {
     await expect(
       outcomesPool.query(`UPDATE outcome_valuation_model_run SET status='cancelled'`)
     ).rejects.toThrow(/append-only/i);
+
+    const policyClient = await outcomesPool.connect();
+    try {
+      await policyClient.query('BEGIN');
+      const policyClock = await policyClient.query<{ trusted_now: Date }>(
+        'SELECT clock_timestamp() AS trusted_now'
+      );
+      const policyStartedAt = policyClock.rows[0]!.trusted_now.toISOString();
+      await policyClient.query(`SET LOCAL session_replication_role='replica'`);
+      const policyValidThrough = new Date(Date.parse(policyStartedAt) + 20_000).toISOString();
+      const policyLeaseExpiresAt = new Date(Date.parse(policyStartedAt) + 60_000).toISOString();
+      const expiredClaimedAt = new Date(Date.parse(policyStartedAt) - 10_000).toISOString();
+      const expiredLeaseAt = new Date(Date.parse(policyStartedAt) - 1_000).toISOString();
+      const policyRequestId = `private-valuation-dispatch:${hash('a')}`;
+      const policyClaimId = `private-valuation-dispatch-claim:${hash('b')}`;
+      const policyLeaseToken = hash('c');
+      const policyFactualOutputId = `private-valuation-factual-output:${hash('d')}`;
+      const policyHpnCalculationId = `hpn-pav-season:${hash('e')}`;
+      const policyHpnMethodId = `hpn-pav-method:${hash('f')}`;
+      const policyFactualRunId = `factual-reconciliation-run:${hash('a')}`;
+      const policyOperation = createAflTradePrivateValuationModelOperation({
+        scopeKey: 'model-run-fixture',
+        factualValuesSha256: hash('1'),
+        hpnValuesSha256: hash('2'),
+        hpnMethodId: policyHpnMethodId,
+        player: {
+          modelId: intentContent.modelId,
+          modelVersion: intentContent.modelVersion,
+          protocolId,
+          datasetId,
+          datasetAdmissionId: admissionId,
+        },
+        pick: {
+          protocolId: `model-protocol:${hash('3')}`,
+          datasetId: `dataset:${hash('4')}`,
+          datasetAdmissionId: `dataset-admission:${hash('5')}`,
+          policyId: `pick-pav-policy:${hash('6')}`,
+        },
+        qualificationPolicyId: `model-qualification-policy:${hash('7')}`,
+      });
+      const policyIntentContent = {
+        ...intentContent,
+        environment: 'non_production' as const,
+        job: {
+          ...intentContent.job,
+          jobId: 'private-valuation-policy-proof',
+          initiatedBy: 'system:weekly-valuation-coordinator',
+          workerIdentity: 'system:weekly-valuation-coordinator',
+        },
+        startedAt: policyStartedAt,
+      };
+      const policyIntentId = createAflTradeContentAddress('model-run-intent', policyIntentContent);
+      const policyIntent = { intentId: policyIntentId, content: policyIntentContent };
+
+      await policyClient.query(
+        `UPDATE outcome_valuation_dataset_operation_authority
+            SET environment='non_production'
+          WHERE receipt_id=$1`,
+        [authorityReceiptId]
+      );
+      await policyClient.query(
+        `UPDATE outcome_gate_decision
+            SET environment='non_production',
+                decision_json=jsonb_set(
+                  decision_json,'{content,environment}','"non_production"'::jsonb)
+          WHERE decision_id=ANY($1::text[])`,
+        [[gate0DecisionId, gate2DecisionId]]
+      );
+      await policyClient.query(
+        `UPDATE outcome_valuation_dataset_gate0_evaluation
+            SET environment='non_production',evaluated_at=$2,recorded_at=$2,
+                receipt_json=jsonb_set(
+                  jsonb_set(
+                    jsonb_set(receipt_json,'{content,request,evaluatedAt}',to_jsonb($3::text)),
+                    '{content,request,environment}','"non_production"'::jsonb),
+                  '{content,recordedAt}',to_jsonb($3::text))
+          WHERE receipt_id=$1`,
+        [runStartReceiptId, policyStartedAt, policyStartedAt]
+      );
+      await policyClient.query(
+        `UPDATE outcome_valuation_dataset_gate0_evaluation
+            SET receipt_json=jsonb_set(
+              receipt_json,'{content,request,environment}','"non_production"'::jsonb)
+          WHERE receipt_id=$1`,
+        [admissionReceiptId]
+      );
+      await policyClient.query(
+        `INSERT INTO outcome_hpn_pav_method
+          (method_id,method_sha256,environment,source_artifact_id,captured_at,registered_at,
+           method_canonical_json,method_json)
+         VALUES ($1,$2,'non_production',$3,$4,$4,'{}','{}'::jsonb)`,
+        [policyHpnMethodId, hash('f'), `artifact:${hash('f')}`, policyStartedAt]
+      );
+      await policyClient.query(
+        `INSERT INTO outcome_private_valuation_dispatch_request
+          (request_id,scope_key,trigger_kind,scheduled_for,authority_key,status,available_at,
+           claim_id,lease_token_sha256,lease_expires_at,claimed_at,request_json,claim_sequence)
+         VALUES ($1,'model-run-fixture','ad_hoc',$2,'policy-proof','claimed',$2,
+                 $3,$4,$5,$2,'{}'::jsonb,1)`,
+        [policyRequestId, policyStartedAt, policyClaimId, policyLeaseToken, policyLeaseExpiresAt]
+      );
+      await policyClient.query(
+        `INSERT INTO outcome_private_valuation_dispatch_attempt
+          (claim_id,request_id,attempt_sequence,attempt_number,worker_id,lease_token_sha256,
+           claimed_at,lease_expires_at,heartbeat_at)
+         VALUES ($1,$2,1,1,'system:weekly-valuation-coordinator',$3,$4,$5,$4)`,
+        [policyClaimId, policyRequestId, policyLeaseToken, policyStartedAt, policyLeaseExpiresAt]
+      );
+      await policyClient.query(
+        `INSERT INTO outcome_private_valuation_factual_output
+          (output_id,request_id,capture_binding_id,source_admission_id,normalization_run_id,
+           fact_batch_id,factual_run_id,candidate_id,factual_release_id,prepared_at,output_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'{}'::jsonb)`,
+        [
+          policyFactualOutputId,
+          policyRequestId,
+          `private-valuation-capture-binding:${hash('8')}`,
+          `private-valuation-source-admission:${hash('9')}`,
+          `provider-normalization-run:${hash('a')}`,
+          `source-fact-batch:${hash('b')}`,
+          policyFactualRunId,
+          `factual-release-candidate:${hash('c')}`,
+          `outcome-release:${hash('d')}`,
+          policyStartedAt,
+        ]
+      );
+      await policyClient.query(
+        `INSERT INTO outcome_hpn_pav_calculation
+          (calculation_id,calculation_sha256,schema_version,input_set_id,method_id,
+           environment,competition,season_year,effective_through,calculated_at,value_unit,
+           status,team_count,player_count,calculation_canonical_json,calculation_json,finalized_at)
+         VALUES ($1,$2,'afl-trade-hpn-pav-season-calculation/v3',$3,$4,'non_production',
+                 'AFLM',2026,$5,$5,'season_pav','finalized',2,2,'{}',$6::jsonb,$5)`,
+        [
+          policyHpnCalculationId,
+          hash('e'),
+          `hpn-pav-input-set:${hash('e')}`,
+          policyHpnMethodId,
+          policyStartedAt,
+          JSON.stringify({ content: { factualRunId: policyFactualRunId } }),
+        ]
+      );
+      await policyClient.query(
+        `INSERT INTO outcome_private_valuation_model_operation
+          (operation_id,scope_key,factual_values_sha256,hpn_values_sha256,hpn_method_id,
+           player_model_id,player_model_version,player_protocol_id,player_dataset_id,
+           player_dataset_admission_id,pick_protocol_id,pick_dataset_id,
+           pick_dataset_admission_id,pick_policy_id,qualification_policy_id,
+           operation_canonical_json,operation_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17::jsonb)`,
+        [
+          policyOperation.operationId,
+          policyOperation.content.scopeKey,
+          policyOperation.content.factualValuesSha256,
+          policyOperation.content.hpnValuesSha256,
+          policyOperation.content.hpnMethodId,
+          policyOperation.content.player.modelId,
+          policyOperation.content.player.modelVersion,
+          policyOperation.content.player.protocolId,
+          policyOperation.content.player.datasetId,
+          policyOperation.content.player.datasetAdmissionId,
+          policyOperation.content.pick.protocolId,
+          policyOperation.content.pick.datasetId,
+          policyOperation.content.pick.datasetAdmissionId,
+          policyOperation.content.pick.policyId,
+          policyOperation.content.qualificationPolicyId,
+          canonicalizeAflTradeJson(policyOperation.content),
+          canonicalizeAflTradeJson(policyOperation),
+        ]
+      );
+      await policyClient.query(
+        `INSERT INTO outcome_private_valuation_model_request_binding
+          (request_id,operation_id,factual_output_id,hpn_calculation_id,claim_id,attempt_number)
+         VALUES ($1,$2,$3,$4,$5,1)`,
+        [
+          policyRequestId,
+          policyOperation.operationId,
+          policyFactualOutputId,
+          policyHpnCalculationId,
+          policyClaimId,
+        ]
+      );
+      await policyClient.query(
+        `INSERT INTO outcome_valuation_model_run_intent
+          (intent_id,environment,dataset_id,admission_id,protocol_id,observation_set_id,
+           started_at,intent_canonical_json,intent_json)
+         VALUES ($1,'non_production',$2,$3,$4,$5,$6,$7,$8::jsonb)`,
+        [
+          policyIntentId,
+          datasetId,
+          admissionId,
+          protocolId,
+          observationSetId,
+          policyStartedAt,
+          canonicalizeAflTradeJson(policyIntentContent),
+          canonicalizeAflTradeJson(policyIntent),
+        ]
+      );
+      await policyClient.query(`SET LOCAL session_replication_role='origin'`);
+
+      const policyOperationalAuthorization =
+        createAflTradePrivateValuationModelRunOperationalAuthorization({
+          runIntentId: policyIntentId,
+          datasetId,
+          datasetAdmissionId: admissionId,
+          modelProtocolId: protocolId,
+          observationSetId,
+          dispatchRequestId: policyRequestId,
+          substantiveOperationId: policyOperation.operationId,
+          dispatchClaimId: policyClaimId,
+          dispatchAttemptNumber: 1,
+          dispatchLeaseTokenSha256: policyLeaseToken,
+          factualOutputId: policyFactualOutputId,
+          hpnCalculationId: policyHpnCalculationId,
+          factualValuesSha256: policyOperation.content.factualValuesSha256,
+          hpnValuesSha256: policyOperation.content.hpnValuesSha256,
+          authorizedAt: policyStartedAt,
+          validThrough: policyValidThrough,
+        });
+      const insertPolicyOperationalAuthorization = (
+        authorization = policyOperationalAuthorization
+      ) =>
+        policyClient.query(
+          `INSERT INTO outcome_valuation_model_run_operational_authorization
+            (receipt_id,intent_id,environment,dataset_id,admission_id,protocol_id,
+             observation_set_id,authorized_at,valid_through,principal_ref,authority_evidence_id,
+             receipt_canonical_json,receipt_json)
+           VALUES ($1,$2,'non_production',$3,$4,$5,$6,$7,$8,$9,NULL,$10,$11::jsonb)`,
+          [
+            authorization.receiptId,
+            policyIntentId,
+            datasetId,
+            admissionId,
+            protocolId,
+            observationSetId,
+            policyStartedAt,
+            policyValidThrough,
+            authorization.content.principalRef,
+            canonicalizeAflTradeJson(authorization.content),
+            canonicalizeAflTradeJson(authorization),
+          ]
+        );
+
+      const staleInputAuthorization =
+        createAflTradePrivateValuationModelRunOperationalAuthorization({
+          ...policyOperationalAuthorization.content,
+          factualValuesSha256: hash('0'),
+        });
+      await policyClient.query('SAVEPOINT stale_policy_input');
+      await expect(insertPolicyOperationalAuthorization(staleInputAuthorization)).rejects.toThrow(
+        /input|ancestry|invalid/i
+      );
+      await policyClient.query('ROLLBACK TO SAVEPOINT stale_policy_input');
+
+      await policyClient.query('SAVEPOINT expired_policy_claim');
+      await policyClient.query(`SET LOCAL session_replication_role='replica'`);
+      await policyClient.query(
+        `UPDATE outcome_private_valuation_dispatch_request
+            SET claimed_at=$2,lease_expires_at=$3
+          WHERE request_id=$1`,
+        [policyRequestId, expiredClaimedAt, expiredLeaseAt]
+      );
+      await policyClient.query(
+        `UPDATE outcome_private_valuation_dispatch_attempt
+            SET claimed_at=$2,heartbeat_at=$2,lease_expires_at=$3
+          WHERE claim_id=$1`,
+        [policyClaimId, expiredClaimedAt, expiredLeaseAt]
+      );
+      await policyClient.query(`SET LOCAL session_replication_role='origin'`);
+      await expect(insertPolicyOperationalAuthorization()).rejects.toThrow(/claim|invalid/i);
+      await policyClient.query('ROLLBACK TO SAVEPOINT expired_policy_claim');
+      await policyClient.query(`SET LOCAL session_replication_role='origin'`);
+      await expect(insertPolicyOperationalAuthorization()).resolves.toMatchObject({ rowCount: 1 });
+
+      const policyAuthorizationContent = {
+        ...authorizationContent,
+        environment: 'non_production' as const,
+        runIntentId: policyIntentId,
+        operationalAuthorizationReceiptId: policyOperationalAuthorization.receiptId,
+        authorizedAt: policyStartedAt,
+        validThrough: policyValidThrough,
+      };
+      const policyAuthorizationId = createAflTradeContentAddress(
+        'model-run-authorization',
+        policyAuthorizationContent
+      );
+      const insertPolicyAuthorization = () =>
+        policyClient.query(
+          `INSERT INTO outcome_valuation_model_run_authorization
+            (authorization_id,intent_id,operational_authorization_receipt_id,
+             gate_ledger_revision,authorized_at,valid_through,
+             authorization_canonical_json,authorization_json)
+           VALUES ($1,$2,$3,2,$4,$5,$6,$7::jsonb)`,
+          [
+            policyAuthorizationId,
+            policyIntentId,
+            policyOperationalAuthorization.receiptId,
+            policyStartedAt,
+            policyValidThrough,
+            canonicalizeAflTradeJson(policyAuthorizationContent),
+            canonicalizeAflTradeJson({
+              authorizationId: policyAuthorizationId,
+              content: policyAuthorizationContent,
+            }),
+          ]
+        );
+
+      await policyClient.query('SAVEPOINT reclaimed_policy_claim');
+      await policyClient.query(`SET LOCAL session_replication_role='replica'`);
+      const replacementClaimId = `private-valuation-dispatch-claim:${hash('0')}`;
+      await policyClient.query(
+        `UPDATE outcome_private_valuation_dispatch_attempt
+            SET finished_at=$2,outcome='lease_expired'
+          WHERE claim_id=$1`,
+        [policyClaimId, policyStartedAt]
+      );
+      await policyClient.query(
+        `INSERT INTO outcome_private_valuation_dispatch_attempt
+          (claim_id,request_id,attempt_sequence,attempt_number,worker_id,lease_token_sha256,
+           claimed_at,lease_expires_at,heartbeat_at)
+         VALUES ($1,$2,2,2,'system:weekly-valuation-coordinator',$3,$4,$5,$4)`,
+        [replacementClaimId, policyRequestId, hash('0'), policyStartedAt, policyLeaseExpiresAt]
+      );
+      await policyClient.query(
+        `UPDATE outcome_private_valuation_dispatch_request
+            SET claim_id=$2,lease_token_sha256=$3,claim_sequence=2
+          WHERE request_id=$1`,
+        [policyRequestId, replacementClaimId, hash('0')]
+      );
+      await policyClient.query(`SET LOCAL session_replication_role='origin'`);
+      await expect(insertPolicyAuthorization()).rejects.toThrow(/claim|stale|misbound/i);
+      await policyClient.query('ROLLBACK TO SAVEPOINT reclaimed_policy_claim');
+      await policyClient.query(`SET LOCAL session_replication_role='origin'`);
+      await expect(insertPolicyAuthorization()).resolves.toMatchObject({ rowCount: 1 });
+      await policyClient.query('ROLLBACK');
+    } catch (error) {
+      await policyClient.query('ROLLBACK').catch(() => undefined);
+      throw error;
+    } finally {
+      policyClient.release();
+    }
   });
 });

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1105,6 +1105,7 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0076_role_aware_private_valuation_capture_binding',
       '0077_projected_hpn_pav_input_authority',
       '0078_private_valuation_hpn_source_admission',
+      '0079_dispatch_bound_private_model_pair',
     ]);
 
     const tables = await query<{ table_name: string }>(
@@ -1117,6 +1118,8 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       'outcome_current_valuation_cohort_operation',
       'outcome_current_valuation_cohort_operation_result',
       'outcome_governed_pick_pav_model_execution',
+      'outcome_private_valuation_model_operation',
+      'outcome_private_valuation_model_request_binding',
       'outcome_source_capture_attempt',
       'outcome_source_capture_season',
       'outcome_import_row',

--- a/tests/outcomes-integration/afl-private-valuation-capture-binding-postgres.test.ts
+++ b/tests/outcomes-integration/afl-private-valuation-capture-binding-postgres.test.ts
@@ -1,5 +1,5 @@
 import { Pool } from 'pg';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
 import { PostgresAflTradePrivateValuationCaptureBindingRepository } from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationCaptureBindingRepository';
@@ -110,6 +110,41 @@ afterAll(async () => {
   }
   if (failures.length > 0) {
     throw new AggregateError(failures, 'Capture-binding PostgreSQL cleanup failed.');
+  }
+});
+
+afterEach(async () => {
+  const connection = await outcomesPool.connect();
+  try {
+    await connection.query('BEGIN');
+    await connection.query('SET LOCAL ROLE afl_trade_private_valuation_scheduler_owner');
+    await connection.query(
+      `UPDATE outcome_private_valuation_dispatch_attempt attempt
+          SET finished_at=date_trunc('milliseconds',statement_timestamp()),
+              outcome='completed',
+              result_json=jsonb_build_object('state','unexpected_failure')
+         FROM outcome_private_valuation_dispatch_request request
+        WHERE request.status='claimed'
+          AND attempt.claim_id=request.claim_id
+          AND attempt.finished_at IS NULL`
+    );
+    await connection.query(
+      `UPDATE outcome_private_valuation_dispatch_request
+          SET status='completed',
+              completed_at=date_trunc('milliseconds',statement_timestamp()),
+              result_json=jsonb_build_object('state','unexpected_failure'),
+              claim_id=NULL,
+              lease_token_sha256=NULL,
+              lease_expires_at=NULL,
+              claimed_at=NULL
+        WHERE status='claimed'`
+    );
+    await connection.query('COMMIT');
+  } catch (error) {
+    await connection.query('ROLLBACK').catch(() => undefined);
+    throw error;
+  } finally {
+    connection.release();
   }
 });
 
@@ -299,15 +334,12 @@ describe.sequential('private valuation capture binding in PostgreSQL', () => {
         [requestId]
       );
       const guardedAcceptance = outcomesPool
-        .query(
-          `SELECT accept_outcome_private_valuation_dispatch_capture($1,$2,$3,$4)`,
-          [
-            requestId,
-            claimed.rows[0]!.claim_id,
-            leaseTokenSha256,
-            normalizationRunId,
-          ]
-        )
+        .query(`SELECT accept_outcome_private_valuation_dispatch_capture($1,$2,$3,$4)`, [
+          requestId,
+          claimed.rows[0]!.claim_id,
+          leaseTokenSha256,
+          normalizationRunId,
+        ])
         .then(
           () => ({ state: 'fulfilled' as const, error: null }),
           (error: unknown) => ({ state: 'rejected' as const, error })
@@ -351,6 +383,11 @@ describe.sequential('private valuation capture binding in PostgreSQL', () => {
       claim: { claimId: acceptedClaim!.claimId, leaseToken: acceptedClaim!.leaseToken },
       normalizationRunId,
     });
+    await schedule.reschedule({
+      claimId: acceptedClaim!.claimId,
+      leaseToken: acceptedClaim!.leaseToken,
+      state: 'transient_failure',
+    });
 
     const rejectedRequestId = await enqueueDispatch('capture-binding-during-field-map-change');
     const rejectedClaim = await schedule.claim(
@@ -386,13 +423,7 @@ describe.sequential('private valuation capture binding in PostgreSQL', () => {
           (error: unknown) => ({ state: 'rejected' as const, binding: null, error })
         );
 
-      await expect(
-        repository.accept({
-          request: acceptedClaim!.request,
-          claim: { claimId: acceptedClaim!.claimId, leaseToken: acceptedClaim!.leaseToken },
-          normalizationRunId,
-        })
-      ).resolves.toEqual(acceptedBinding);
+      await expect(repository.load(acceptedClaim!.request)).resolves.toEqual(acceptedBinding);
       await expect(
         Promise.race([
           guardedAcceptance.then(() => 'settled' as const),

--- a/tests/outcomes-integration/afl-private-valuation-model-pair-postgres.test.ts
+++ b/tests/outcomes-integration/afl-private-valuation-model-pair-postgres.test.ts
@@ -1,0 +1,1034 @@
+import { createHash } from 'node:crypto';
+
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  canonicalizeAflTradeJson,
+  createAflTradeContentAddress,
+} from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import {
+  AFL_TRADE_HPN_PAV_FINALIZED_CALCULATION_SCHEMA_VERSION,
+  aflTradeFinalizedHpnPavCalculationSchema,
+} from '@/server/aflTradeIntelligence/modeling/hpnPavCalculationService';
+import { calculateAflTradeHpnPavCore } from '@/server/aflTradeIntelligence/modeling/hpnPavCore';
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import {
+  loadAflTradePrivateValuationModelPairExactInput,
+  PostgresAflTradePrivateValuationModelPairRepository,
+} from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationModelPair';
+import {
+  createAflTradePrivateValuationModelOperation,
+  createAflTradePrivateValuationModelPairCoordinator,
+  type AflTradePrivateValuationModelPairExactInput,
+  type AflTradePrivateValuationModelPairRepository,
+} from '@/server/aflTradeIntelligence/valuation/privateValuationModelPair';
+import { createAflTradePrivateValuationFactualOutput } from '@/server/aflTradeIntelligence/valuation/privateValuationFactualOutput';
+
+import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('A disposable AFL_OUTCOMES_TEST_DATABASE_URL is required.');
+  })();
+const schemaName = `afl_private_model_pair_${process.pid}_${Date.now()}`;
+const adminPool = new Pool({ connectionString: databaseUrl });
+const outcomesPool = new Pool({
+  connectionString: databaseUrl,
+  options: `-c search_path=${schemaName}`,
+  max: 4,
+});
+
+function scopedDatabaseUrl(): string {
+  const scoped = new URL(databaseUrl);
+  scoped.searchParams.set('schema', schemaName);
+  return scoped.toString();
+}
+
+const digest = (value: string): string => createHash('sha256').update(value, 'utf8').digest('hex');
+const addressed = (prefix: string, value: string): string => `${prefix}:${digest(value)}`;
+
+const loaderPlayerStats = {
+  totalPoints: 10,
+  hitOuts: 1,
+  goalAssists: 1,
+  inside50s: 2,
+  marks: 3,
+  marksInside50: 1,
+  freeKicksFor: 2,
+  freeKicksAgainst: 1,
+  rebound50s: 1,
+  onePercenters: 1,
+  clearances: 2,
+  tackles: 3,
+};
+
+function loaderCalculation(factualRunId: string, custodyKey: string) {
+  const core = calculateAflTradeHpnPavCore([
+    {
+      teamId: 'club:loader-home',
+      pointsFor: 100,
+      pointsAgainst: 80,
+      inside50sFor: 50,
+      inside50sAgainst: 40,
+      players: [
+        {
+          spellVersionId: addressed('acquisition-spell-version', `${custodyKey}-home`),
+          playerId: 'player:loader-home',
+          sourceRowIds: [`row:${custodyKey}-home`],
+          ...loaderPlayerStats,
+        },
+      ],
+    },
+    {
+      teamId: 'club:loader-away',
+      pointsFor: 80,
+      pointsAgainst: 100,
+      inside50sFor: 40,
+      inside50sAgainst: 50,
+      players: [
+        {
+          spellVersionId: addressed('acquisition-spell-version', `${custodyKey}-away`),
+          playerId: 'player:loader-away',
+          sourceRowIds: [`row:${custodyKey}-away`],
+          ...loaderPlayerStats,
+        },
+      ],
+    },
+  ]);
+  const content = {
+    schemaVersion: AFL_TRADE_HPN_PAV_FINALIZED_CALCULATION_SCHEMA_VERSION,
+    authorityBoundary:
+      'private_finalized_hpn_input_exact_method_bytes_no_publication_or_fantasy_ownership' as const,
+    publicationEligible: false as const,
+    environment: 'non_production' as const,
+    competition: 'AFLM' as const,
+    seasonYear: 2026,
+    effectiveThrough: '2026-08-23T00:00:00.000Z',
+    calculatedAt: '2026-08-24T00:00:01.000Z',
+    methodId: addressed('hpn-pav-method', 'loader-method'),
+    inputSetId: addressed('hpn-pav-input-set', `${custodyKey}-input`),
+    inputSetSha256: digest(`${custodyKey}-input`),
+    factualRunId,
+    factualInputSetSha256: digest(`${custodyKey}-factual-input`),
+    primaryProviders: ['afl_tables'],
+    corroboratingProviders: ['footywire'],
+    resultSourceRowIds: [`row:${custodyKey}-result`],
+    valueUnit: 'season_pav' as const,
+    ...core,
+    players: core.players.map((player) => ({
+      ...player,
+      source: { ...player.source, gamesPlayed: 1 },
+    })),
+  };
+  return aflTradeFinalizedHpnPavCalculationSchema.parse({
+    calculationId: createAflTradeContentAddress('hpn-pav-season', content),
+    content,
+  });
+}
+
+const modelPairTargets = {
+  player: {
+    modelId: addressed('development-grade-model', 'player-model'),
+    modelVersion: 'player-model-v1',
+    protocolId: addressed('model-protocol', 'player-protocol'),
+    datasetId: addressed('dataset', 'player-dataset'),
+    datasetAdmissionId: addressed('dataset-admission', 'player-admission'),
+  },
+  pick: {
+    protocolId: addressed('model-protocol', 'pick-protocol'),
+    datasetId: addressed('dataset', 'pick-dataset'),
+    datasetAdmissionId: addressed('dataset-admission', 'pick-admission'),
+    policyId: addressed('pick-pav-policy', 'pick-policy'),
+  },
+  qualificationPolicyId: addressed('model-qualification-policy', 'qualification-policy'),
+} as const;
+
+function loaderFactualOutput(requestId: string, custodyKey: string, factualRunId: string) {
+  return createAflTradePrivateValuationFactualOutput({
+    requestId,
+    valuationScopeKey: 'afl-men:2026-trades',
+    captureBindingId: addressed('private-valuation-capture-binding', `${custodyKey}-capture`),
+    sourceAdmissionId: addressed('private-valuation-source-admission', `${custodyKey}-admission`),
+    normalizationRunId: addressed('provider-normalization-run', `${custodyKey}-normalization`),
+    factBatch: {
+      batchId: addressed('source-fact-batch', `${custodyKey}-batch`),
+      batchSha256: digest(`${custodyKey}-batch`),
+    },
+    reconciliation: {
+      factualRunId,
+      runSha256: factualRunId.slice('factual-reconciliation-run:'.length),
+      outputSetSha256: digest('exact-loader-output-set'),
+      finalizedAt: '2026-08-24T00:00:00.000Z',
+    },
+    spellMetricBatches: [
+      {
+        batchId: addressed('acquisition-spell-metric-batch', `${custodyKey}-metrics`),
+        batchSha256: digest(`${custodyKey}-metrics`),
+      },
+    ],
+    candidate: {
+      candidateId: addressed('factual-release-candidate', `${custodyKey}-candidate`),
+      candidateSha256: digest(`${custodyKey}-candidate`),
+      memberSetSha256: digest('exact-loader-members'),
+    },
+    factualRelease: {
+      releaseId: addressed('outcome-release', `${custodyKey}-release`),
+      releaseSha256: digest(`${custodyKey}-release`),
+    },
+    preparedAt: '2026-08-24T00:00:01.000Z',
+  });
+}
+
+beforeAll(async () => {
+  await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
+  runOutcomesPrismaTestCommand(['migrate', 'deploy'], { databaseUrl: scopedDatabaseUrl() });
+});
+
+afterAll(async () => {
+  const failures: unknown[] = [];
+  try {
+    await outcomesPool.end();
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await adminPool.end();
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Private model-pair PostgreSQL cleanup failed.');
+  }
+});
+
+describe.sequential('dispatch-bound private model pair in PostgreSQL', () => {
+  it('reconstructs after each retained component, pair acceptance, and qualification', async () => {
+    const leaseToken = digest('restart-proof-lease-token');
+    const requestId = addressed('private-valuation-dispatch', 'request');
+    const claimId = addressed('private-valuation-dispatch-claim', 'claim');
+    const playerRunId = addressed('model-run', 'player-component');
+    const pickRunId = addressed('model-run', 'pick-component');
+    const playerNativeRunId = addressed('model-run', 'player-native');
+    const pickNativeExecutionId = addressed('pick-pav-model-execution', 'pick-native');
+    const qualificationId = addressed('model-qualification', 'qualification');
+    const factualOutputId = addressed('private-valuation-factual-output', 'factual-output');
+    const factualRunId = addressed('factual-reconciliation-run', 'factual-run');
+    const hpnCalculation = loaderCalculation(factualRunId, 'restart-proof');
+    const hpnCalculationId = hpnCalculation.calculationId;
+    const playerIntentId = addressed('model-run-intent', 'player-intent');
+    const operationalReceiptId = addressed('architecture-operation-receipt', 'operation');
+    const playerAuthorizationId = addressed('model-run-authorization', 'authorization');
+    const now = new Date();
+    const operation = createAflTradePrivateValuationModelOperation({
+      scopeKey: 'afl-men:2026-trades',
+      factualValuesSha256: digest('exact-loader-members'),
+      hpnValuesSha256: '7346d98d175cac145dd32bf9a6040ad0c952191219760793bb6d1db36e09de5a',
+      hpnMethodId: hpnCalculation.content.methodId,
+      ...modelPairTargets,
+    });
+    const exactInput: AflTradePrivateValuationModelPairExactInput = {
+      requestId,
+      scopeKey: operation.content.scopeKey,
+      factualOutputId,
+      hpnCalculationId,
+      substantive: {
+        factualValuesSha256: operation.content.factualValuesSha256,
+        hpnValuesSha256: operation.content.hpnValuesSha256,
+        hpnMethodId: operation.content.hpnMethodId,
+        player: operation.content.player,
+        pick: operation.content.pick,
+        qualificationPolicyId: operation.content.qualificationPolicyId,
+      },
+    };
+
+    const seed = await adminPool.connect();
+    try {
+      await seed.query('BEGIN');
+      await seed.query(`SET LOCAL search_path TO "${schemaName}"`);
+      await seed.query('SET LOCAL session_replication_role = replica');
+      await seed.query(
+        `INSERT INTO outcome_private_valuation_dispatch_request
+          (request_id,scope_key,trigger_kind,scheduled_for,authority_key,status,available_at,
+           claim_id,lease_token_sha256,lease_expires_at,claimed_at,request_json,claim_sequence)
+         VALUES ($1,$2,'ad_hoc',$3,'restart-proof','claimed',$3,$4,$5,$6,$3,'{}'::jsonb,1)`,
+        [
+          requestId,
+          operation.content.scopeKey,
+          now,
+          claimId,
+          digest(leaseToken),
+          new Date(now.getTime() + 300_000),
+        ]
+      );
+      await seed.query(
+        `INSERT INTO outcome_private_valuation_dispatch_attempt
+          (claim_id,request_id,attempt_sequence,attempt_number,worker_id,lease_token_sha256,
+           claimed_at,lease_expires_at,heartbeat_at)
+         VALUES ($1,$2,1,1,'system:weekly-valuation-coordinator',$3,$4,$5,$4)`,
+        [claimId, requestId, digest(leaseToken), now, new Date(now.getTime() + 300_000)]
+      );
+      await seed.query(
+        `INSERT INTO outcome_hpn_pav_method
+          (method_id,method_sha256,environment,source_artifact_id,captured_at,registered_at,
+           method_canonical_json,method_json)
+         VALUES ($1,$2,'non_production',$3,$4,$4,'{}','{}'::jsonb)
+         ON CONFLICT (method_id) DO NOTHING`,
+        [
+          operation.content.hpnMethodId,
+          operation.content.hpnMethodId.split(':')[1],
+          addressed('artifact', 'hpn-method'),
+          now,
+        ]
+      );
+      await seed.query(
+        `INSERT INTO outcome_private_valuation_factual_output
+          (output_id,request_id,capture_binding_id,source_admission_id,normalization_run_id,fact_batch_id,
+           factual_run_id,candidate_id,factual_release_id,prepared_at,output_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb)`,
+        [
+          factualOutputId,
+          requestId,
+          addressed('private-valuation-capture-binding', 'capture-binding'),
+          addressed('private-valuation-source-admission', 'source-admission'),
+          addressed('provider-normalization-run', 'normalization'),
+          addressed('source-fact-batch', 'fact-batch'),
+          factualRunId,
+          addressed('factual-release-candidate', 'candidate'),
+          addressed('outcome-release', 'release'),
+          now,
+          JSON.stringify({
+            content: {
+              candidate: { memberSetSha256: operation.content.factualValuesSha256 },
+            },
+          }),
+        ]
+      );
+      await seed.query(
+        `INSERT INTO outcome_hpn_pav_calculation
+          (calculation_id,calculation_sha256,schema_version,input_set_id,method_id,
+           environment,competition,season_year,effective_through,calculated_at,value_unit,
+           status,team_count,player_count,calculation_canonical_json,calculation_json,finalized_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,'finalized',$12,$13,$14,$15::jsonb,$10)`,
+        [
+          hpnCalculationId,
+          hpnCalculationId.slice('hpn-pav-season:'.length),
+          hpnCalculation.content.schemaVersion,
+          hpnCalculation.content.inputSetId,
+          hpnCalculation.content.methodId,
+          hpnCalculation.content.environment,
+          hpnCalculation.content.competition,
+          hpnCalculation.content.seasonYear,
+          hpnCalculation.content.effectiveThrough,
+          hpnCalculation.content.calculatedAt,
+          hpnCalculation.content.valueUnit,
+          hpnCalculation.content.teams.length,
+          hpnCalculation.content.players.length,
+          canonicalizeAflTradeJson(hpnCalculation.content),
+          canonicalizeAflTradeJson(hpnCalculation),
+        ]
+      );
+      await seed.query(
+        `INSERT INTO outcome_valuation_model_run_intent
+          (intent_id,environment,dataset_id,admission_id,protocol_id,observation_set_id,
+           started_at,intent_canonical_json,intent_json)
+         VALUES ($1,'non_production',$2,$3,$4,$5,$6,'{}',$7::jsonb)`,
+        [
+          playerIntentId,
+          operation.content.player.datasetId,
+          operation.content.player.datasetAdmissionId,
+          operation.content.player.protocolId,
+          addressed('player-observation-set', 'observation'),
+          now,
+          JSON.stringify({
+            content: {
+              modelId: operation.content.player.modelId,
+              modelVersion: operation.content.player.modelVersion,
+            },
+          }),
+        ]
+      );
+      const policyContent = {
+        authorityBoundary: 'policy_owned_local_private_valuation_for_one_exact_model_run_intent',
+        dispatchRequestId: requestId,
+        substantiveOperationId: operation.operationId,
+        dispatchClaimId: claimId,
+        dispatchAttemptNumber: 1,
+        dispatchLeaseTokenSha256: digest(leaseToken),
+        factualOutputId,
+        hpnCalculationId,
+        factualValuesSha256: operation.content.factualValuesSha256,
+        hpnValuesSha256: operation.content.hpnValuesSha256,
+      };
+      await seed.query(
+        `INSERT INTO outcome_valuation_model_run_operational_authorization
+          (receipt_id,intent_id,environment,dataset_id,admission_id,protocol_id,
+           observation_set_id,authorized_at,valid_through,principal_ref,authority_evidence_id,
+           receipt_canonical_json,receipt_json)
+         VALUES ($1,$2,'non_production',$3,$4,$5,$6,$7,$8,
+           'system:weekly-valuation-coordinator',NULL,'{}',$9::jsonb)`,
+        [
+          operationalReceiptId,
+          playerIntentId,
+          operation.content.player.datasetId,
+          operation.content.player.datasetAdmissionId,
+          operation.content.player.protocolId,
+          addressed('player-observation-set', 'observation'),
+          now,
+          new Date(now.getTime() + 20_000),
+          JSON.stringify({ content: policyContent }),
+        ]
+      );
+      await seed.query(
+        `INSERT INTO outcome_valuation_model_run_authorization
+          (authorization_id,intent_id,operational_authorization_receipt_id,
+           gate_ledger_revision,authorized_at,valid_through,consumed_at,
+           authorization_canonical_json,authorization_json)
+         VALUES ($1,$2,$3,0,$4,$5,$4,'{}','{}'::jsonb)`,
+        [
+          playerAuthorizationId,
+          playerIntentId,
+          operationalReceiptId,
+          now,
+          new Date(now.getTime() + 20_000),
+        ]
+      );
+      await seed.query(
+        `INSERT INTO outcome_valuation_model_run
+          (run_id,intent_id,authorization_id,status,started_at,finished_at,run_canonical_json,run_json)
+         VALUES ($1,$2,$3,'succeeded',$4,$4,'{}','{}'::jsonb)`,
+        [playerNativeRunId, playerIntentId, playerAuthorizationId, now]
+      );
+      await seed.query(
+        `INSERT INTO outcome_governed_pick_pav_model_execution
+          (execution_id,observation_set_id,dataset_id,dataset_artifact_id,
+           dataset_admission_id,dataset_admission_artifact_id,
+           dataset_admission_gate_ledger_revision,protocol_id,protocol_artifact_id,
+           execution_artifact_id,final_test_evaluation_started_at,completed_at,
+           content_sha256,content_canonical_json,execution_json)
+         VALUES ($1,$2,$3,$4,$5,$6,1,$7,$8,$9,$10,$10,$11,'{}',$12::jsonb)`,
+        [
+          pickNativeExecutionId,
+          addressed('pick-pav-observation-set', 'pick-observation'),
+          operation.content.pick.datasetId,
+          addressed('artifact', 'pick-dataset-artifact'),
+          operation.content.pick.datasetAdmissionId,
+          addressed('artifact', 'pick-admission-artifact'),
+          operation.content.pick.protocolId,
+          addressed('artifact', 'pick-protocol-artifact'),
+          addressed('artifact', 'pick-execution-artifact'),
+          now,
+          digest('pick-execution'),
+          JSON.stringify({
+            content: {
+              schemaVersion: 'afl-trade-pick-pav-model-execution/v4',
+              policyId: operation.content.pick.policyId,
+              privateInput: {
+                requestId,
+                operationId: operation.operationId,
+                claimId,
+                attemptNumber: 1,
+                leaseTokenSha256: digest(leaseToken),
+                factualOutputId,
+                hpnCalculationId,
+                factualValuesSha256: operation.content.factualValuesSha256,
+                hpnValuesSha256: operation.content.hpnValuesSha256,
+              },
+            },
+          }),
+        ]
+      );
+      for (const component of [
+        {
+          runId: playerRunId,
+          role: 'player_contribution_and_availability',
+          kind: 'admitted_player_model_run',
+          nativeId: playerNativeRunId,
+          target: operation.content.player,
+        },
+        {
+          runId: pickRunId,
+          role: 'draft_pick_and_future_pick_distribution',
+          kind: 'governed_pick_pav_model_execution',
+          nativeId: pickNativeExecutionId,
+          target: operation.content.pick,
+        },
+      ] as const) {
+        await seed.query(
+          `INSERT INTO outcome_governed_valuation_component_run
+            (run_id,role,native_execution_kind,native_execution_id,artifact_id,
+             native_execution_artifact_id,protocol_id,protocol_artifact_id,dataset_id,
+             dataset_artifact_id,dataset_admission_id,dataset_admission_artifact_id,
+             dataset_admission_gate_ledger_revision,registered_at,content_sha256,
+             content_canonical_json,manifest_json)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,1,$13,$14,'{}','{}'::jsonb)`,
+          [
+            component.runId,
+            component.role,
+            component.kind,
+            component.nativeId,
+            addressed('artifact', `${component.role}-manifest`),
+            addressed('artifact', `${component.role}-native`),
+            component.target.protocolId,
+            addressed('artifact', `${component.role}-protocol`),
+            component.target.datasetId,
+            addressed('artifact', `${component.role}-dataset`),
+            component.target.datasetAdmissionId,
+            addressed('artifact', `${component.role}-admission`),
+            now,
+            digest(`${component.role}-content`),
+          ]
+        );
+      }
+      await seed.query(
+        `INSERT INTO outcome_governed_valuation_model_qualification
+          (qualification_id,scope_key,outcome,artifact_id,player_run_id,pick_run_id,
+           policy_artifact_id,player_criteria_artifact_id,pick_criteria_artifact_id,
+           player_evidence_artifact_id,pick_evidence_artifact_id,evaluated_at,
+           content_sha256,content_canonical_json,qualification_json)
+         VALUES ($1,$2,'qualified',$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'{}',$13::jsonb)`,
+        [
+          qualificationId,
+          operation.content.scopeKey,
+          addressed('artifact', 'qualification'),
+          playerRunId,
+          pickRunId,
+          addressed('artifact', 'policy'),
+          addressed('artifact', 'player-criteria'),
+          addressed('artifact', 'pick-criteria'),
+          addressed('artifact', 'player-evidence'),
+          addressed('artifact', 'pick-evidence'),
+          now,
+          digest('qualification-content'),
+          JSON.stringify({
+            content: { policy: { policyVersion: operation.content.qualificationPolicyId } },
+          }),
+        ]
+      );
+      await seed.query('COMMIT');
+    } catch (error) {
+      await seed.query('ROLLBACK');
+      throw error;
+    } finally {
+      seed.release();
+    }
+
+    const client = createPgAflOutcomeSqlClient(outcomesPool);
+    const claim = { claimId, leaseToken };
+    const coordinator = (crashAfter: 'player' | 'pick' | 'pair' | 'qualification' | null) => {
+      const retained = new PostgresAflTradePrivateValuationModelPairRepository(client);
+      const repository: AflTradePrivateValuationModelPairRepository = {
+        bindInput: (input) => retained.bindInput(input),
+        async acceptComponent(input) {
+          const state = await retained.acceptComponent(input);
+          if (crashAfter === input.role) throw new Error(`simulated restart after ${input.role}`);
+          return state;
+        },
+        async acceptPair(input) {
+          const state = await retained.acceptPair(input);
+          if (crashAfter === 'pair') throw new Error('simulated restart after pair');
+          return state;
+        },
+        async bindQualification(input) {
+          const state = await retained.bindQualification(input);
+          if (crashAfter === 'qualification') {
+            throw new Error('simulated restart after qualification');
+          }
+          return state;
+        },
+      };
+      return createAflTradePrivateValuationModelPairCoordinator({
+        prepareExactInput: async () => exactInput,
+        repository,
+        executePlayer: async () => ({ state: 'completed', runId: playerRunId }),
+        executePick: async () => ({ state: 'completed', runId: pickRunId }),
+        qualify: async () => ({ qualificationId, outcome: 'qualified' }),
+      });
+    };
+
+    const mutateFixture = async (sql: string, parameters: readonly unknown[]) => {
+      const connection = await adminPool.connect();
+      try {
+        await connection.query('BEGIN');
+        await connection.query(`SET LOCAL search_path TO "${schemaName}"`);
+        await connection.query('SET LOCAL session_replication_role = replica');
+        await connection.query(sql, parameters);
+        await connection.query('COMMIT');
+      } catch (error) {
+        await connection.query('ROLLBACK');
+        throw error;
+      } finally {
+        connection.release();
+      }
+    };
+
+    const concurrentRepositories = [
+      new PostgresAflTradePrivateValuationModelPairRepository(
+        createPgAflOutcomeSqlClient(outcomesPool)
+      ),
+      new PostgresAflTradePrivateValuationModelPairRepository(
+        createPgAflOutcomeSqlClient(outcomesPool)
+      ),
+    ] as const;
+    const concurrentBindings = await Promise.all(
+      concurrentRepositories.map((repository) => repository.bindInput({ exactInput, claim }))
+    );
+    expect(concurrentBindings).toMatchObject([
+      { operation: { operationId: operation.operationId }, attemptNumber: 1 },
+      { operation: { operationId: operation.operationId }, attemptNumber: 1 },
+    ]);
+    await expect(
+      outcomesPool.query(
+        `SELECT
+           (SELECT count(*)::int FROM outcome_private_valuation_model_operation
+             WHERE operation_id=$1) AS operation_count,
+           (SELECT count(*)::int FROM outcome_private_valuation_model_request_binding
+             WHERE request_id=$2 AND operation_id=$1 AND attempt_number=1) AS binding_count`,
+        [operation.operationId, requestId]
+      )
+    ).resolves.toMatchObject({
+      rows: [{ operation_count: 1, binding_count: 1 }],
+    });
+
+    await mutateFixture(
+      `UPDATE outcome_private_valuation_dispatch_attempt
+          SET claimed_at=$2,heartbeat_at=$2,lease_expires_at=$3
+        WHERE claim_id=$1`,
+      [claimId, new Date(now.getTime() - 10_000), new Date(now.getTime() - 1_000)]
+    );
+    await expect(
+      client.query(`SELECT load_outcome_private_valuation_dispatch_request_for_claim($1,$2,$3)`, [
+        requestId,
+        claimId,
+        digest(leaseToken),
+      ])
+    ).rejects.toThrow('lost its live claim fence');
+    await expect(
+      client.query(
+        `INSERT INTO outcome_governed_pick_pav_model_execution
+          SELECT $2,observation_set_id,dataset_id,dataset_artifact_id,
+                 dataset_admission_id,dataset_admission_artifact_id,
+                 dataset_admission_gate_ledger_revision,protocol_id,protocol_artifact_id,
+                 execution_artifact_id,final_test_evaluation_started_at,completed_at,
+                 content_sha256,content_canonical_json,execution_json
+            FROM outcome_governed_pick_pav_model_execution WHERE execution_id=$1`,
+        [pickNativeExecutionId, addressed('pick-pav-model-execution', 'stale-native')]
+      )
+    ).rejects.toThrow('lost its live claim fence');
+    await expect(
+      client.query(
+        `INSERT INTO outcome_governed_valuation_component_run
+          SELECT $2,role,native_execution_kind,native_execution_id,artifact_id,
+                 native_execution_artifact_id,protocol_id,protocol_artifact_id,dataset_id,
+                 dataset_artifact_id,dataset_admission_id,dataset_admission_artifact_id,
+                 dataset_admission_gate_ledger_revision,registered_at,content_sha256,
+                 content_canonical_json,manifest_json
+            FROM outcome_governed_valuation_component_run WHERE run_id=$1`,
+        [pickRunId, addressed('model-run', 'stale-pick-component')]
+      )
+    ).rejects.toThrow('lost its live claim fence');
+    await expect(
+      client.query(
+        `INSERT INTO outcome_governed_valuation_component_run
+          SELECT $2,role,native_execution_kind,native_execution_id,artifact_id,
+                 native_execution_artifact_id,protocol_id,protocol_artifact_id,dataset_id,
+                 dataset_artifact_id,dataset_admission_id,dataset_admission_artifact_id,
+                 dataset_admission_gate_ledger_revision,registered_at,content_sha256,
+                 content_canonical_json,manifest_json
+            FROM outcome_governed_valuation_component_run WHERE run_id=$1`,
+        [playerRunId, addressed('model-run', 'stale-player-component')]
+      )
+    ).rejects.toThrow('lost its live claim fence');
+    await mutateFixture(
+      `UPDATE outcome_private_valuation_dispatch_attempt
+          SET claimed_at=$2,heartbeat_at=$2,lease_expires_at=$3
+        WHERE claim_id=$1`,
+      [claimId, now, new Date(now.getTime() + 300_000)]
+    );
+
+    await mutateFixture(
+      `UPDATE outcome_valuation_model_run_operational_authorization
+          SET receipt_json=jsonb_set(receipt_json,'{content,factualOutputId}',to_jsonb($2::text))
+        WHERE receipt_id=$1`,
+      [operationalReceiptId, addressed('private-valuation-factual-output', 'wrong-factual')]
+    );
+    await expect(coordinator(null).prepare({ requestId, claim })).rejects.toThrow('wrong ancestry');
+    await mutateFixture(
+      `UPDATE outcome_valuation_model_run_operational_authorization
+          SET receipt_json=jsonb_set(receipt_json,'{content,factualOutputId}',to_jsonb($2::text))
+        WHERE receipt_id=$1`,
+      [operationalReceiptId, factualOutputId]
+    );
+
+    await expect(coordinator('player').prepare({ requestId, claim })).rejects.toThrow(
+      'simulated restart after player'
+    );
+    await mutateFixture(
+      `UPDATE outcome_governed_pick_pav_model_execution
+          SET execution_json=jsonb_set(
+            execution_json,'{content,privateInput,hpnCalculationId}',to_jsonb($2::text))
+        WHERE execution_id=$1`,
+      [pickNativeExecutionId, addressed('hpn-pav-season', 'wrong-calculation')]
+    );
+    await expect(coordinator(null).prepare({ requestId, claim })).rejects.toThrow('wrong ancestry');
+    await mutateFixture(
+      `UPDATE outcome_governed_pick_pav_model_execution
+          SET execution_json=jsonb_set(
+            execution_json,'{content,privateInput,hpnCalculationId}',to_jsonb($2::text))
+        WHERE execution_id=$1`,
+      [pickNativeExecutionId, hpnCalculationId]
+    );
+    await expect(coordinator('pick').prepare({ requestId, claim })).rejects.toThrow(
+      'simulated restart after pick'
+    );
+    await expect(coordinator('pair').prepare({ requestId, claim })).rejects.toThrow(
+      'simulated restart after pair'
+    );
+    await mutateFixture(
+      `UPDATE outcome_governed_valuation_model_qualification
+          SET qualification_json=jsonb_set(
+            qualification_json,'{content,policy,policyVersion}',to_jsonb($2::text))
+        WHERE qualification_id=$1`,
+      [qualificationId, addressed('model-qualification-policy', 'wrong-policy')]
+    );
+    await expect(coordinator(null).prepare({ requestId, claim })).rejects.toThrow(
+      'wrong accepted pair'
+    );
+    await mutateFixture(
+      `UPDATE outcome_governed_valuation_model_qualification
+          SET qualification_json=jsonb_set(
+            qualification_json,'{content,policy,policyVersion}',to_jsonb($2::text))
+        WHERE qualification_id=$1`,
+      [qualificationId, operation.content.qualificationPolicyId]
+    );
+    await expect(coordinator('qualification').prepare({ requestId, claim })).rejects.toThrow(
+      'simulated restart after qualification'
+    );
+
+    const replay = await coordinator(null).prepare({ requestId, claim });
+    expect(replay).toMatchObject({
+      state: 'already_qualified',
+      operationId: operation.operationId,
+      qualificationId,
+    });
+    await expect(
+      client.transaction(async (transaction) => {
+        await transaction.query('SET LOCAL ROLE afl_trade_private_evaluation_coordinator');
+        await transaction.query(
+          `UPDATE outcome_private_valuation_model_operation SET
+             player_attempt_number=2,
+             qualification_outcome='failed'
+           WHERE operation_id=$1`,
+          [operation.operationId]
+        );
+      })
+    ).rejects.toThrow('immutable after acceptance');
+    await outcomesPool.query(
+      `SELECT complete_outcome_private_valuation_dispatch($1,$2,$3::jsonb)`,
+      [claimId, digest(leaseToken), JSON.stringify({ state: 'activated' })]
+    );
+  });
+
+  it('loads only the exact retained private factual and finalized HPN input', async () => {
+    const requestId = addressed('private-valuation-dispatch', 'exact-loader-request');
+    const requests = [
+      { requestId, trigger: 'ad_hoc', custodyKey: 'exact-loader' },
+      {
+        requestId: addressed('private-valuation-dispatch', 'exact-loader-weekly-request'),
+        trigger: 'weekly',
+        custodyKey: 'exact-loader-weekly',
+      },
+      {
+        requestId: addressed('private-valuation-dispatch', 'exact-loader-qualified-request'),
+        trigger: 'model_qualified',
+        custodyKey: 'exact-loader-qualified',
+      },
+    ] as const;
+    const factualInputs = requests.map((request) => {
+      const factualRunId = addressed('factual-reconciliation-run', `${request.custodyKey}-run`);
+      return {
+        ...request,
+        factual: loaderFactualOutput(request.requestId, request.custodyKey, factualRunId),
+        calculation: loaderCalculation(factualRunId, request.custodyKey),
+      };
+    });
+    const factual = factualInputs[0]!.factual;
+    const calculation = factualInputs[0]!.calculation;
+    const seed = await adminPool.connect();
+    try {
+      await seed.query('BEGIN');
+      await seed.query(`SET LOCAL search_path TO "${schemaName}"`);
+      await seed.query('SET LOCAL session_replication_role = replica');
+      for (const [index, input] of factualInputs.entries()) {
+        await seed.query(
+          `INSERT INTO outcome_private_valuation_dispatch_request
+            (request_id,scope_key,trigger_kind,scheduled_for,authority_key,status,available_at,
+             request_json,claim_sequence)
+           VALUES ($1,'afl-men:2026-trades',$2,$3,$4,'pending',$3,
+             '{}'::jsonb,0)`,
+          [
+            input.requestId,
+            input.trigger,
+            `2026-08-24T00:00:0${index}.000Z`,
+            `${input.trigger}-exact-loader`,
+          ]
+        );
+        await seed.query(
+          `INSERT INTO outcome_private_valuation_factual_output
+            (output_id,request_id,capture_binding_id,source_admission_id,normalization_run_id,
+             fact_batch_id,factual_run_id,candidate_id,factual_release_id,prepared_at,output_json)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb)`,
+          [
+            input.factual.outputId,
+            input.requestId,
+            input.factual.content.captureBindingId,
+            input.factual.content.sourceAdmissionId,
+            input.factual.content.normalizationRunId,
+            input.factual.content.factBatch.batchId,
+            input.factual.content.reconciliation.factualRunId,
+            input.factual.content.candidate.candidateId,
+            input.factual.content.factualRelease.releaseId,
+            input.factual.content.preparedAt,
+            canonicalizeAflTradeJson(input.factual),
+          ]
+        );
+      }
+      await seed.query(
+        `INSERT INTO outcome_hpn_pav_method
+          (method_id,method_sha256,environment,source_artifact_id,captured_at,registered_at,
+           method_canonical_json,method_json)
+         VALUES ($1,$2,'non_production',$3,$4,$4,'{}','{}'::jsonb)
+         ON CONFLICT (method_id) DO NOTHING`,
+        [
+          calculation.content.methodId,
+          calculation.content.methodId.slice('hpn-pav-method:'.length),
+          addressed('artifact', 'exact-loader-method'),
+          '2026-08-24T00:00:00.000Z',
+        ]
+      );
+      await seed.query(
+        `INSERT INTO outcome_hpn_pav_method
+          (method_id,method_sha256,environment,source_artifact_id,captured_at,registered_at,
+           method_canonical_json,method_json)
+         VALUES ($1,$2,'non_production',$3,$4,$4,'{}','{}'::jsonb)
+         ON CONFLICT (method_id) DO NOTHING`,
+        [
+          addressed('hpn-pav-method', 'method'),
+          digest('method'),
+          addressed('artifact', 'forged-exact-loader-method'),
+          '2026-08-24T00:00:00.000Z',
+        ]
+      );
+      for (const input of factualInputs) {
+        await seed.query(
+          `INSERT INTO outcome_hpn_pav_calculation
+            (calculation_id,calculation_sha256,schema_version,input_set_id,method_id,
+             environment,competition,season_year,effective_through,calculated_at,value_unit,
+             status,team_count,player_count,calculation_canonical_json,calculation_json,finalized_at)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,'finalized',$12,$13,$14,$15::jsonb,$10)`,
+          [
+            input.calculation.calculationId,
+            input.calculation.calculationId.slice('hpn-pav-season:'.length),
+            input.calculation.content.schemaVersion,
+            input.calculation.content.inputSetId,
+            input.calculation.content.methodId,
+            input.calculation.content.environment,
+            input.calculation.content.competition,
+            input.calculation.content.seasonYear,
+            input.calculation.content.effectiveThrough,
+            input.calculation.content.calculatedAt,
+            input.calculation.content.valueUnit,
+            input.calculation.content.teams.length,
+            input.calculation.content.players.length,
+            canonicalizeAflTradeJson(input.calculation.content),
+            canonicalizeAflTradeJson(input.calculation),
+          ]
+        );
+      }
+      await seed.query('COMMIT');
+    } catch (error) {
+      await seed.query('ROLLBACK');
+      throw error;
+    } finally {
+      seed.release();
+    }
+
+    const client = createPgAflOutcomeSqlClient(outcomesPool);
+    const prepared = {
+      state: 'prepared' as const,
+      requestId,
+      factualOutputId: factual.outputId,
+      inputSetId: calculation.content.inputSetId,
+      calculationId: calculation.calculationId,
+      captureBindingIds: [factual.content.captureBindingId],
+      sourceAdmissionIds: [factual.content.sourceAdmissionId],
+      publicationEligible: false as const,
+    };
+    const targets = modelPairTargets;
+    const exact = await loadAflTradePrivateValuationModelPairExactInput({
+      client,
+      prepared,
+      targets,
+    });
+    expect(exact).toMatchObject({
+      requestId,
+      scopeKey: 'afl-men:2026-trades',
+      factualOutputId: factual.outputId,
+      hpnCalculationId: calculation.calculationId,
+      substantive: {
+        factualValuesSha256: factual.content.candidate.memberSetSha256,
+        hpnMethodId: calculation.content.methodId,
+        player: targets.player,
+        pick: targets.pick,
+        qualificationPolicyId: targets.qualificationPolicyId,
+      },
+    });
+    expect(exact.substantive.hpnValuesSha256).toBe(
+      '7346d98d175cac145dd32bf9a6040ad0c952191219760793bb6d1db36e09de5a'
+    );
+    const leaseToken = digest('exact-loader-lease-token');
+    const claimed = await outcomesPool.query<{ claim_id: string }>(
+      `SELECT claim_id FROM claim_outcome_private_valuation_dispatch($1,$2,120,$3)`,
+      ['exact-loader-worker', digest(leaseToken), requestId]
+    );
+    const claimId = claimed.rows[0]?.claim_id;
+    if (claimId === undefined) throw new Error('Exact-loader dispatch was not claimed.');
+    const pairRepository = new PostgresAflTradePrivateValuationModelPairRepository(client);
+    await expect(
+      pairRepository.bindInput({
+        exactInput: { ...exact, scopeKey: 'afl-men:2025-trades' },
+        claim: { claimId, leaseToken },
+      })
+    ).rejects.toThrow('exact live dispatch custody');
+    await expect(
+      pairRepository.bindInput({
+        exactInput: {
+          ...exact,
+          substantive: {
+            ...exact.substantive,
+            factualValuesSha256: digest('forged-factual-values'),
+          },
+        },
+        claim: { claimId, leaseToken },
+      })
+    ).rejects.toThrow('exact live dispatch custody');
+    await expect(
+      pairRepository.bindInput({
+        exactInput: {
+          ...exact,
+          substantive: {
+            ...exact.substantive,
+            hpnValuesSha256: digest('forged-hpn-values'),
+          },
+        },
+        claim: { claimId, leaseToken },
+      })
+    ).rejects.toThrow('exact live dispatch custody');
+    await expect(
+      pairRepository.bindInput({
+        exactInput: {
+          ...exact,
+          substantive: {
+            ...exact.substantive,
+            hpnMethodId: addressed('hpn-pav-method', 'method'),
+          },
+        },
+        claim: { claimId, leaseToken },
+      })
+    ).rejects.toThrow('exact live dispatch custody');
+    await expect(
+      loadAflTradePrivateValuationModelPairExactInput({
+        client,
+        prepared: {
+          ...prepared,
+          factualOutputId: addressed(
+            'private-valuation-factual-output',
+            'missing-exact-loader-output'
+          ),
+        },
+        targets,
+      })
+    ).rejects.toThrow('Exact private factual and HPN model input is unavailable.');
+
+    const firstBinding = await pairRepository.bindInput({
+      exactInput: exact,
+      claim: { claimId, leaseToken },
+    });
+    await outcomesPool.query(
+      `SELECT reschedule_outcome_private_valuation_dispatch($1,$2,'retry_pending')`,
+      [claimId, digest(leaseToken)]
+    );
+    const operationIds = [firstBinding.operation.operationId];
+    for (const input of factualInputs.slice(1)) {
+      const nextLeaseToken = digest(`${input.custodyKey}-lease-token`);
+      const nextClaim = await outcomesPool.query<{ claim_id: string }>(
+        `SELECT claim_id FROM claim_outcome_private_valuation_dispatch($1,$2,120,$3)`,
+        [`${input.custodyKey}-worker`, digest(nextLeaseToken), input.requestId]
+      );
+      const nextClaimId = nextClaim.rows[0]?.claim_id;
+      if (nextClaimId === undefined) throw new Error(`${input.trigger} dispatch was not claimed.`);
+      const nextPrepared = {
+        ...prepared,
+        requestId: input.requestId,
+        factualOutputId: input.factual.outputId,
+        inputSetId: input.calculation.content.inputSetId,
+        calculationId: input.calculation.calculationId,
+        captureBindingIds: [input.factual.content.captureBindingId],
+        sourceAdmissionIds: [input.factual.content.sourceAdmissionId],
+      };
+      const nextExact = await loadAflTradePrivateValuationModelPairExactInput({
+        client,
+        prepared: nextPrepared,
+        targets,
+      });
+      const nextBinding = await pairRepository.bindInput({
+        exactInput: nextExact,
+        claim: { claimId: nextClaimId, leaseToken: nextLeaseToken },
+      });
+      operationIds.push(nextBinding.operation.operationId);
+      await outcomesPool.query(
+        `SELECT reschedule_outcome_private_valuation_dispatch($1,$2,'retry_pending')`,
+        [nextClaimId, digest(nextLeaseToken)]
+      );
+    }
+    expect(new Set(operationIds)).toEqual(new Set([firstBinding.operation.operationId]));
+    expect(new Set(factualInputs.map((input) => input.calculation.calculationId)).size).toBe(3);
+    await expect(
+      outcomesPool.query(
+        `SELECT
+           (SELECT count(*)::int FROM outcome_private_valuation_model_operation
+             WHERE operation_id=$1) AS operation_count,
+           (SELECT count(*)::int FROM outcome_private_valuation_model_request_binding
+             WHERE operation_id=$1) AS binding_count,
+           (SELECT array_agg(request.trigger_kind ORDER BY request.trigger_kind)
+              FROM outcome_private_valuation_model_request_binding binding
+              JOIN outcome_private_valuation_dispatch_request request
+                ON request.request_id=binding.request_id
+             WHERE binding.operation_id=$1 AND binding.request_id=ANY($2::text[])) AS trigger_kinds,
+           (SELECT pair_accepted_at IS NOT NULL
+              FROM outcome_private_valuation_model_operation
+             WHERE operation_id=$1) AS pair_accepted,
+           (SELECT qualification_outcome
+              FROM outcome_private_valuation_model_operation
+             WHERE operation_id=$1) AS qualification_outcome`,
+        [firstBinding.operation.operationId, factualInputs.map((input) => input.requestId)]
+      )
+    ).resolves.toMatchObject({
+      rows: [
+        {
+          operation_count: 1,
+          binding_count: 4,
+          trigger_kinds: ['ad_hoc', 'model_qualified', 'weekly'],
+          pair_accepted: true,
+          qualification_outcome: 'qualified',
+        },
+      ],
+    });
+  });
+});

--- a/tests/outcomes-integration/afl-private-valuation-model-pair-postgres.test.ts
+++ b/tests/outcomes-integration/afl-private-valuation-model-pair-postgres.test.ts
@@ -1005,7 +1005,7 @@ describe.sequential('dispatch-bound private model pair in PostgreSQL', () => {
            (SELECT count(*)::int FROM outcome_private_valuation_model_operation
              WHERE operation_id=$1) AS operation_count,
            (SELECT count(*)::int FROM outcome_private_valuation_model_request_binding
-             WHERE operation_id=$1) AS binding_count,
+             WHERE operation_id=$1 AND request_id=ANY($2::text[])) AS binding_count,
            (SELECT array_agg(request.trigger_kind ORDER BY request.trigger_kind)
               FROM outcome_private_valuation_model_request_binding binding
               JOIN outcome_private_valuation_dispatch_request request
@@ -1023,7 +1023,7 @@ describe.sequential('dispatch-bound private model pair in PostgreSQL', () => {
       rows: [
         {
           operation_count: 1,
-          binding_count: 4,
+          binding_count: 3,
           trigger_kinds: ['ad_hoc', 'model_qualified', 'weekly'],
           pair_accepted: true,
           qualification_outcome: 'qualified',

--- a/tests/outcomes-integration/afl-private-valuation-scheduling-postgres.test.ts
+++ b/tests/outcomes-integration/afl-private-valuation-scheduling-postgres.test.ts
@@ -62,7 +62,8 @@ beforeAll(async () => {
   ).match(
     /CREATE FUNCTION "outcome_afl_trade_canonical_json"[\s\S]*?\$\$ LANGUAGE plpgsql IMMUTABLE STRICT;/
   )?.[0];
-  if (canonicalFunction === undefined) throw new Error('Canonical JSON SQL function was not found.');
+  if (canonicalFunction === undefined)
+    throw new Error('Canonical JSON SQL function was not found.');
   await pool.query(canonicalFunction);
   await pool.query(`CREATE TABLE outcome_current_prepared_valuation_input_set (
     scope_key text PRIMARY KEY,prepared_input_set_id text NOT NULL,revision integer NOT NULL
@@ -88,6 +89,19 @@ beforeAll(async () => {
       'utf8'
     )
   );
+  const scopeSerializedClaim = readFileSync(
+    join(
+      process.cwd(),
+      'prisma/afl-trade-outcomes/migrations/0079_dispatch_bound_private_model_pair/migration.sql'
+    ),
+    'utf8'
+  ).match(
+    /CREATE OR REPLACE FUNCTION "claim_outcome_private_valuation_dispatch"[\s\S]*?END \$\$;/
+  )?.[0];
+  if (scopeSerializedClaim === undefined) {
+    throw new Error('Scope-serialized private valuation claim function was not found.');
+  }
+  await pool.query(scopeSerializedClaim);
 });
 
 afterAll(async () => {
@@ -108,12 +122,12 @@ beforeEach(async () => {
 
 describe('private valuation scheduling PostgreSQL boundary', () => {
   it('coalesces startup catch-up and retains newly-qualified immediate work after commit', async () => {
-    await expect(repository.enqueueStartupCatchUp('2026-06-03T03:00:00.000Z')).resolves.toHaveLength(
-      1
-    );
-    await expect(repository.enqueueStartupCatchUp('2026-07-22T03:00:00.000Z')).resolves.toHaveLength(
-      1
-    );
+    await expect(
+      repository.enqueueStartupCatchUp('2026-06-03T03:00:00.000Z')
+    ).resolves.toHaveLength(1);
+    await expect(
+      repository.enqueueStartupCatchUp('2026-07-22T03:00:00.000Z')
+    ).resolves.toHaveLength(1);
 
     await pool.query(`BEGIN`);
     await pool.query(
@@ -173,7 +187,12 @@ describe('private valuation scheduling PostgreSQL boundary', () => {
       dispatcher.dispatchOne(),
       dispatcher.dispatchOne(),
     ]);
-    expect(dispatched.every(({ state }) => state === 'completed')).toBe(true);
+    let completed = dispatched.filter(({ state }) => state === 'completed').length;
+    while (completed < 3) {
+      const next = await dispatcher.dispatchOne();
+      expect(next.state).toBe('completed');
+      completed += 1;
+    }
     expect(run).toHaveBeenCalledTimes(3);
     await expect(dispatcher.dispatchOne()).resolves.toEqual({ state: 'idle' });
     const retained = await pool.query<{ result_json: { state: string } }>(
@@ -186,6 +205,27 @@ describe('private valuation scheduling PostgreSQL boundary', () => {
       'already_current',
     ]);
     expect(first).toMatch(/^private-valuation-dispatch:/);
+  });
+
+  it('allows only one live dispatch claim per valuation scope', async () => {
+    await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'scope-claim-a',
+    });
+    await repository.enqueueAdHoc({
+      scopeKey: 'afl-men:2026-trades',
+      operationKey: 'scope-claim-b',
+    });
+    const otherRepository = new PostgresAflTradePrivateValuationScheduleRepository(
+      createPgAflOutcomeSqlClient(pool)
+    );
+
+    const claims = await Promise.all([
+      repository.claim('scope-worker-a'),
+      otherRepository.claim('scope-worker-b'),
+    ]);
+
+    expect(claims.filter((claim) => claim !== null)).toHaveLength(1);
   });
 
   it('passes the exact retained request and live claim fence to the coordinator', async () => {
@@ -535,10 +575,11 @@ describe('private valuation scheduling PostgreSQL boundary', () => {
       await restricted.query('BEGIN');
       await restricted.query(`SET LOCAL ROLE afl_trade_private_evaluation_coordinator`);
       await expect(
-        restricted.query(
-          `SELECT complete_outcome_private_valuation_dispatch($1,$2,$3::jsonb)`,
-          [claim!.claimId, 'd'.repeat(64), JSON.stringify({ state: 'already_current' })]
-        )
+        restricted.query(`SELECT complete_outcome_private_valuation_dispatch($1,$2,$3::jsonb)`, [
+          claim!.claimId,
+          'd'.repeat(64),
+          JSON.stringify({ state: 'already_current' }),
+        ])
       ).rejects.toThrow('claim was lost');
       await restricted.query('ROLLBACK');
     } finally {
@@ -608,9 +649,21 @@ describe('private valuation scheduling PostgreSQL boundary', () => {
   }, 10_000);
 
   it('judges completion, reschedule, and heartbeat expiry after their row locks are acquired', async () => {
+    const scopes = [
+      'afl-men:2026-blocked-completion',
+      'afl-men:2026-blocked-reschedule',
+      'afl-men:2026-blocked-heartbeat',
+    ];
+    await pool.query(
+      `INSERT INTO outcome_current_prepared_valuation_input_set
+        (scope_key,prepared_input_set_id,revision)
+       SELECT scope_key,'prepared:'||ordinality,1
+         FROM unnest($1::text[]) WITH ORDINALITY AS scope(scope_key,ordinality)`,
+      [scopes]
+    );
     const requestIds = await Promise.all(
-      ['blocked-completion', 'blocked-reschedule', 'blocked-heartbeat'].map((operationKey) =>
-        repository.enqueueAdHoc({ scopeKey: 'afl-men:2026-trades', operationKey })
+      ['blocked-completion', 'blocked-reschedule', 'blocked-heartbeat'].map((operationKey, index) =>
+        repository.enqueueAdHoc({ scopeKey: scopes[index]!, operationKey })
       )
     );
     const tokenSha256s = ['1'.repeat(64), '2'.repeat(64), '3'.repeat(64)];

--- a/tests/unit/afl-trade-intelligence-admitted-model-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-admitted-model-authority.test.ts
@@ -1422,6 +1422,7 @@ describe('admitted AFL trade model authority contracts', () => {
     expect(policyAuthorization.content).toMatchObject({
       authorityBoundary: 'policy_owned_local_private_valuation_for_one_exact_model_run_intent',
       principalRef: 'system:weekly-valuation-coordinator',
+      role: 'afl_trade_private_evaluation_coordinator',
       environment: 'non_production',
       executionMode: 'local',
       publicationEligible: false,
@@ -1453,12 +1454,18 @@ describe('admitted AFL trade model authority contracts', () => {
     const authorization = createAflTradePrivateValuationModelRunOperationalAuthorization({
       ...input,
       principalRef: 'caller-controlled-principal',
+      role: 'afl_trade_model_run_operator',
       environment: 'production',
+      executionMode: 'remote',
+      publicationEligible: true,
+      publicationProhibited: false,
     } as never);
     expect(authorization.content).toMatchObject({
       principalRef: 'system:weekly-valuation-coordinator',
+      role: 'afl_trade_private_evaluation_coordinator',
       environment: 'non_production',
       executionMode: 'local',
+      publicationEligible: false,
       publicationProhibited: true,
     });
   });

--- a/tests/unit/afl-trade-intelligence-admitted-model-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-admitted-model-authority.test.ts
@@ -24,6 +24,7 @@ import {
   AflTradeAdmittedModelRunner,
   AflTradeAdmittedModelRunAuthorityService,
   createAflTradeModelRunOperationalAuthorization,
+  createAflTradePrivateValuationModelRunOperationalAuthorization,
   type AflTradeAdmittedModelRunEvidence,
   type AflTradeModelRunAuthorizationStore,
 } from '@/server/aflTradeIntelligence/modeling/admittedModelRunAuthority';
@@ -1395,5 +1396,70 @@ describe('admitted AFL trade model authority contracts', () => {
         },
       })
     ).toThrow(/authority evidence/i);
+  });
+
+  it('creates exact local non-production authority through the fixed private valuation policy', () => {
+    const fixture = admittedRunFixture();
+    const policyAuthorization = createAflTradePrivateValuationModelRunOperationalAuthorization({
+      runIntentId: fixture.intent.intentId,
+      datasetId: fixture.intent.content.datasetId,
+      datasetAdmissionId: fixture.intent.content.datasetAdmissionId,
+      modelProtocolId: fixture.intent.content.modelProtocolId,
+      observationSetId: fixture.intent.content.observationSetId,
+      dispatchRequestId: `private-valuation-dispatch:${digest('d')}`,
+      substantiveOperationId: `private-valuation-model-operation:${digest('e')}`,
+      dispatchClaimId: `private-valuation-dispatch-claim:${digest('f')}`,
+      dispatchAttemptNumber: 1,
+      dispatchLeaseTokenSha256: digest('a'),
+      factualOutputId: `private-valuation-factual-output:${digest('1')}`,
+      hpnCalculationId: `hpn-pav-season:${digest('2')}`,
+      factualValuesSha256: digest('3'),
+      hpnValuesSha256: digest('4'),
+      authorizedAt: fixture.intent.content.startedAt,
+      validThrough: '2026-08-10T00:03:30.000Z',
+    });
+
+    expect(policyAuthorization.content).toMatchObject({
+      authorityBoundary: 'policy_owned_local_private_valuation_for_one_exact_model_run_intent',
+      principalRef: 'system:weekly-valuation-coordinator',
+      environment: 'non_production',
+      executionMode: 'local',
+      publicationEligible: false,
+      publicationProhibited: true,
+    });
+  });
+
+  it('does not let callers override the private valuation policy authorization', () => {
+    const fixture = admittedRunFixture();
+    const input = {
+      runIntentId: fixture.intent.intentId,
+      datasetId: fixture.intent.content.datasetId,
+      datasetAdmissionId: fixture.intent.content.datasetAdmissionId,
+      modelProtocolId: fixture.intent.content.modelProtocolId,
+      observationSetId: fixture.intent.content.observationSetId,
+      dispatchRequestId: `private-valuation-dispatch:${digest('d')}`,
+      substantiveOperationId: `private-valuation-model-operation:${digest('e')}`,
+      dispatchClaimId: `private-valuation-dispatch-claim:${digest('f')}`,
+      dispatchAttemptNumber: 1,
+      dispatchLeaseTokenSha256: digest('a'),
+      factualOutputId: `private-valuation-factual-output:${digest('1')}`,
+      hpnCalculationId: `hpn-pav-season:${digest('2')}`,
+      factualValuesSha256: digest('3'),
+      hpnValuesSha256: digest('4'),
+      authorizedAt: fixture.intent.content.startedAt,
+      validThrough: '2026-08-10T00:03:30.000Z',
+    };
+
+    const authorization = createAflTradePrivateValuationModelRunOperationalAuthorization({
+      ...input,
+      principalRef: 'caller-controlled-principal',
+      environment: 'production',
+    } as never);
+    expect(authorization.content).toMatchObject({
+      principalRef: 'system:weekly-valuation-coordinator',
+      environment: 'non_production',
+      executionMode: 'local',
+      publicationProhibited: true,
+    });
   });
 });

--- a/tests/unit/afl-trade-intelligence-governed-pick-pav-model-execution.test.ts
+++ b/tests/unit/afl-trade-intelligence-governed-pick-pav-model-execution.test.ts
@@ -3,11 +3,10 @@ import { createHash } from 'node:crypto';
 import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
 import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
 import { createAflTradePickPavPolicy } from '@/server/aflTradeIntelligence/modeling/pickOutcomeContracts';
-import {
-  computeAflTradePickPavModelExecutionOutputs,
-} from '@/server/aflTradeIntelligence/modeling/pickPavModelExecution';
+import { computeAflTradePickPavModelExecutionOutputs } from '@/server/aflTradeIntelligence/modeling/pickPavModelExecution';
 import { materializeAflTradePickPavObservationSet } from '@/server/aflTradeIntelligence/modeling/pickPavObservationService';
 import {
+  createDispatchBoundGovernedAflTradePickPavModelExecution,
   createGovernedAflTradePickPavModelExecution,
   governedAflTradePickPavModelExecutionSchema,
 } from '@/server/aflTradeIntelligence/modeling/governedPickPavModelExecution';
@@ -126,33 +125,31 @@ describe('governed pick-PAV model execution', () => {
     const set = observationSet();
     const retainedAt = '2015-01-03T00:00:00.000Z';
     const datasetId = addressed('dataset', 'governed-pick-dataset');
-    const datasetAdmissionId = addressed(
-      'dataset-admission',
-      'governed-pick-dataset-admission'
-    );
+    const datasetAdmissionId = addressed('dataset-admission', 'governed-pick-dataset-admission');
     const protocolId = addressed('model-protocol', 'governed-pick-protocol');
+    const outputs = computeAflTradePickPavModelExecutionOutputs({
+      observationSet: set,
+      benchmarkConfig: {
+        schemaVersion: 'afl-trade-pick-pav-distribution-benchmark-config/v1',
+        minimumBlockObservations: 1,
+        eligibility: 'mature_open_access_national_draft_training_observations',
+        informationWeight: 'eligible_selection_count',
+        smoother: 'weighted_non_increasing_isotonic',
+        sparseBlockMergePolicy: 'nearest_adjacent_fitted_mean_left_tie_break',
+        interpolation: 'left_block_carry_forward_within_training_domain',
+        extrapolation: 'prohibited',
+        estimatorStatus: 'benchmark_only_requires_temporal_validation_and_approval',
+      },
+      validationConfig: {
+        schemaVersion: 'afl-trade-pick-pav-validation-config/v1',
+        evaluatedAt: retainedAt,
+        minimumEligibleObservations: 3,
+        minimumPartitionObservations: 1,
+        nominalIntervalCoverage: 0.8,
+      },
+    });
     const execution = createGovernedAflTradePickPavModelExecution({
-      outputs: computeAflTradePickPavModelExecutionOutputs({
-        observationSet: set,
-        benchmarkConfig: {
-          schemaVersion: 'afl-trade-pick-pav-distribution-benchmark-config/v1',
-          minimumBlockObservations: 1,
-          eligibility: 'mature_open_access_national_draft_training_observations',
-          informationWeight: 'eligible_selection_count',
-          smoother: 'weighted_non_increasing_isotonic',
-          sparseBlockMergePolicy: 'nearest_adjacent_fitted_mean_left_tie_break',
-          interpolation: 'left_block_carry_forward_within_training_domain',
-          extrapolation: 'prohibited',
-          estimatorStatus: 'benchmark_only_requires_temporal_validation_and_approval',
-        },
-        validationConfig: {
-          schemaVersion: 'afl-trade-pick-pav-validation-config/v1',
-          evaluatedAt: retainedAt,
-          minimumEligibleObservations: 3,
-          minimumPartitionObservations: 1,
-          nominalIntervalCoverage: 0.8,
-        },
-      }),
+      outputs,
       completedAt: '2015-01-03T00:00:01.000Z',
       authority: {
         datasetId,
@@ -186,10 +183,37 @@ describe('governed pick-PAV model execution', () => {
     });
     expect(execution.content).not.toHaveProperty('grade');
 
-    const {
-      qualificationStatus: _qualificationStatus,
-      ...successorWithoutQualificationStatus
-    } = execution.content;
+    const dispatchExecution = createDispatchBoundGovernedAflTradePickPavModelExecution({
+      outputs,
+      completedAt: '2015-01-03T00:00:01.000Z',
+      authority: {
+        datasetId,
+        datasetArtifact: execution.content.datasetArtifact,
+        datasetAdmissionId,
+        datasetAdmissionArtifact: execution.content.datasetAdmissionArtifact,
+        datasetAdmissionGateLedgerRevision: 7,
+        protocolId,
+        protocolArtifact: execution.content.protocolArtifact,
+      },
+      privateInput: {
+        requestId: addressed('private-valuation-dispatch', 'request'),
+        operationId: addressed('private-valuation-model-operation', 'operation'),
+        claimId: addressed('private-valuation-dispatch-claim', 'claim'),
+        attemptNumber: 2,
+        leaseTokenSha256: sha('lease'),
+        factualOutputId: addressed('private-valuation-factual-output', 'factual'),
+        hpnCalculationId: addressed('hpn-pav-season', 'calculation'),
+        factualValuesSha256: sha('factual-values'),
+        hpnValuesSha256: sha('hpn-values'),
+      },
+    });
+    expect(dispatchExecution.content).toMatchObject({
+      schemaVersion: 'afl-trade-pick-pav-model-execution/v4',
+      privateInput: { attemptNumber: 2 },
+    });
+
+    const { qualificationStatus: _qualificationStatus, ...successorWithoutQualificationStatus } =
+      execution.content;
     const legacyContent = {
       ...successorWithoutQualificationStatus,
       schemaVersion: 'afl-trade-pick-pav-model-execution/v2' as const,

--- a/tests/unit/afl-trade-intelligence-private-valuation-model-pair-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-model-pair-migration.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const migrationPath = join(
+  root,
+  'prisma/afl-trade-outcomes/migrations/0079_dispatch_bound_private_model_pair/migration.sql'
+);
+const schemaPath = join(root, 'prisma/afl-trade-outcomes/schema.prisma');
+
+describe('dispatch-bound private model-pair migration', () => {
+  it('adds only request lineage and monotonic operation custody over existing owners', () => {
+    const migration = readFileSync(migrationPath, 'utf8');
+    const schema = readFileSync(schemaPath, 'utf8');
+
+    expect(migration).toContain('outcome_private_valuation_model_operation');
+    expect(migration).toContain('outcome_private_valuation_model_request_binding');
+    expect(migration.match(/CREATE TABLE/g)).toHaveLength(2);
+    expect(migration).toContain('outcome_governed_valuation_component_run');
+    expect(migration).toContain('outcome_governed_valuation_model_qualification');
+    expect(migration).toContain('outcome_private_valuation_dispatch_attempt');
+    expect(migration).not.toMatch(/retry_count|retry_number|model_attempt/);
+
+    expect(schema).toContain('model OutcomePrivateValuationModelOperation');
+    expect(schema).toContain('model OutcomePrivateValuationModelRequestBinding');
+  });
+
+  it('keeps human authorization intact and admits only the fixed local private policy variant', () => {
+    const migration = readFileSync(migrationPath, 'utf8');
+
+    expect(migration).toContain('human_operational_authorization_for_one_exact_model_run_intent');
+    expect(migration).toContain(
+      'policy_owned_local_private_valuation_for_one_exact_model_run_intent'
+    );
+    expect(migration).toContain('system:weekly-valuation-coordinator');
+    expect(migration).toContain("content->>'dispatchLeaseTokenSha256'");
+    expect(migration).toContain("content->>'factualOutputId'");
+    expect(migration).toContain("content->>'hpnCalculationId'");
+    expect(migration).toContain("content->>'executionMode'<>'local'");
+    expect(migration).toContain("content->'publicationProhibited' IS DISTINCT FROM 'true'::JSONB");
+    expect(migration).toContain('NEW."environment"<>\'non_production\'');
+    expect(migration.match(/policy_owned:=COALESCE\(/g)).toHaveLength(2);
+    expect(migration).toContain(
+      "content->>'authorityBoundary' IS DISTINCT FROM\n         'human_operational_authorization_for_one_exact_model_run_intent'"
+    );
+    expect(migration.match(/attempt\."lease_expires_at">trusted_now/g)).toHaveLength(2);
+    expect(migration.match(/NEW\."valid_through"<=attempt\."lease_expires_at"/g)).toHaveLength(2);
+    expect(
+      migration.match(/PERFORM "load_outcome_private_valuation_dispatch_request_for_claim"\(/g)
+    ).toHaveLength(6);
+    expect(migration).toContain('outcome_dispatch_bound_pick_execution_claim_fence');
+    expect(migration).toContain('outcome_dispatch_bound_component_claim_fence');
+    expect(migration).toContain('outcome_dispatch_bound_model_qualification_claim_fence');
+    expect(migration).toContain(
+      'claim_outcome_private_valuation_dispatch(TEXT,TEXT,INTEGER,TEXT) SET search_path'
+    );
+    expect(
+      migration.match(/OWNER TO afl_trade_private_valuation_scheduler_owner/g)?.length
+    ).toBeGreaterThanOrEqual(9);
+    expect(migration).toContain(
+      'REVOKE ALL ON FUNCTION "fence_outcome_dispatch_bound_model_qualification"() FROM PUBLIC'
+    );
+  });
+
+  it('accepts only exact dispatch-bound components and the declared qualification policy', () => {
+    const migration = readFileSync(migrationPath, 'utf8');
+
+    expect(migration).toContain('afl-trade-pick-pav-model-execution/v4');
+    expect(migration).toContain('Expected governed pick v3 validator was not found');
+    expect(migration).toContain(
+      'Expected governed pick qualification evidence validator was not found'
+    );
+    expect(migration).toContain("'privateInput'->>'operationId'");
+    expect(migration).toContain("'privateInput'->>'factualOutputId'");
+    expect(migration).toContain("'privateInput'->>'hpnCalculationId'");
+    expect(migration).toContain("'policy'->>'policyVersion'");
+    expect(migration).toContain(
+      'operation."player_run_id"=NEW."player_run_id"\n       AND operation."pick_run_id"=NEW."pick_run_id"'
+    );
+  });
+
+  it('does not mutate public factual or publication pointers', () => {
+    const migration = readFileSync(migrationPath, 'utf8');
+
+    expect(migration).not.toMatch(/UPDATE\s+"?outcome_active_release"?/i);
+    expect(migration).not.toMatch(/UPDATE\s+"?outcome_current_valuation_publication"?/i);
+  });
+});

--- a/tests/unit/afl-trade-intelligence-private-valuation-model-pair.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-model-pair.test.ts
@@ -1,0 +1,653 @@
+import { createHash } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createAflTradeContentAddress } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import {
+  createAflTradeDispatchBoundAdmittedPlayerExecutor,
+  createAflTradeDispatchBoundGovernedPickExecutor,
+  createAflTradeDispatchBoundQualificationRegistrar,
+} from '@/server/aflTradeIntelligence/valuation/postgresPrivateValuationModelPair';
+import {
+  createAflTradePrivateValuationModelOperation,
+  createAflTradePrivateValuationModelPairCoordinator,
+  type AflTradePrivateValuationModelOperationState,
+  type AflTradePrivateValuationModelPairRepository,
+} from '@/server/aflTradeIntelligence/valuation/privateValuationModelPair';
+import { createGovernedValuationModelQualificationPolicy } from '@/server/aflTradeIntelligence/valuation/internal/governedValuationModelQualification';
+
+import { createGovernedPickPavModelExecutionFixture } from '../testUtils/governedPickPavModelExecutionFixture';
+
+const digest = (character: string) => character.repeat(64);
+const sha256 = (value: string) => createHash('sha256').update(value, 'utf8').digest('hex');
+const id = (prefix: string, character: string) => `${prefix}:${digest(character)}`;
+
+function exactInput(requestId = id('private-valuation-dispatch', '1')) {
+  return {
+    requestId,
+    scopeKey: 'afl-men:2026-trades',
+    factualOutputId: id('private-valuation-factual-output', '2'),
+    hpnCalculationId: id('hpn-pav-season', '3'),
+    substantive: {
+      factualValuesSha256: digest('4'),
+      hpnValuesSha256: digest('5'),
+      hpnMethodId: id('hpn-pav-method', '6'),
+      player: {
+        modelId: 'player-value-model',
+        modelVersion: '2026.08.1',
+        protocolId: id('model-protocol', '7'),
+        datasetId: id('dataset', '8'),
+        datasetAdmissionId: id('dataset-admission', '9'),
+      },
+      pick: {
+        protocolId: id('model-protocol', 'a'),
+        datasetId: id('dataset', 'b'),
+        datasetAdmissionId: id('dataset-admission', 'c'),
+        policyId: id('pick-pav-policy', 'e'),
+      },
+      qualificationPolicyId: id('model-qualification-policy', 'd'),
+    },
+  } as const;
+}
+
+const claim = {
+  claimId: id('private-valuation-dispatch-claim', 'e'),
+  leaseToken: digest('f'),
+};
+
+class MemoryPairRepository implements AflTradePrivateValuationModelPairRepository {
+  private readonly operations = new Map<string, AflTradePrivateValuationModelOperationState>();
+  readonly requestOperations = new Map<string, string>();
+  attemptNumber = 1;
+
+  async bindInput(input: Parameters<AflTradePrivateValuationModelPairRepository['bindInput']>[0]) {
+    const operation = createAflTradePrivateValuationModelOperation({
+      scopeKey: input.exactInput.scopeKey,
+      ...input.exactInput.substantive,
+    });
+    this.requestOperations.set(input.exactInput.requestId, operation.operationId);
+    const retained = this.operations.get(operation.operationId) ?? {
+      operation,
+      attemptNumber: this.attemptNumber,
+      playerRunId: null,
+      pickRunId: null,
+      pairAccepted: false,
+      qualificationId: null,
+      qualificationOutcome: null,
+    };
+    const claimed = { ...retained, attemptNumber: this.attemptNumber };
+    this.operations.set(operation.operationId, claimed);
+    return claimed;
+  }
+
+  async acceptComponent(
+    input: Parameters<AflTradePrivateValuationModelPairRepository['acceptComponent']>[0]
+  ) {
+    const state = this.operations.get(input.operationId)!;
+    const key = input.role === 'player' ? 'playerRunId' : 'pickRunId';
+    const existing = state[key];
+    if (existing !== null && existing !== input.runId) throw new Error('component conflict');
+    const next = { ...state, [key]: input.runId };
+    this.operations.set(input.operationId, next);
+    return next;
+  }
+
+  async acceptPair(
+    input: Parameters<AflTradePrivateValuationModelPairRepository['acceptPair']>[0]
+  ) {
+    const state = this.operations.get(input.operationId)!;
+    if (state.playerRunId !== input.playerRunId || state.pickRunId !== input.pickRunId) {
+      throw new Error('pair conflict');
+    }
+    const next = { ...state, pairAccepted: true };
+    this.operations.set(input.operationId, next);
+    return next;
+  }
+
+  async bindQualification(
+    input: Parameters<AflTradePrivateValuationModelPairRepository['bindQualification']>[0]
+  ) {
+    const state = this.operations.get(input.operationId)!;
+    const next = {
+      ...state,
+      qualificationId: input.qualificationId,
+      qualificationOutcome: input.outcome,
+    };
+    this.operations.set(input.operationId, next);
+    return next;
+  }
+
+  operation(operationId: string) {
+    return this.operations.get(operationId)!;
+  }
+}
+
+function coordinator(input?: {
+  repository?: MemoryPairRepository;
+  pickResults?: Array<'completed' | 'transient_failure'>;
+  qualificationOutcome?: 'qualified' | 'failed';
+  qualificationError?: 'deterministic_failure' | 'stale_authority';
+}) {
+  const repository = input?.repository ?? new MemoryPairRepository();
+  const calls: string[] = [];
+  const pickResults = [...(input?.pickResults ?? ['completed'])];
+  return {
+    repository,
+    calls,
+    value: createAflTradePrivateValuationModelPairCoordinator({
+      prepareExactInput: async ({ requestId }) => {
+        calls.push('prepare_input');
+        return exactInput(requestId);
+      },
+      repository,
+      executePlayer: async ({ exactInput: prepared, attemptNumber }) => {
+        calls.push(
+          `player:${attemptNumber}:${prepared.factualOutputId}:${prepared.hpnCalculationId}`
+        );
+        return { state: 'completed', runId: id('model-run', 'a') };
+      },
+      executePick: async ({ exactInput: prepared, attemptNumber }) => {
+        calls.push(
+          `pick:${attemptNumber}:${prepared.factualOutputId}:${prepared.hpnCalculationId}`
+        );
+        const result = pickResults.shift() ?? 'completed';
+        return result === 'completed'
+          ? { state: 'completed', runId: id('model-run', 'b') }
+          : { state: 'transient_failure', reason: 'temporary executor outage' };
+      },
+      qualify: async ({ playerRunId, pickRunId }) => {
+        calls.push(`qualify:${playerRunId}:${pickRunId}`);
+        if (input?.qualificationError !== undefined) {
+          return { state: input.qualificationError, reason: 'qualification input is invalid' };
+        }
+        return {
+          qualificationId: id('model-qualification', 'c'),
+          outcome: input?.qualificationOutcome ?? 'qualified',
+        };
+      },
+    }),
+  };
+}
+
+describe('private valuation dispatch-bound model pair', () => {
+  it('composes the existing admitted player runner with fixed claim-bound policy authority', async () => {
+    const preparedAuthorities: unknown[] = [];
+    const runRequests: unknown[] = [];
+    const intent = {
+      intentId: id('model-run-intent', '1'),
+      content: {
+        environment: 'non_production',
+        datasetId: exactInput().substantive.player.datasetId,
+        datasetAdmissionId: exactInput().substantive.player.datasetAdmissionId,
+        modelProtocolId: exactInput().substantive.player.protocolId,
+        observationSetId: id('player-observation-set', '2'),
+        startedAt: '2026-08-24T01:00:00.000Z',
+      },
+    };
+    const operation = createAflTradePrivateValuationModelOperation({
+      scopeKey: exactInput().scopeKey,
+      ...exactInput().substantive,
+    });
+    const executor = createAflTradeDispatchBoundAdmittedPlayerExecutor({
+      authorityPreparation: {
+        async prepare(value) {
+          preparedAuthorities.push(value.operationalAuthorization);
+        },
+      },
+      admittedRunner: {
+        async run(value) {
+          runRequests.push(value);
+          return {
+            status: 'completed',
+            authorization: {} as never,
+            run: { runId: id('model-run', '3') } as never,
+            blockers: [],
+          };
+        },
+      },
+      prepareRun: async () =>
+        ({
+          intent,
+          protocol: { protocolId: exactInput().substantive.player.protocolId },
+          observationSet: {},
+          runStartEvaluationReceipts: [],
+          validThrough: '2026-08-24T01:00:20.000Z',
+        }) as never,
+      registerComponent: async () => ({ runId: id('model-run', '4') }),
+    });
+
+    const result = await executor.execute({
+      exactInput: exactInput(),
+      operation,
+      attemptNumber: 1,
+      claim,
+    });
+
+    expect(result).toEqual({ state: 'completed', runId: id('model-run', '4') });
+    expect(runRequests).toHaveLength(1);
+    expect(preparedAuthorities).toMatchObject([
+      {
+        content: {
+          dispatchRequestId: exactInput().requestId,
+          substantiveOperationId: operation.operationId,
+          dispatchClaimId: claim.claimId,
+          dispatchAttemptNumber: 1,
+          dispatchLeaseTokenSha256: sha256(claim.leaseToken),
+          factualOutputId: exactInput().factualOutputId,
+          hpnCalculationId: exactInput().hpnCalculationId,
+          publicationProhibited: true,
+        },
+      },
+    ]);
+  });
+
+  it('runs and retains the existing governed pick execution with exact dispatch ancestry', async () => {
+    const fixture = createGovernedPickPavModelExecutionFixture();
+    const source = fixture.execution.content;
+    const prepared = {
+      outputs: {
+        observationSet: source.observationSet,
+        benchmarkConfig: source.benchmarkConfig,
+        validationConfig: source.validationConfig,
+        benchmark: source.benchmark,
+        validationReport: source.validationReport,
+      },
+      completedAt: source.completedAt,
+      registeredAt: '2015-01-03T00:00:02.000Z',
+      authority: {
+        datasetId: source.datasetId,
+        datasetArtifact: source.datasetArtifact,
+        datasetAdmissionId: source.datasetAdmissionId,
+        datasetAdmissionArtifact: source.datasetAdmissionArtifact,
+        datasetAdmissionGateLedgerRevision: source.datasetAdmissionGateLedgerRevision,
+        protocolId: source.protocolId,
+        protocolArtifact: source.protocolArtifact,
+      },
+    };
+    const dispatchInput = {
+      ...exactInput(),
+      substantive: {
+        ...exactInput().substantive,
+        pick: {
+          protocolId: source.protocolId,
+          datasetId: source.datasetId,
+          datasetAdmissionId: source.datasetAdmissionId,
+          policyId: source.policyId,
+        },
+      },
+    };
+    const operation = createAflTradePrivateValuationModelOperation({
+      scopeKey: dispatchInput.scopeKey,
+      ...dispatchInput.substantive,
+    });
+    const retainedExecutions: unknown[] = [];
+    const executor = createAflTradeDispatchBoundGovernedPickExecutor({
+      runModel: async () => prepared,
+      retainArtifact: async ({ document, createdAt }) =>
+        createAflTradeCanonicalJsonArtifactRef(document, createdAt),
+      executionRepository: {
+        async register(value) {
+          retainedExecutions.push(value.execution);
+          return value;
+        },
+      },
+      componentRepository: {
+        async register(value) {
+          return value;
+        },
+      },
+    });
+
+    const result = await executor.execute({
+      exactInput: dispatchInput,
+      operation,
+      attemptNumber: 2,
+      claim,
+    });
+
+    expect(result.state).toBe('completed');
+    expect(retainedExecutions).toMatchObject([
+      {
+        content: {
+          schemaVersion: 'afl-trade-pick-pav-model-execution/v4',
+          privateInput: {
+            requestId: dispatchInput.requestId,
+            operationId: operation.operationId,
+            claimId: claim.claimId,
+            attemptNumber: 2,
+            leaseTokenSha256: sha256(claim.leaseToken),
+            factualOutputId: dispatchInput.factualOutputId,
+            hpnCalculationId: dispatchInput.hpnCalculationId,
+          },
+        },
+      },
+    ]);
+  });
+
+  it('derives and registers qualification only for the accepted pair and operation policy', async () => {
+    const evaluatedAt = '2026-08-24T02:00:00.000Z';
+    const operation = createAflTradePrivateValuationModelOperation({
+      scopeKey: exactInput().scopeKey,
+      ...exactInput().substantive,
+    });
+    const policy = createGovernedValuationModelQualificationPolicy({
+      player: {
+        schemaVersion: 'governed-player-model-qualification-criteria/v1',
+        minimumComparableObservations: 1,
+        minimumRelativeMaeImprovement: 0.01,
+        minimumRelativeRmseImprovement: 0.01,
+        requiredAcceptanceOutcome: 'meets_declared_predictive_thresholds',
+      },
+      pick: {
+        schemaVersion: 'governed-pick-model-qualification-criteria/v1',
+        evaluatedScope: 'final_test',
+        minimumObservations: 1,
+        maximumMulticlassBrierScore: 0.1,
+        maximumMulticlassLogLoss: 0.1,
+        maximumRankedProbabilityScore: 0.1,
+        maximumContributionCrps: 1,
+        maximumMeanAbsoluteContributionError: 1,
+        maximumRootMeanSquaredContributionError: 1,
+        maximumMeanAbsoluteGamesError: 1,
+        maximumRootMeanSquaredGamesError: 1,
+        minimumEmpiricalP10P90Coverage: 0.7,
+        maximumEmpiricalP10P90Coverage: 0.9,
+        maximumMeanEmpiricalIntervalWidth: 1,
+        maximumZeroProbabilityObservationCount: 0,
+      },
+    });
+    const boundOperation = createAflTradePrivateValuationModelOperation({
+      ...operation.content,
+      qualificationPolicyId: policy.policyVersion,
+    });
+    const qualificationExactInput = {
+      ...exactInput(),
+      substantive: {
+        ...exactInput().substantive,
+        qualificationPolicyId: policy.policyVersion,
+      },
+    };
+    const playerRunId = id('model-run', 'a');
+    const pickRunId = id('model-run', 'b');
+    const artifact = (value: unknown) => createAflTradeCanonicalJsonArtifactRef(value, evaluatedAt);
+    const playerEvidence = {
+      schemaVersion: 'governed-player-model-qualification-evidence/v1' as const,
+      validationReportId: id('player-validation-report', '1'),
+      comparableObservationCount: 2,
+      acceptanceOutcome: 'meets_declared_predictive_thresholds' as const,
+      relativeMaeImprovement: 0.02,
+      relativeRmseImprovement: 0.02,
+    };
+    const pickEvidence = {
+      schemaVersion: 'governed-pick-model-qualification-evidence/v1' as const,
+      validationReportId: id('pick-pav-validation-report', '2'),
+      evaluationStatus: 'scored_not_approved' as const,
+      scope: 'final_test' as const,
+      observationCount: 2,
+      metrics: {
+        multiclassBrierScore: 0.2,
+        multiclassLogLoss: 0.2,
+        rankedProbabilityScore: 0.2,
+        contributionCrps: 2,
+        meanAbsoluteContributionError: 2,
+        rootMeanSquaredContributionError: 2,
+        meanAbsoluteGamesError: 2,
+        rootMeanSquaredGamesError: 2,
+        empiricalP10P90Coverage: 0.8,
+        meanEmpiricalIntervalWidth: 2,
+        zeroProbabilityObservationCount: 0,
+      },
+    };
+    const registered: unknown[] = [];
+    const fences: unknown[] = [];
+    const registrar = createAflTradeDispatchBoundQualificationRegistrar({
+      prepareQualification: async () => ({
+        environment: 'non_production',
+        scopeKey: boundOperation.content.scopeKey,
+        evaluatedAt,
+        policy,
+        policyArtifact: artifact(policy),
+        components: {
+          player: {
+            role: 'player_contribution_and_availability',
+            runId: playerRunId,
+            runArtifact: artifact({ playerRunId }),
+            protocolId: boundOperation.content.player.protocolId,
+            protocolArtifact: artifact({ playerProtocol: true }),
+            criteriaArtifact: artifact(policy.player),
+            validationEvidence: playerEvidence,
+            validationEvidenceArtifact: artifact(playerEvidence),
+          },
+          pick: {
+            role: 'draft_pick_and_future_pick_distribution',
+            runId: pickRunId,
+            runArtifact: artifact({ pickRunId }),
+            protocolId: boundOperation.content.pick.protocolId,
+            protocolArtifact: artifact({ pickProtocol: true }),
+            criteriaArtifact: artifact(policy.pick),
+            validationEvidence: pickEvidence,
+            validationEvidenceArtifact: artifact(pickEvidence),
+          },
+        },
+      }),
+      retainArtifact: async ({ document, createdAt }) =>
+        createAflTradeCanonicalJsonArtifactRef(document, createdAt),
+      prepareRegistration: async () => ({
+        expectedGateLedgerRevision: 1,
+        expectedCurrentRevision: 1,
+      }),
+      repository: {
+        async register(value, options) {
+          fences.push(options?.dispatchClaimFence);
+          registered.push(value.qualification);
+          return {
+            status: 'failed_retained',
+            qualification: value.qualification,
+            current: null,
+            idempotentReplay: false,
+          };
+        },
+      },
+    });
+
+    const result = await registrar.register({
+      exactInput: qualificationExactInput,
+      operation: boundOperation,
+      playerRunId,
+      pickRunId,
+      claim,
+    });
+
+    expect(result.outcome).toBe('failed');
+    expect(fences).toEqual([
+      {
+        requestId: exactInput().requestId,
+        claimId: claim.claimId,
+        leaseTokenSha256: sha256(claim.leaseToken),
+      },
+    ]);
+    expect(registered).toMatchObject([
+      {
+        content: {
+          scopeKey: boundOperation.content.scopeKey,
+          policy: { policyVersion: policy.policyVersion },
+          player: { runId: playerRunId },
+          pick: { runId: pickRunId },
+        },
+      },
+    ]);
+    await expect(
+      registrar.register({
+        exactInput: exactInput(),
+        operation,
+        playerRunId,
+        pickRunId,
+        claim,
+      })
+    ).resolves.toMatchObject({ state: 'deterministic_failure' });
+  });
+
+  it('classifies thrown deterministic adapter failures instead of leaking them into lease retry', async () => {
+    const operation = createAflTradePrivateValuationModelOperation({
+      scopeKey: exactInput().scopeKey,
+      ...exactInput().substantive,
+    });
+    const execution = { exactInput: exactInput(), operation, attemptNumber: 1, claim };
+    const player = createAflTradeDispatchBoundAdmittedPlayerExecutor({
+      prepareRun: async () => {
+        throw new TypeError('invalid player input');
+      },
+      authorityPreparation: {} as never,
+      admittedRunner: {} as never,
+      registerComponent: async () => {
+        throw new Error('unreachable');
+      },
+    });
+    const pick = createAflTradeDispatchBoundGovernedPickExecutor({
+      runModel: async () => {
+        throw new RangeError('invalid pick input');
+      },
+      retainArtifact: async () => {
+        throw new Error('unreachable');
+      },
+      executionRepository: {} as never,
+      componentRepository: {} as never,
+    });
+    const codedPick = (code: string) =>
+      createAflTradeDispatchBoundGovernedPickExecutor({
+        runModel: async () => {
+          throw Object.assign(new Error(code), { code });
+        },
+        retainArtifact: async () => {
+          throw new Error('unreachable');
+        },
+        executionRepository: {} as never,
+        componentRepository: {} as never,
+      });
+
+    await expect(player.execute(execution)).resolves.toEqual({
+      state: 'deterministic_failure',
+      reason: 'invalid player input',
+    });
+    await expect(pick.execute(execution)).resolves.toEqual({
+      state: 'deterministic_failure',
+      reason: 'invalid pick input',
+    });
+    await expect(codedPick('READBACK_MISMATCH').execute(execution)).resolves.toMatchObject({
+      state: 'deterministic_failure',
+    });
+    await expect(codedPick('08006').execute(execution)).resolves.toMatchObject({
+      state: 'transient_failure',
+    });
+    await expect(codedPick('EAI_AGAIN').execute(execution)).resolves.toMatchObject({
+      state: 'transient_failure',
+    });
+  });
+
+  it('uses the exact private factual and HPN inputs and accepts one qualified pair', async () => {
+    const fixture = coordinator();
+
+    const result = await fixture.value.prepare({
+      requestId: exactInput().requestId,
+      claim,
+    });
+
+    expect(result).toMatchObject({ state: 'qualified', attemptNumber: 1 });
+    expect(fixture.calls).toEqual([
+      'prepare_input',
+      `player:1:${exactInput().factualOutputId}:${exactInput().hpnCalculationId}`,
+      `pick:1:${exactInput().factualOutputId}:${exactInput().hpnCalculationId}`,
+      `qualify:${id('model-run', 'a')}:${id('model-run', 'b')}`,
+    ]);
+  });
+
+  it('retains a successful player output when the pick execution fails transiently', async () => {
+    const fixture = coordinator({ pickResults: ['transient_failure', 'completed'] });
+    const first = await fixture.value.prepare({ requestId: exactInput().requestId, claim });
+    expect(first).toMatchObject({ state: 'transient_failure', attemptNumber: 1 });
+
+    fixture.repository.attemptNumber = 2;
+    const second = await fixture.value.prepare({ requestId: exactInput().requestId, claim });
+
+    expect(second).toMatchObject({ state: 'qualified' });
+    expect(fixture.calls.filter((entry) => entry.startsWith('player:'))).toHaveLength(1);
+    expect(fixture.calls.filter((entry) => entry.startsWith('pick:'))).toHaveLength(2);
+  });
+
+  it('recovers after pair acceptance without rerunning either component', async () => {
+    const fixture = coordinator();
+    const operation = createAflTradePrivateValuationModelOperation({
+      scopeKey: exactInput().scopeKey,
+      ...exactInput().substantive,
+    });
+    await fixture.repository.bindInput({ exactInput: exactInput(), claim });
+    await fixture.repository.acceptComponent({
+      operationId: operation.operationId,
+      role: 'player',
+      runId: id('model-run', 'a'),
+      claim,
+    });
+    await fixture.repository.acceptComponent({
+      operationId: operation.operationId,
+      role: 'pick',
+      runId: id('model-run', 'b'),
+      claim,
+    });
+    await fixture.repository.acceptPair({
+      operationId: operation.operationId,
+      playerRunId: id('model-run', 'a'),
+      pickRunId: id('model-run', 'b'),
+      claim,
+    });
+
+    const result = await fixture.value.prepare({ requestId: exactInput().requestId, claim });
+
+    expect(result).toMatchObject({ state: 'qualified' });
+    expect(fixture.calls).toEqual([
+      'prepare_input',
+      `qualify:${id('model-run', 'a')}:${id('model-run', 'b')}`,
+    ]);
+  });
+
+  it('converges different request identities on substantive inputs and replays qualification', async () => {
+    const fixture = coordinator();
+    const first = await fixture.value.prepare({ requestId: exactInput().requestId, claim });
+    const otherRequestId = createAflTradeContentAddress('private-valuation-dispatch', 'ad-hoc');
+    const second = await fixture.value.prepare({ requestId: otherRequestId, claim });
+
+    expect(second).toMatchObject({
+      state: 'already_qualified',
+      operationId: first.operationId,
+    });
+    expect(fixture.repository.requestOperations.get(otherRequestId)).toBe(first.operationId);
+    expect(fixture.calls.filter((entry) => entry.startsWith('player:'))).toHaveLength(1);
+    expect(fixture.calls.filter((entry) => entry.startsWith('pick:'))).toHaveLength(1);
+    expect(fixture.calls.filter((entry) => entry.startsWith('qualify:'))).toHaveLength(1);
+  });
+
+  it('retains a failed qualification without reporting the pair as current', async () => {
+    const fixture = coordinator({ qualificationOutcome: 'failed' });
+    const result = await fixture.value.prepare({ requestId: exactInput().requestId, claim });
+
+    expect(result).toMatchObject({
+      state: 'qualification_failed',
+      qualificationId: id('model-qualification', 'c'),
+    });
+    expect(fixture.repository.operation(result.operationId)).toMatchObject({
+      pairAccepted: true,
+      qualificationOutcome: 'failed',
+    });
+  });
+
+  it('terminates deterministic qualification errors without binding or blind retry', async () => {
+    const fixture = coordinator({ qualificationError: 'deterministic_failure' });
+    const result = await fixture.value.prepare({ requestId: exactInput().requestId, claim });
+
+    expect(result).toMatchObject({
+      state: 'deterministic_failure',
+      reason: 'qualification input is invalid',
+    });
+    expect(fixture.repository.operation(result.operationId).qualificationId).toBeNull();
+  });
+});

--- a/tests/unit/afl-trade-intelligence-private-valuation-model-pair.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-model-pair.test.ts
@@ -562,6 +562,35 @@ describe('private valuation dispatch-bound model pair', () => {
     ]);
   });
 
+  it('rejects a repository no-op instead of qualifying an unaccepted pair', async () => {
+    const fixture = coordinator();
+    const acceptPair = fixture.repository.acceptPair.bind(fixture.repository);
+    fixture.repository.acceptPair = async (input) => ({
+      ...(await acceptPair(input)),
+      pairAccepted: false,
+    });
+
+    await expect(
+      fixture.value.prepare({ requestId: exactInput().requestId, claim })
+    ).rejects.toThrow('Private valuation pair was not accepted with the exact retained runs.');
+  });
+
+  it('rejects a repository no-op instead of returning a null qualification identity', async () => {
+    const fixture = coordinator();
+    const bindQualification = fixture.repository.bindQualification.bind(fixture.repository);
+    fixture.repository.bindQualification = async (input) => ({
+      ...(await bindQualification(input)),
+      qualificationId: null,
+      qualificationOutcome: null,
+    });
+
+    await expect(
+      fixture.value.prepare({ requestId: exactInput().requestId, claim })
+    ).rejects.toThrow(
+      'Private valuation qualification was not bound to the accepted pair exactly once.'
+    );
+  });
+
   it('retains a successful player output when the pick execution fails transiently', async () => {
     const fixture = coordinator({ pickResults: ['transient_failure', 'completed'] });
     const first = await fixture.value.prepare({ requestId: exactInput().requestId, claim });


### PR DESCRIPTION
Closes #563.

## What changed

- Composes the existing admitted player runner, governed pick execution, component register, qualification register, Gate 3/current-pair authority, and private dispatch scheduler for one exact factual-output and finalized-HPN input.
- Adds the fixed non-production, local, publication-prohibited policy-owned player authorization variant while preserving the existing human-authorized path.
- Adds only the two bounded custody seams required by the issue: immutable request/input lineage and monotonic substantive model-operation progress. Dispatch attempts remain the sole three-attempt retry ledger.
- Adds exact claim fences, component/pair restart reconstruction, same-scope serialization, substantive convergence across weekly/ad-hoc/model-qualified requests, and failed-qualification preservation.
- Preserves public factual-release and valuation-publication pointers; this PR does not publish or deploy anything.

## Important decisions

- Dispatch identity and fresh custody metadata are excluded from substantive model-pair identity, so equivalent values and model targets converge without rerunning accepted components.
- Player, pick, and qualification ancestry are revalidated at their PostgreSQL authority boundaries rather than trusted from coordinator callbacks.
- Accepted component and qualification custody metadata are immutable together with their retained IDs.
- Existing pick execution v2/v3 artifacts remain valid for existing flows; dispatch-bound private execution uses the v4 envelope only.

## Verification

- `npm run docs:check` — passed.
- `npm run lint:ci` — passed.
- `NODE_OPTIONS=--max-old-space-size=4096 npm run typecheck` — passed.
- `npm run test:unit` — passed: 600 files, 3,772 tests.
- Focused model-pair/authority/pick unit run after final review fix — passed: 4 files, 27 tests.
- `npm run test:outcomes:int` after final migration fix — passed: 30 files, 133 tests.
- Production `npm run build` with the checked-in CI placeholder configuration — passed.
- `git diff --check` — passed.

## Existing test-infrastructure blockers

- Root `npm run test:int` is not independently runnable in this checkout without `DATABASE_URL_TEST`; with an explicit disposable SQLite target it reaches an existing Prisma migration/schema-engine failure, and the configured suite currently discovers no tests.
- Root `npm run test:e2e` with a disposable SQLite target reaches the existing global fixture failure because `Draft` is queried before the schema exists. Browser cases therefore do not start.
- The supported AFL outcomes PostgreSQL integration harness is green and owns all database behavior changed here.

## Security, data, deployment, and compatibility

- No credentials, environment files, local databases, generated output, shared data, or production data are included or mutated.
- The automated authority principal, role, environment, execution mode, and publication prohibition are fixed by policy and rechecked against the live claim in PostgreSQL.
- No public API route, public release pointer, valuation publication pointer, or deployment configuration changes.
- The human operational-authorization path is preserved.

## Follow-up

- Observation rebuilding, worker composition, and prepared-v3 activation remain the next focused boundary (#564). This PR intentionally does not duplicate that worker or publication infrastructure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dispatch-bound private valuation workflow for complete-trade analysis.
  * Supports automated player and pick valuation, qualification, and finalized model-pair results.
  * Ensures repeated requests with identical inputs converge consistently.
* **Reliability**
  * Added lease-aware claiming, retry handling, and recovery for interrupted valuation jobs.
  * Prevents stale, expired, or mismatched inputs from producing accepted results.
* **Validation**
  * Strengthened safeguards for input lineage, execution authority, and result ancestry.
* **Documentation**
  * Updated architecture documentation to describe the new valuation flow and remaining activation work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->