### PR TITLE
Add a durable no-change tracer for current valuation refresh

### DIFF
--- a/docs/architecture/afl-trade-intelligence.md
+++ b/docs/architecture/afl-trade-intelligence.md
@@ -1998,6 +1998,26 @@ whatever exact prepared-v3 head is current. Observation rebuild and prepared-v3 
 to be composed around this dispatch-bound model-pair coordinator before the worker can run raw data
 through to recalculation without manual orchestration.
 
+### Current valuation refresh trace
+
+The backend current-valuation refresh operation now retains the restart-safe terminal case where no
+downstream work is required. Here, `no_change` has a narrow structural meaning: the current factual
+release, qualified model pair, prepared-v3 input set, and private evaluation batch all exist and agree
+on their exact IDs and revisions. It does not compare numerical outputs, authorize a calculation, or
+claim that newly ingested observations have already been prepared.
+
+Callers provide a valuation scope, one of the existing `weekly`, `model_qualified`, or `ad_hoc`
+triggers, and a stable operation key. One PostgreSQL-owned operation captures the aligned authority,
+content-addresses the scope, trigger, stable key, authority, and trusted capture time, and retains the
+result append-only. Exact retry returns the retained result without downstream writes. Reusing the
+stable key for another scope or trigger fails, and missing or incoherent authority fails closed. The
+result explicitly remains local, private, non-production, publication-ineligible, and
+publication-prohibited.
+
+This trace closes only the durable no-change branch. Automated factual observation refresh, factual
+release advancement, prepared-v3 rebuild and activation, and the calculation branch remain separate
+work that must be composed before raw data can flow to recalculation automatically.
+
 A structurally valid fixture report always retains `publicationReady: false` and the remaining
 external blockers: a real historical-data run, component-model calibration exit criteria, downstream
 Gate approvals, and production storage and release evidence. Stage 5 therefore establishes the

--- a/prisma/afl-trade-outcomes/migrations/0080_current_valuation_refresh_tracer/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0080_current_valuation_refresh_tracer/migration.sql
@@ -293,8 +293,6 @@ END $paths$;
 
 REVOKE ALL ON "outcome_current_valuation_refresh_operation"
   FROM PUBLIC,afl_trade_private_evaluation_coordinator;
-GRANT SELECT ON "outcome_current_valuation_refresh_operation"
-  TO afl_trade_private_evaluation_coordinator;
 REVOKE ALL ON FUNCTION "retain_outcome_current_valuation_refresh_no_change"(TEXT,TEXT,TEXT)
   FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION "retain_outcome_current_valuation_refresh_no_change"(TEXT,TEXT,TEXT)

--- a/prisma/afl-trade-outcomes/migrations/0080_current_valuation_refresh_tracer/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0080_current_valuation_refresh_tracer/migration.sql
@@ -1,0 +1,310 @@
+-- Retain the first restart-safe no-change slice of the local current-valuation refresh coordinator.
+-- No-change means the factual, model, prepared-input, and private-batch heads already agree.
+
+CREATE TABLE "outcome_current_valuation_refresh_operation" (
+  "operation_id" TEXT PRIMARY KEY,
+  "scope_key" TEXT NOT NULL,
+  "trigger_kind" TEXT NOT NULL CHECK ("trigger_kind" IN ('weekly','model_qualified','ad_hoc')),
+  "stable_operation_key" TEXT NOT NULL,
+  "factual_release_scope_key" TEXT NOT NULL,
+  "factual_release_id" TEXT NOT NULL REFERENCES "outcome_release_manifest"("release_id") ON DELETE RESTRICT,
+  "factual_release_revision" INTEGER NOT NULL CHECK ("factual_release_revision">0),
+  "model_qualification_id" TEXT NOT NULL REFERENCES "outcome_governed_valuation_model_qualification"("qualification_id") ON DELETE RESTRICT,
+  "model_qualification_work_id" TEXT NOT NULL REFERENCES "outcome_governed_model_qualification_work"("work_id") ON DELETE RESTRICT,
+  "model_pair_revision" INTEGER NOT NULL CHECK ("model_pair_revision">0),
+  "prepared_input_set_id" TEXT NOT NULL REFERENCES "outcome_prepared_valuation_input_set"("prepared_input_set_id") ON DELETE RESTRICT,
+  "prepared_input_set_revision" INTEGER NOT NULL CHECK ("prepared_input_set_revision">0),
+  "private_batch_id" TEXT NOT NULL REFERENCES "outcome_private_evaluation_batch"("batch_id") ON DELETE RESTRICT,
+  "private_batch_revision" INTEGER NOT NULL CHECK ("private_batch_revision">0),
+  "private_batch_transition_id" TEXT NOT NULL REFERENCES "outcome_private_evaluation_batch_transition"("transition_id") ON DELETE RESTRICT,
+  "captured_at" TIMESTAMPTZ(3) NOT NULL,
+  "completed_at" TIMESTAMPTZ(3) NOT NULL,
+  "operation_json" JSONB NOT NULL,
+  "result_json" JSONB NOT NULL,
+  CONSTRAINT "outcome_current_valuation_refresh_operation_id_check"
+    CHECK ("operation_id" ~ '^current-valuation-refresh-operation:[a-f0-9]{64}$'),
+  CONSTRAINT "outcome_current_valuation_refresh_operation_key"
+    UNIQUE ("stable_operation_key"),
+  CONSTRAINT "outcome_current_valuation_refresh_chronology_check"
+    CHECK ("completed_at">="captured_at")
+);
+
+CREATE OR REPLACE FUNCTION "current_valuation_refresh_authority_json"(
+  factual_scope TEXT,factual_id TEXT,factual_revision INTEGER,
+  qualification_id TEXT,qualification_work_id TEXT,model_revision INTEGER,
+  prepared_id TEXT,prepared_revision INTEGER,batch_id TEXT,batch_revision INTEGER,
+  batch_transition_id TEXT
+) RETURNS JSONB LANGUAGE SQL IMMUTABLE STRICT AS $$
+  SELECT jsonb_build_object(
+    'factualReleaseScopeKey',factual_scope,
+    'factualReleaseId',factual_id,
+    'factualReleaseRevision',factual_revision,
+    'modelQualificationId',qualification_id,
+    'modelQualificationWorkId',qualification_work_id,
+    'modelPairRevision',model_revision,
+    'preparedInputSetId',prepared_id,
+    'preparedInputSetRevision',prepared_revision,
+    'privateBatchId',batch_id,
+    'privateBatchRevision',batch_revision,
+    'privateBatchTransitionId',batch_transition_id)
+$$;
+
+CREATE OR REPLACE FUNCTION "current_valuation_refresh_operation_content_json"(
+  target_scope_key TEXT,target_trigger TEXT,target_stable_operation_key TEXT,
+  target_authority JSONB,target_captured_at TIMESTAMPTZ
+) RETURNS JSONB LANGUAGE SQL IMMUTABLE STRICT AS $$
+  SELECT jsonb_build_object(
+    'schemaVersion','afl-current-valuation-refresh-operation-v1',
+    'scopeKey',target_scope_key,'trigger',target_trigger,
+    'stableOperationKey',target_stable_operation_key,'capturedAuthority',target_authority,
+    'capturedAt',to_char(target_captured_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'executionLocation','local','visibility','private','environment','non_production',
+    'publicationEligible',false,'publicationProhibited',true,
+    'limitation','Private local non-production current-authority refresh trace only; no factual, model, prepared-input, private-evaluation, production, activation, or publication authority is granted.')
+$$;
+
+CREATE OR REPLACE FUNCTION "current_valuation_refresh_result_json"(
+  target_operation_id TEXT,target_scope_key TEXT,target_trigger TEXT,
+  target_stable_operation_key TEXT,target_authority JSONB,
+  target_captured_at TIMESTAMPTZ,target_completed_at TIMESTAMPTZ
+) RETURNS JSONB LANGUAGE SQL IMMUTABLE STRICT AS $$
+  SELECT jsonb_build_object(
+    'schemaVersion','afl-current-valuation-refresh-result-v1',
+    'operationId',target_operation_id,'scopeKey',target_scope_key,'trigger',target_trigger,
+    'stableOperationKey',target_stable_operation_key,'state','no_change',
+    'capturedAuthority',target_authority,
+    'capturedAt',to_char(target_captured_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'completedAt',to_char(target_completed_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'executionLocation','local','visibility','private','environment','non_production',
+    'publicationEligible',false,'publicationProhibited',true,
+    'limitation','Private local non-production current-authority refresh trace only; no factual, model, prepared-input, private-evaluation, production, activation, or publication authority is granted.')
+$$;
+
+CREATE OR REPLACE FUNCTION "validate_outcome_current_valuation_refresh_operation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE authority JSONB; operation_content JSONB; expected_id TEXT;
+BEGIN
+  authority:="current_valuation_refresh_authority_json"(
+    NEW."factual_release_scope_key",NEW."factual_release_id",NEW."factual_release_revision",
+    NEW."model_qualification_id",NEW."model_qualification_work_id",NEW."model_pair_revision",
+    NEW."prepared_input_set_id",NEW."prepared_input_set_revision",NEW."private_batch_id",
+    NEW."private_batch_revision",NEW."private_batch_transition_id");
+  operation_content:="current_valuation_refresh_operation_content_json"(
+    NEW."scope_key",NEW."trigger_kind",NEW."stable_operation_key",authority,NEW."captured_at");
+  expected_id:='current-valuation-refresh-operation:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(operation_content),'UTF8')),'hex');
+  IF NEW."operation_id" IS DISTINCT FROM expected_id
+    OR NEW."operation_json" IS DISTINCT FROM jsonb_build_object(
+      'operationId',expected_id,'content',operation_content)
+    OR NEW."result_json" IS DISTINCT FROM "current_valuation_refresh_result_json"(
+      expected_id,NEW."scope_key",NEW."trigger_kind",NEW."stable_operation_key",authority,
+      NEW."captured_at",NEW."completed_at")
+    OR NEW."captured_at">statement_timestamp()
+    OR NEW."completed_at">statement_timestamp()
+    OR NOT EXISTS (
+      SELECT 1
+        FROM "outcome_current_prepared_valuation_input_set" prepared_head
+        JOIN "outcome_prepared_valuation_input_set" prepared
+          ON prepared."prepared_input_set_id"=prepared_head."prepared_input_set_id"
+        JOIN "outcome_active_release" active_release
+          ON active_release."scope_key"=prepared."factual_release_scope_key"
+         AND active_release."release_id"=prepared."factual_release_id"
+        JOIN "outcome_current_governed_valuation_model_pair" model_head
+          ON model_head."scope_key"=prepared_head."scope_key"
+        JOIN "outcome_current_private_evaluation_batch" batch_head
+          ON batch_head."scope_key"=prepared_head."scope_key"
+        JOIN "outcome_private_evaluation_batch" batch
+          ON batch."batch_id"=batch_head."batch_id"
+        JOIN "outcome_private_evaluation_cohort_batch" batch_binding
+          ON batch_binding."batch_id"=batch."batch_id"
+        JOIN "outcome_private_evaluation_cohort_capture" batch_capture
+          ON batch_capture."operation_id"=batch_binding."operation_id"
+       WHERE prepared_head."scope_key"=NEW."scope_key"
+         AND prepared."schema_version"='afl-trade-prepared-valuation-input-set/v3'
+         AND prepared."environment"='non_production'
+         AND prepared."factual_release_scope_key"=NEW."factual_release_scope_key"
+         AND active_release."release_id"=NEW."factual_release_id"
+         AND active_release."revision"=NEW."factual_release_revision"
+         AND model_head."qualification_id"=NEW."model_qualification_id"
+         AND model_head."work_id"=NEW."model_qualification_work_id"
+         AND model_head."revision"=NEW."model_pair_revision"
+         AND prepared_head."prepared_input_set_id"=NEW."prepared_input_set_id"
+         AND prepared_head."revision"=NEW."prepared_input_set_revision"
+         AND batch."scope_key"=NEW."scope_key"
+         AND batch."prepared_input_set_id"=NEW."prepared_input_set_id"
+         AND batch."prepared_input_set_revision"=NEW."prepared_input_set_revision"
+         AND batch."factual_release_id"=NEW."factual_release_id"
+         AND batch."model_qualification_id"=NEW."model_qualification_id"
+         AND batch."model_qualification_work_id"=NEW."model_qualification_work_id"
+         AND batch_head."batch_id"=NEW."private_batch_id"
+         AND batch_head."revision"=NEW."private_batch_revision"
+         AND batch_head."last_transition_id"=NEW."private_batch_transition_id"
+         AND batch_capture."factual_release_revision"=NEW."factual_release_revision"
+         AND batch_capture."model_pair_revision"=NEW."model_pair_revision")
+  THEN
+    RAISE EXCEPTION 'Current valuation refresh operation custody is invalid';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER "outcome_current_valuation_refresh_operation_validate"
+BEFORE INSERT ON "outcome_current_valuation_refresh_operation"
+FOR EACH ROW EXECUTE FUNCTION "validate_outcome_current_valuation_refresh_operation"();
+
+CREATE OR REPLACE FUNCTION "reject_outcome_current_valuation_refresh_operation_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Current valuation refresh operation history is append-only';
+END $$;
+CREATE TRIGGER "outcome_current_valuation_refresh_operation_no_update"
+BEFORE UPDATE ON "outcome_current_valuation_refresh_operation"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_current_valuation_refresh_operation_mutation"();
+CREATE TRIGGER "outcome_current_valuation_refresh_operation_no_delete"
+BEFORE DELETE ON "outcome_current_valuation_refresh_operation"
+FOR EACH ROW EXECUTE FUNCTION "reject_outcome_current_valuation_refresh_operation_mutation"();
+
+CREATE OR REPLACE FUNCTION "retain_outcome_current_valuation_refresh_no_change"(
+  target_scope_key TEXT,target_trigger TEXT,target_stable_operation_key TEXT
+) RETURNS TABLE(operation_id TEXT,operation_json JSONB,result_json JSONB)
+LANGUAGE plpgsql AS $$
+DECLARE current_authority RECORD; retained RECORD; trusted_at TIMESTAMPTZ(3);
+  authority JSONB; operation_content JSONB; target_operation_id TEXT;
+BEGIN
+  IF target_scope_key IS NULL OR target_scope_key IS DISTINCT FROM btrim(target_scope_key)
+    OR length(target_scope_key) NOT BETWEEN 1 AND 400
+    OR target_trigger IS NULL
+    OR target_trigger NOT IN ('weekly','model_qualified','ad_hoc')
+    OR target_stable_operation_key IS NULL
+    OR target_stable_operation_key IS DISTINCT FROM btrim(target_stable_operation_key)
+    OR length(target_stable_operation_key) NOT BETWEEN 1 AND 400
+  THEN RAISE EXCEPTION 'Current valuation refresh request is malformed'; END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(target_stable_operation_key,0));
+  SELECT operation.* INTO retained FROM "outcome_current_valuation_refresh_operation" operation
+   WHERE operation."stable_operation_key"=target_stable_operation_key;
+  IF FOUND THEN
+    IF retained."scope_key" IS DISTINCT FROM target_scope_key
+      OR retained."trigger_kind" IS DISTINCT FROM target_trigger THEN
+      RAISE EXCEPTION 'Current valuation refresh request conflicts with retained custody';
+    END IF;
+    operation_id:=retained."operation_id";
+    operation_json:=retained."operation_json";
+    result_json:=retained."result_json";
+    RETURN NEXT;
+    RETURN;
+  END IF;
+  trusted_at:=date_trunc('milliseconds',statement_timestamp());
+  SELECT prepared."factual_release_scope_key",active_release."release_id" AS factual_release_id,
+         active_release."revision" AS factual_release_revision,
+         model_head."qualification_id",model_head."work_id",model_head."revision" AS model_pair_revision,
+         prepared_head."prepared_input_set_id",prepared_head."revision" AS prepared_input_set_revision,
+         batch_head."batch_id",batch_head."revision" AS private_batch_revision,
+         batch_head."last_transition_id",batch_capture."factual_release_revision" AS batch_factual_revision,
+         batch_capture."model_pair_revision" AS batch_model_revision
+    INTO current_authority
+    FROM "outcome_current_prepared_valuation_input_set" prepared_head
+    JOIN "outcome_prepared_valuation_input_set" prepared
+      ON prepared."prepared_input_set_id"=prepared_head."prepared_input_set_id"
+    JOIN "outcome_active_release" active_release
+      ON active_release."scope_key"=prepared."factual_release_scope_key"
+     AND active_release."release_id"=prepared."factual_release_id"
+    JOIN "outcome_current_governed_valuation_model_pair" model_head
+      ON model_head."scope_key"=prepared_head."scope_key"
+    JOIN "outcome_current_private_evaluation_batch" batch_head
+      ON batch_head."scope_key"=prepared_head."scope_key"
+    JOIN "outcome_private_evaluation_batch" batch ON batch."batch_id"=batch_head."batch_id"
+    JOIN "outcome_private_evaluation_cohort_batch" batch_binding
+      ON batch_binding."batch_id"=batch."batch_id"
+    JOIN "outcome_private_evaluation_cohort_capture" batch_capture
+      ON batch_capture."operation_id"=batch_binding."operation_id"
+   WHERE prepared_head."scope_key"=target_scope_key
+     AND prepared."schema_version"='afl-trade-prepared-valuation-input-set/v3'
+     AND prepared."environment"='non_production'
+     AND batch."scope_key"=target_scope_key
+     AND batch."prepared_input_set_id"=prepared_head."prepared_input_set_id"
+     AND batch."prepared_input_set_revision"=prepared_head."revision"
+     AND batch."factual_release_id"=active_release."release_id"
+     AND batch."model_qualification_id"=model_head."qualification_id"
+     AND batch."model_qualification_work_id"=model_head."work_id"
+     AND batch_capture."factual_release_revision"=active_release."revision"
+     AND batch_capture."model_pair_revision"=model_head."revision";
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Current valuation refresh cannot retain no change because governed authority is not current';
+  END IF;
+  authority:="current_valuation_refresh_authority_json"(
+    current_authority."factual_release_scope_key",current_authority."factual_release_id",
+    current_authority."factual_release_revision",current_authority."qualification_id",
+    current_authority."work_id",current_authority."model_pair_revision",
+    current_authority."prepared_input_set_id",current_authority."prepared_input_set_revision",
+    current_authority."batch_id",current_authority."private_batch_revision",
+    current_authority."last_transition_id");
+  operation_content:="current_valuation_refresh_operation_content_json"(
+    target_scope_key,target_trigger,target_stable_operation_key,authority,trusted_at);
+  target_operation_id:='current-valuation-refresh-operation:'||encode(sha256(convert_to(
+    "outcome_afl_trade_canonical_json"(operation_content),'UTF8')),'hex');
+  INSERT INTO "outcome_current_valuation_refresh_operation" (
+    operation_id,scope_key,trigger_kind,stable_operation_key,
+    factual_release_scope_key,factual_release_id,factual_release_revision,
+    model_qualification_id,model_qualification_work_id,model_pair_revision,
+    prepared_input_set_id,prepared_input_set_revision,private_batch_id,private_batch_revision,
+    private_batch_transition_id,captured_at,completed_at,operation_json,result_json)
+  VALUES (
+    target_operation_id,target_scope_key,target_trigger,target_stable_operation_key,
+    current_authority."factual_release_scope_key",current_authority."factual_release_id",
+    current_authority."factual_release_revision",current_authority."qualification_id",
+    current_authority."work_id",current_authority."model_pair_revision",
+    current_authority."prepared_input_set_id",current_authority."prepared_input_set_revision",
+    current_authority."batch_id",current_authority."private_batch_revision",
+    current_authority."last_transition_id",trusted_at,trusted_at,
+    jsonb_build_object('operationId',target_operation_id,'content',operation_content),
+    "current_valuation_refresh_result_json"(
+      target_operation_id,target_scope_key,target_trigger,target_stable_operation_key,
+      authority,trusted_at,trusted_at));
+  operation_id:=target_operation_id;
+  operation_json:=jsonb_build_object('operationId',target_operation_id,'content',operation_content);
+  SELECT operation."result_json" INTO result_json
+    FROM "outcome_current_valuation_refresh_operation" operation
+   WHERE operation."operation_id"=target_operation_id;
+  RETURN NEXT;
+END $$;
+
+DO $roles$ BEGIN
+  BEGIN CREATE ROLE afl_trade_current_valuation_refresh_owner NOLOGIN;
+  EXCEPTION WHEN duplicate_object THEN NULL; END;
+  BEGIN CREATE ROLE afl_trade_private_evaluation_coordinator NOLOGIN;
+  EXCEPTION WHEN duplicate_object THEN NULL; END;
+  EXECUTE format('GRANT afl_trade_current_valuation_refresh_owner TO %I',current_user);
+  EXECUTE format('GRANT afl_trade_private_evaluation_coordinator TO %I',current_user);
+  EXECUTE format('GRANT USAGE,CREATE ON SCHEMA %I TO afl_trade_current_valuation_refresh_owner',current_schema());
+  EXECUTE format('GRANT USAGE ON SCHEMA %I TO afl_trade_private_evaluation_coordinator',current_schema());
+END $roles$;
+
+ALTER TABLE "outcome_current_valuation_refresh_operation" OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "current_valuation_refresh_authority_json"(TEXT,TEXT,INTEGER,TEXT,TEXT,INTEGER,TEXT,INTEGER,TEXT,INTEGER,TEXT) OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "current_valuation_refresh_operation_content_json"(TEXT,TEXT,TEXT,JSONB,TIMESTAMPTZ) OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "current_valuation_refresh_result_json"(TEXT,TEXT,TEXT,TEXT,JSONB,TIMESTAMPTZ,TIMESTAMPTZ) OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "validate_outcome_current_valuation_refresh_operation"() OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "reject_outcome_current_valuation_refresh_operation_mutation"() OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "retain_outcome_current_valuation_refresh_no_change"(TEXT,TEXT,TEXT) OWNER TO afl_trade_current_valuation_refresh_owner;
+
+DO $paths$ BEGIN
+  EXECUTE format('REVOKE CREATE ON SCHEMA %I FROM PUBLIC,afl_trade_private_evaluation_coordinator',current_schema());
+  EXECUTE format('ALTER FUNCTION %I.retain_outcome_current_valuation_refresh_no_change(TEXT,TEXT,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+END $paths$;
+
+REVOKE ALL ON "outcome_current_valuation_refresh_operation"
+  FROM PUBLIC,afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_current_valuation_refresh_operation"
+  TO afl_trade_private_evaluation_coordinator;
+REVOKE ALL ON FUNCTION "retain_outcome_current_valuation_refresh_no_change"(TEXT,TEXT,TEXT)
+  FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "retain_outcome_current_valuation_refresh_no_change"(TEXT,TEXT,TEXT)
+  TO afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_active_release","outcome_prepared_valuation_input_set",
+  "outcome_current_prepared_valuation_input_set","outcome_current_governed_valuation_model_pair",
+  "outcome_private_evaluation_batch","outcome_current_private_evaluation_batch",
+  "outcome_private_evaluation_cohort_batch","outcome_private_evaluation_cohort_capture"
+  TO afl_trade_current_valuation_refresh_owner;
+
+DO $membership$ BEGIN
+  EXECUTE format('REVOKE afl_trade_current_valuation_refresh_owner FROM %I',current_user);
+END $membership$;

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -5417,6 +5417,30 @@ model OutcomePrivateValuationDispatchRequest {
   @@map("outcome_private_valuation_dispatch_request")
 }
 
+model OutcomeCurrentValuationRefreshOperation {
+  operationId              String   @id @map("operation_id") @outcomes.Text
+  scopeKey                 String   @map("scope_key") @outcomes.Text
+  triggerKind              String   @map("trigger_kind") @outcomes.Text
+  stableOperationKey       String   @unique(map: "outcome_current_valuation_refresh_operation_key") @map("stable_operation_key") @outcomes.Text
+  factualReleaseScopeKey   String   @map("factual_release_scope_key") @outcomes.Text
+  factualReleaseId         String   @map("factual_release_id") @outcomes.Text
+  factualReleaseRevision   Int      @map("factual_release_revision")
+  modelQualificationId     String   @map("model_qualification_id") @outcomes.Text
+  modelQualificationWorkId String   @map("model_qualification_work_id") @outcomes.Text
+  modelPairRevision        Int      @map("model_pair_revision")
+  preparedInputSetId       String   @map("prepared_input_set_id") @outcomes.Text
+  preparedInputSetRevision Int      @map("prepared_input_set_revision")
+  privateBatchId           String   @map("private_batch_id") @outcomes.Text
+  privateBatchRevision     Int      @map("private_batch_revision")
+  privateBatchTransitionId String   @map("private_batch_transition_id") @outcomes.Text
+  capturedAt               DateTime @map("captured_at") @outcomes.Timestamptz(3)
+  completedAt              DateTime @map("completed_at") @outcomes.Timestamptz(3)
+  operationJson            Json     @map("operation_json")
+  resultJson               Json     @map("result_json")
+
+  @@map("outcome_current_valuation_refresh_operation")
+}
+
 model OutcomePrivateValuationDispatchAttempt {
   claimId          String                                 @id @map("claim_id") @outcomes.Text
   requestId        String                                 @map("request_id") @outcomes.Text

--- a/src/server/aflTradeIntelligence/valuation/currentValuationRefresh.ts
+++ b/src/server/aflTradeIntelligence/valuation/currentValuationRefresh.ts
@@ -1,0 +1,129 @@
+import { z } from 'zod';
+
+import { aflTradeContentAddressedIdSchema } from '../artifacts/contentAddress';
+import type { AflOutcomeSqlClient } from '../outcomes/postgresOutcomeReleaseRepository';
+import { aflTradePrivateValuationDispatchTriggerSchema } from './privateValuationScheduling';
+
+export const AFL_TRADE_CURRENT_VALUATION_REFRESH_RESULT_SCHEMA_VERSION =
+  'afl-current-valuation-refresh-result-v1' as const;
+export const AFL_TRADE_CURRENT_VALUATION_REFRESH_LIMITATION =
+  'Private local non-production current-authority refresh trace only; no factual, model, prepared-input, private-evaluation, production, activation, or publication authority is granted.' as const;
+
+const EXECUTION_DATABASE_ROLE = 'afl_trade_private_evaluation_coordinator';
+
+const idSchema = z.string().trim().min(1).max(400);
+const instantSchema = z.iso.datetime({ offset: true });
+
+export const aflTradeCurrentValuationRefreshTriggerSchema =
+  aflTradePrivateValuationDispatchTriggerSchema;
+
+export const aflTradeCurrentValuationRefreshRequestSchema = z
+  .object({
+    scopeKey: idSchema,
+    trigger: aflTradeCurrentValuationRefreshTriggerSchema,
+    stableOperationKey: idSchema,
+  })
+  .strict();
+
+export const aflTradeCurrentValuationRefreshAuthoritySchema = z
+  .object({
+    factualReleaseScopeKey: idSchema,
+    factualReleaseId: aflTradeContentAddressedIdSchema('outcome-release'),
+    factualReleaseRevision: z.number().int().positive(),
+    modelQualificationId: aflTradeContentAddressedIdSchema('model-qualification'),
+    modelQualificationWorkId: aflTradeContentAddressedIdSchema('model-qualification-work'),
+    modelPairRevision: z.number().int().positive(),
+    preparedInputSetId: aflTradeContentAddressedIdSchema('prepared-valuation-input-set'),
+    preparedInputSetRevision: z.number().int().positive(),
+    privateBatchId: aflTradeContentAddressedIdSchema('private-evaluation-batch'),
+    privateBatchRevision: z.number().int().positive(),
+    privateBatchTransitionId: aflTradeContentAddressedIdSchema(
+      'private-evaluation-batch-transition'
+    ),
+  })
+  .strict();
+
+export const aflTradeCurrentValuationRefreshResultSchema = z
+  .object({
+    schemaVersion: z.literal(AFL_TRADE_CURRENT_VALUATION_REFRESH_RESULT_SCHEMA_VERSION),
+    operationId: aflTradeContentAddressedIdSchema('current-valuation-refresh-operation'),
+    scopeKey: idSchema,
+    trigger: aflTradeCurrentValuationRefreshTriggerSchema,
+    stableOperationKey: idSchema,
+    state: z.literal('no_change'),
+    capturedAuthority: aflTradeCurrentValuationRefreshAuthoritySchema,
+    capturedAt: instantSchema,
+    completedAt: instantSchema,
+    executionLocation: z.literal('local'),
+    visibility: z.literal('private'),
+    environment: z.literal('non_production'),
+    publicationEligible: z.literal(false),
+    publicationProhibited: z.literal(true),
+    limitation: z.literal(AFL_TRADE_CURRENT_VALUATION_REFRESH_LIMITATION),
+  })
+  .strict()
+  .superRefine((result, context) => {
+    if (Date.parse(result.completedAt) < Date.parse(result.capturedAt)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['completedAt'],
+        message: 'Current valuation refresh cannot complete before authority capture.',
+      });
+    }
+  });
+
+export type AflTradeCurrentValuationRefreshRequest = z.infer<
+  typeof aflTradeCurrentValuationRefreshRequestSchema
+>;
+export type AflTradeCurrentValuationRefreshResult = z.infer<
+  typeof aflTradeCurrentValuationRefreshResultSchema
+>;
+
+export interface AflTradeCurrentValuationRefresh {
+  refreshCurrent(
+    request: AflTradeCurrentValuationRefreshRequest
+  ): Promise<AflTradeCurrentValuationRefreshResult>;
+}
+
+interface RetainedRefreshRow {
+  readonly operation_id: string;
+  readonly operation_json: unknown;
+  readonly result_json: unknown;
+}
+
+export function createAflTradeCurrentValuationRefresh(dependencies: {
+  readonly client: AflOutcomeSqlClient;
+}): AflTradeCurrentValuationRefresh {
+  return {
+    async refreshCurrent(unparsedRequest) {
+      const request = aflTradeCurrentValuationRefreshRequestSchema.parse(unparsedRequest);
+      const retained = await dependencies.client.transaction(async (transaction) => {
+        await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+        return transaction.query<RetainedRefreshRow>(
+          'SELECT * FROM retain_outcome_current_valuation_refresh_no_change($1,$2,$3)',
+          [request.scopeKey, request.trigger, request.stableOperationKey]
+        );
+      });
+      const row = retained.rows[0];
+      if (row === undefined || retained.rows.length !== 1) {
+        throw new TypeError('Current valuation refresh did not retain exactly one result.');
+      }
+      const result = aflTradeCurrentValuationRefreshResultSchema.parse(row.result_json);
+      if (result.operationId !== row.operation_id) {
+        throw new TypeError(
+          'Current valuation refresh result disagrees with retained operation custody.'
+        );
+      }
+      if (
+        result.scopeKey !== request.scopeKey ||
+        result.trigger !== request.trigger ||
+        result.stableOperationKey !== request.stableOperationKey
+      ) {
+        throw new TypeError(
+          'Current valuation refresh result conflicts with the requested operation.'
+        );
+      }
+      return result;
+    },
+  };
+}

--- a/tests/outcomes-integration/afl-current-valuation-refresh-postgres.test.ts
+++ b/tests/outcomes-integration/afl-current-valuation-refresh-postgres.test.ts
@@ -1,0 +1,306 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import {
+  aflTradeCurrentValuationRefreshResultSchema,
+  createAflTradeCurrentValuationRefresh,
+} from '@/server/aflTradeIntelligence/valuation/currentValuationRefresh';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('AFL_OUTCOMES_TEST_DATABASE_URL must identify disposable PostgreSQL.');
+  })();
+const schemaName = `afl_current_valuation_refresh_${process.pid}_${Date.now()}`;
+const pool = new Pool({
+  connectionString: databaseUrl,
+  max: 4,
+  options: `-c search_path=${schemaName}`,
+});
+
+const ids = {
+  release: `outcome-release:${'1'.repeat(64)}`,
+  qualification: `model-qualification:${'2'.repeat(64)}`,
+  work: `model-qualification-work:${'3'.repeat(64)}`,
+  prepared: `prepared-valuation-input-set:${'4'.repeat(64)}`,
+  batch: `private-evaluation-batch:${'5'.repeat(64)}`,
+  transition: `private-evaluation-batch-transition:${'6'.repeat(64)}`,
+  cohortOperation: `private-evaluation-cohort-run:${'7'.repeat(64)}`,
+};
+
+beforeAll(async () => {
+  await pool.query(`DO $roles$ BEGIN
+    BEGIN CREATE ROLE afl_trade_private_evaluation_coordinator NOLOGIN;
+    EXCEPTION WHEN duplicate_object THEN NULL; END;
+    GRANT afl_trade_private_evaluation_coordinator TO CURRENT_USER;
+  END $roles$`);
+  await pool.query(`CREATE SCHEMA "${schemaName}"`);
+  const canonicalFunction = readFileSync(
+    join(
+      process.cwd(),
+      'prisma/afl-trade-outcomes/migrations/0037_valuation_publication_custody_index/migration.sql'
+    ),
+    'utf8'
+  ).match(
+    /CREATE FUNCTION "outcome_afl_trade_canonical_json"[\s\S]*?\$\$ LANGUAGE plpgsql IMMUTABLE STRICT;/
+  )?.[0];
+  if (canonicalFunction === undefined)
+    throw new Error('Canonical JSON SQL function was not found.');
+  await pool.query(canonicalFunction);
+  await pool.query(`
+    CREATE TABLE outcome_release_manifest (release_id text PRIMARY KEY);
+    CREATE TABLE outcome_governed_valuation_model_qualification (
+      qualification_id text PRIMARY KEY
+    );
+    CREATE TABLE outcome_governed_model_qualification_work (work_id text PRIMARY KEY);
+    CREATE TABLE outcome_active_release (
+      scope_key text PRIMARY KEY,release_id text NOT NULL,revision integer NOT NULL
+    );
+    CREATE TABLE outcome_prepared_valuation_input_set (
+      prepared_input_set_id text PRIMARY KEY,scope_key text NOT NULL,
+      factual_release_scope_key text NOT NULL,factual_release_id text NOT NULL,
+      schema_version text NOT NULL,environment text NOT NULL
+    );
+    CREATE TABLE outcome_current_prepared_valuation_input_set (
+      scope_key text PRIMARY KEY,prepared_input_set_id text NOT NULL,revision integer NOT NULL
+    );
+    CREATE TABLE outcome_current_governed_valuation_model_pair (
+      scope_key text PRIMARY KEY,qualification_id text NOT NULL,work_id text NOT NULL,
+      revision integer NOT NULL
+    );
+    CREATE TABLE outcome_private_evaluation_batch (
+      batch_id text PRIMARY KEY,scope_key text NOT NULL,prepared_input_set_id text NOT NULL,
+      prepared_input_set_revision integer NOT NULL,factual_release_id text NOT NULL,
+      model_qualification_id text NOT NULL,model_qualification_work_id text NOT NULL
+    );
+    CREATE TABLE outcome_current_private_evaluation_batch (
+      scope_key text PRIMARY KEY,batch_id text NOT NULL,revision integer NOT NULL,
+      last_transition_id text NOT NULL
+    );
+    CREATE TABLE outcome_private_evaluation_cohort_capture (
+      operation_id text PRIMARY KEY,factual_release_revision integer NOT NULL,
+      model_pair_revision integer NOT NULL
+    );
+    CREATE TABLE outcome_private_evaluation_cohort_batch (
+      operation_id text NOT NULL,batch_id text PRIMARY KEY
+    );
+    CREATE TABLE outcome_private_valuation_dispatch_request (request_id text PRIMARY KEY);
+    CREATE TABLE outcome_local_private_trade_evaluation_generation (generation_id text PRIMARY KEY);
+    CREATE TABLE outcome_private_evaluation_batch_transition (transition_id text PRIMARY KEY);
+    CREATE TABLE outcome_private_evaluation_authority_snapshot (snapshot_id text PRIMARY KEY);
+    CREATE TABLE outcome_private_evaluation_inspection_receipt (inspection_id text PRIMARY KEY);
+    CREATE TABLE outcome_private_evaluation_transition_intent (transition_intent_id text PRIMARY KEY);
+    CREATE TABLE outcome_private_evaluation_transition_receipt (transition_id text PRIMARY KEY);
+    CREATE TABLE outcome_local_private_trade_evaluation_head (
+      valuation_scope_key text NOT NULL,trade_id text NOT NULL,
+      PRIMARY KEY (valuation_scope_key,trade_id)
+    );
+  `);
+  await pool.query(
+    readFileSync(
+      join(
+        process.cwd(),
+        'prisma/afl-trade-outcomes/migrations/0080_current_valuation_refresh_tracer/migration.sql'
+      ),
+      'utf8'
+    )
+  );
+});
+
+afterAll(async () => {
+  await pool.query(`SET search_path TO public`);
+  await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  await pool.end();
+});
+
+beforeEach(async () => {
+  await pool.query(`TRUNCATE outcome_current_valuation_refresh_operation,
+    outcome_release_manifest,outcome_governed_valuation_model_qualification,
+    outcome_governed_model_qualification_work,
+    outcome_active_release,outcome_prepared_valuation_input_set,
+    outcome_current_prepared_valuation_input_set,outcome_current_governed_valuation_model_pair,
+    outcome_private_evaluation_batch,outcome_current_private_evaluation_batch,
+    outcome_private_evaluation_cohort_capture,outcome_private_evaluation_cohort_batch,
+    outcome_private_valuation_dispatch_request,outcome_local_private_trade_evaluation_generation,
+    outcome_private_evaluation_batch_transition,outcome_private_evaluation_authority_snapshot,
+    outcome_private_evaluation_inspection_receipt,outcome_private_evaluation_transition_intent,
+    outcome_private_evaluation_transition_receipt,outcome_local_private_trade_evaluation_head`);
+  const connection = await pool.connect();
+  try {
+    await connection.query('BEGIN');
+    await connection.query(`INSERT INTO outcome_release_manifest VALUES ($1)`, [ids.release]);
+    await connection.query(
+      `INSERT INTO outcome_governed_valuation_model_qualification VALUES ($1)`,
+      [ids.qualification]
+    );
+    await connection.query(`INSERT INTO outcome_governed_model_qualification_work VALUES ($1)`, [
+      ids.work,
+    ]);
+    await connection.query(`INSERT INTO outcome_active_release VALUES ('afl-men:2026',$1,9)`, [
+      ids.release,
+    ]);
+    await connection.query(
+      `INSERT INTO outcome_prepared_valuation_input_set VALUES
+        ($1,'afl-men:2026-trades','afl-men:2026',$2,
+         'afl-trade-prepared-valuation-input-set/v3','non_production')`,
+      [ids.prepared, ids.release]
+    );
+    await connection.query(
+      `INSERT INTO outcome_current_prepared_valuation_input_set VALUES
+        ('afl-men:2026-trades',$1,7)`,
+      [ids.prepared]
+    );
+    await connection.query(
+      `INSERT INTO outcome_current_governed_valuation_model_pair VALUES
+        ('afl-men:2026-trades',$1,$2,4)`,
+      [ids.qualification, ids.work]
+    );
+    await connection.query(
+      `INSERT INTO outcome_private_evaluation_batch VALUES
+        ($1,'afl-men:2026-trades',$2,7,$3,$4,$5)`,
+      [ids.batch, ids.prepared, ids.release, ids.qualification, ids.work]
+    );
+    await connection.query(`INSERT INTO outcome_private_evaluation_batch_transition VALUES ($1)`, [
+      ids.transition,
+    ]);
+    await connection.query(
+      `INSERT INTO outcome_current_private_evaluation_batch VALUES
+        ('afl-men:2026-trades',$1,3,$2)`,
+      [ids.batch, ids.transition]
+    );
+    await connection.query(
+      `INSERT INTO outcome_private_evaluation_cohort_capture VALUES ($1,9,4)`,
+      [ids.cohortOperation]
+    );
+    await connection.query(`INSERT INTO outcome_private_evaluation_cohort_batch VALUES ($1,$2)`, [
+      ids.cohortOperation,
+      ids.batch,
+    ]);
+    await connection.query('COMMIT');
+  } catch (error) {
+    await connection.query('ROLLBACK');
+    throw error;
+  } finally {
+    connection.release();
+  }
+});
+
+describe('current valuation refresh PostgreSQL tracer', () => {
+  it('retains and exactly replays no change without downstream writes', async () => {
+    const refresh = createAflTradeCurrentValuationRefresh({
+      client: createPgAflOutcomeSqlClient(pool),
+    });
+    const request = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'weekly' as const,
+      stableOperationKey: 'weekly-data-check-2026-08-24',
+    };
+
+    const first = await refresh.refreshCurrent(request);
+    await expect(refresh.refreshCurrent(request)).resolves.toEqual(first);
+    expect(first).toMatchObject({
+      state: 'no_change',
+      executionLocation: 'local',
+      visibility: 'private',
+      environment: 'non_production',
+      publicationEligible: false,
+      publicationProhibited: true,
+      capturedAuthority: {
+        factualReleaseRevision: 9,
+        modelPairRevision: 4,
+        preparedInputSetRevision: 7,
+        privateBatchRevision: 3,
+      },
+    });
+    await expect(
+      pool.query(`SELECT count(*)::int AS count FROM outcome_current_valuation_refresh_operation`)
+    ).resolves.toMatchObject({ rows: [{ count: 1 }] });
+    await expect(
+      pool.query(`SELECT
+        (SELECT count(*)::int FROM outcome_private_valuation_dispatch_request) AS dispatches,
+        (SELECT count(*)::int FROM outcome_local_private_trade_evaluation_generation) AS generations,
+        (SELECT count(*)::int FROM outcome_private_evaluation_batch) AS batches,
+        (SELECT count(*)::int FROM outcome_private_evaluation_batch_transition) AS batch_transitions,
+        (SELECT count(*)::int FROM outcome_private_evaluation_authority_snapshot) AS snapshots,
+        (SELECT count(*)::int FROM outcome_private_evaluation_inspection_receipt) AS inspections,
+        (SELECT count(*)::int FROM outcome_private_evaluation_transition_intent) AS intents,
+        (SELECT count(*)::int FROM outcome_private_evaluation_transition_receipt) AS receipts,
+        (SELECT count(*)::int FROM outcome_local_private_trade_evaluation_head) AS trade_heads`)
+    ).resolves.toMatchObject({
+      rows: [
+        {
+          dispatches: 0,
+          generations: 0,
+          batches: 1,
+          batch_transitions: 1,
+          snapshots: 0,
+          inspections: 0,
+          intents: 0,
+          receipts: 0,
+          trade_heads: 0,
+        },
+      ],
+    });
+  });
+
+  it('rejects conflicting reuse of a stable operation key', async () => {
+    const refresh = createAflTradeCurrentValuationRefresh({
+      client: createPgAflOutcomeSqlClient(pool),
+    });
+    await refresh.refreshCurrent({
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'model_qualified',
+      stableOperationKey: 'shared-operation',
+    });
+
+    await expect(
+      refresh.refreshCurrent({
+        scopeKey: 'afl-men:2026-trades',
+        trigger: 'ad_hoc',
+        stableOperationKey: 'shared-operation',
+      })
+    ).rejects.toThrow('conflicts with retained custody');
+    await expect(
+      pool.query(`SELECT count(*)::int AS count FROM outcome_current_valuation_refresh_operation`)
+    ).resolves.toMatchObject({ rows: [{ count: 1 }] });
+  });
+
+  it('uses statement time for capture and rejects noncanonical direct-SQL keys', async () => {
+    const connection = await pool.connect();
+    try {
+      await connection.query('BEGIN');
+      const transaction = await connection.query<{ started_at: Date }>(
+        `SELECT transaction_timestamp() AS started_at`
+      );
+      await connection.query(`SELECT pg_sleep(0.02)`);
+      await connection.query(`SET LOCAL ROLE afl_trade_private_evaluation_coordinator`);
+      const retained = await connection.query<{ result_json: unknown }>(
+        `SELECT result_json FROM retain_outcome_current_valuation_refresh_no_change($1,$2,$3)`,
+        ['afl-men:2026-trades', 'ad_hoc', 'statement-time-check']
+      );
+      await connection.query('COMMIT');
+      const result = aflTradeCurrentValuationRefreshResultSchema.parse(
+        retained.rows[0]?.result_json
+      );
+      expect(Date.parse(result.capturedAt)).toBeGreaterThan(
+        transaction.rows[0]!.started_at.getTime()
+      );
+
+      await connection.query('BEGIN');
+      await connection.query(`SET LOCAL ROLE afl_trade_private_evaluation_coordinator`);
+      await expect(
+        connection.query(
+          `SELECT * FROM retain_outcome_current_valuation_refresh_no_change($1,$2,$3)`,
+          [' afl-men:2026-trades', 'ad_hoc', 'padded-key ']
+        )
+      ).rejects.toThrow('request is malformed');
+      await connection.query('ROLLBACK');
+    } finally {
+      connection.release();
+    }
+  });
+});

--- a/tests/outcomes-integration/afl-current-valuation-refresh-postgres.test.ts
+++ b/tests/outcomes-integration/afl-current-valuation-refresh-postgres.test.ts
@@ -269,6 +269,26 @@ describe('current valuation refresh PostgreSQL tracer', () => {
     ).resolves.toMatchObject({ rows: [{ count: 1 }] });
   });
 
+  it('keeps retained history behind the scoped function', async () => {
+    const connection = await pool.connect();
+    try {
+      await connection.query('BEGIN');
+      await connection.query(`SET LOCAL ROLE afl_trade_private_evaluation_coordinator`);
+      await expect(
+        connection.query(
+          `SELECT * FROM retain_outcome_current_valuation_refresh_no_change($1,$2,$3)`,
+          ['afl-men:2026-trades', 'ad_hoc', 'scoped-function-only']
+        )
+      ).resolves.toMatchObject({ rowCount: 1 });
+      await expect(
+        connection.query(`SELECT * FROM outcome_current_valuation_refresh_operation`)
+      ).rejects.toThrow('permission denied');
+    } finally {
+      await connection.query('ROLLBACK');
+      connection.release();
+    }
+  });
+
   it('uses statement time for capture and rejects noncanonical direct-SQL keys', async () => {
     const connection = await pool.connect();
     try {

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1106,6 +1106,7 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0077_projected_hpn_pav_input_authority',
       '0078_private_valuation_hpn_source_admission',
       '0079_dispatch_bound_private_model_pair',
+      '0080_current_valuation_refresh_tracer',
     ]);
 
     const tables = await query<{ table_name: string }>(

--- a/tests/unit/afl-trade-intelligence-current-valuation-refresh.test.ts
+++ b/tests/unit/afl-trade-intelligence-current-valuation-refresh.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import {
+  type AflTradeCurrentValuationRefreshResult,
+  createAflTradeCurrentValuationRefresh,
+} from '@/server/aflTradeIntelligence/valuation/currentValuationRefresh';
+
+const operationId = `current-valuation-refresh-operation:${'a'.repeat(64)}`;
+const triggers = ['weekly', 'model_qualified', 'ad_hoc'] as const;
+
+function retainedResult(trigger: (typeof triggers)[number]): AflTradeCurrentValuationRefreshResult {
+  return {
+    schemaVersion: 'afl-current-valuation-refresh-result-v1',
+    operationId,
+    scopeKey: 'afl-men:2026-trades',
+    trigger,
+    stableOperationKey: `refresh-${trigger}`,
+    state: 'no_change',
+    capturedAuthority: {
+      factualReleaseScopeKey: 'afl-men:2026',
+      factualReleaseId: `outcome-release:${'b'.repeat(64)}`,
+      factualReleaseRevision: 9,
+      modelQualificationId: `model-qualification:${'c'.repeat(64)}`,
+      modelQualificationWorkId: `model-qualification-work:${'d'.repeat(64)}`,
+      modelPairRevision: 4,
+      preparedInputSetId: `prepared-valuation-input-set:${'e'.repeat(64)}`,
+      preparedInputSetRevision: 7,
+      privateBatchId: `private-evaluation-batch:${'f'.repeat(64)}`,
+      privateBatchRevision: 3,
+      privateBatchTransitionId: `private-evaluation-batch-transition:${'1'.repeat(64)}`,
+    },
+    capturedAt: '2026-08-21T08:00:00.000Z',
+    completedAt: '2026-08-21T08:00:00.000Z',
+    executionLocation: 'local',
+    visibility: 'private',
+    environment: 'non_production',
+    publicationEligible: false,
+    publicationProhibited: true,
+    limitation:
+      'Private local non-production current-authority refresh trace only; no factual, model, prepared-input, private-evaluation, production, activation, or publication authority is granted.',
+  };
+}
+
+function fakeClient(result: AflTradeCurrentValuationRefreshResult) {
+  const statements: Array<{ readonly sql: string; readonly parameters: readonly unknown[] }> = [];
+  const query = async (sql: string, parameters: readonly unknown[] = []) => {
+    statements.push({ sql, parameters });
+    if (sql.includes('SET LOCAL ROLE')) return { rows: [], rowCount: null };
+    if (sql.includes('retain_outcome_current_valuation_refresh_no_change')) {
+      return {
+        rows: [{ operation_id: result.operationId, operation_json: {}, result_json: result }],
+        rowCount: 1,
+      };
+    }
+    throw new Error(`Unexpected SQL: ${sql}`);
+  };
+  const client = {
+    query,
+    transaction: async (work: Parameters<AflOutcomeSqlClient['transaction']>[0]) => work({ query }),
+  } as AflOutcomeSqlClient;
+  return { client, statements };
+}
+
+describe('current valuation refresh', () => {
+  it.each(triggers)('owns durable %s no-change custody behind one operation', async (trigger) => {
+    const expected = retainedResult(trigger);
+    const database = fakeClient(expected);
+    const refresh = createAflTradeCurrentValuationRefresh({ client: database.client });
+
+    await expect(
+      refresh.refreshCurrent({
+        scopeKey: expected.scopeKey,
+        trigger,
+        stableOperationKey: expected.stableOperationKey,
+      })
+    ).resolves.toEqual(expected);
+    expect(database.statements).toEqual([
+      {
+        sql: 'SET LOCAL ROLE afl_trade_private_evaluation_coordinator',
+        parameters: [],
+      },
+      {
+        sql: 'SELECT * FROM retain_outcome_current_valuation_refresh_no_change($1,$2,$3)',
+        parameters: [expected.scopeKey, trigger, expected.stableOperationKey],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- add one deep backend current-valuation refresh operation that owns PostgreSQL custody
- retain an append-only, content-addressed terminal no-change result for aligned factual release, qualified model pair, prepared-v3 input, and private evaluation batch authority
- support weekly, model_qualified, and ad_hoc triggers with exact replay and fail-closed stable-key conflicts
- authenticate the result as local, private, non-production, publication-ineligible, and publication-prohibited
- keep retained history behind the explicit scope-taking function; the coordinator role cannot read the history table directly
- document the narrow no-change meaning and the remaining raw-data refresh gap

## Owning boundary and decisions

The AFL trade-intelligence valuation boundary owns this operation. Callers provide only scope, trigger, stable operation key, and the SQL client; they cannot inject a persistence callback or gain access to stage repositories. PostgreSQL owns trusted capture time, authority alignment, serialization, content addressing, append-only retention, and exact replay.

No-change means the four current authority heads already agree. It does not compare numerical output, dispatch calculations, advance authority, or grant factual, model, evaluation, production, activation, or publication authority.

The coordinator receives only EXECUTE on the fixed-search-path security-definer function. It has no direct SELECT privilege on the retained-history table, preventing unscoped reads.

## Verification

- npm run docs:check
- npm run lint:ci
- npm run typecheck
- npm run outcomes:prisma:validate
- npm run test:unit: full coverage completed across the main pass and dependency-corrected rerun, 601 files and 3,777 tests passing
- npm run test:int: 3 files and 3 tests passing against disposable SQLite
- focused disposable PostgreSQL refresh test: 4 tests passing, including scoped-function success and direct-table denial
- complete CI-faithful disposable PostgreSQL suite: 31 files and 137 tests passing
- npm run test:e2e: 24 of 26 passed initially; the two Chromium timing failures both passed on isolated rerun, while Firefox and WebKit equivalents were already green
- npm run build: production compile, TypeScript, 80 static pages, optimization, and route generation passed with non-secret fixture Firebase client configuration
- git diff --check
- final independent Standards review: no findings
- final independent Spec review: no missing requirement, wrong implementation, or scope creep

## Security, data, deployment, and compatibility

- the new operation uses a fixed private coordinator role and a security-definer function with a fixed search path
- the coordinator can execute the scope-taking function but cannot select the retained-history table
- retained history is append-only; protected fantasy state and public release pointers are not mutated
- no production or shared data was used or changed; verification used disposable SQLite and PostgreSQL databases and disposable Redis
- the migration is additive and is registered as outcomes migration 0080
- no deployment is included or implied

## Residual risk and follow-up

CI remains the deterministic authority for the two transient Chromium timing cases. Automated factual observation refresh, factual release advancement, prepared-v3 rebuild and activation, and the calculation branch remain follow-up work; this pull request closes only the durable no-change prerequisite.

Closes #549

## Summary by Sourcery

Retain a durable, restart-safe no-change trace for current valuation refreshes without advancing authorities or performing downstream valuation work.

New Features:
- Add a current valuation refresh operation that durably records when aligned factual, model, prepared-input, and private evaluation authorities require no downstream change.
- Support weekly, model-qualified, and ad hoc refresh triggers with exact replay and stable-key conflict detection.

Enhancements:
- Enforce PostgreSQL-owned, content-addressed, append-only custody for private non-production refresh results that cannot grant publication or other authority.

Documentation:
- Document the narrow structural meaning of a no-change refresh and identify the remaining automated refresh and calculation work.

Tests:
- Add unit, migration, and disposable PostgreSQL integration coverage for replay, authority validation, timestamp capture, malformed requests, stable-key conflicts, and scoped table access.
