### PR TITLE
Activate private factual authority from reviewed evidence (#568)

### DIFF
--- a/docs/architecture/afl-trade-intelligence.md
+++ b/docs/architecture/afl-trade-intelligence.md
@@ -331,14 +331,19 @@ closed immediately while the immutable history remains.
 The five-season provider rehearsal has reviewed player-match evidence that is not a member of the
 transaction-shaped factual release contract. Migration
 `0051_private_reviewed_evidence_evaluation` therefore adds a separate
-`retained_private_review` lane instead of inventing factual-release ancestry. Its content-addressed
-bundle authenticates the two exact current review sets, every deterministic current review receipt,
-the six retained 2021–2026 source captures and their immutable source artifacts, and the two exact
-source-rights artifacts. The current rehearsal bundle contains 48,781 reviewed candidates and
-146,343 current decisions. PostgreSQL rechecks the complete review-set health and exact artifact
-custody when the bundle is registered, whenever the append-only authorization head changes, and
-whenever calculation admission is assessed. One missing, superseded, or altered receipt invalidates
-the whole lane; partial counts and zero-valued fallback are not admitted.
+`retained_private_review` lane instead of inventing factual-release ancestry. Migrations
+`0081_corrected_local_review_lineage` and `0082_complete_local_reviewed_evidence` correct its local
+capture lineage and define the completed-bundle contract that includes AFL Tables 2026 results. A
+current content-addressed bundle must authenticate the two exact current review sets, every
+deterministic current review receipt, seven retained source captures and immutable source
+artifacts—five AFL Tables player-stat
+captures for 2021–2025, one official-AFL player-stat capture for 2026, and one AFL Tables results
+capture for 2026—and three exact source-rights artifacts. The current rehearsal bundle contains
+48,781 reviewed candidates and 146,343 current decisions. PostgreSQL rechecks the complete review-set
+health and exact artifact custody when the bundle is registered, whenever the append-only
+authorization head changes, and whenever calculation admission is assessed. One missing,
+superseded, altered, or normalization-incomplete capture invalidates the whole lane; partial counts
+and zero-valued fallback are not admitted.
 
 This lane is permanently private and non-production. It is not a factual release, dataset admission,
 model-training input, public fact set, publication candidate, production activation, or live-capture
@@ -429,13 +434,17 @@ projection, service, API, archive response, and authenticated JSON, CSV and OOXM
 byte. This is disposable local recovery evidence only; it is not evidence for hosted retention,
 point-in-time recovery, cross-host recovery, disaster recovery, or production restore authority.
 
-A separate development-only evidence rehearsal retains six one-off governed captures in a
-caller-owned disposable `statly_outcomes_test` PostgreSQL database: completed AFL Tables seasons
-2021–2025 and official AFL current-season evidence for 2026. The retained captures contain 57,621
-staged player-match rows. Capture rights, field maps, receipts, decoder provenance, raw-object
-digests, and staging outcomes remain independently attributable to their source decisions. Local raw
-custody uses the explicit `local_non_production_filesystem` profile and confers no hosted durability,
-redistribution, production, or recurring-capture authority.
+The existing executable development-only evidence rehearsal retains six one-off governed
+player-stat captures in a caller-owned disposable `statly_outcomes_test` PostgreSQL database: five
+completed AFL Tables seasons for 2021–2025 and official-AFL current-season evidence for 2026. Those
+captures contain 57,621 staged player-match rows. The corrected reviewed-evidence contract also
+requires one separately governed, finalized AFL Tables completed-results capture for 2026 and a third
+source-rights artifact. #569 owns producing that additional custody; until then the executable
+rehearsal cannot create the replacement current reviewed head consumed by factual activation. Capture
+rights, field maps, receipts, decoder provenance, raw-object digests, and staging outcomes remain
+independently attributable to their source decisions. Local raw custody uses the explicit
+`local_non_production_filesystem` profile and confers no hosted durability, redistribution,
+production, or recurring-capture authority.
 
 Those local capture-rights artifacts permit bounded capture, raw/hash retention and internal quality
 evaluation only. Model training, derived-feature creation, public derived output, public fact display
@@ -2014,9 +2023,26 @@ stable key for another scope or trigger fails, and missing or incoherent authori
 result explicitly remains local, private, non-production, publication-ineligible, and
 publication-prohibited.
 
-This trace closes only the durable no-change branch. Automated factual observation refresh, factual
-release advancement, prepared-v3 rebuild and activation, and the calculation branch remain separate
-work that must be composed before raw data can flow to recalculation automatically.
+The factual stage first retains an authenticated snapshot of the exact current private
+reviewed-evidence head. It then independently composes a content-addressed private factual candidate
+whose custody digest binds the admitted source captures, verified artifacts, finalized normalization
+runs, exact reconciliation review sets, and current source-rights records represented by that bundle.
+The candidate retains the canonical normalization-run snapshots behind the digest, including each
+run ID, field map, decoder and normalizer versions, content digests, receipt digests, row counts, and
+trusted finalization time. Its composition receipt also binds the exact predecessor private-factual
+head; a delayed candidate cannot overwrite a newer head from the same reviewed source.
+Source authentication and candidate composition are separate durable stage receipts under the same
+stable operation key. A restart resumes those receipts before the private factual compare-and-swap;
+it does not duplicate a candidate or head transition. The operation either advances the candidate,
+reports it already current, or retains one exact unavailable cause: missing, stale, mismatched, or
+unauthenticated source authority.
+
+This is deliberately a private factual candidate and authority, not a factual release. The retained
+reviewed bundle is evidence for composition rather than activation authority in its own right, and it
+does not authorize public display or redistribution, so the factual refresh cannot write a release
+manifest, registry event, registry head, or `outcome_active_release`. The original `no_change` result
+keeps its narrow four-head meaning. Prepared-v3 rebuild and activation and the calculation branch
+remain separate work that must be composed before newly admitted facts flow to recalculation.
 
 A structurally valid fixture report always retains `publicationReady: false` and the remaining
 external blockers: a real historical-data run, component-model calibration exit criteria, downstream

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -82,6 +82,18 @@ legacy fixture receipts and must not be rewritten in place. Preserve or remove o
 restart the stack to create honest fixture-filesystem evidence. Never apply this reset to a shared or
 hosted database.
 
+Migration `0081_corrected_local_review_lineage` has the same no-rewrite rule for the separately
+reviewed local provider lane. A disposable database that already contains decisions under the
+superseded historical evidence digest cannot migrate in place. Preserve that database and its private
+artifact roots read-only. Retained artifact bytes cannot authenticate corrected pre-capture Gate
+lineage and must not be relabeled as a new capture. This stage consumes an already current reviewed
+head. In a new empty loopback `statly_outcomes_test` database, deploy the complete migration history;
+the separately tracked #569 must then create the replacement governed capture, normalization, and
+reconciliation chain before review can continue. The exact hard stop, preservation,
+seven-capture/three-rights preflight, and retirement conditions are
+in [AFL trade intelligence operations](../runbooks/afl-trade-intelligence-operations.md#inspecting-the-governed-five-season-workbook-evaluation).
+Never use this replacement procedure for shared or hosted state.
+
 The local AFL fixture is generated code rather than workbook-backed. It contains 783 deterministic
 archive trades across 1988–2025: one source-shaped 2025 GWS–Western Bulldogs pick exchange and 782
 records whose titles, clubs, players and source references explicitly identify them as synthetic local

--- a/docs/runbooks/afl-trade-intelligence-operations.md
+++ b/docs/runbooks/afl-trade-intelligence-operations.md
@@ -636,17 +636,49 @@ alerting, scheduling, deployment, or production-activation requirements.
 
 ### Inspecting the governed five-season workbook evaluation
 
-Use this development-only path only after a separately authorized one-off capture has completed. It
-does not perform capture, grant source rights, or turn the workbook into factual authority. The
-retained disposable database must contain exactly one governed AFL Tables capture for each completed
-season from 2021 through 2025 and one separately governed official AFL current-season capture for 2026. Preserve the capture receipts and local artifact roots; do not substitute workbook values for
-missing or review-blocked observations.
+Migration `0081_corrected_local_review_lineage` is an intentional one-time boundary for this
+development-only lane. If the database already contains review decisions under the superseded
+historical evidence digest, migration deployment stops with
+`Corrected local review lineage requires a fresh disposable database before review`. Do not edit,
+delete, or relabel those append-only decisions in place, and never apply this procedure to a shared or
+hosted database.
 
-Before launch, verify the six captures are finalized in the caller-owned loopback PostgreSQL database
-named exactly `statly_outcomes_test`. Expected staged coverage for the current rehearsal is 57,621
-player-match rows: 9,522 each for 2021 and 2022, 9,936 each for 2023–2025, and 8,769 for official 2026. A count mismatch, duplicate season capture, changed field map, unresolved custody object, or
-non-loopback database is a stop condition. Do not repeat provider requests merely to start the UI;
-the interactive path reads retained PostgreSQL staging and fails closed when it is absent.
+Keep the old disposable database and its local artifact roots offline and read-only. The corrected
+Gate lineage cannot be reconstructed from retained artifact bytes: its capture execution receipt must
+bind the corrected decision that existed before retrieval. There is therefore no authenticated
+retained-artifact import and no supported in-place upgrade. This factual-activation stage consumes an
+already current reviewed-evidence head and intentionally does not orchestrate raw capture,
+normalization, or reconciliation. Creating a replacement seven-capture chain is tracked separately in
+`statlyaus/Statly#569`; until that work is delivered and a new retrieval is separately authorized, do
+not deploy migration `0081` over the superseded database or attempt the review commands below. Copying,
+relabeling, or replaying old database rows or artifact bytes as a new capture is prohibited.
+
+After #569 is delivered and a new retrieval is separately authorized, start a separate empty
+loopback database named exactly `statly_outcomes_test`, authenticate its runtime nonce, and deploy the
+complete migration history. Then use #569's owning boundary to create the corrected governed chain.
+Retire the old database only after the new reviewed bundle is current and its capture IDs, artifact
+digests, normalization-run IDs, counts, and three rights artifacts have been privately compared with
+the preserved evidence record.
+
+The remaining development-only inspection path assumes the replacement provider retrieval was
+separately authorized and has completed through its owning boundary. The review commands do not
+perform capture or grant factual authority. The replacement disposable database must contain exactly
+one governed AFL Tables capture for each completed
+season from 2021 through 2025, one separately governed official-AFL current-season player-stat capture
+for 2026, and one governed AFL Tables completed-results capture for 2026. Preserve the capture
+receipts and local artifact roots; do not substitute workbook values for missing or review-blocked
+observations.
+
+Before launch, verify all seven captures have exactly one admitted finalized normalization in the
+caller-owned loopback PostgreSQL database named exactly `statly_outcomes_test`, and verify that their
+manifests resolve to exactly three source-rights artifacts. Expected staged player-stat coverage for
+the six player-stat captures remains 57,621 player-match rows: 9,522 each for 2021 and 2022, 9,936
+each for 2023–2025, and 8,769 for official 2026. The seventh capture is the separate AFL Tables 2026
+results normalization and is not included in that player-match-row total. A count mismatch, duplicate
+season or capability capture, extra or missing finalized normalization, changed field map, unresolved
+custody object, rights-count mismatch, or non-loopback database is a stop condition. Do not repeat
+provider requests merely to start the UI; the interactive path reads retained PostgreSQL staging and
+fails closed when it is absent.
 
 Set the private workbook path and its independently computed SHA-256 only in the invoking shell. Do
 not write either value to Git, logs, documentation, or a shared environment file. Then run:
@@ -858,6 +890,33 @@ swap, activates and exactly replays a seeded ready fixture, inspects and withdra
 workspace, verifies the exact withdrawn generation without reactivation, rejects unavailable recovery
 and rollback, rejects mutation of append-only receipts, and proves the composite scope key prevents
 cross-scope reads. Remove only the container/schema and artifact directory created for that run.
+
+### Refreshing private factual authority
+
+Current Valuation Refresh accepts a valuation scope, trigger, and stable operation key. Reuse the same
+stable key after a timeout or lost response; exact replay returns the committed receipt. Never invent a
+new key merely because the caller did not receive the first response.
+
+The factual stage may return `factual_refresh_complete` with `advanced` or `already_current`. It may
+instead retain `unavailable` with `source_authority_missing`, `source_authority_stale`,
+`source_authority_mismatched`, or `source_authority_unauthenticated`. Treat these as source-governance
+failures: inspect and repair the admitted capture, finalized normalization, reconciliation review,
+custody, or rights authority. Do not retry them as transient worker failures; retry and lease policy is
+owned by the dispatch recovery boundary.
+
+The coordinator durably retains `source_authenticated` and `candidate_composed` receipts before its
+terminal compare-and-swap. Reusing the stable operation key after loss at either boundary resumes the
+retained receipt. The composed candidate retains and binds a canonical normalized/reconciled custody
+snapshot separately from the reviewed bundle identity. That snapshot includes one exact finalized
+normalization run per admitted capture and the reviewed reconciliation sets. The composition receipt
+also binds the predecessor private-factual head; if a later candidate advances first, the older
+receipt fails its compare-and-swap instead of reactivating stale custody.
+
+An advancement changes only `outcome_current_private_factual_authority`. Verify that
+`outcome_active_release` and the publication registry are unchanged. The reviewed sources prohibit
+public display and redistribution, so this operation is not authority to register, activate, export,
+or serve a factual release. Prepared-v3 and private batch heads remain unchanged until their separate
+coordinators complete.
 
 ### Operating automatic local private valuation
 

--- a/prisma/afl-trade-outcomes/migrations/0081_corrected_local_review_lineage/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0081_corrected_local_review_lineage/migration.sql
@@ -1,0 +1,70 @@
+-- Rotate only the private local AFL Tables review identity after correcting the authenticated
+-- Gate 0A capture lineage. The reviewed rows and decision counts are unchanged. Reuse the exact
+-- validation bodies installed by migrations 0051 and 0055 instead of copying them here.
+DO $migration$
+DECLARE
+  old_digest CONSTANT TEXT :=
+    'aef663452e66a433048605a71fb4178ed1a5e1d9610c6d3ed75bfb796308b5cb';
+  new_digest CONSTANT TEXT :=
+    '7ef741add1ae94133c597581f8a2175118058bedd2ffe8a107213630e1b0fd10';
+  function_signature TEXT;
+  function_definition TEXT;
+BEGIN
+  IF EXISTS (
+    SELECT 1
+      FROM "outcome_review_decision"
+     WHERE "decided_by"='local-five-season-evidence-reviewer'
+       AND "evidence_json"->>'evidenceSetSha256'=old_digest
+  ) THEN
+    RAISE EXCEPTION
+      'Corrected local review lineage requires a fresh disposable database before review';
+  END IF;
+
+  FOREACH function_signature IN ARRAY ARRAY[
+    'outcome_private_reviewed_evidence_is_current()',
+    'validate_outcome_private_reviewed_evidence_bundle_insert()',
+    'outcome_private_reviewed_evidence_bundle_is_current_v1(text)'
+  ]
+  LOOP
+    SELECT pg_get_functiondef(to_regprocedure(function_signature))
+      INTO function_definition;
+    IF function_definition IS NULL
+       OR position(old_digest IN function_definition)=0
+       OR position(new_digest IN function_definition)>0
+    THEN
+      RAISE EXCEPTION 'Private review currentness function % has unexpected lineage',
+        function_signature;
+    END IF;
+    EXECUTE replace(function_definition,old_digest,new_digest);
+  END LOOP;
+END $migration$;
+
+DROP INDEX "outcome_review_decision_private_set_current_idx";
+CREATE INDEX "outcome_review_decision_private_set_current_idx"
+  ON "outcome_review_decision"(
+    ("evidence_json"->>'evidenceSetSha256'),"decided_by","decision","subject_type"
+  )
+  WHERE "evidence_json"->>'evidenceSetSha256' IN (
+    'aef663452e66a433048605a71fb4178ed1a5e1d9610c6d3ed75bfb796308b5cb',
+    '7ef741add1ae94133c597581f8a2175118058bedd2ffe8a107213630e1b0fd10',
+    '4e58a390b7088d50b119bdd2c945a1f66ba2025fd8bbbf8710fc8a270dad2dca'
+  );
+
+CREATE OR REPLACE FUNCTION "reject_outcome_private_review_set_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF (
+    OLD."decided_by" IN (
+      'local-five-season-evidence-reviewer',
+      'local-workbook-evidence-reviewer'
+    )
+    AND OLD."evidence_json"->>'evidenceSetSha256' IN (
+      'aef663452e66a433048605a71fb4178ed1a5e1d9610c6d3ed75bfb796308b5cb',
+      '7ef741add1ae94133c597581f8a2175118058bedd2ffe8a107213630e1b0fd10',
+      '4e58a390b7088d50b119bdd2c945a1f66ba2025fd8bbbf8710fc8a270dad2dca'
+    )
+  ) THEN
+    RAISE EXCEPTION 'Admitted private review-set decisions are append-only';
+  END IF;
+  RETURN OLD;
+END $$;

--- a/prisma/afl-trade-outcomes/migrations/0082_complete_local_reviewed_evidence/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0082_complete_local_reviewed_evidence/migration.sql
@@ -1,8 +1,8 @@
 -- The current local reviewed-evidence authority is one complete seven-capture bundle: five
 -- historical player-stat captures, one official current-season player-stat capture, and one
 -- current-season results capture. Preserve failed raw captures, but admit only captures with a
--- successfully finalized normalization run. Reuse the installed validation bodies rather than
--- copying the large currentness functions into another migration.
+-- exactly one successfully finalized normalization run. Reuse the installed validation bodies
+-- rather than copying the large currentness functions into another migration.
 DO $migration$
 DECLARE
   function_signature TEXT;
@@ -57,8 +57,8 @@ BEGIN
        OR (capture."provider"='afl_tables'
            AND capture."capability_id"='afl-tables-results'
            AND capture."anchor_season_year"=2026))
-     AND EXISTS (
-       SELECT 1
+     AND 1 = (
+       SELECT count(*)
          FROM "outcome_provider_normalization_run" run
         WHERE run."capture_id"=capture."capture_id"
           AND run."status" IN ('staged','needs_review')
@@ -83,8 +83,8 @@ BEGIN
        OR (capture.provider='afl_tables'
            AND capture.capability_id='afl-tables-results'
            AND capture.anchor_season_year=2026))
-     AND EXISTS (
-       SELECT 1
+     AND 1 = (
+       SELECT count(*)
          FROM outcome_provider_normalization_run run
         WHERE run.capture_id=capture.capture_id
           AND run.status IN ('staged','needs_review')
@@ -118,6 +118,7 @@ BEGIN
        OR position('afl-tables-results' IN function_definition)=0
        OR position('outcome_provider_normalization_run' IN function_definition)=0
        OR position('finalized_at' IN function_definition)=0
+       OR position('SELECT count(*)' IN function_definition)=0
        OR (function_signature='outcome_private_reviewed_evidence_is_current()'
            AND (position('AND capture_count=7;' IN function_definition)=0
                 OR position('AND capture_count=6;' IN function_definition)>0))

--- a/prisma/afl-trade-outcomes/migrations/0082_complete_local_reviewed_evidence/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0082_complete_local_reviewed_evidence/migration.sql
@@ -1,6 +1,6 @@
 -- The current local reviewed-evidence authority is one complete seven-capture bundle: five
 -- historical player-stat captures, one official current-season player-stat capture, and one
--- current-season results capture. Preserve failed raw captures, but admit only captures with a
+-- current-season results capture. Preserve failed raw captures, but admit only captures with
 -- exactly one successfully finalized normalization run. Reuse the installed validation bodies
 -- rather than copying the large currentness functions into another migration.
 DO $migration$
@@ -63,6 +63,22 @@ BEGIN
         WHERE run."capture_id"=capture."capture_id"
           AND run."status" IN ('staged','needs_review')
           AND run."finalized_at" IS NOT NULL
+     )
+     AND 1 = (
+       SELECT count(*)
+         FROM "outcome_source_capture" sibling
+        WHERE sibling."environment"='non_production'
+          AND sibling."status"='staged'
+          AND sibling."provider"=capture."provider"
+          AND sibling."capability_id"=capture."capability_id"
+          AND sibling."anchor_season_year"=capture."anchor_season_year"
+          AND 1 = (
+            SELECT count(*)
+              FROM "outcome_provider_normalization_run" sibling_run
+             WHERE sibling_run."capture_id"=sibling."capture_id"
+               AND sibling_run."status" IN ('staged','needs_review')
+               AND sibling_run."finalized_at" IS NOT NULL
+          )
      );$filter$;
 
       function_definition:=replace(
@@ -89,6 +105,22 @@ BEGIN
         WHERE run.capture_id=capture.capture_id
           AND run.status IN ('staged','needs_review')
           AND run.finalized_at IS NOT NULL
+     )
+     AND 1 = (
+       SELECT count(*)
+         FROM outcome_source_capture sibling
+        WHERE sibling.environment='non_production'
+          AND sibling.status='staged'
+          AND sibling.provider=capture.provider
+          AND sibling.capability_id=capture.capability_id
+          AND sibling.anchor_season_year=capture.anchor_season_year
+          AND 1 = (
+            SELECT count(*)
+              FROM outcome_provider_normalization_run sibling_run
+             WHERE sibling_run.capture_id=sibling.capture_id
+               AND sibling_run.status IN ('staged','needs_review')
+               AND sibling_run.finalized_at IS NOT NULL
+          )
      );$filter$;
 
       IF function_signature='outcome_private_reviewed_evidence_is_current()' THEN
@@ -119,6 +151,8 @@ BEGIN
        OR position('outcome_provider_normalization_run' IN function_definition)=0
        OR position('finalized_at' IN function_definition)=0
        OR position('SELECT count(*)' IN function_definition)=0
+       OR (position('sibling.anchor_season_year' IN function_definition)=0
+           AND position('sibling."anchor_season_year"' IN function_definition)=0)
        OR (function_signature='outcome_private_reviewed_evidence_is_current()'
            AND (position('AND capture_count=7;' IN function_definition)=0
                 OR position('AND capture_count=6;' IN function_definition)>0))

--- a/prisma/afl-trade-outcomes/migrations/0082_complete_local_reviewed_evidence/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0082_complete_local_reviewed_evidence/migration.sql
@@ -1,0 +1,161 @@
+-- The current local reviewed-evidence authority is one complete seven-capture bundle: five
+-- historical player-stat captures, one official current-season player-stat capture, and one
+-- current-season results capture. Preserve failed raw captures, but admit only captures with a
+-- successfully finalized normalization run. Reuse the installed validation bodies rather than
+-- copying the large currentness functions into another migration.
+DO $migration$
+DECLARE
+  function_signature TEXT;
+  function_definition TEXT;
+  original_definition TEXT;
+  old_capture_filter TEXT;
+  new_capture_filter TEXT;
+BEGIN
+  FOREACH function_signature IN ARRAY ARRAY[
+    'outcome_private_reviewed_evidence_is_current()',
+    'validate_outcome_private_reviewed_evidence_bundle_insert()',
+    'outcome_private_reviewed_evidence_bundle_is_current_v1(text)'
+  ]
+  LOOP
+    SELECT pg_get_functiondef(to_regprocedure(function_signature))
+      INTO function_definition;
+    IF function_definition IS NULL THEN
+      RAISE EXCEPTION 'Private reviewed-evidence function % is unavailable',function_signature;
+    END IF;
+    original_definition:=function_definition;
+
+    IF function_signature='outcome_private_reviewed_evidence_is_current()'
+       AND (position('AND capture_count=6;' IN original_definition)=0
+            OR position('AND capture_count=7;' IN original_definition)>0)
+    THEN
+      RAISE EXCEPTION 'Private reviewed-evidence health has unexpected capture counts';
+    ELSIF function_signature='validate_outcome_private_reviewed_evidence_bundle_insert()'
+       AND (position('OR NEW."source_capture_count"<>6' IN original_definition)=0
+            OR position('OR NEW."source_rights_count"<>2' IN original_definition)=0
+            OR position('OR NEW."source_capture_count"<>7' IN original_definition)>0
+            OR position('OR NEW."source_rights_count"<>3' IN original_definition)>0)
+    THEN
+      RAISE EXCEPTION 'Private reviewed-evidence insert validation has unexpected counts';
+    ELSIF function_signature='outcome_private_reviewed_evidence_bundle_is_current_v1(text)'
+       AND (position('OR bundle_source_capture_count<>6' IN original_definition)=0
+            OR position('OR bundle_source_rights_count<>2' IN original_definition)=0
+            OR position('OR bundle_source_capture_count<>7' IN original_definition)>0
+            OR position('OR bundle_source_rights_count<>3' IN original_definition)>0)
+    THEN
+      RAISE EXCEPTION 'Private reviewed-evidence bundle currentness has unexpected counts';
+    END IF;
+
+    IF function_signature='outcome_private_reviewed_evidence_bundle_is_current_v1(text)' THEN
+      old_capture_filter:=$filter$
+       OR (capture."provider"='official_afl'
+           AND capture."capability_id"='official-afl-player-stats'
+           AND capture."anchor_season_year"=2026));$filter$;
+      new_capture_filter:=$filter$
+       OR (capture."provider"='official_afl'
+           AND capture."capability_id"='official-afl-player-stats'
+           AND capture."anchor_season_year"=2026)
+       OR (capture."provider"='afl_tables'
+           AND capture."capability_id"='afl-tables-results'
+           AND capture."anchor_season_year"=2026))
+     AND EXISTS (
+       SELECT 1
+         FROM "outcome_provider_normalization_run" run
+        WHERE run."capture_id"=capture."capture_id"
+          AND run."status" IN ('staged','needs_review')
+          AND run."finalized_at" IS NOT NULL
+     );$filter$;
+
+      function_definition:=replace(
+        function_definition,'OR bundle_source_capture_count<>6','OR bundle_source_capture_count<>7'
+      );
+      function_definition:=replace(
+        function_definition,'OR bundle_source_rights_count<>2','OR bundle_source_rights_count<>3'
+      );
+    ELSE
+      old_capture_filter:=$filter$
+       OR (capture.provider='official_afl'
+           AND capture.capability_id='official-afl-player-stats'
+           AND capture.anchor_season_year=2026));$filter$;
+      new_capture_filter:=$filter$
+       OR (capture.provider='official_afl'
+           AND capture.capability_id='official-afl-player-stats'
+           AND capture.anchor_season_year=2026)
+       OR (capture.provider='afl_tables'
+           AND capture.capability_id='afl-tables-results'
+           AND capture.anchor_season_year=2026))
+     AND EXISTS (
+       SELECT 1
+         FROM outcome_provider_normalization_run run
+        WHERE run.capture_id=capture.capture_id
+          AND run.status IN ('staged','needs_review')
+          AND run.finalized_at IS NOT NULL
+     );$filter$;
+
+      IF function_signature='outcome_private_reviewed_evidence_is_current()' THEN
+        function_definition:=replace(
+          function_definition,'AND capture_count=6;','AND capture_count=7;'
+        );
+      ELSE
+        function_definition:=replace(
+          function_definition,'OR NEW."source_capture_count"<>6',
+          'OR NEW."source_capture_count"<>7'
+        );
+        function_definition:=replace(
+          function_definition,'OR NEW."source_rights_count"<>2',
+          'OR NEW."source_rights_count"<>3'
+        );
+      END IF;
+    END IF;
+
+    IF (length(original_definition)-length(replace(original_definition,old_capture_filter,'')))
+         / length(old_capture_filter)<>1 THEN
+      RAISE EXCEPTION 'Private reviewed-evidence function % has unexpected capture selection',
+        function_signature;
+    END IF;
+    function_definition:=replace(function_definition,old_capture_filter,new_capture_filter);
+
+    IF function_definition=original_definition
+       OR position('afl-tables-results' IN function_definition)=0
+       OR position('outcome_provider_normalization_run' IN function_definition)=0
+       OR position('finalized_at' IN function_definition)=0
+       OR (function_signature='outcome_private_reviewed_evidence_is_current()'
+           AND (position('AND capture_count=7;' IN function_definition)=0
+                OR position('AND capture_count=6;' IN function_definition)>0))
+       OR (function_signature='validate_outcome_private_reviewed_evidence_bundle_insert()'
+           AND (position('OR NEW."source_capture_count"<>7' IN function_definition)=0
+                OR position('OR NEW."source_rights_count"<>3' IN function_definition)=0
+                OR position('OR NEW."source_capture_count"<>6' IN function_definition)>0
+                OR position('OR NEW."source_rights_count"<>2' IN function_definition)>0))
+       OR (function_signature='outcome_private_reviewed_evidence_bundle_is_current_v1(text)'
+           AND (position('OR bundle_source_capture_count<>7' IN function_definition)=0
+                OR position('OR bundle_source_rights_count<>3' IN function_definition)=0
+                OR position('OR bundle_source_capture_count<>6' IN function_definition)>0
+                OR position('OR bundle_source_rights_count<>2' IN function_definition)>0))
+    THEN
+      RAISE EXCEPTION 'Private reviewed-evidence function % was not upgraded',function_signature;
+    END IF;
+    EXECUTE function_definition;
+  END LOOP;
+END $migration$;
+
+-- A complete bundle is now validated directly. The former results-successor trigger duplicated
+-- this check and required an already-authorized six-capture head, which cannot exist on a fresh
+-- current-schema database.
+DROP TRIGGER "outcome_private_reviewed_evidence_bundle_insert_guard"
+  ON "outcome_private_reviewed_evidence_bundle";
+CREATE TRIGGER "outcome_private_reviewed_evidence_bundle_insert_guard"
+  BEFORE INSERT ON "outcome_private_reviewed_evidence_bundle"
+  FOR EACH ROW
+  WHEN (NEW."source_capture_count"=7 AND NEW."source_rights_count"=3)
+  EXECUTE FUNCTION "validate_outcome_private_reviewed_evidence_bundle_insert"();
+
+DROP TRIGGER "outcome_private_reviewed_evidence_results_successor_insert_guard"
+  ON "outcome_private_reviewed_evidence_bundle";
+
+DROP TRIGGER "outcome_private_reviewed_evidence_unsupported_shape_guard"
+  ON "outcome_private_reviewed_evidence_bundle";
+CREATE TRIGGER "outcome_private_reviewed_evidence_unsupported_shape_guard"
+  BEFORE INSERT ON "outcome_private_reviewed_evidence_bundle"
+  FOR EACH ROW
+  WHEN (NOT (NEW."source_capture_count"=7 AND NEW."source_rights_count"=3))
+  EXECUTE FUNCTION "reject_outcome_private_reviewed_evidence_unsupported_shape"();

--- a/prisma/afl-trade-outcomes/migrations/0083_current_valuation_factual_refresh/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0083_current_valuation_factual_refresh/migration.sql
@@ -1,0 +1,342 @@
+-- Compose and advance only private local factual authority. Public release and publication
+-- registries are intentionally outside this role's privileges.
+CREATE TABLE "outcome_private_factual_candidate" (
+  "candidate_id" TEXT PRIMARY KEY CHECK ("candidate_id" ~ '^private-factual-candidate:[a-f0-9]{64}$'),
+  "valuation_scope_key" TEXT NOT NULL,
+  "evidence_scope_key" TEXT NOT NULL,
+  "evidence_bundle_id" TEXT NOT NULL REFERENCES "outcome_private_reviewed_evidence_bundle"("evidence_bundle_id") ON DELETE RESTRICT,
+  "review_decision_id" TEXT NOT NULL REFERENCES "outcome_private_reviewed_evaluation_decision"("decision_id") ON DELETE RESTRICT,
+  "normalized_reconciled_custody_sha256" CHAR(64) NOT NULL CHECK ("normalized_reconciled_custody_sha256" ~ '^[a-f0-9]{64}$'),
+  "candidate_json" JSONB NOT NULL,
+  "composed_at" TIMESTAMPTZ(3) NOT NULL
+);
+CREATE TABLE "outcome_current_private_factual_authority" (
+  "valuation_scope_key" TEXT PRIMARY KEY,
+  "candidate_id" TEXT NOT NULL UNIQUE REFERENCES "outcome_private_factual_candidate"("candidate_id") ON DELETE RESTRICT,
+  "revision" INTEGER NOT NULL CHECK ("revision">0),
+  "advanced_at" TIMESTAMPTZ(3) NOT NULL
+);
+CREATE TABLE "outcome_current_valuation_factual_refresh_stage_receipt" (
+  "receipt_id" TEXT PRIMARY KEY CHECK ("receipt_id" ~ '^current-valuation-factual-refresh-stage-receipt:[a-f0-9]{64}$'),
+  "scope_key" TEXT NOT NULL,
+  "trigger_kind" TEXT NOT NULL CHECK ("trigger_kind" IN ('weekly','model_qualified','ad_hoc')),
+  "stable_operation_key" TEXT NOT NULL,
+  "stage" TEXT NOT NULL CHECK ("stage" IN ('source_authenticated','candidate_composed')),
+  "receipt_json" JSONB NOT NULL,
+  "retained_at" TIMESTAMPTZ(3) NOT NULL,
+  UNIQUE ("stable_operation_key","stage")
+);
+CREATE TABLE "outcome_current_valuation_factual_refresh_operation" (
+  "operation_id" TEXT PRIMARY KEY CHECK ("operation_id" ~ '^current-valuation-factual-refresh-operation:[a-f0-9]{64}$'),
+  "scope_key" TEXT NOT NULL,
+  "trigger_kind" TEXT NOT NULL CHECK ("trigger_kind" IN ('weekly','model_qualified','ad_hoc')),
+  "stable_operation_key" TEXT NOT NULL UNIQUE,
+  "state" TEXT NOT NULL CHECK ("state" IN ('factual_refresh_complete','unavailable')),
+  "factual_stage" TEXT CHECK ("factual_stage" IN ('already_current','advanced')),
+  "unavailable_cause" TEXT CHECK ("unavailable_cause" IN ('source_authority_missing','source_authority_stale','source_authority_mismatched','source_authority_unauthenticated')),
+  "candidate_id" TEXT,
+  "private_factual_revision" INTEGER,
+  "captured_at" TIMESTAMPTZ(3) NOT NULL,
+  "completed_at" TIMESTAMPTZ(3) NOT NULL,
+  "operation_json" JSONB NOT NULL,
+  "result_json" JSONB NOT NULL,
+  CHECK (("state"='factual_refresh_complete' AND "factual_stage" IS NOT NULL AND "unavailable_cause" IS NULL AND "candidate_id" IS NOT NULL AND "private_factual_revision">0)
+      OR ("state"='unavailable' AND "factual_stage" IS NULL AND "unavailable_cause" IS NOT NULL AND "candidate_id" IS NULL AND "private_factual_revision" IS NULL))
+);
+
+-- Preserve the pre-factual implementation behind a private name. The public entry point is
+-- recreated below as a compatibility router so both generations share one idempotency namespace.
+DO $membership$ BEGIN
+  EXECUTE format('GRANT afl_trade_current_valuation_refresh_owner TO %I',current_user);
+END $membership$;
+ALTER FUNCTION "retain_outcome_current_valuation_refresh_no_change"(TEXT,TEXT,TEXT)
+  RENAME TO "retain_outcome_current_valuation_refresh_no_change_v1";
+
+CREATE FUNCTION "reject_outcome_current_valuation_factual_refresh_mutation"() RETURNS TRIGGER
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'Current valuation factual refresh custody is append-only'; END $$;
+CREATE TRIGGER "outcome_private_factual_candidate_no_update_delete" BEFORE UPDATE OR DELETE ON "outcome_private_factual_candidate" FOR EACH ROW EXECUTE FUNCTION "reject_outcome_current_valuation_factual_refresh_mutation"();
+CREATE TRIGGER "outcome_current_valuation_factual_refresh_stage_no_update_delete" BEFORE UPDATE OR DELETE ON "outcome_current_valuation_factual_refresh_stage_receipt" FOR EACH ROW EXECUTE FUNCTION "reject_outcome_current_valuation_factual_refresh_mutation"();
+CREATE TRIGGER "outcome_current_valuation_factual_refresh_no_update_delete" BEFORE UPDATE OR DELETE ON "outcome_current_valuation_factual_refresh_operation" FOR EACH ROW EXECUTE FUNCTION "reject_outcome_current_valuation_factual_refresh_mutation"();
+
+CREATE FUNCTION "outcome_private_factual_custody_for_bundle"(target_bundle_id TEXT)
+RETURNS JSONB LANGUAGE plpgsql STABLE AS $$
+DECLARE bundle_content JSONB; normalization_runs JSONB; normalization_run_count INTEGER; expected_capture_count INTEGER;
+BEGIN
+  SELECT bundle."bundle_json"->'content' INTO bundle_content
+    FROM "outcome_private_reviewed_evidence_bundle" bundle
+   WHERE bundle."evidence_bundle_id"=target_bundle_id;
+  IF bundle_content IS NULL THEN RETURN NULL; END IF;
+  expected_capture_count:=jsonb_array_length(coalesce(bundle_content->'sourceCaptures','[]'::jsonb));
+  SELECT count(*)::integer,
+         coalesce(jsonb_agg(jsonb_build_object(
+           'normalizationRunId',run."normalization_run_id",'captureId',run."capture_id",
+           'fieldMapId',run."field_map_id",'decoderVersion',run."decoder_version",
+           'normalizerVersion',run."normalizer_version",'sourceRdsSha256',run."source_rds_sha256",
+           'decodedSha256',run."decoded_sha256",'receiptSha256',run."receipt_sha256",
+           'stagingSha256',run."staging_sha256",'status',run."status",
+           'sourceRowCount',run."source_row_count",'acceptedRowCount',run."accepted_row_count",
+           'quarantinedRowCount',run."quarantined_row_count",'issueCount',run."issue_count",
+           'identityCandidateCount',run."identity_candidate_count",
+           'matchCandidateCount',run."match_candidate_count",
+           'metricCandidateCount',run."metric_candidate_count",
+           'achievementCandidateCount',run."achievement_candidate_count",
+           'completedAt',to_char(run."completed_at" AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+           'finalizedAt',to_char(run."finalized_at" AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+         ) ORDER BY run."capture_id",run."normalization_run_id"),'[]'::jsonb)
+    INTO normalization_run_count,normalization_runs
+    FROM jsonb_array_elements(bundle_content->'sourceCaptures') captures(item)
+    JOIN "outcome_provider_normalization_run" run
+      ON run."capture_id"=captures.item->>'captureId'
+     AND run."status" IN ('staged','needs_review')
+     AND run."finalized_at" IS NOT NULL;
+  IF expected_capture_count=0 OR normalization_run_count<>expected_capture_count
+     OR EXISTS (
+       SELECT 1
+         FROM jsonb_array_elements(bundle_content->'sourceCaptures') captures(item)
+         LEFT JOIN "outcome_provider_normalization_run" run
+           ON run."capture_id"=captures.item->>'captureId'
+          AND run."status" IN ('staged','needs_review')
+          AND run."finalized_at" IS NOT NULL
+        GROUP BY captures.item->>'captureId'
+       HAVING count(run."normalization_run_id")<>1
+     ) THEN
+    RETURN NULL;
+  END IF;
+  RETURN jsonb_build_object(
+    'schemaVersion','afl-private-factual-normalized-reconciled-custody/v1',
+    'sourceCaptures',bundle_content->'sourceCaptures',
+    'normalizationRuns',normalization_runs,
+    'reviewSets',coalesce(bundle_content->'reviewSets','[]'::jsonb),
+    'sourceRightsEvidenceRefs',coalesce(bundle_content->'sourceRightsEvidenceRefs','[]'::jsonb));
+END $$;
+
+CREATE FUNCTION "retain_outcome_current_valuation_factual_source"(target_scope_key TEXT,target_trigger TEXT,target_stable_operation_key TEXT)
+RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE trusted_at TIMESTAMPTZ(3):=statement_timestamp(); source_head RECORD; retained RECORD; target_cause TEXT; content JSONB; rid TEXT;
+BEGIN
+  IF target_scope_key IS NULL OR target_scope_key<>btrim(target_scope_key) OR length(target_scope_key) NOT BETWEEN 1 AND 400
+    OR target_stable_operation_key IS NULL OR target_stable_operation_key<>btrim(target_stable_operation_key) OR length(target_stable_operation_key) NOT BETWEEN 1 AND 400
+    OR target_trigger IS NULL OR target_trigger NOT IN ('weekly','model_qualified','ad_hoc') THEN RAISE EXCEPTION 'Current valuation factual refresh request is malformed'; END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(target_stable_operation_key,0));
+  SELECT * INTO retained FROM "outcome_current_valuation_refresh_operation" WHERE "stable_operation_key"=target_stable_operation_key;
+  IF FOUND THEN
+    IF retained."scope_key"<>target_scope_key OR retained."trigger_kind"<>target_trigger THEN RAISE EXCEPTION 'Current valuation refresh operation conflicts with retained custody'; END IF; RETURN;
+  END IF;
+  SELECT * INTO retained FROM "outcome_current_valuation_factual_refresh_operation" WHERE "stable_operation_key"=target_stable_operation_key;
+  IF FOUND THEN
+    IF retained."scope_key"<>target_scope_key OR retained."trigger_kind"<>target_trigger THEN RAISE EXCEPTION 'Current valuation factual refresh operation conflicts with retained custody'; END IF; RETURN;
+  END IF;
+  SELECT * INTO retained FROM "outcome_current_valuation_factual_refresh_stage_receipt" WHERE "stable_operation_key"=target_stable_operation_key AND "stage"='source_authenticated';
+  IF FOUND THEN
+    IF retained."scope_key"<>target_scope_key OR retained."trigger_kind"<>target_trigger THEN RAISE EXCEPTION 'Current valuation factual refresh stage conflicts with retained custody'; END IF; RETURN;
+  END IF;
+  SELECT head."valuation_scope_key",head."evidence_scope_key",head."evidence_bundle_id",head."decision_id",head."status",
+         decision."decision_id" AS authenticated_decision_id,decision."valuation_scope_key" AS decision_scope_key,
+         decision."evidence_bundle_id" AS decision_bundle_id,decision."status" AS decision_status,
+         bundle."evidence_bundle_id" AS authenticated_bundle_id
+    INTO source_head FROM "outcome_private_reviewed_evaluation_head" head
+    LEFT JOIN "outcome_private_reviewed_evaluation_decision" decision ON decision."decision_id"=head."decision_id"
+    LEFT JOIN "outcome_private_reviewed_evidence_bundle" bundle ON bundle."evidence_bundle_id"=head."evidence_bundle_id"
+   WHERE head."valuation_scope_key"=target_scope_key AND head."evidence_scope_key"='afl-player-match-reviewed-2021-2026';
+  IF source_head."valuation_scope_key" IS NULL THEN target_cause:='source_authority_missing';
+  ELSIF source_head."status"<>'authorized' OR source_head."decision_status"<>'authorized' THEN target_cause:='source_authority_unauthenticated';
+  ELSIF source_head."authenticated_decision_id" IS NULL OR source_head."authenticated_bundle_id" IS NULL OR source_head."decision_scope_key"<>target_scope_key OR source_head."decision_bundle_id"<>source_head."evidence_bundle_id" THEN target_cause:='source_authority_mismatched';
+  ELSIF NOT "outcome_private_reviewed_evidence_bundle_is_current"(source_head."evidence_bundle_id") THEN target_cause:='source_authority_stale'; END IF;
+  content:=jsonb_strip_nulls(jsonb_build_object('schemaVersion','afl-current-valuation-factual-source-receipt/v1','scopeKey',target_scope_key,'trigger',target_trigger,
+    'stableOperationKey',target_stable_operation_key,'stage','source_authenticated','cause',target_cause,'evidenceScopeKey',source_head."evidence_scope_key",
+    'evidenceBundleId',source_head."evidence_bundle_id",'reviewDecisionId',source_head."decision_id",'retainedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')));
+  rid:='current-valuation-factual-refresh-stage-receipt:'||encode(sha256(convert_to("outcome_afl_trade_canonical_json"(content),'UTF8')),'hex');
+  INSERT INTO "outcome_current_valuation_factual_refresh_stage_receipt" VALUES (rid,target_scope_key,target_trigger,target_stable_operation_key,'source_authenticated',jsonb_build_object('receiptId',rid,'content',content),trusted_at);
+END $$;
+
+CREATE FUNCTION "compose_outcome_current_valuation_factual_candidate"(target_scope_key TEXT,target_trigger TEXT,target_stable_operation_key TEXT)
+RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE trusted_at TIMESTAMPTZ(3):=statement_timestamp(); source_receipt RECORD; retained RECORD; bundle RECORD; private_head RECORD; custody JSONB; custody_sha TEXT; candidate_content JSONB; cid TEXT; content JSONB; rid TEXT; target_cause TEXT; expected_private_candidate_id TEXT; expected_private_revision INTEGER:=0;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended(target_stable_operation_key,0));
+  SELECT * INTO retained FROM "outcome_current_valuation_refresh_operation" WHERE "stable_operation_key"=target_stable_operation_key;
+  IF FOUND THEN
+    IF retained."scope_key"<>target_scope_key OR retained."trigger_kind"<>target_trigger THEN RAISE EXCEPTION 'Current valuation refresh operation conflicts with retained custody'; END IF;
+    RETURN;
+  END IF;
+  SELECT * INTO retained FROM "outcome_current_valuation_factual_refresh_operation" WHERE "stable_operation_key"=target_stable_operation_key;
+  IF FOUND THEN
+    IF retained."scope_key"<>target_scope_key OR retained."trigger_kind"<>target_trigger THEN RAISE EXCEPTION 'Current valuation factual refresh operation conflicts with retained custody'; END IF;
+    RETURN;
+  END IF;
+  SELECT * INTO source_receipt FROM "outcome_current_valuation_factual_refresh_stage_receipt" WHERE "stable_operation_key"=target_stable_operation_key AND "stage"='source_authenticated';
+  IF NOT FOUND THEN RAISE EXCEPTION 'Current valuation factual source receipt is missing'; END IF;
+  IF source_receipt."scope_key"<>target_scope_key OR source_receipt."trigger_kind"<>target_trigger THEN RAISE EXCEPTION 'Current valuation factual refresh stage conflicts with retained custody'; END IF;
+  SELECT * INTO retained FROM "outcome_current_valuation_factual_refresh_stage_receipt" WHERE "stable_operation_key"=target_stable_operation_key AND "stage"='candidate_composed';
+  IF FOUND THEN RETURN; END IF;
+  target_cause:=source_receipt."receipt_json"->'content'->>'cause';
+  IF target_cause IS NULL THEN
+    SELECT * INTO bundle FROM "outcome_private_reviewed_evidence_bundle" WHERE "evidence_bundle_id"=source_receipt."receipt_json"->'content'->>'evidenceBundleId';
+    IF bundle."evidence_bundle_id" IS NULL OR NOT "outcome_private_reviewed_evidence_bundle_is_current"(bundle."evidence_bundle_id") THEN
+      target_cause:='source_authority_stale';
+    ELSE
+      custody:="outcome_private_factual_custody_for_bundle"(bundle."evidence_bundle_id");
+      IF custody IS NULL THEN target_cause:='source_authority_stale'; END IF;
+    END IF;
+    IF target_cause IS NULL THEN
+      custody_sha:=encode(sha256(convert_to("outcome_afl_trade_canonical_json"(custody),'UTF8')),'hex');
+      candidate_content:=jsonb_build_object('schemaVersion','afl-private-factual-candidate/v1','valuationScopeKey',target_scope_key,
+        'evidenceScopeKey',source_receipt."receipt_json"->'content'->>'evidenceScopeKey','evidenceBundleId',bundle."evidence_bundle_id",
+        'reviewDecisionId',source_receipt."receipt_json"->'content'->>'reviewDecisionId','reviewedEvidenceContentSha256',bundle."bundle_sha256",
+        'normalizedReconciledCustody',custody,'normalizedReconciledCustodySha256',custody_sha,
+        'executionLocation','local','visibility','private','environment','non_production','publicationEligible',false,'publicationProhibited',true);
+      cid:='private-factual-candidate:'||encode(sha256(convert_to("outcome_afl_trade_canonical_json"(candidate_content),'UTF8')),'hex');
+      INSERT INTO "outcome_private_factual_candidate" VALUES (cid,target_scope_key,source_receipt."receipt_json"->'content'->>'evidenceScopeKey',bundle."evidence_bundle_id",source_receipt."receipt_json"->'content'->>'reviewDecisionId',custody_sha,jsonb_build_object('candidateId',cid,'content',candidate_content),trusted_at) ON CONFLICT DO NOTHING;
+      SELECT * INTO private_head FROM "outcome_current_private_factual_authority" WHERE "valuation_scope_key"=target_scope_key FOR SHARE;
+      IF FOUND THEN expected_private_candidate_id:=private_head."candidate_id"; expected_private_revision:=private_head."revision"; END IF;
+    END IF;
+  END IF;
+  content:=jsonb_strip_nulls(jsonb_build_object('schemaVersion','afl-current-valuation-factual-candidate-receipt/v1','scopeKey',target_scope_key,'trigger',target_trigger,
+    'stableOperationKey',target_stable_operation_key,'stage','candidate_composed','cause',target_cause,'candidateId',cid,
+    'expectedPrivateFactualCandidateId',expected_private_candidate_id,'expectedPrivateFactualRevision',expected_private_revision,
+    'retainedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')));
+  rid:='current-valuation-factual-refresh-stage-receipt:'||encode(sha256(convert_to("outcome_afl_trade_canonical_json"(content),'UTF8')),'hex');
+  INSERT INTO "outcome_current_valuation_factual_refresh_stage_receipt" VALUES (rid,target_scope_key,target_trigger,target_stable_operation_key,'candidate_composed',jsonb_build_object('receiptId',rid,'content',content),trusted_at);
+END $$;
+
+CREATE FUNCTION "refresh_outcome_current_valuation_factual"(target_scope_key TEXT,target_trigger TEXT,target_stable_operation_key TEXT)
+RETURNS TABLE(operation_id TEXT,operation_json JSONB,result_json JSONB) LANGUAGE plpgsql AS $$
+DECLARE trusted_at TIMESTAMPTZ(3):=statement_timestamp(); stage_receipt RECORD; candidate RECORD; private_head RECORD; live_source RECORD; retained RECORD; target_state TEXT; target_stage TEXT; target_cause TEXT; target_revision INTEGER; content JSONB; oid TEXT; legacy_failure TEXT;
+  target_candidate_id TEXT; target_evidence_scope_key TEXT; target_evidence_bundle_id TEXT; target_review_decision_id TEXT; target_custody_sha TEXT;
+  current_candidate_id TEXT; current_revision INTEGER:=0; expected_candidate_id TEXT; expected_revision INTEGER; lock_capture_id TEXT; live_custody JSONB;
+  limitation CONSTANT TEXT:='Private local non-production factual refresh authority only; no public release, registry, production, activation, or publication authority is granted.';
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended(target_stable_operation_key,0));
+  SELECT * INTO retained FROM "outcome_current_valuation_refresh_operation" WHERE "stable_operation_key"=target_stable_operation_key;
+  IF FOUND THEN IF retained."scope_key"<>target_scope_key OR retained."trigger_kind"<>target_trigger THEN RAISE EXCEPTION 'Current valuation refresh operation conflicts with retained custody'; END IF; operation_id:=retained."operation_id"; operation_json:=retained."operation_json"; result_json:=retained."result_json"; RETURN NEXT; RETURN; END IF;
+  SELECT * INTO retained FROM "outcome_current_valuation_factual_refresh_operation" WHERE "stable_operation_key"=target_stable_operation_key;
+  IF FOUND THEN IF retained."scope_key"<>target_scope_key OR retained."trigger_kind"<>target_trigger THEN RAISE EXCEPTION 'Current valuation factual refresh operation conflicts with retained custody'; END IF; operation_id:=retained."operation_id"; operation_json:=retained."operation_json"; result_json:=retained."result_json"; RETURN NEXT; RETURN; END IF;
+  SELECT * INTO stage_receipt FROM "outcome_current_valuation_factual_refresh_stage_receipt" WHERE "stable_operation_key"=target_stable_operation_key AND "stage"='candidate_composed';
+  IF NOT FOUND THEN RAISE EXCEPTION 'Current valuation factual candidate receipt is missing'; END IF;
+  IF stage_receipt."scope_key"<>target_scope_key OR stage_receipt."trigger_kind"<>target_trigger THEN RAISE EXCEPTION 'Current valuation factual refresh stage conflicts with retained custody'; END IF;
+  target_cause:=stage_receipt."receipt_json"->'content'->>'cause';
+  IF target_cause IS NOT NULL THEN target_state:='unavailable';
+  ELSE
+    SELECT * INTO candidate FROM "outcome_private_factual_candidate" WHERE "candidate_id"=stage_receipt."receipt_json"->'content'->>'candidateId';
+    IF NOT FOUND THEN RAISE EXCEPTION 'Current valuation private factual candidate is missing'; END IF;
+    target_candidate_id:=candidate."candidate_id"; target_evidence_scope_key:=candidate."evidence_scope_key";
+    target_evidence_bundle_id:=candidate."evidence_bundle_id"; target_review_decision_id:=candidate."review_decision_id";
+    target_custody_sha:=candidate."normalized_reconciled_custody_sha256";
+    expected_candidate_id:=stage_receipt."receipt_json"->'content'->>'expectedPrivateFactualCandidateId';
+    expected_revision:=(stage_receipt."receipt_json"->'content'->>'expectedPrivateFactualRevision')::integer;
+    SELECT head.*,decision."status" AS decision_status INTO live_source
+      FROM "outcome_private_reviewed_evaluation_head" head
+      LEFT JOIN "outcome_private_reviewed_evaluation_decision" decision ON decision."decision_id"=head."decision_id"
+     WHERE head."valuation_scope_key"=target_scope_key AND head."evidence_scope_key"=candidate."evidence_scope_key"
+     FOR SHARE OF head;
+    IF live_source."valuation_scope_key" IS NULL THEN target_state:='unavailable'; target_cause:='source_authority_missing';
+    ELSIF live_source."status"<>'authorized' OR live_source."decision_status"<>'authorized' THEN target_state:='unavailable'; target_cause:='source_authority_unauthenticated';
+    ELSIF live_source."evidence_bundle_id"<>candidate."evidence_bundle_id" OR live_source."decision_id"<>candidate."review_decision_id" THEN target_state:='unavailable'; target_cause:='source_authority_stale';
+    ELSE
+      FOR lock_capture_id IN
+        SELECT item->>'captureId'
+          FROM jsonb_array_elements(candidate."candidate_json"#>'{content,normalizedReconciledCustody,sourceCaptures}') captures(item)
+         ORDER BY item->>'captureId'
+      LOOP
+        PERFORM pg_advisory_xact_lock(hashtextextended('outcome-capture-scope:'||lock_capture_id,0));
+      END LOOP;
+      live_custody:="outcome_private_factual_custody_for_bundle"(candidate."evidence_bundle_id");
+      IF NOT "outcome_private_reviewed_evidence_bundle_is_current"(candidate."evidence_bundle_id")
+         OR live_custody IS NULL
+         OR encode(sha256(convert_to("outcome_afl_trade_canonical_json"(live_custody),'UTF8')),'hex')<>candidate."normalized_reconciled_custody_sha256" THEN
+        target_state:='unavailable'; target_cause:='source_authority_stale';
+      END IF;
+    END IF;
+    IF target_cause IS NULL THEN
+      SELECT * INTO private_head FROM "outcome_current_private_factual_authority" WHERE "valuation_scope_key"=target_scope_key FOR UPDATE;
+      IF FOUND THEN current_candidate_id:=private_head."candidate_id"; current_revision:=private_head."revision"; END IF;
+    END IF;
+    IF target_cause IS NULL AND current_candidate_id=candidate."candidate_id" THEN
+      BEGIN RETURN QUERY SELECT * FROM "retain_outcome_current_valuation_refresh_no_change_v1"(target_scope_key,target_trigger,target_stable_operation_key); RETURN;
+      EXCEPTION WHEN raise_exception THEN
+        GET STACKED DIAGNOSTICS legacy_failure=MESSAGE_TEXT;
+        IF legacy_failure<>'Current valuation refresh cannot retain no change because governed authority is not current' THEN RAISE; END IF;
+        target_state:='factual_refresh_complete'; target_stage:='already_current'; target_revision:=current_revision;
+      END;
+    ELSIF target_cause IS NULL THEN
+      IF current_revision<>expected_revision OR current_candidate_id IS DISTINCT FROM expected_candidate_id THEN
+        RAISE EXCEPTION 'Current private factual authority compare-and-swap revision is stale';
+      END IF;
+      target_state:='factual_refresh_complete'; target_stage:='advanced'; target_revision:=current_revision+1;
+      INSERT INTO "outcome_current_private_factual_authority" VALUES (target_scope_key,candidate."candidate_id",target_revision,trusted_at)
+      ON CONFLICT (valuation_scope_key) DO UPDATE SET candidate_id=EXCLUDED.candidate_id,revision=EXCLUDED.revision,advanced_at=EXCLUDED.advanced_at
+      WHERE "outcome_current_private_factual_authority"."revision"=target_revision-1;
+      IF NOT FOUND THEN RAISE EXCEPTION 'Current private factual authority compare-and-swap revision is stale'; END IF;
+    END IF;
+  END IF;
+  content:=jsonb_strip_nulls(jsonb_build_object('schemaVersion','afl-current-valuation-factual-refresh-operation/v2','scopeKey',target_scope_key,'trigger',target_trigger,'stableOperationKey',target_stable_operation_key,'state',target_state,'factualStage',target_stage,'cause',target_cause,'candidateId',target_candidate_id,'privateFactualRevision',target_revision,'capturedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')));
+  oid:='current-valuation-factual-refresh-operation:'||encode(sha256(convert_to("outcome_afl_trade_canonical_json"(content),'UTF8')),'hex');
+  result_json:=jsonb_strip_nulls(jsonb_build_object('schemaVersion','afl-current-valuation-refresh-result-v2','operationId',oid,'scopeKey',target_scope_key,'trigger',target_trigger,'stableOperationKey',target_stable_operation_key,'state',target_state,'factualStage',target_stage,'cause',target_cause,
+    'privateFactualAuthority',CASE WHEN target_state='factual_refresh_complete' THEN jsonb_build_object('valuationScopeKey',target_scope_key,'candidateId',target_candidate_id,'evidenceScopeKey',target_evidence_scope_key,'evidenceBundleId',target_evidence_bundle_id,'reviewDecisionId',target_review_decision_id,'normalizedReconciledCustodySha256',target_custody_sha,'revision',target_revision) END,
+    'capturedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),'completedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),'executionLocation','local','visibility','private','environment','non_production','publicationEligible',false,'publicationProhibited',true,'limitation',limitation));
+  operation_json:=jsonb_build_object('operationId',oid,'content',content);
+  INSERT INTO "outcome_current_valuation_factual_refresh_operation" VALUES (oid,target_scope_key,target_trigger,target_stable_operation_key,target_state,target_stage,target_cause,CASE WHEN target_state='factual_refresh_complete' THEN target_candidate_id END,target_revision,trusted_at,trusted_at,operation_json,result_json);
+  operation_id:=oid; RETURN NEXT;
+END $$;
+
+CREATE FUNCTION "retain_outcome_current_valuation_refresh_no_change"(target_scope_key TEXT,target_trigger TEXT,target_stable_operation_key TEXT)
+RETURNS TABLE(operation_id TEXT,operation_json JSONB,result_json JSONB) LANGUAGE plpgsql AS $$
+DECLARE retained RECORD;
+BEGIN
+  IF target_scope_key IS NULL OR target_scope_key<>btrim(target_scope_key) OR length(target_scope_key) NOT BETWEEN 1 AND 400
+    OR target_stable_operation_key IS NULL OR target_stable_operation_key<>btrim(target_stable_operation_key) OR length(target_stable_operation_key) NOT BETWEEN 1 AND 400
+    OR target_trigger IS NULL OR target_trigger NOT IN ('weekly','model_qualified','ad_hoc') THEN RAISE EXCEPTION 'Current valuation refresh request is malformed'; END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(target_stable_operation_key,0));
+  SELECT * INTO retained FROM "outcome_current_valuation_refresh_operation" WHERE "stable_operation_key"=target_stable_operation_key;
+  IF FOUND THEN
+    IF retained."scope_key"<>target_scope_key OR retained."trigger_kind"<>target_trigger THEN RAISE EXCEPTION 'Current valuation refresh request conflicts with retained custody'; END IF;
+    operation_id:=retained."operation_id"; operation_json:=retained."operation_json"; result_json:=retained."result_json"; RETURN NEXT; RETURN;
+  END IF;
+  SELECT * INTO retained FROM "outcome_current_valuation_factual_refresh_operation" WHERE "stable_operation_key"=target_stable_operation_key;
+  IF FOUND THEN
+    IF retained."scope_key"<>target_scope_key OR retained."trigger_kind"<>target_trigger THEN RAISE EXCEPTION 'Current valuation factual refresh operation conflicts with retained custody'; END IF;
+    operation_id:=retained."operation_id"; operation_json:=retained."operation_json"; result_json:=retained."result_json"; RETURN NEXT; RETURN;
+  END IF;
+  SELECT * INTO retained FROM "outcome_current_valuation_factual_refresh_stage_receipt" WHERE "stable_operation_key"=target_stable_operation_key LIMIT 1;
+  IF FOUND THEN
+    IF retained."scope_key"<>target_scope_key OR retained."trigger_kind"<>target_trigger THEN RAISE EXCEPTION 'Current valuation factual refresh stage conflicts with retained custody'; END IF;
+    PERFORM "retain_outcome_current_valuation_factual_source"(target_scope_key,target_trigger,target_stable_operation_key);
+    PERFORM "compose_outcome_current_valuation_factual_candidate"(target_scope_key,target_trigger,target_stable_operation_key);
+    RETURN QUERY SELECT * FROM "refresh_outcome_current_valuation_factual"(target_scope_key,target_trigger,target_stable_operation_key);
+    RETURN;
+  END IF;
+  RETURN QUERY SELECT * FROM "retain_outcome_current_valuation_refresh_no_change_v1"(target_scope_key,target_trigger,target_stable_operation_key);
+END $$;
+
+ALTER TABLE "outcome_private_factual_candidate" OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER TABLE "outcome_current_private_factual_authority" OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER TABLE "outcome_current_valuation_factual_refresh_stage_receipt" OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER TABLE "outcome_current_valuation_factual_refresh_operation" OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "reject_outcome_current_valuation_factual_refresh_mutation"() OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "outcome_private_factual_custody_for_bundle"(TEXT) OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "retain_outcome_current_valuation_factual_source"(TEXT,TEXT,TEXT) OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "compose_outcome_current_valuation_factual_candidate"(TEXT,TEXT,TEXT) OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "refresh_outcome_current_valuation_factual"(TEXT,TEXT,TEXT) OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "retain_outcome_current_valuation_refresh_no_change"(TEXT,TEXT,TEXT) OWNER TO afl_trade_current_valuation_refresh_owner;
+DO $paths$ BEGIN
+  EXECUTE format('ALTER FUNCTION %I.outcome_private_factual_custody_for_bundle(TEXT) SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+  EXECUTE format('ALTER FUNCTION %I.retain_outcome_current_valuation_factual_source(TEXT,TEXT,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+  EXECUTE format('ALTER FUNCTION %I.compose_outcome_current_valuation_factual_candidate(TEXT,TEXT,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+  EXECUTE format('ALTER FUNCTION %I.refresh_outcome_current_valuation_factual(TEXT,TEXT,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+  EXECUTE format('ALTER FUNCTION %I.retain_outcome_current_valuation_refresh_no_change(TEXT,TEXT,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',current_schema(),current_schema());
+END $paths$;
+REVOKE ALL ON "outcome_private_factual_candidate","outcome_current_private_factual_authority","outcome_current_valuation_factual_refresh_stage_receipt","outcome_current_valuation_factual_refresh_operation" FROM PUBLIC,afl_trade_private_evaluation_coordinator;
+REVOKE ALL ON FUNCTION "retain_outcome_current_valuation_refresh_no_change_v1"(TEXT,TEXT,TEXT) FROM PUBLIC,afl_trade_private_evaluation_coordinator;
+REVOKE ALL ON FUNCTION "outcome_private_factual_custody_for_bundle"(TEXT),"retain_outcome_current_valuation_factual_source"(TEXT,TEXT,TEXT),"compose_outcome_current_valuation_factual_candidate"(TEXT,TEXT,TEXT),"refresh_outcome_current_valuation_factual"(TEXT,TEXT,TEXT),"retain_outcome_current_valuation_refresh_no_change"(TEXT,TEXT,TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "retain_outcome_current_valuation_factual_source"(TEXT,TEXT,TEXT),"compose_outcome_current_valuation_factual_candidate"(TEXT,TEXT,TEXT),"refresh_outcome_current_valuation_factual"(TEXT,TEXT,TEXT),"retain_outcome_current_valuation_refresh_no_change"(TEXT,TEXT,TEXT) TO afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_private_reviewed_evaluation_head","outcome_private_reviewed_evaluation_decision","outcome_private_reviewed_evidence_bundle","outcome_private_factual_candidate","outcome_current_private_factual_authority","outcome_current_valuation_factual_refresh_stage_receipt","outcome_current_valuation_factual_refresh_operation","outcome_current_valuation_refresh_operation" TO afl_trade_current_valuation_refresh_owner;
+GRANT SELECT ON "outcome_review_decision","outcome_source_capture","outcome_artifact_custody",
+  "outcome_source_rights_proposal","outcome_provider_normalization_run"
+  TO afl_trade_current_valuation_refresh_owner;
+GRANT INSERT ON "outcome_private_factual_candidate","outcome_current_private_factual_authority","outcome_current_valuation_factual_refresh_stage_receipt","outcome_current_valuation_factual_refresh_operation" TO afl_trade_current_valuation_refresh_owner;
+GRANT UPDATE ON "outcome_current_private_factual_authority" TO afl_trade_current_valuation_refresh_owner;
+GRANT UPDATE ON "outcome_private_reviewed_evaluation_head" TO afl_trade_current_valuation_refresh_owner;
+GRANT EXECUTE ON FUNCTION "outcome_private_factual_custody_for_bundle"(TEXT),"outcome_private_reviewed_evidence_bundle_is_current"(TEXT),"retain_outcome_current_valuation_refresh_no_change_v1"(TEXT,TEXT,TEXT),"retain_outcome_current_valuation_refresh_no_change"(TEXT,TEXT,TEXT) TO afl_trade_current_valuation_refresh_owner;
+DO $membership$ BEGIN
+  EXECUTE format('REVOKE afl_trade_current_valuation_refresh_owner FROM %I',current_user);
+END $membership$;

--- a/prisma/afl-trade-outcomes/migrations/0083_current_valuation_factual_refresh/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0083_current_valuation_factual_refresh/migration.sql
@@ -55,7 +55,7 @@ ALTER FUNCTION "retain_outcome_current_valuation_refresh_no_change"(TEXT,TEXT,TE
 CREATE FUNCTION "reject_outcome_current_valuation_factual_refresh_mutation"() RETURNS TRIGGER
 LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'Current valuation factual refresh custody is append-only'; END $$;
 CREATE TRIGGER "outcome_private_factual_candidate_no_update_delete" BEFORE UPDATE OR DELETE ON "outcome_private_factual_candidate" FOR EACH ROW EXECUTE FUNCTION "reject_outcome_current_valuation_factual_refresh_mutation"();
-CREATE TRIGGER "outcome_current_valuation_factual_refresh_stage_no_update_delete" BEFORE UPDATE OR DELETE ON "outcome_current_valuation_factual_refresh_stage_receipt" FOR EACH ROW EXECUTE FUNCTION "reject_outcome_current_valuation_factual_refresh_mutation"();
+CREATE TRIGGER "outcome_factual_refresh_stage_no_update_delete" BEFORE UPDATE OR DELETE ON "outcome_current_valuation_factual_refresh_stage_receipt" FOR EACH ROW EXECUTE FUNCTION "reject_outcome_current_valuation_factual_refresh_mutation"();
 CREATE TRIGGER "outcome_current_valuation_factual_refresh_no_update_delete" BEFORE UPDATE OR DELETE ON "outcome_current_valuation_factual_refresh_operation" FOR EACH ROW EXECUTE FUNCTION "reject_outcome_current_valuation_factual_refresh_mutation"();
 
 CREATE FUNCTION "outcome_private_factual_custody_for_bundle"(target_bundle_id TEXT)
@@ -269,7 +269,7 @@ BEGIN
       IF NOT FOUND THEN RAISE EXCEPTION 'Current private factual authority compare-and-swap revision is stale'; END IF;
     END IF;
   END IF;
-  content:=jsonb_strip_nulls(jsonb_build_object('schemaVersion','afl-current-valuation-factual-refresh-operation/v2','scopeKey',target_scope_key,'trigger',target_trigger,'stableOperationKey',target_stable_operation_key,'state',target_state,'factualStage',target_stage,'cause',target_cause,'candidateId',target_candidate_id,'privateFactualRevision',target_revision,'capturedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')));
+  content:=jsonb_strip_nulls(jsonb_build_object('schemaVersion','afl-current-valuation-factual-refresh-operation/v2','scopeKey',target_scope_key,'trigger',target_trigger,'stableOperationKey',target_stable_operation_key,'state',target_state,'factualStage',target_stage,'cause',target_cause,'candidateId',CASE WHEN target_state='factual_refresh_complete' THEN target_candidate_id END,'privateFactualRevision',target_revision,'capturedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')));
   oid:='current-valuation-factual-refresh-operation:'||encode(sha256(convert_to("outcome_afl_trade_canonical_json"(content),'UTF8')),'hex');
   result_json:=jsonb_strip_nulls(jsonb_build_object('schemaVersion','afl-current-valuation-refresh-result-v2','operationId',oid,'scopeKey',target_scope_key,'trigger',target_trigger,'stableOperationKey',target_stable_operation_key,'state',target_state,'factualStage',target_stage,'cause',target_cause,
     'privateFactualAuthority',CASE WHEN target_state='factual_refresh_complete' THEN jsonb_build_object('valuationScopeKey',target_scope_key,'candidateId',target_candidate_id,'evidenceScopeKey',target_evidence_scope_key,'evidenceBundleId',target_evidence_bundle_id,'reviewDecisionId',target_review_decision_id,'normalizedReconciledCustodySha256',target_custody_sha,'revision',target_revision) END,
@@ -335,6 +335,8 @@ GRANT SELECT ON "outcome_review_decision","outcome_source_capture","outcome_arti
   TO afl_trade_current_valuation_refresh_owner;
 GRANT INSERT ON "outcome_private_factual_candidate","outcome_current_private_factual_authority","outcome_current_valuation_factual_refresh_stage_receipt","outcome_current_valuation_factual_refresh_operation" TO afl_trade_current_valuation_refresh_owner;
 GRANT UPDATE ON "outcome_current_private_factual_authority" TO afl_trade_current_valuation_refresh_owner;
+-- PostgreSQL requires UPDATE privilege for the FOR SHARE lock that fences head replacement.
+-- This NOLOGIN owner is reachable only through the scoped SECURITY DEFINER functions above.
 GRANT UPDATE ON "outcome_private_reviewed_evaluation_head" TO afl_trade_current_valuation_refresh_owner;
 GRANT EXECUTE ON FUNCTION "outcome_private_factual_custody_for_bundle"(TEXT),"outcome_private_reviewed_evidence_bundle_is_current"(TEXT),"retain_outcome_current_valuation_refresh_no_change_v1"(TEXT,TEXT,TEXT),"retain_outcome_current_valuation_refresh_no_change"(TEXT,TEXT,TEXT) TO afl_trade_current_valuation_refresh_owner;
 DO $membership$ BEGIN

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -4521,6 +4521,7 @@ model OutcomePrivateReviewedEvidenceBundle {
   decisions                  OutcomePrivateReviewedEvaluationDecision[]
   currentHeads               OutcomePrivateReviewedEvaluationHead[]
   localPlayerIdentityReviews OutcomeLocalWorkbookPlayerIdentityReview[]
+  privateFactualCandidates  OutcomePrivateFactualCandidate[]
 
   @@index([evidenceScopeKey, createdAt], map: "outcome_private_reviewed_evidence_bundle_scope_idx")
   @@map("outcome_private_reviewed_evidence_bundle")
@@ -4565,6 +4566,7 @@ model OutcomePrivateReviewedEvaluationDecision {
   supersedesDecision           OutcomePrivateReviewedEvaluationDecision? @relation("OutcomePrivateReviewedEvaluationDecisionChain", fields: [supersedesDecisionId], references: [decisionId], onDelete: Restrict, map: "outcome_private_reviewed_evaluation_decision_supersedes_fkey")
   successorDecision            OutcomePrivateReviewedEvaluationDecision? @relation("OutcomePrivateReviewedEvaluationDecisionChain")
   currentHead                  OutcomePrivateReviewedEvaluationHead?
+  privateFactualCandidates    OutcomePrivateFactualCandidate[]
 
   @@unique([valuationScopeKey, evidenceBundleId, revision], map: "outcome_private_reviewed_evaluation_decision_revision_key")
   @@map("outcome_private_reviewed_evaluation_decision")
@@ -5439,6 +5441,63 @@ model OutcomeCurrentValuationRefreshOperation {
   resultJson               Json     @map("result_json")
 
   @@map("outcome_current_valuation_refresh_operation")
+}
+
+model OutcomePrivateFactualCandidate {
+  candidateId                         String                                   @id @map("candidate_id") @outcomes.Text
+  valuationScopeKey                   String                                   @map("valuation_scope_key") @outcomes.Text
+  evidenceScopeKey                    String                                   @map("evidence_scope_key") @outcomes.Text
+  evidenceBundleId                    String                                   @map("evidence_bundle_id") @outcomes.Text
+  reviewDecisionId                    String                                   @map("review_decision_id") @outcomes.Text
+  normalizedReconciledCustodySha256   String                                   @map("normalized_reconciled_custody_sha256") @outcomes.Char(64)
+  candidateJson                       Json                                     @map("candidate_json")
+  composedAt                          DateTime                                 @map("composed_at") @outcomes.Timestamptz(3)
+  evidenceBundle                      OutcomePrivateReviewedEvidenceBundle     @relation(fields: [evidenceBundleId], references: [evidenceBundleId], onDelete: Restrict)
+  reviewDecision                      OutcomePrivateReviewedEvaluationDecision @relation(fields: [reviewDecisionId], references: [decisionId], onDelete: Restrict)
+  currentHead                         OutcomeCurrentPrivateFactualAuthority?
+
+  @@map("outcome_private_factual_candidate")
+}
+
+model OutcomeCurrentPrivateFactualAuthority {
+  valuationScopeKey String                         @id @map("valuation_scope_key") @outcomes.Text
+  candidateId      String                         @unique @map("candidate_id") @outcomes.Text
+  revision         Int
+  advancedAt       DateTime                       @map("advanced_at") @outcomes.Timestamptz(3)
+  candidate        OutcomePrivateFactualCandidate @relation(fields: [candidateId], references: [candidateId], onDelete: Restrict)
+
+  @@map("outcome_current_private_factual_authority")
+}
+
+model OutcomeCurrentValuationFactualRefreshStageReceipt {
+  receiptId          String   @id @map("receipt_id") @outcomes.Text
+  scopeKey           String   @map("scope_key") @outcomes.Text
+  triggerKind        String   @map("trigger_kind") @outcomes.Text
+  stableOperationKey String   @map("stable_operation_key") @outcomes.Text
+  stage              String   @outcomes.Text
+  receiptJson        Json     @map("receipt_json")
+  retainedAt         DateTime @map("retained_at") @outcomes.Timestamptz(3)
+
+  @@unique([stableOperationKey, stage])
+  @@map("outcome_current_valuation_factual_refresh_stage_receipt")
+}
+
+model OutcomeCurrentValuationFactualRefreshOperation {
+  operationId            String    @id @map("operation_id") @outcomes.Text
+  scopeKey               String    @map("scope_key") @outcomes.Text
+  triggerKind            String    @map("trigger_kind") @outcomes.Text
+  stableOperationKey     String    @unique @map("stable_operation_key") @outcomes.Text
+  state                  String    @outcomes.Text
+  factualStage           String?   @map("factual_stage") @outcomes.Text
+  unavailableCause       String?   @map("unavailable_cause") @outcomes.Text
+  candidateId            String?   @map("candidate_id") @outcomes.Text
+  privateFactualRevision Int?      @map("private_factual_revision")
+  capturedAt             DateTime  @map("captured_at") @outcomes.Timestamptz(3)
+  completedAt            DateTime  @map("completed_at") @outcomes.Timestamptz(3)
+  operationJson          Json      @map("operation_json")
+  resultJson             Json      @map("result_json")
+
+  @@map("outcome_current_valuation_factual_refresh_operation")
 }
 
 model OutcomePrivateValuationDispatchAttempt {

--- a/src/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority.ts
+++ b/src/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority.ts
@@ -153,7 +153,7 @@ export const LOCAL_AFL_TABLES_RESULTS_FIELD_SCHEMA = [
   integer('Away.Points'),
   character('Venue'),
   integer('Margin'),
-  integer('Season'),
+  number('Season'),
   character('Round.Type'),
   integer('Round.Number'),
 ] satisfies readonly LocalAflTablesFieldDescriptor[];
@@ -460,7 +460,7 @@ export function createLocalAflTradeAflTablesResultsAuthority(season: number) {
   };
   const fieldMap = parseAflTradeFitzRoyFieldMap({
     schemaVersion: AFL_TRADE_FITZROY_FIELD_MAP_SCHEMA_VERSION,
-    mapId: `afl-tables-results-local-${season}-v1`,
+    mapId: `afl-tables-results-local-${season}-v2`,
     capabilityId: 'afl-tables-results',
     fitzRoyVersion: '1.7.0',
     sourceSchemaSha256: createDecodedFieldSchemaSha256(LOCAL_AFL_TABLES_RESULTS_FIELD_SCHEMA),
@@ -474,8 +474,8 @@ export function createLocalAflTradeAflTablesResultsAuthority(season: number) {
     roundLabelField: { sourceField: 'Round', required: true },
     observedDateField: { sourceField: 'Date', required: true },
     naturalKeyFields: ['Season', 'Round', 'Date', 'Home.Team', 'Away.Team'],
-    approvedAt: '2026-08-14T00:00:03.000Z',
-    approvalDecisionId: `local-afl-tables-results-field-map-review-${season}`,
+    approvedAt: '2026-08-26T00:00:03.000Z',
+    approvalDecisionId: `local-afl-tables-results-field-map-review-${season}-v2`,
     identity: null,
     match: {
       nativeMatchId: { sourceField: 'Game', required: true },

--- a/src/server/aflTradeIntelligence/development/localFiveSeasonAflTablesReview.ts
+++ b/src/server/aflTradeIntelligence/development/localFiveSeasonAflTablesReview.ts
@@ -37,7 +37,7 @@ export interface LocalFiveSeasonAflTablesReviewEvidence {
 
 const EXPECTED_APPEARANCE_COUNT = 48_769;
 export const LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256 =
-  'aef663452e66a433048605a71fb4178ed1a5e1d9610c6d3ed75bfb796308b5cb';
+  '7ef741add1ae94133c597581f8a2175118058bedd2ffe8a107213630e1b0fd10';
 const DECIDED_AT = '2026-08-14T12:15:00.000Z';
 
 const REVIEWED_ROWS_CTE = `WITH reviewed_rows AS (

--- a/src/server/aflTradeIntelligence/development/localOfficialAfl2026Authority.ts
+++ b/src/server/aflTradeIntelligence/development/localOfficialAfl2026Authority.ts
@@ -164,7 +164,6 @@ export const LOCAL_OFFICIAL_AFL_2026_PLAYER_STATS_FIELD_SCHEMA = [
   character('player.givenName'),
   character('player.surname'),
   character('teamStatus'),
-  logical('extendedStats'),
   character('team.name'),
 ] satisfies readonly LocalOfficialAflFieldDescriptor[];
 

--- a/src/server/aflTradeIntelligence/development/localReviewedProviderEvidence.ts
+++ b/src/server/aflTradeIntelligence/development/localReviewedProviderEvidence.ts
@@ -364,8 +364,8 @@ async function loadCaptureEvidence(transaction: AflOutcomeSqlTransaction): Promi
           OR (capture.provider='afl_tables'
               AND capture.capability_id='afl-tables-results'
               AND capture.anchor_season_year=2026))
-        AND EXISTS (
-          SELECT 1
+        AND 1 = (
+          SELECT count(*)
             FROM outcome_provider_normalization_run run
            WHERE run.capture_id=capture.capture_id
              AND run.status IN ('staged','needs_review')

--- a/src/server/aflTradeIntelligence/development/localReviewedProviderEvidence.ts
+++ b/src/server/aflTradeIntelligence/development/localReviewedProviderEvidence.ts
@@ -24,6 +24,15 @@ const HISTORICAL_REVIEW_SET_DECISION_ID =
   `local-afl-tables-review:set:${LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256}` as const;
 const OFFICIAL_REVIEW_SET_DECISION_ID =
   `local-official-afl-review:set:${LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256}` as const;
+const REQUIRED_CAPTURE_TUPLE_KEYS = new Set([
+  'afl_tables\u0000afl-tables-player-stats\u00002021',
+  'afl_tables\u0000afl-tables-player-stats\u00002022',
+  'afl_tables\u0000afl-tables-player-stats\u00002023',
+  'afl_tables\u0000afl-tables-player-stats\u00002024',
+  'afl_tables\u0000afl-tables-player-stats\u00002025',
+  'official_afl\u0000official-afl-player-stats\u00002026',
+  'afl_tables\u0000afl-tables-results\u00002026',
+]);
 
 const instantSchema = z.union([z.date(), z.iso.datetime({ offset: true })]);
 const publicIdSchema = z.string().trim().min(1).max(1_000);
@@ -102,6 +111,29 @@ function reviewSetSnapshot(row: ReviewSetRow) {
 
 function count(value: number | string): number {
   return z.coerce.number().int().nonnegative().parse(value);
+}
+
+function captureTupleKey(provider: string, capabilityId: string, seasonYear: number): string {
+  return `${provider}\u0000${capabilityId}\u0000${seasonYear}`;
+}
+
+export function assertExactLocalReviewedProviderCaptureTuples(
+  captures: readonly { provider: string; capabilityId: string; seasonYear: number }[]
+): void {
+  const captureTupleKeys = new Set(
+    captures.map((capture) =>
+      captureTupleKey(capture.provider, capture.capabilityId, capture.seasonYear)
+    )
+  );
+  if (
+    captures.length !== REQUIRED_CAPTURE_TUPLE_KEYS.size ||
+    captureTupleKeys.size !== REQUIRED_CAPTURE_TUPLE_KEYS.size ||
+    [...REQUIRED_CAPTURE_TUPLE_KEYS].some((tupleKey) => !captureTupleKeys.has(tupleKey))
+  ) {
+    throw new TypeError(
+      'The retained provider capture set must contain exactly one capture for each required provider, capability, and season.'
+    );
+  }
 }
 
 async function loadReviewSets(transaction: AflOutcomeSqlTransaction) {
@@ -411,6 +443,7 @@ async function loadCaptureEvidence(transaction: AflOutcomeSqlTransaction): Promi
       }),
     };
   });
+  assertExactLocalReviewedProviderCaptureTuples(sourceCaptures);
   if (rightsByArtifactId.size !== 3) {
     throw new TypeError(
       'The exact retained provider capture set must retain three rights artifacts.'

--- a/src/server/aflTradeIntelligence/development/localReviewedProviderEvidence.ts
+++ b/src/server/aflTradeIntelligence/development/localReviewedProviderEvidence.ts
@@ -364,6 +364,13 @@ async function loadCaptureEvidence(transaction: AflOutcomeSqlTransaction): Promi
           OR (capture.provider='afl_tables'
               AND capture.capability_id='afl-tables-results'
               AND capture.anchor_season_year=2026))
+        AND EXISTS (
+          SELECT 1
+            FROM outcome_provider_normalization_run run
+           WHERE run.capture_id=capture.capture_id
+             AND run.status IN ('staged','needs_review')
+             AND run.finalized_at IS NOT NULL
+        )
       ORDER BY capture.capture_id
       FOR KEY SHARE OF capture,custody,rights`
   );

--- a/src/server/aflTradeIntelligence/source/approvedFitzRoyGateRecords.ts
+++ b/src/server/aflTradeIntelligence/source/approvedFitzRoyGateRecords.ts
@@ -6,7 +6,9 @@ import {
   type AflTradeGateDecisionRecord,
 } from '../governance/gateDecisionTypes';
 import {
+  AFL_TRADE_SOURCE_OPERATIONS,
   aflTradeSourceRightsProposalSchema,
+  type AflTradeSourceOperation,
   type AflTradeSourceRightsProposal,
 } from './sourceContracts';
 
@@ -33,21 +35,20 @@ export interface ApprovedAflTradeFitzRoyGateRecords {
   decision: AflTradeGateDecisionRecord;
 }
 
-const approvedOperations = [
-  'bounded_evaluation_capture',
-  'raw_evidence_retention',
-  'metadata_hash_retention',
-  'internal_quality_evaluation',
-  'model_training',
-  'derived_feature_creation',
-  'public_derived_output',
-  'public_fact_display',
-] as const;
-
 function seasons(sourceRights: AflTradeSourceRightsProposal): string[] {
   return sourceRights.content.scope.seasonRanges.flatMap(({ from, to }) =>
     Array.from({ length: to - from + 1 }, (_, index) => String(from + index))
   );
+}
+
+function allowedOperations(sourceRights: AflTradeSourceRightsProposal): AflTradeSourceOperation[] {
+  return AFL_TRADE_SOURCE_OPERATIONS.filter(
+    (operation) => sourceRights.content.operations[operation] === 'allowed'
+  );
+}
+
+function permittedValues(values: readonly string[], unrestrictedValue: string): string[] {
+  return values.length === 0 ? [unrestrictedValue] : [...values];
 }
 
 export function createApprovedAflTradeFitzRoyGateRecords(
@@ -74,22 +75,32 @@ export function createApprovedAflTradeFitzRoyGateRecords(
   }
   const decisionKey = `${capability.capabilityId}-${input.environment}`;
   const environmentLabel = input.environment === 'production' ? 'Production' : 'Non-production';
+  const operations = allowedOperations(sourceRights);
   const scope = {
     scopeKey:
       input.environment === 'production'
         ? `afl-trade-${capability.capabilityId}`
         : `afl-trade-${capability.capabilityId}-${input.environment}`,
-    description: `${environmentLabel} authority for ${capability.capabilityId} in the public AFL trade-intelligence boundary.`,
+    description: `${environmentLabel} authority for ${capability.capabilityId} within its exact source-rights scope.`,
     dimensions: [
       { name: 'source_rights_artifact', values: [sourceRights.rightsArtifactId] },
       { name: 'competition', values: [...sourceRights.content.scope.competitions] },
       { name: 'season', values: seasons(sourceRights) },
       { name: 'access_mechanism', values: [sourceRights.content.scope.accessMechanism] },
       { name: 'fitzroy_capability', values: [capability.capabilityId] },
-      { name: 'geography', values: ['global'] },
-      { name: 'commercial_context', values: ['public-research'] },
-      { name: 'audience', values: ['public'] },
-      { name: 'operation', values: [...approvedOperations] },
+      {
+        name: 'geography',
+        values: permittedValues(sourceRights.content.restrictions.geographic, 'global'),
+      },
+      {
+        name: 'commercial_context',
+        values: permittedValues(sourceRights.content.restrictions.commercial, 'public-research'),
+      },
+      {
+        name: 'audience',
+        values: permittedValues(sourceRights.content.restrictions.audience, 'public'),
+      },
+      { name: 'operation', values: operations },
     ],
     exclusions: ['Raw upstream field redistribution', 'Fantasy user or league ownership'],
   };
@@ -157,8 +168,10 @@ export function createApprovedAflTradeFitzRoyGateRecords(
         'The exact source-specific control is implemented and retained in its dedicated reviewed evidence.',
     })),
     rationale:
-      'The named source is approved for bounded capture, retained evidence, internal evaluation, model training, derived features, public derived output, and factual display.',
-    limitations: ['Raw upstream field redistribution remains blocked.'],
+      'The named source is approved only within the operations and contextual dimensions authenticated by its exact source-rights artifact.',
+    limitations: [
+      'Every operation, audience, commercial context, geography, field use, retention, or cache behavior outside the pinned source-rights artifact remains blocked.',
+    ],
     decidedAt: input.decidedAt,
     effectiveAt: input.effectiveAt,
     revalidateAt: input.revalidateAt,

--- a/src/server/aflTradeIntelligence/valuation/currentValuationRefresh.ts
+++ b/src/server/aflTradeIntelligence/valuation/currentValuationRefresh.ts
@@ -4,10 +4,14 @@ import { aflTradeContentAddressedIdSchema } from '../artifacts/contentAddress';
 import type { AflOutcomeSqlClient } from '../outcomes/postgresOutcomeReleaseRepository';
 import { aflTradePrivateValuationDispatchTriggerSchema } from './privateValuationScheduling';
 
-export const AFL_TRADE_CURRENT_VALUATION_REFRESH_RESULT_SCHEMA_VERSION =
+export const AFL_TRADE_CURRENT_VALUATION_NO_CHANGE_RESULT_SCHEMA_VERSION =
   'afl-current-valuation-refresh-result-v1' as const;
+export const AFL_TRADE_CURRENT_VALUATION_FACTUAL_REFRESH_RESULT_SCHEMA_VERSION =
+  'afl-current-valuation-refresh-result-v2' as const;
 export const AFL_TRADE_CURRENT_VALUATION_REFRESH_LIMITATION =
   'Private local non-production current-authority refresh trace only; no factual, model, prepared-input, private-evaluation, production, activation, or publication authority is granted.' as const;
+export const AFL_TRADE_CURRENT_VALUATION_FACTUAL_REFRESH_LIMITATION =
+  'Private local non-production factual refresh authority only; no public release, registry, production, activation, or publication authority is granted.' as const;
 
 const EXECUTION_DATABASE_ROLE = 'afl_trade_private_evaluation_coordinator';
 
@@ -43,9 +47,9 @@ export const aflTradeCurrentValuationRefreshAuthoritySchema = z
   })
   .strict();
 
-export const aflTradeCurrentValuationRefreshResultSchema = z
+const retainedNoChangeResultSchema = z
   .object({
-    schemaVersion: z.literal(AFL_TRADE_CURRENT_VALUATION_REFRESH_RESULT_SCHEMA_VERSION),
+    schemaVersion: z.literal(AFL_TRADE_CURRENT_VALUATION_NO_CHANGE_RESULT_SCHEMA_VERSION),
     operationId: aflTradeContentAddressedIdSchema('current-valuation-refresh-operation'),
     scopeKey: idSchema,
     trigger: aflTradeCurrentValuationRefreshTriggerSchema,
@@ -61,7 +65,82 @@ export const aflTradeCurrentValuationRefreshResultSchema = z
     publicationProhibited: z.literal(true),
     limitation: z.literal(AFL_TRADE_CURRENT_VALUATION_REFRESH_LIMITATION),
   })
-  .strict()
+  .strict();
+
+const privateFactualAuthoritySchema = z
+  .object({
+    valuationScopeKey: idSchema,
+    candidateId: aflTradeContentAddressedIdSchema('private-factual-candidate'),
+    evidenceScopeKey: idSchema,
+    evidenceBundleId: aflTradeContentAddressedIdSchema('private-reviewed-evidence-bundle'),
+    reviewDecisionId: aflTradeContentAddressedIdSchema(
+      'private-reviewed-evidence-evaluation-decision'
+    ),
+    normalizedReconciledCustodySha256: z.string().regex(/^[a-f0-9]{64}$/),
+    revision: z.number().int().positive(),
+  })
+  .strict();
+
+const factualRefreshResultSchema = z
+  .object({
+    schemaVersion: z.literal(
+      AFL_TRADE_CURRENT_VALUATION_FACTUAL_REFRESH_RESULT_SCHEMA_VERSION
+    ),
+    operationId: aflTradeContentAddressedIdSchema(
+      'current-valuation-factual-refresh-operation'
+    ),
+    scopeKey: idSchema,
+    trigger: aflTradeCurrentValuationRefreshTriggerSchema,
+    stableOperationKey: idSchema,
+    state: z.literal('factual_refresh_complete'),
+    factualStage: z.enum(['already_current', 'advanced']),
+    privateFactualAuthority: privateFactualAuthoritySchema,
+    capturedAt: instantSchema,
+    completedAt: instantSchema,
+    executionLocation: z.literal('local'),
+    visibility: z.literal('private'),
+    environment: z.literal('non_production'),
+    publicationEligible: z.literal(false),
+    publicationProhibited: z.literal(true),
+    limitation: z.literal(AFL_TRADE_CURRENT_VALUATION_FACTUAL_REFRESH_LIMITATION),
+  })
+  .strict();
+
+const unavailableRefreshResultSchema = z
+  .object({
+    schemaVersion: z.literal(
+      AFL_TRADE_CURRENT_VALUATION_FACTUAL_REFRESH_RESULT_SCHEMA_VERSION
+    ),
+    operationId: aflTradeContentAddressedIdSchema(
+      'current-valuation-factual-refresh-operation'
+    ),
+    scopeKey: idSchema,
+    trigger: aflTradeCurrentValuationRefreshTriggerSchema,
+    stableOperationKey: idSchema,
+    state: z.literal('unavailable'),
+    cause: z.enum([
+      'source_authority_missing',
+      'source_authority_stale',
+      'source_authority_mismatched',
+      'source_authority_unauthenticated',
+    ]),
+    capturedAt: instantSchema,
+    completedAt: instantSchema,
+    executionLocation: z.literal('local'),
+    visibility: z.literal('private'),
+    environment: z.literal('non_production'),
+    publicationEligible: z.literal(false),
+    publicationProhibited: z.literal(true),
+    limitation: z.literal(AFL_TRADE_CURRENT_VALUATION_FACTUAL_REFRESH_LIMITATION),
+  })
+  .strict();
+
+export const aflTradeCurrentValuationRefreshResultSchema = z
+  .discriminatedUnion('state', [
+    retainedNoChangeResultSchema,
+    factualRefreshResultSchema,
+    unavailableRefreshResultSchema,
+  ])
   .superRefine((result, context) => {
     if (Date.parse(result.completedAt) < Date.parse(result.capturedAt)) {
       context.addIssue({
@@ -97,10 +176,23 @@ export function createAflTradeCurrentValuationRefresh(dependencies: {
   return {
     async refreshCurrent(unparsedRequest) {
       const request = aflTradeCurrentValuationRefreshRequestSchema.parse(unparsedRequest);
+      for (const statement of [
+        'SELECT retain_outcome_current_valuation_factual_source($1,$2,$3)',
+        'SELECT compose_outcome_current_valuation_factual_candidate($1,$2,$3)',
+      ]) {
+        await dependencies.client.transaction(async (transaction) => {
+          await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+          await transaction.query(statement, [
+            request.scopeKey,
+            request.trigger,
+            request.stableOperationKey,
+          ]);
+        });
+      }
       const retained = await dependencies.client.transaction(async (transaction) => {
         await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
         return transaction.query<RetainedRefreshRow>(
-          'SELECT * FROM retain_outcome_current_valuation_refresh_no_change($1,$2,$3)',
+          'SELECT * FROM refresh_outcome_current_valuation_factual($1,$2,$3)',
           [request.scopeKey, request.trigger, request.stableOperationKey]
         );
       });

--- a/tests/outcomes-integration/afl-current-valuation-refresh-postgres.test.ts
+++ b/tests/outcomes-integration/afl-current-valuation-refresh-postgres.test.ts
@@ -30,6 +30,10 @@ const ids = {
   batch: `private-evaluation-batch:${'5'.repeat(64)}`,
   transition: `private-evaluation-batch-transition:${'6'.repeat(64)}`,
   cohortOperation: `private-evaluation-cohort-run:${'7'.repeat(64)}`,
+  oldBundle: `private-reviewed-evidence-bundle:${'8'.repeat(64)}`,
+  newBundle: `private-reviewed-evidence-bundle:${'9'.repeat(64)}`,
+  oldDecision: `private-reviewed-evidence-evaluation-decision:${'a'.repeat(64)}`,
+  newDecision: `private-reviewed-evidence-evaluation-decision:${'b'.repeat(64)}`,
 };
 
 beforeAll(async () => {
@@ -99,12 +103,55 @@ beforeAll(async () => {
       valuation_scope_key text NOT NULL,trade_id text NOT NULL,
       PRIMARY KEY (valuation_scope_key,trade_id)
     );
+    CREATE TABLE outcome_review_decision (placeholder integer);
+    CREATE TABLE outcome_source_capture (capture_id text PRIMARY KEY);
+    CREATE TABLE outcome_artifact_custody (placeholder integer);
+    CREATE TABLE outcome_source_rights_proposal (placeholder integer);
+    CREATE TABLE outcome_provider_normalization_run (
+      normalization_run_id text PRIMARY KEY,capture_id text NOT NULL,field_map_id text NOT NULL,
+      decoder_version text NOT NULL,normalizer_version text NOT NULL,
+      source_rds_sha256 text NOT NULL,decoded_sha256 text NOT NULL,receipt_sha256 text NOT NULL,
+      staging_sha256 text NOT NULL,status text NOT NULL,source_row_count integer NOT NULL,
+      accepted_row_count integer NOT NULL,quarantined_row_count integer NOT NULL,
+      issue_count integer NOT NULL,identity_candidate_count integer NOT NULL,
+      match_candidate_count integer NOT NULL,metric_candidate_count integer NOT NULL,
+      achievement_candidate_count integer NOT NULL,completed_at timestamptz NOT NULL,
+      finalized_at timestamptz
+    );
+    CREATE TABLE outcome_private_reviewed_evidence_bundle (
+      evidence_bundle_id text PRIMARY KEY,evidence_scope_key text NOT NULL,
+      is_current boolean NOT NULL,bundle_sha256 text NOT NULL,
+      bundle_json jsonb NOT NULL
+    );
+    CREATE TABLE outcome_private_reviewed_evaluation_decision (
+      decision_id text PRIMARY KEY,valuation_scope_key text NOT NULL,
+      evidence_bundle_id text NOT NULL,status text NOT NULL
+    );
+    CREATE TABLE outcome_private_reviewed_evaluation_head (
+      valuation_scope_key text NOT NULL,evidence_scope_key text NOT NULL,
+      evidence_bundle_id text NOT NULL,decision_id text NOT NULL,status text NOT NULL,
+      PRIMARY KEY (valuation_scope_key,evidence_scope_key)
+    );
+    CREATE FUNCTION outcome_private_reviewed_evidence_bundle_is_current(target_id text)
+    RETURNS boolean LANGUAGE sql STABLE AS $$
+      SELECT coalesce((SELECT is_current FROM outcome_private_reviewed_evidence_bundle
+        WHERE evidence_bundle_id=target_id),false)
+    $$;
   `);
   await pool.query(
     readFileSync(
       join(
         process.cwd(),
         'prisma/afl-trade-outcomes/migrations/0080_current_valuation_refresh_tracer/migration.sql'
+      ),
+      'utf8'
+    )
+  );
+  await pool.query(
+    readFileSync(
+      join(
+        process.cwd(),
+        'prisma/afl-trade-outcomes/migrations/0083_current_valuation_factual_refresh/migration.sql'
       ),
       'utf8'
     )
@@ -118,7 +165,10 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-  await pool.query(`TRUNCATE outcome_current_valuation_refresh_operation,
+  await pool.query(`TRUNCATE outcome_current_valuation_factual_refresh_operation,
+    outcome_current_valuation_factual_refresh_stage_receipt,
+    outcome_current_private_factual_authority,outcome_private_factual_candidate,
+    outcome_current_valuation_refresh_operation,
     outcome_release_manifest,outcome_governed_valuation_model_qualification,
     outcome_governed_model_qualification_work,
     outcome_active_release,outcome_prepared_valuation_input_set,
@@ -128,7 +178,10 @@ beforeEach(async () => {
     outcome_private_valuation_dispatch_request,outcome_local_private_trade_evaluation_generation,
     outcome_private_evaluation_batch_transition,outcome_private_evaluation_authority_snapshot,
     outcome_private_evaluation_inspection_receipt,outcome_private_evaluation_transition_intent,
-    outcome_private_evaluation_transition_receipt,outcome_local_private_trade_evaluation_head`);
+    outcome_private_evaluation_transition_receipt,outcome_local_private_trade_evaluation_head,
+    outcome_private_reviewed_evaluation_head,outcome_private_reviewed_evaluation_decision,
+    outcome_private_reviewed_evidence_bundle,outcome_provider_normalization_run,
+    outcome_source_capture`);
   const connection = await pool.connect();
   try {
     await connection.query('BEGIN');
@@ -189,8 +242,78 @@ beforeEach(async () => {
   }
 });
 
+async function seedReviewedAuthority(input: {
+  readonly bundleId: string;
+  readonly decisionId: string;
+  readonly isCurrent: boolean;
+  readonly status?: 'authorized' | 'withdrawn';
+}) {
+  const status = input.status ?? 'authorized';
+  const suffix = input.bundleId.slice(-64);
+  const captureId = `source-capture:${suffix}`;
+  const normalizationRunId = `provider-normalization-run:${suffix}`;
+  await pool.query(`INSERT INTO outcome_source_capture VALUES ($1)`, [captureId]);
+  await pool.query(
+    `INSERT INTO outcome_provider_normalization_run VALUES
+      ($1,$2,$3,'decoder-v1','normalizer-v1',$4,$5,$6,$7,'staged',1,1,0,0,1,1,1,0,
+       '2026-08-25T00:00:00.000Z','2026-08-25T00:00:00.000Z')`,
+    [
+      normalizationRunId,
+      captureId,
+      `provider-field-map:${suffix}`,
+      'c'.repeat(64),
+      'd'.repeat(64),
+      'e'.repeat(64),
+      'f'.repeat(64),
+    ]
+  );
+  await pool.query(
+    `INSERT INTO outcome_private_reviewed_evidence_bundle VALUES
+      ($1,'afl-player-match-reviewed-2021-2026',$2,$3,$4::jsonb)`,
+    [
+      input.bundleId,
+      input.isCurrent,
+      suffix,
+      JSON.stringify({
+        content: {
+          sourceCaptures: [{ captureId }],
+          reviewSets: [{ reviewSetId: suffix }],
+          sourceRightsEvidenceRefs: [{ artifactId: `artifact:${suffix}` }],
+        },
+      }),
+    ]
+  );
+  await pool.query(
+    `INSERT INTO outcome_private_reviewed_evaluation_decision VALUES ($1,$2,$3,$4)`,
+    [input.decisionId, 'afl-men:2026-trades', input.bundleId, status]
+  );
+  await pool.query(
+    `INSERT INTO outcome_private_reviewed_evaluation_head VALUES
+      ($1,'afl-player-match-reviewed-2021-2026',$2,$3,$4)
+      ON CONFLICT (valuation_scope_key,evidence_scope_key) DO UPDATE SET
+        evidence_bundle_id=EXCLUDED.evidence_bundle_id,
+        decision_id=EXCLUDED.decision_id,
+        status=EXCLUDED.status`,
+    ['afl-men:2026-trades', input.bundleId, input.decisionId, status]
+  );
+}
+
 describe('current valuation refresh PostgreSQL tracer', () => {
   it('retains and exactly replays no change without downstream writes', async () => {
+    await seedReviewedAuthority({
+      bundleId: ids.newBundle,
+      decisionId: ids.newDecision,
+      isCurrent: true,
+    });
+    await pool.query(`SELECT retain_outcome_current_valuation_factual_source(
+      'afl-men:2026-trades','weekly','seed-current')`);
+    await pool.query(`SELECT compose_outcome_current_valuation_factual_candidate(
+      'afl-men:2026-trades','weekly','seed-current')`);
+    await pool.query(`INSERT INTO outcome_current_private_factual_authority
+      SELECT 'afl-men:2026-trades',receipt_json->'content'->>'candidateId',1,now()
+        FROM outcome_current_valuation_factual_refresh_stage_receipt
+       WHERE stable_operation_key='seed-current' AND stage='candidate_composed'`);
+    await pool.query(`TRUNCATE outcome_current_valuation_factual_refresh_stage_receipt`);
     const refresh = createAflTradeCurrentValuationRefresh({
       client: createPgAflOutcomeSqlClient(pool),
     });
@@ -265,8 +388,416 @@ describe('current valuation refresh PostgreSQL tracer', () => {
       })
     ).rejects.toThrow('conflicts with retained custody');
     await expect(
-      pool.query(`SELECT count(*)::int AS count FROM outcome_current_valuation_refresh_operation`)
+      pool.query(
+        `SELECT count(*)::int AS count FROM outcome_current_valuation_factual_refresh_operation`
+      )
     ).resolves.toMatchObject({ rows: [{ count: 1 }] });
+  });
+
+  it('serializes concurrent compatibility and factual callers to one retained operation', async () => {
+    await seedReviewedAuthority({
+      bundleId: ids.newBundle,
+      decisionId: ids.newDecision,
+      isCurrent: true,
+    });
+    const refresh = createAflTradeCurrentValuationRefresh({
+      client: createPgAflOutcomeSqlClient(pool),
+    });
+    const request = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'weekly' as const,
+      stableOperationKey: 'cross-generation-concurrency',
+    };
+
+    const [factualResult, compatibilityRows] = await Promise.all([
+      refresh.refreshCurrent(request),
+      pool.query<{ result_json: unknown }>(
+        `SELECT result_json FROM retain_outcome_current_valuation_refresh_no_change($1,$2,$3)`,
+        [request.scopeKey, request.trigger, request.stableOperationKey]
+      ),
+    ]);
+    const compatibilityResult = aflTradeCurrentValuationRefreshResultSchema.parse(
+      compatibilityRows.rows[0]?.result_json
+    );
+
+    expect(compatibilityResult).toEqual(factualResult);
+    await expect(
+      pool.query(`SELECT
+        (SELECT count(*)::int FROM outcome_current_valuation_refresh_operation) +
+        (SELECT count(*)::int FROM outcome_current_valuation_factual_refresh_operation) AS count`)
+    ).resolves.toMatchObject({ rows: [{ count: 1 }] });
+  });
+
+  it('replays a retained pre-factual no-change operation without requiring stage receipts', async () => {
+    const legacy = await pool.query<{ result_json: unknown }>(
+      `SELECT result_json FROM retain_outcome_current_valuation_refresh_no_change($1,$2,$3)`,
+      ['afl-men:2026-trades', 'weekly', 'pre-factual-retained-operation']
+    );
+    const refresh = createAflTradeCurrentValuationRefresh({
+      client: createPgAflOutcomeSqlClient(pool),
+    });
+
+    await expect(
+      refresh.refreshCurrent({
+        scopeKey: 'afl-men:2026-trades',
+        trigger: 'weekly',
+        stableOperationKey: 'pre-factual-retained-operation',
+      })
+    ).resolves.toEqual(
+      aflTradeCurrentValuationRefreshResultSchema.parse(legacy.rows[0]?.result_json)
+    );
+    await expect(
+      pool.query(`SELECT count(*)::int AS count
+      FROM outcome_current_valuation_factual_refresh_stage_receipt`)
+    ).resolves.toMatchObject({ rows: [{ count: 0 }] });
+  });
+
+  it('advances the private factual head once and replays acknowledged loss', async () => {
+    await pool.query(
+      `INSERT INTO outcome_private_reviewed_evidence_bundle VALUES
+        ($1,'afl-player-match-reviewed-2021-2026',false,$2,'{}'::jsonb)`,
+      [ids.oldBundle, ids.oldBundle.slice(-64)]
+    );
+    await pool.query(
+      `INSERT INTO outcome_private_reviewed_evaluation_decision VALUES
+        ($1,'afl-men:2026-trades',$2,'authorized')`,
+      [ids.oldDecision, ids.oldBundle]
+    );
+    await seedReviewedAuthority({
+      bundleId: ids.newBundle,
+      decisionId: ids.newDecision,
+      isCurrent: true,
+    });
+    const refresh = createAflTradeCurrentValuationRefresh({
+      client: createPgAflOutcomeSqlClient(pool),
+    });
+    const request = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'weekly' as const,
+      stableOperationKey: 'new-admitted-evidence',
+    };
+
+    await pool.query(`SELECT retain_outcome_current_valuation_factual_source($1,$2,$3)`, [
+      request.scopeKey,
+      request.trigger,
+      request.stableOperationKey,
+    ]);
+    const committed = await refresh.refreshCurrent(request);
+    await expect(refresh.refreshCurrent(request)).resolves.toEqual(committed);
+    expect(committed).toMatchObject({
+      state: 'factual_refresh_complete',
+      factualStage: 'advanced',
+      privateFactualAuthority: {
+        candidateId: expect.stringMatching(/^private-factual-candidate:/),
+        evidenceBundleId: ids.newBundle,
+        reviewDecisionId: ids.newDecision,
+        normalizedReconciledCustodySha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+        revision: 1,
+      },
+      publicationEligible: false,
+      publicationProhibited: true,
+    });
+    await expect(
+      pool.query(`SELECT candidate.evidence_bundle_id,head.revision
+        FROM outcome_current_private_factual_authority head
+        JOIN outcome_private_factual_candidate candidate USING (candidate_id)`)
+    ).resolves.toMatchObject({ rows: [{ evidence_bundle_id: ids.newBundle, revision: 1 }] });
+    await expect(
+      pool.query(`SELECT release_id,revision FROM outcome_active_release`)
+    ).resolves.toMatchObject({ rows: [{ release_id: ids.release, revision: 9 }] });
+    await expect(
+      pool.query(`SELECT count(*)::int AS count
+        FROM outcome_current_valuation_factual_refresh_operation`)
+    ).resolves.toMatchObject({ rows: [{ count: 1 }] });
+    await expect(
+      pool.query(
+        `SELECT stage FROM outcome_current_valuation_factual_refresh_stage_receipt ORDER BY stage`
+      )
+    ).resolves.toMatchObject({
+      rows: [{ stage: 'candidate_composed' }, { stage: 'source_authenticated' }],
+    });
+  });
+
+  it('resumes a committed candidate receipt without duplicating custody', async () => {
+    await seedReviewedAuthority({
+      bundleId: ids.newBundle,
+      decisionId: ids.newDecision,
+      isCurrent: true,
+    });
+    const request = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'ad_hoc' as const,
+      stableOperationKey: 'lost-after-candidate-composition',
+    };
+    await pool.query(`SELECT retain_outcome_current_valuation_factual_source($1,$2,$3)`, [
+      request.scopeKey,
+      request.trigger,
+      request.stableOperationKey,
+    ]);
+    await pool.query(`SELECT compose_outcome_current_valuation_factual_candidate($1,$2,$3)`, [
+      request.scopeKey,
+      request.trigger,
+      request.stableOperationKey,
+    ]);
+
+    const refresh = createAflTradeCurrentValuationRefresh({
+      client: createPgAflOutcomeSqlClient(pool),
+    });
+    await expect(refresh.refreshCurrent(request)).resolves.toMatchObject({
+      state: 'factual_refresh_complete',
+      factualStage: 'advanced',
+    });
+    await expect(
+      pool.query(`SELECT
+      (SELECT count(*)::int FROM outcome_private_factual_candidate) AS candidates,
+      (SELECT count(*)::int FROM outcome_current_private_factual_authority) AS heads,
+      (SELECT count(*)::int FROM outcome_current_valuation_factual_refresh_stage_receipt) AS stages`)
+    ).resolves.toMatchObject({ rows: [{ candidates: 1, heads: 1, stages: 2 }] });
+  });
+
+  it('retains stale when reviewed authority changes after source authentication', async () => {
+    await seedReviewedAuthority({
+      bundleId: ids.newBundle,
+      decisionId: ids.newDecision,
+      isCurrent: true,
+    });
+    const request = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'weekly' as const,
+      stableOperationKey: 'source-stale-after-authentication',
+    };
+    await pool.query(`SELECT retain_outcome_current_valuation_factual_source($1,$2,$3)`, [
+      request.scopeKey,
+      request.trigger,
+      request.stableOperationKey,
+    ]);
+    await pool.query(
+      `UPDATE outcome_private_reviewed_evidence_bundle
+        SET is_current=false WHERE evidence_bundle_id=$1`,
+      [ids.newBundle]
+    );
+
+    const refresh = createAflTradeCurrentValuationRefresh({
+      client: createPgAflOutcomeSqlClient(pool),
+    });
+    const first = await refresh.refreshCurrent(request);
+    await expect(refresh.refreshCurrent(request)).resolves.toEqual(first);
+    expect(first).toMatchObject({ state: 'unavailable', cause: 'source_authority_stale' });
+    await expect(
+      pool.query(
+        `SELECT stage FROM outcome_current_valuation_factual_refresh_stage_receipt
+          WHERE stable_operation_key=$1 ORDER BY stage`,
+        [request.stableOperationKey]
+      )
+    ).resolves.toMatchObject({
+      rows: [{ stage: 'candidate_composed' }, { stage: 'source_authenticated' }],
+    });
+  });
+
+  it('retains stale when normalized custody becomes ambiguous after authentication', async () => {
+    await seedReviewedAuthority({
+      bundleId: ids.newBundle,
+      decisionId: ids.newDecision,
+      isCurrent: true,
+    });
+    const request = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'ad_hoc' as const,
+      stableOperationKey: 'normalization-stale-after-authentication',
+    };
+    await pool.query(`SELECT retain_outcome_current_valuation_factual_source($1,$2,$3)`, [
+      request.scopeKey,
+      request.trigger,
+      request.stableOperationKey,
+    ]);
+    await pool.query(
+      `INSERT INTO outcome_provider_normalization_run
+        SELECT $1,capture_id,field_map_id,decoder_version,normalizer_version,
+               source_rds_sha256,$2,$3,$4,status,source_row_count,accepted_row_count,
+               quarantined_row_count,issue_count,identity_candidate_count,match_candidate_count,
+               metric_candidate_count,achievement_candidate_count,completed_at,finalized_at
+          FROM outcome_provider_normalization_run`,
+      [
+        `provider-normalization-run:${'0'.repeat(64)}`,
+        '1'.repeat(64),
+        '2'.repeat(64),
+        '3'.repeat(64),
+      ]
+    );
+
+    const refresh = createAflTradeCurrentValuationRefresh({
+      client: createPgAflOutcomeSqlClient(pool),
+    });
+    const first = await refresh.refreshCurrent(request);
+    await expect(refresh.refreshCurrent(request)).resolves.toEqual(first);
+    expect(first).toMatchObject({ state: 'unavailable', cause: 'source_authority_stale' });
+  });
+
+  it('does not reactivate a superseded candidate when an older operation resumes late', async () => {
+    await seedReviewedAuthority({
+      bundleId: ids.oldBundle,
+      decisionId: ids.oldDecision,
+      isCurrent: true,
+    });
+    const older = ['afl-men:2026-trades', 'weekly', 'older-composed-candidate'] as const;
+    await pool.query(`SELECT retain_outcome_current_valuation_factual_source($1,$2,$3)`, older);
+    await pool.query(`SELECT compose_outcome_current_valuation_factual_candidate($1,$2,$3)`, older);
+    await seedReviewedAuthority({
+      bundleId: ids.newBundle,
+      decisionId: ids.newDecision,
+      isCurrent: true,
+    });
+    const refresh = createAflTradeCurrentValuationRefresh({
+      client: createPgAflOutcomeSqlClient(pool),
+    });
+    await expect(
+      refresh.refreshCurrent({
+        scopeKey: 'afl-men:2026-trades',
+        trigger: 'weekly',
+        stableOperationKey: 'newer-candidate',
+      })
+    ).resolves.toMatchObject({ state: 'factual_refresh_complete', factualStage: 'advanced' });
+
+    await expect(
+      refresh.refreshCurrent({
+        scopeKey: older[0],
+        trigger: older[1],
+        stableOperationKey: older[2],
+      })
+    ).resolves.toMatchObject({ state: 'unavailable', cause: 'source_authority_stale' });
+    await expect(
+      pool.query(`SELECT candidate.evidence_bundle_id,head.revision
+      FROM outcome_current_private_factual_authority head
+      JOIN outcome_private_factual_candidate candidate USING (candidate_id)`)
+    ).resolves.toMatchObject({ rows: [{ evidence_bundle_id: ids.newBundle, revision: 1 }] });
+  });
+
+  it('binds exact normalization custody and retains a late same-source candidate as stale', async () => {
+    await seedReviewedAuthority({
+      bundleId: ids.newBundle,
+      decisionId: ids.newDecision,
+      isCurrent: true,
+    });
+    const older = ['afl-men:2026-trades', 'ad_hoc', 'older-normalization-custody'] as const;
+    await pool.query(`SELECT retain_outcome_current_valuation_factual_source($1,$2,$3)`, older);
+    await pool.query(`SELECT compose_outcome_current_valuation_factual_candidate($1,$2,$3)`, older);
+    const firstCandidate = await pool.query<{
+      candidate_id: string;
+      run_id: string;
+      expected_revision: number;
+    }>(
+      `SELECT candidate.candidate_id,
+              candidate.candidate_json#>>'{content,normalizedReconciledCustody,normalizationRuns,0,normalizationRunId}' AS run_id,
+              (receipt.receipt_json#>>'{content,expectedPrivateFactualRevision}')::integer AS expected_revision
+         FROM outcome_private_factual_candidate candidate
+         JOIN outcome_current_valuation_factual_refresh_stage_receipt receipt
+           ON receipt.receipt_json#>>'{content,candidateId}'=candidate.candidate_id
+        WHERE receipt.stable_operation_key=$1 AND receipt.stage='candidate_composed'`,
+      [older[2]]
+    );
+    expect(firstCandidate.rows[0]).toMatchObject({
+      run_id: `provider-normalization-run:${ids.newBundle.slice(-64)}`,
+      expected_revision: 0,
+    });
+
+    await pool.query(
+      `UPDATE outcome_provider_normalization_run
+      SET normalization_run_id=$1,decoded_sha256=$2,receipt_sha256=$3,staging_sha256=$4`,
+      [
+        `provider-normalization-run:${'0'.repeat(64)}`,
+        '1'.repeat(64),
+        '2'.repeat(64),
+        '3'.repeat(64),
+      ]
+    );
+    const refresh = createAflTradeCurrentValuationRefresh({
+      client: createPgAflOutcomeSqlClient(pool),
+    });
+    const newer = await refresh.refreshCurrent({
+      scopeKey: older[0],
+      trigger: older[1],
+      stableOperationKey: 'newer-normalization-custody',
+    });
+    expect(newer).toMatchObject({ state: 'factual_refresh_complete', factualStage: 'advanced' });
+    expect(newer.privateFactualAuthority?.candidateId).not.toBe(
+      firstCandidate.rows[0]?.candidate_id
+    );
+
+    await expect(
+      refresh.refreshCurrent({
+        scopeKey: older[0],
+        trigger: older[1],
+        stableOperationKey: older[2],
+      })
+    ).resolves.toMatchObject({ state: 'unavailable', cause: 'source_authority_stale' });
+    await expect(
+      pool.query(`SELECT candidate_id,revision
+      FROM outcome_current_private_factual_authority`)
+    ).resolves.toMatchObject({
+      rows: [{ candidate_id: newer.privateFactualAuthority?.candidateId, revision: 1 }],
+    });
+  });
+
+  it.each([
+    ['source_authority_missing', null, null, null],
+    ['source_authority_stale', ids.newBundle, ids.newDecision, 'stale'],
+    ['source_authority_unauthenticated', ids.newBundle, ids.newDecision, 'withdrawn'],
+  ] as const)('retains exact unavailable cause %s', async (cause, bundleId, decisionId, setup) => {
+    await pool.query(`DELETE FROM outcome_private_evaluation_cohort_capture`);
+    if (bundleId !== null && decisionId !== null) {
+      await seedReviewedAuthority({
+        bundleId,
+        decisionId,
+        isCurrent: setup !== 'stale',
+        status: setup === 'withdrawn' ? 'withdrawn' : 'authorized',
+      });
+    }
+    const refresh = createAflTradeCurrentValuationRefresh({
+      client: createPgAflOutcomeSqlClient(pool),
+    });
+    const request = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'ad_hoc' as const,
+      stableOperationKey: `unavailable-${cause}`,
+    };
+
+    const first = await refresh.refreshCurrent(request);
+    await expect(refresh.refreshCurrent(request)).resolves.toEqual(first);
+    expect(first).toMatchObject({ state: 'unavailable', cause });
+  });
+
+  it('retains mismatched source authority without advancing either factual pointer', async () => {
+    await pool.query(`DELETE FROM outcome_private_evaluation_cohort_capture`);
+    await pool.query(
+      `INSERT INTO outcome_private_reviewed_evidence_bundle VALUES
+        ($1,'afl-player-match-reviewed-2021-2026',true,$2,'{}'::jsonb)`,
+      [ids.newBundle, ids.newBundle.slice(-64)]
+    );
+    await pool.query(
+      `INSERT INTO outcome_private_reviewed_evaluation_head VALUES
+        ('afl-men:2026-trades','afl-player-match-reviewed-2021-2026',$1,$2,'authorized')`,
+      [ids.newBundle, ids.newDecision]
+    );
+    const refresh = createAflTradeCurrentValuationRefresh({
+      client: createPgAflOutcomeSqlClient(pool),
+    });
+
+    await expect(
+      refresh.refreshCurrent({
+        scopeKey: 'afl-men:2026-trades',
+        trigger: 'ad_hoc',
+        stableOperationKey: 'unavailable-mismatched',
+      })
+    ).resolves.toMatchObject({
+      state: 'unavailable',
+      cause: 'source_authority_mismatched',
+    });
+    await expect(
+      pool.query(`SELECT count(*)::int AS count FROM outcome_current_private_factual_authority`)
+    ).resolves.toMatchObject({ rows: [{ count: 0 }] });
+    await expect(
+      pool.query(`SELECT release_id,revision FROM outcome_active_release`)
+    ).resolves.toMatchObject({ rows: [{ release_id: ids.release, revision: 9 }] });
   });
 
   it('keeps retained history behind the scoped function', async () => {
@@ -282,6 +813,15 @@ describe('current valuation refresh PostgreSQL tracer', () => {
       ).resolves.toMatchObject({ rowCount: 1 });
       await expect(
         connection.query(`SELECT * FROM outcome_current_valuation_refresh_operation`)
+      ).rejects.toThrow('permission denied');
+      await connection.query('ROLLBACK');
+      await connection.query('BEGIN');
+      await connection.query(`SET LOCAL ROLE afl_trade_private_evaluation_coordinator`);
+      await expect(
+        connection.query(
+          `SELECT * FROM retain_outcome_current_valuation_refresh_no_change_v1($1,$2,$3)`,
+          ['afl-men:2026-trades', 'ad_hoc', 'scoped-function-v1-denied']
+        )
       ).rejects.toThrow('permission denied');
     } finally {
       await connection.query('ROLLBACK');

--- a/tests/outcomes-integration/afl-current-valuation-refresh-postgres.test.ts
+++ b/tests/outcomes-integration/afl-current-valuation-refresh-postgres.test.ts
@@ -719,9 +719,10 @@ describe('current valuation refresh PostgreSQL tracer', () => {
       stableOperationKey: 'newer-normalization-custody',
     });
     expect(newer).toMatchObject({ state: 'factual_refresh_complete', factualStage: 'advanced' });
-    expect(newer.privateFactualAuthority?.candidateId).not.toBe(
-      firstCandidate.rows[0]?.candidate_id
-    );
+    if (newer.state !== 'factual_refresh_complete') {
+      throw new TypeError(`Expected factual refresh completion, received ${newer.state}.`);
+    }
+    expect(newer.privateFactualAuthority.candidateId).not.toBe(firstCandidate.rows[0]?.candidate_id);
 
     await expect(
       refresh.refreshCurrent({
@@ -734,7 +735,7 @@ describe('current valuation refresh PostgreSQL tracer', () => {
       pool.query(`SELECT candidate_id,revision
       FROM outcome_current_private_factual_authority`)
     ).resolves.toMatchObject({
-      rows: [{ candidate_id: newer.privateFactualAuthority?.candidateId, revision: 1 }],
+      rows: [{ candidate_id: newer.privateFactualAuthority.candidateId, revision: 1 }],
     });
   });
 
@@ -764,6 +765,16 @@ describe('current valuation refresh PostgreSQL tracer', () => {
     const first = await refresh.refreshCurrent(request);
     await expect(refresh.refreshCurrent(request)).resolves.toEqual(first);
     expect(first).toMatchObject({ state: 'unavailable', cause });
+    await expect(
+      pool.query(
+        `SELECT candidate_id,operation_json#>'{content,candidateId}' AS retained_candidate_id
+           FROM outcome_current_valuation_factual_refresh_operation
+          WHERE operation_id=$1`,
+        [first.operationId]
+      )
+    ).resolves.toMatchObject({
+      rows: [{ candidate_id: null, retained_candidate_id: null }],
+    });
   });
 
   it('retains mismatched source authority without advancing either factual pointer', async () => {

--- a/tests/outcomes-integration/afl-hpn-pav-projected-input-postgres.test.ts
+++ b/tests/outcomes-integration/afl-hpn-pav-projected-input-postgres.test.ts
@@ -136,12 +136,12 @@ const reviewedCaptureSources = [
     authority: createLocalAflTradeFiveSeasonAflTablesAuthority(reviewedSeasonYear),
   })),
   {
-    suffix: 'reviewed-official-2026',
+    suffix: 'corroborating',
     seasonYear,
     authority: createLocalAflTradeOfficialAfl2026Authority(),
   },
   {
-    suffix: 'reviewed-results-2026',
+    suffix: 'results',
     seasonYear,
     authority: createLocalAflTradeAflTablesResultsAuthority(seasonYear),
   },
@@ -470,6 +470,65 @@ async function seedSourceAndFactualAuthority(
          VALUES ($1,$2,$3) ON CONFLICT DO NOTHING`,
         [id('source-capture', source.suffix), competition, source.seasonYear]
       );
+      const decodeMap = source.authority.fieldMap;
+      await transaction.query(
+        `INSERT INTO outcome_review_decision
+          (decision_id,subject_type,subject_id,decision,rationale,evidence_json,
+           decided_by,decided_at)
+         VALUES ($1,'provider_field_map',$2,'approved',$3,
+                 jsonb_build_object('fieldMapSha256',$4::text),$5,$6)
+         ON CONFLICT (decision_id) DO NOTHING`,
+        [
+          decodeMap.approvalDecisionId,
+          decodeMap.mapId,
+          'Approve the exact disposable reviewed-evidence decode map.',
+          sha256(canonicalizeAflTradeJson(decodeMap)),
+          'projected-hpn-input-fixture-reviewer',
+          decodeMap.approvedAt,
+        ]
+      );
+      await transaction.query(
+        `INSERT INTO outcome_provider_field_map
+          (field_map_id,capability_id,fitzroy_version,source_schema_sha256,
+           field_map_sha256,approval_decision_id,approved_at,map_json)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb)
+         ON CONFLICT (field_map_id) DO NOTHING`,
+        [
+          decodeMap.mapId,
+          decodeMap.capabilityId,
+          decodeMap.fitzRoyVersion,
+          decodeMap.sourceSchemaSha256,
+          sha256(canonicalizeAflTradeJson(decodeMap)),
+          decodeMap.approvalDecisionId,
+          decodeMap.approvedAt,
+          canonicalizeAflTradeJson(decodeMap),
+        ]
+      );
+      if (source.suffix !== 'results' && source.suffix !== 'corroborating') {
+        await transaction.query(
+          `INSERT INTO outcome_provider_normalization_run
+          (normalization_run_id,capture_id,field_map_id,decoder_version,normalizer_version,
+           source_rds_sha256,decoded_sha256,receipt_sha256,staging_sha256,status,
+           source_row_count,accepted_row_count,quarantined_row_count,issue_count,
+           identity_candidate_count,match_candidate_count,metric_candidate_count,
+           achievement_candidate_count,started_at,completed_at,finalized_at,receipt_json)
+         VALUES ($1,$2,$3,'reviewed-fixture','reviewed-fixture',$4,$5,$6,$7,
+                 'staged',0,0,0,0,0,0,0,0,
+                 $8,$9,$9,'{}'::jsonb)
+         ON CONFLICT (normalization_run_id) DO NOTHING`,
+        [
+          id('provider-normalization-run', `reviewed:${source.suffix}`),
+          id('source-capture', source.suffix),
+          decodeMap.mapId,
+          sha256(`reviewed-rds:${source.suffix}`),
+          sha256(`reviewed-decoded:${source.suffix}`),
+          sha256(`reviewed-receipt:${source.suffix}`),
+          sha256(`reviewed-staging:${source.suffix}`),
+          fixtureAt,
+          finalizedAt,
+          ]
+        );
+      }
     }
     for (const projected of projections) {
       const { lane, decodeMap } = projected;
@@ -514,7 +573,8 @@ async function seedSourceAndFactualAuthority(
           (decision_id,subject_type,subject_id,decision,rationale,evidence_json,
            decided_by,decided_at)
          VALUES ($1,'provider_field_map',$2,'approved',$3,
-                 jsonb_build_object('fieldMapSha256',$4::text),$5,$6)`,
+                 jsonb_build_object('fieldMapSha256',$4::text),$5,$6)
+         ON CONFLICT (decision_id) DO NOTHING`,
         [
           decodeMap.approvalDecisionId,
           decodeMap.mapId,
@@ -528,7 +588,8 @@ async function seedSourceAndFactualAuthority(
         `INSERT INTO outcome_provider_field_map
           (field_map_id,capability_id,fitzroy_version,source_schema_sha256,
            field_map_sha256,approval_decision_id,approved_at,map_json)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb)`,
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb)
+         ON CONFLICT (field_map_id) DO NOTHING`,
         [
           decodeMap.mapId,
           decodeMap.capabilityId,
@@ -1731,6 +1792,74 @@ async function prepareShortLivedResultsInput(): Promise<{
 beforeAll(async () => {
   await adminPool.query(`CREATE SCHEMA "${schemaName}"`);
   runOutcomesPrismaTestCommand(['migrate', 'deploy'], { databaseUrl: scopedDatabaseUrl() });
+  await outcomesPool.query(`
+    CREATE FUNCTION outcome_projected_hpn_fixture_bundle_is_current(target_id text)
+    RETURNS boolean LANGUAGE sql STABLE AS $$
+      SELECT coalesce((SELECT
+        bundle.candidate_count=1 AND bundle.decision_count=1
+        AND bundle.source_capture_count=7 AND bundle.source_rights_count=3
+        AND bundle.bundle_json->'content'->'reviewSets'->0->>'reviewerId'=
+          'projected-hpn-input-fixture-reviewer'
+        AND jsonb_array_length(bundle.bundle_json->'content'->'sourceCaptures')=7
+        AND jsonb_array_length(bundle.bundle_json->'content'->'sourceRightsEvidenceRefs')=3
+        AND (SELECT count(DISTINCT item->>'captureId')
+               FROM jsonb_array_elements(bundle.bundle_json->'content'->'sourceCaptures') item)=7
+        AND (SELECT count(DISTINCT item->>'artifactId')
+               FROM jsonb_array_elements(
+                 bundle.bundle_json->'content'->'sourceRightsEvidenceRefs') item)=3
+        AND NOT EXISTS (
+          SELECT 1
+            FROM outcome_hpn_pav_input_run input_run
+            JOIN outcome_provider_normalization_run run
+              ON run.normalization_run_id=input_run.normalization_run_id
+            JOIN outcome_hpn_projected_field_map projected
+              ON projected.field_map_id=input_run.projected_field_map_id
+            JOIN outcome_hpn_field_map_candidate candidate
+              ON candidate.candidate_id=projected.candidate_id
+           WHERE run.field_map_id IS DISTINCT FROM
+             candidate.candidate_json#>>'{content,providerDecodeMapId}'
+        )
+        FROM outcome_private_reviewed_evidence_bundle bundle
+        WHERE bundle.evidence_bundle_id=target_id),false)
+    $$;
+    CREATE OR REPLACE FUNCTION outcome_private_reviewed_evidence_bundle_is_current(
+      target_evidence_bundle_id text
+    ) RETURNS boolean LANGUAGE sql STABLE AS $$
+      SELECT outcome_private_reviewed_evidence_bundle_is_current_v1(
+               target_evidence_bundle_id)
+          OR outcome_projected_hpn_fixture_bundle_is_current(target_evidence_bundle_id)
+    $$;
+    CREATE FUNCTION validate_outcome_projected_hpn_fixture_bundle_insert()
+    RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN
+      IF NEW.candidate_count<>1 OR NEW.decision_count<>1
+         OR NEW.source_capture_count<>7 OR NEW.source_rights_count<>3
+         OR jsonb_array_length(NEW.bundle_json->'content'->'sourceCaptures')<>7
+         OR jsonb_array_length(NEW.bundle_json->'content'->'sourceRightsEvidenceRefs')<>3
+         OR (SELECT count(DISTINCT item->>'captureId')
+               FROM jsonb_array_elements(NEW.bundle_json->'content'->'sourceCaptures') item)<>7
+         OR (SELECT count(DISTINCT item->>'artifactId')
+               FROM jsonb_array_elements(
+                 NEW.bundle_json->'content'->'sourceRightsEvidenceRefs') item)<>3
+      THEN
+        RAISE EXCEPTION 'Results successor failed exact authentication';
+      END IF;
+      RETURN NEW;
+    END $$;
+    DROP TRIGGER outcome_private_reviewed_evidence_bundle_insert_guard
+      ON outcome_private_reviewed_evidence_bundle;
+    CREATE TRIGGER outcome_private_reviewed_evidence_bundle_insert_guard
+      BEFORE INSERT ON outcome_private_reviewed_evidence_bundle
+      FOR EACH ROW
+      WHEN (NEW.bundle_json->'content'->'reviewSets'->0->>'reviewerId'<>
+        'projected-hpn-input-fixture-reviewer')
+      EXECUTE FUNCTION validate_outcome_private_reviewed_evidence_bundle_insert();
+    CREATE TRIGGER outcome_projected_hpn_fixture_bundle_insert_guard
+      BEFORE INSERT ON outcome_private_reviewed_evidence_bundle
+      FOR EACH ROW
+      WHEN (NEW.bundle_json->'content'->'reviewSets'->0->>'reviewerId'=
+        'projected-hpn-input-fixture-reviewer')
+      EXECUTE FUNCTION validate_outcome_projected_hpn_fixture_bundle_insert();
+  `);
 });
 
 afterAll(async () => {
@@ -2247,7 +2376,7 @@ describe.sequential('private valuation HPN preparation with projected authority 
         WHERE input_kind='completed_match_result'
         ORDER BY field_map_id LIMIT 1`
     );
-    const alternateDecodeMapId = 'afl-tables-results-local-2026-v1-alternate';
+    const alternateDecodeMapId = 'afl-tables-results-local-2026-v2-alternate';
     const alternateNormalizationRunId = id(
       'provider-normalization-run',
       'results-alternate-map'
@@ -2262,7 +2391,7 @@ describe.sequential('private valuation HPN preparation with projected authority 
                 approval_decision_id,approved_at,
                 jsonb_set(map_json,'{mapId}',to_jsonb($1::text),false)
            FROM outcome_provider_field_map
-          WHERE field_map_id='afl-tables-results-local-2026-v1'`,
+          WHERE field_map_id='afl-tables-results-local-2026-v2'`,
         [alternateDecodeMapId, sha256(alternateDecodeMapId)]
       );
       await transaction.query(
@@ -2314,7 +2443,7 @@ describe.sequential('private valuation HPN preparation with projected authority 
         );
         await transaction.query(
           `UPDATE outcome_provider_normalization_run
-              SET field_map_id='afl-tables-results-local-2026-v1-alternate'
+              SET field_map_id='afl-tables-results-local-2026-v2-alternate'
             WHERE normalization_run_id=$1`,
           [id('provider-normalization-run', 'results')]
         );

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1200,7 +1200,9 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       'outcome_private_reviewed_evidence_bundle',
       'outcome_private_reviewed_evaluation_decision',
       'outcome_private_reviewed_evaluation_head',
+      'outcome_private_factual_candidate',
       'outcome_current_private_factual_authority',
+      'outcome_current_valuation_factual_refresh_stage_receipt',
       'outcome_current_valuation_factual_refresh_operation',
       'outcome_hpn_field_map_candidate',
       'outcome_hpn_field_map_review_decision',
@@ -1283,6 +1285,8 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       'outcome_private_reviewed_evidence_bundle_mutation_guard',
       'outcome_private_reviewed_evaluation_decision_mutation_guard',
       'outcome_private_reviewed_evaluation_head_delete_guard',
+      'outcome_private_factual_candidate_no_update_delete',
+      'outcome_factual_refresh_stage_no_update_delete',
       'outcome_current_valuation_factual_refresh_no_update_delete',
     ]) {
       expect(triggerNames).toContain(expected);

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1107,7 +1107,20 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0078_private_valuation_hpn_source_admission',
       '0079_dispatch_bound_private_model_pair',
       '0080_current_valuation_refresh_tracer',
+      '0081_corrected_local_review_lineage',
+      '0082_complete_local_reviewed_evidence',
+      '0083_current_valuation_factual_refresh',
     ]);
+
+    const factualRefreshReads = await query<{ permitted: boolean }>(
+      `SELECT bool_and(has_table_privilege(
+         'afl_trade_current_valuation_refresh_owner',table_name,'SELECT')) AS permitted
+       FROM unnest(ARRAY[
+         'outcome_review_decision','outcome_source_capture','outcome_artifact_custody',
+         'outcome_source_rights_proposal','outcome_provider_normalization_run'
+       ]) AS required(table_name)`
+    );
+    expect(factualRefreshReads.rows).toEqual([{ permitted: true }]);
 
     const tables = await query<{ table_name: string }>(
       `SELECT table_name FROM information_schema.tables
@@ -1187,6 +1200,8 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       'outcome_private_reviewed_evidence_bundle',
       'outcome_private_reviewed_evaluation_decision',
       'outcome_private_reviewed_evaluation_head',
+      'outcome_current_private_factual_authority',
+      'outcome_current_valuation_factual_refresh_operation',
       'outcome_hpn_field_map_candidate',
       'outcome_hpn_field_map_review_decision',
       'outcome_hpn_projected_field_map',
@@ -1268,6 +1283,7 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       'outcome_private_reviewed_evidence_bundle_mutation_guard',
       'outcome_private_reviewed_evaluation_decision_mutation_guard',
       'outcome_private_reviewed_evaluation_head_delete_guard',
+      'outcome_current_valuation_factual_refresh_no_update_delete',
     ]) {
       expect(triggerNames).toContain(expected);
     }

--- a/tests/unit/afl-trade-intelligence-current-valuation-refresh.test.ts
+++ b/tests/unit/afl-trade-intelligence-current-valuation-refresh.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@/server/aflTradeIntelligence/valuation/currentValuationRefresh';
 
 const operationId = `current-valuation-refresh-operation:${'a'.repeat(64)}`;
+const factualOperationId = `current-valuation-factual-refresh-operation:${'2'.repeat(64)}`;
 const triggers = ['weekly', 'model_qualified', 'ad_hoc'] as const;
 
 function retainedResult(trigger: (typeof triggers)[number]): AflTradeCurrentValuationRefreshResult {
@@ -42,12 +43,44 @@ function retainedResult(trigger: (typeof triggers)[number]): AflTradeCurrentValu
   };
 }
 
+function factualResult(): AflTradeCurrentValuationRefreshResult {
+  return {
+    schemaVersion: 'afl-current-valuation-refresh-result-v2',
+    operationId: factualOperationId,
+    scopeKey: 'afl-men:2026-trades',
+    trigger: 'weekly',
+    stableOperationKey: 'refresh-new-facts',
+    state: 'factual_refresh_complete',
+    factualStage: 'advanced',
+    privateFactualAuthority: {
+      valuationScopeKey: 'afl-men:2026-trades',
+      candidateId: `private-factual-candidate:${'5'.repeat(64)}`,
+      evidenceScopeKey: 'afl-player-match-reviewed-2021-2026',
+      evidenceBundleId: `private-reviewed-evidence-bundle:${'3'.repeat(64)}`,
+      reviewDecisionId: `private-reviewed-evidence-evaluation-decision:${'4'.repeat(64)}`,
+      normalizedReconciledCustodySha256: '6'.repeat(64),
+      revision: 1,
+    },
+    capturedAt: '2026-08-28T08:00:00.000Z',
+    completedAt: '2026-08-28T08:00:00.000Z',
+    executionLocation: 'local',
+    visibility: 'private',
+    environment: 'non_production',
+    publicationEligible: false,
+    publicationProhibited: true,
+    limitation:
+      'Private local non-production factual refresh authority only; no public release, registry, production, activation, or publication authority is granted.',
+  };
+}
+
 function fakeClient(result: AflTradeCurrentValuationRefreshResult) {
   const statements: Array<{ readonly sql: string; readonly parameters: readonly unknown[] }> = [];
   const query = async (sql: string, parameters: readonly unknown[] = []) => {
     statements.push({ sql, parameters });
     if (sql.includes('SET LOCAL ROLE')) return { rows: [], rowCount: null };
-    if (sql.includes('retain_outcome_current_valuation_refresh_no_change')) {
+    if (sql.includes('retain_outcome_current_valuation_factual_source')) return { rows: [], rowCount: 1 };
+    if (sql.includes('compose_outcome_current_valuation_factual_candidate')) return { rows: [], rowCount: 1 };
+    if (sql.includes('refresh_outcome_current_valuation_factual')) {
       return {
         rows: [{ operation_id: result.operationId, operation_json: {}, result_json: result }],
         rowCount: 1,
@@ -75,15 +108,28 @@ describe('current valuation refresh', () => {
         stableOperationKey: expected.stableOperationKey,
       })
     ).resolves.toEqual(expected);
-    expect(database.statements).toEqual([
-      {
-        sql: 'SET LOCAL ROLE afl_trade_private_evaluation_coordinator',
-        parameters: [],
-      },
-      {
-        sql: 'SELECT * FROM retain_outcome_current_valuation_refresh_no_change($1,$2,$3)',
-        parameters: [expected.scopeKey, trigger, expected.stableOperationKey],
-      },
+    expect(database.statements.filter(({ sql }) => sql.startsWith('SELECT'))).toEqual([
+      { sql: 'SELECT retain_outcome_current_valuation_factual_source($1,$2,$3)', parameters: [expected.scopeKey, trigger, expected.stableOperationKey] },
+      { sql: 'SELECT compose_outcome_current_valuation_factual_candidate($1,$2,$3)', parameters: [expected.scopeKey, trigger, expected.stableOperationKey] },
+      { sql: 'SELECT * FROM refresh_outcome_current_valuation_factual($1,$2,$3)', parameters: [expected.scopeKey, trigger, expected.stableOperationKey] },
     ]);
+  });
+
+  it('returns the retained private factual CAS advancement without publication authority', async () => {
+    const expected = factualResult();
+    const database = fakeClient(expected);
+    const refresh = createAflTradeCurrentValuationRefresh({ client: database.client });
+
+    await expect(
+      refresh.refreshCurrent({
+        scopeKey: expected.scopeKey,
+        trigger: expected.trigger,
+        stableOperationKey: expected.stableOperationKey,
+      })
+    ).resolves.toEqual(expected);
+    expect(database.statements.filter(({ sql }) => sql.startsWith('SELECT')).at(-1)).toEqual({
+      sql: 'SELECT * FROM refresh_outcome_current_valuation_factual($1,$2,$3)',
+      parameters: [expected.scopeKey, expected.trigger, expected.stableOperationKey],
+    });
   });
 });

--- a/tests/unit/afl-trade-intelligence-local-five-season-afl-tables-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-local-five-season-afl-tables-authority.test.ts
@@ -8,6 +8,7 @@ import {
   createLocalAflTradeFiveSeasonAflTablesAuthority,
 } from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority';
 import { createAflTradeFitzRoyInvocation } from '@/server/aflTradeIntelligence/source/fitzRoyCaptureContracts';
+import { evaluateAflTradeGate0A } from '@/server/aflTradeIntelligence/source/gate0aEvaluation';
 
 describe('local five-season AFL Tables authority', () => {
   it('binds one exact reviewed 81-field source contract to each season capture', () => {
@@ -116,6 +117,17 @@ describe('local five-season AFL Tables authority', () => {
     expect(authority.fieldMap.validThroughSeason).toBe(2021);
   });
 
+  it('admits the exact internal-evaluation capture through Gate 0A', () => {
+    const authority = createLocalAflTradeFiveSeasonAflTablesAuthority(2021);
+
+    expect(
+      evaluateAflTradeGate0A(authority.capture.ledger, authority.capture.sourceRights, {
+        ...authority.capture.gateRequest,
+        evaluatedAt: '2026-08-26T00:00:00.000Z',
+      })
+    ).toMatchObject({ status: 'mechanically_eligible', blockers: [] });
+  });
+
   it('binds current-season completed results to their exact offline-inspected fitzRoy schema', () => {
     const authority = createLocalAflTradeAflTablesResultsAuthority(2026);
     const invocation = createAflTradeFitzRoyInvocation(authority.capture.captureRequest);
@@ -138,6 +150,13 @@ describe('local five-season AFL Tables authority', () => {
       'Round.Type',
       'Round.Number',
     ]);
+    expect(LOCAL_AFL_TABLES_RESULTS_FIELD_SCHEMA.find(({ name }) => name === 'Season')).toEqual({
+      name: 'Season',
+      storageType: 'double',
+      classes: ['numeric'],
+      levels: null,
+      timezone: null,
+    });
     expect(authority.capture.captureRequest).toMatchObject({
       capabilityId: 'afl-tables-results',
       authorizationSeason: 2026,
@@ -155,8 +174,10 @@ describe('local five-season AFL Tables authority', () => {
       authorityKind: 'external_human_record',
     });
     expect(authority.fieldMap).toMatchObject({
+      mapId: 'afl-tables-results-local-2026-v2',
       capabilityId: 'afl-tables-results',
       observationKind: 'match_universe',
+      approvalDecisionId: 'local-afl-tables-results-field-map-review-2026-v2',
       invocationArgumentsSha256: sha256AflTradeCanonicalJson(invocation.arguments),
       match: {
         nativeMatchId: { sourceField: 'Game', required: true },

--- a/tests/unit/afl-trade-intelligence-local-official-afl-2026-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-local-official-afl-2026-authority.test.ts
@@ -6,13 +6,14 @@ import {
   createLocalAflTradeOfficialAfl2026Authority,
 } from '@/server/aflTradeIntelligence/development/localOfficialAfl2026Authority';
 import { createAflTradeFitzRoyInvocation } from '@/server/aflTradeIntelligence/source/fitzRoyCaptureContracts';
+import { evaluateAflTradeGate0A } from '@/server/aflTradeIntelligence/source/gate0aEvaluation';
 
 describe('local official AFL 2026 authority', () => {
   it('binds the exact reviewed official schema and request-scoped season', () => {
     const authority = createLocalAflTradeOfficialAfl2026Authority();
     const invocation = createAflTradeFitzRoyInvocation(authority.capture.captureRequest);
 
-    expect(LOCAL_OFFICIAL_AFL_2026_PLAYER_STATS_FIELD_SCHEMA).toHaveLength(96);
+    expect(LOCAL_OFFICIAL_AFL_2026_PLAYER_STATS_FIELD_SCHEMA).toHaveLength(95);
     expect(LOCAL_OFFICIAL_AFL_2026_PLAYER_STATS_FIELD_SCHEMA.map(({ name }) => name)).toEqual(
       expect.arrayContaining([
         'providerId',
@@ -25,6 +26,9 @@ describe('local official AFL 2026 authority', () => {
         'team.name',
         'goals',
       ])
+    );
+    expect(LOCAL_OFFICIAL_AFL_2026_PLAYER_STATS_FIELD_SCHEMA.map(({ name }) => name)).not.toContain(
+      'extendedStats'
     );
     expect(authority.capture.captureRequest).toMatchObject({
       capabilityId: 'official-afl-player-stats',
@@ -67,7 +71,7 @@ describe('local official AFL 2026 authority', () => {
     expect(authority.capture.gateRequest.fieldUses).toEqual(
       expect.arrayContaining([{ sourceField: 'goals', use: 'archive_fact' }])
     );
-    expect(authority.capture.gateRequest.fieldUses).toHaveLength(96);
+    expect(authority.capture.gateRequest.fieldUses).toHaveLength(95);
     expect(authority.fieldMap).toMatchObject({
       capabilityId: 'official-afl-player-stats',
       validFromSeason: 2026,
@@ -99,5 +103,16 @@ describe('local official AFL 2026 authority', () => {
         },
       ],
     });
+  });
+
+  it('admits the exact internal-evaluation capture through Gate 0A', () => {
+    const authority = createLocalAflTradeOfficialAfl2026Authority();
+
+    expect(
+      evaluateAflTradeGate0A(authority.capture.ledger, authority.capture.sourceRights, {
+        ...authority.capture.gateRequest,
+        evaluatedAt: '2026-08-26T00:00:00.000Z',
+      })
+    ).toMatchObject({ status: 'mechanically_eligible', blockers: [] });
   });
 });

--- a/tests/unit/afl-trade-intelligence-private-reviewed-currentness-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-reviewed-currentness-migration.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256 } from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesReview';
+import { assertExactLocalReviewedProviderCaptureTuples } from '@/server/aflTradeIntelligence/development/localReviewedProviderEvidence';
 
 function read(path: string): string {
   return readFileSync(join(process.cwd(), path), 'utf8');
@@ -79,6 +80,15 @@ describe('private reviewed evidence currentness migration', () => {
         /AND 1 = \(\s+SELECT count\(\*\)\s+FROM "?outcome_provider_normalization_run"? run/gu
       )
     ).toHaveLength(2);
+    expect(
+      migration.match(
+        /FROM "?outcome_source_capture"? sibling\s+WHERE sibling\.?"?environment"?='non_production'/gu
+      )
+    ).toHaveLength(2);
+    expect(migration).toContain('sibling.anchor_season_year=capture.anchor_season_year');
+    expect(migration).toContain(
+      'sibling."anchor_season_year"=capture."anchor_season_year"'
+    );
     expect(migration).toContain('NEW."source_capture_count"=7');
     expect(migration).toContain('NEW."source_rights_count"=3');
     expect(migration).toContain('Private reviewed-evidence health has unexpected capture counts');
@@ -96,6 +106,36 @@ describe('private reviewed evidence currentness migration', () => {
     expect(loader).toMatch(
       /AND 1 = \(\s+SELECT count\(\*\)\s+FROM outcome_provider_normalization_run run/u
     );
+    expect(loader).toContain('REQUIRED_CAPTURE_TUPLE_KEYS');
+    expect(loader).toContain("'afl_tables\\u0000afl-tables-player-stats\\u00002021'");
+    expect(loader).toContain("'afl_tables\\u0000afl-tables-results\\u00002026'");
+    expect(loader).toContain(
+      "'official_afl\\u0000official-afl-player-stats\\u00002026'"
+    );
+    expect(loader).toContain('captureTupleKeys.size !== REQUIRED_CAPTURE_TUPLE_KEYS.size');
+  });
+
+  it('rejects a duplicated required season even when seven capture rows are present', () => {
+    const exact = [
+      { provider: 'afl_tables', capabilityId: 'afl-tables-player-stats', seasonYear: 2021 },
+      { provider: 'afl_tables', capabilityId: 'afl-tables-player-stats', seasonYear: 2022 },
+      { provider: 'afl_tables', capabilityId: 'afl-tables-player-stats', seasonYear: 2023 },
+      { provider: 'afl_tables', capabilityId: 'afl-tables-player-stats', seasonYear: 2024 },
+      { provider: 'afl_tables', capabilityId: 'afl-tables-player-stats', seasonYear: 2025 },
+      {
+        provider: 'official_afl',
+        capabilityId: 'official-afl-player-stats',
+        seasonYear: 2026,
+      },
+      { provider: 'afl_tables', capabilityId: 'afl-tables-results', seasonYear: 2026 },
+    ];
+
+    expect(() => assertExactLocalReviewedProviderCaptureTuples(exact)).not.toThrow();
+    expect(() =>
+      assertExactLocalReviewedProviderCaptureTuples(
+        exact.map((capture, index) => (index === 4 ? exact[0]! : capture))
+      )
+    ).toThrow(/exactly one capture for each required provider, capability, and season/u);
   });
 
   it('uses the exact bundle selected by the current reviewed-evaluation head', () => {

--- a/tests/unit/afl-trade-intelligence-private-reviewed-currentness-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-reviewed-currentness-migration.test.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256 } from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesReview';
+
 function read(path: string): string {
   return readFileSync(join(process.cwd(), path), 'utf8');
 }
@@ -39,6 +41,53 @@ describe('private reviewed evidence currentness migration', () => {
     );
     expect(migration).toContain('historical_decision_count<>146307');
     expect(migration).toContain('official_decision_count<>36');
+  });
+
+  it('rotates the historical review identity without rewriting prior migrations', () => {
+    const migration = read(
+      'prisma/afl-trade-outcomes/migrations/0081_corrected_local_review_lineage/migration.sql'
+    );
+
+    expect(LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256).toBe(
+      '7ef741add1ae94133c597581f8a2175118058bedd2ffe8a107213630e1b0fd10'
+    );
+    expect(migration).toContain(LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256);
+    expect(migration).toContain('aef663452e66a433048605a71fb4178ed1a5e1d9610c6d3ed75bfb796308b5cb');
+    expect(migration).toContain('pg_get_functiondef');
+    expect(migration).toContain('outcome_private_reviewed_evidence_is_current()');
+    expect(migration).toContain('validate_outcome_private_reviewed_evidence_bundle_insert()');
+    expect(migration).toContain('outcome_private_reviewed_evidence_bundle_is_current_v1(text)');
+    expect(migration).toContain('Admitted private review-set decisions are append-only');
+  });
+
+  it('admits one complete normalized seven-capture bundle without a transitional successor', () => {
+    const migration = read(
+      'prisma/afl-trade-outcomes/migrations/0082_complete_local_reviewed_evidence/migration.sql'
+    );
+    const loader = read(
+      'src/server/aflTradeIntelligence/development/localReviewedProviderEvidence.ts'
+    );
+
+    expect(migration).toContain('pg_get_functiondef');
+    expect(migration).toContain('outcome_private_reviewed_evidence_is_current()');
+    expect(migration).toContain('validate_outcome_private_reviewed_evidence_bundle_insert()');
+    expect(migration).toContain('outcome_private_reviewed_evidence_bundle_is_current_v1(text)');
+    expect(migration).toContain('outcome_provider_normalization_run');
+    expect(migration).toContain('run."finalized_at" IS NOT NULL');
+    expect(migration).toContain('NEW."source_capture_count"=7');
+    expect(migration).toContain('NEW."source_rights_count"=3');
+    expect(migration).toContain('Private reviewed-evidence health has unexpected capture counts');
+    expect(migration).toContain(
+      'Private reviewed-evidence insert validation has unexpected counts'
+    );
+    expect(migration).toContain(
+      'Private reviewed-evidence bundle currentness has unexpected counts'
+    );
+    expect(migration).toContain(
+      'DROP TRIGGER "outcome_private_reviewed_evidence_results_successor_insert_guard"'
+    );
+    expect(loader).toContain('FROM outcome_provider_normalization_run run');
+    expect(loader).toContain('run.finalized_at IS NOT NULL');
   });
 
   it('uses the exact bundle selected by the current reviewed-evaluation head', () => {

--- a/tests/unit/afl-trade-intelligence-private-reviewed-currentness-migration.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-reviewed-currentness-migration.test.ts
@@ -74,6 +74,11 @@ describe('private reviewed evidence currentness migration', () => {
     expect(migration).toContain('outcome_private_reviewed_evidence_bundle_is_current_v1(text)');
     expect(migration).toContain('outcome_provider_normalization_run');
     expect(migration).toContain('run."finalized_at" IS NOT NULL');
+    expect(
+      migration.match(
+        /AND 1 = \(\s+SELECT count\(\*\)\s+FROM "?outcome_provider_normalization_run"? run/gu
+      )
+    ).toHaveLength(2);
     expect(migration).toContain('NEW."source_capture_count"=7');
     expect(migration).toContain('NEW."source_rights_count"=3');
     expect(migration).toContain('Private reviewed-evidence health has unexpected capture counts');
@@ -88,6 +93,9 @@ describe('private reviewed evidence currentness migration', () => {
     );
     expect(loader).toContain('FROM outcome_provider_normalization_run run');
     expect(loader).toContain('run.finalized_at IS NOT NULL');
+    expect(loader).toMatch(
+      /AND 1 = \(\s+SELECT count\(\*\)\s+FROM outcome_provider_normalization_run run/u
+    );
   });
 
   it('uses the exact bundle selected by the current reviewed-evaluation head', () => {

--- a/tests/unit/afl-trade-intelligence-private-valuation-hpn-preparation.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-hpn-preparation.test.ts
@@ -132,7 +132,7 @@ describe('private valuation HPN preparation', () => {
         provider: 'afl_tables',
         dataset: 'AFL Tables completed match results through fitzRoy',
         capabilityId: 'afl-tables-results',
-        fieldMapId: 'afl-tables-results-local-2026-v1',
+        fieldMapId: createLocalAflTradeAflTablesResultsAuthority(2026).fieldMap.mapId,
         rightsArtifactId:
           createLocalAflTradeAflTablesResultsAuthority(2026).capture.sourceRights.rightsArtifactId,
       },
@@ -140,7 +140,7 @@ describe('private valuation HPN preparation', () => {
         provider: 'afl_tables',
         dataset: 'AFL Tables historical player match statistics',
         capabilityId: 'afl-tables-player-stats',
-        fieldMapId: 'afl-tables-player-stats-local-2026-v1',
+        fieldMapId: createLocalAflTradeFiveSeasonAflTablesAuthority(2026).fieldMap.mapId,
         rightsArtifactId:
           createLocalAflTradeFiveSeasonAflTablesAuthority(2026).capture.sourceRights.rightsArtifactId,
       },
@@ -148,7 +148,7 @@ describe('private valuation HPN preparation', () => {
         provider: 'official_afl',
         dataset: 'Official AFL 2026 player match statistics',
         capabilityId: 'official-afl-player-stats',
-        fieldMapId: 'official-afl-player-stats-local-2026-v1',
+        fieldMapId: createLocalAflTradeOfficialAfl2026Authority().fieldMap.mapId,
         rightsArtifactId:
           createLocalAflTradeOfficialAfl2026Authority().capture.sourceRights.rightsArtifactId,
       },


### PR DESCRIPTION
## Summary

- correct the private reviewed-evidence contract to require the exact seven-capture, three-rights, finalized-normalization authority
- authenticate the current reviewed-evidence head, compose a distinct content-addressed private factual candidate, and advance one revision-fenced private factual head
- retain source-authentication and candidate-composition receipts under one stable operation identity, including exact unavailable outcomes and restart replay
- serialize legacy and factual refresh callers under one idempotency namespace while leaving public release and publication authority unchanged
- keep raw capture, normalization, reconciliation, bundle creation, and reviewed-head advancement in #569

## Migration note

Migration 0081 intentionally stops on a disposable database that already contains the superseded review lineage. There is no supported in-place rewrite or retained-artifact relabel/replay. Preserve that database read-only; #569 owns creation of the replacement governed chain in a fresh local database.

## Verification

- `npm run docs:check`
- `npm run lint:ci`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run typecheck`
- focused unit coverage: 21 passing
- `npm run test:outcomes:int`: 31 files, 149 tests passing
- prior full supported verification on this branch: unit, integration, E2E, and build green
- independent spec review: clean
- independent standards review: clean

Closes #568

Parent #550 remains open for #569 and the final end-to-end provider-evidence proof.

## Summary by Sourcery

Activate revision-fenced private factual authority from an authenticated, fully normalized reviewed-evidence bundle without granting public release or publication authority.

New Features:
- Activate a private, content-addressed factual authority from the current reviewed-evidence head with revision-fenced advancement and restart-safe operation replay.

Bug Fixes:
- Correct the local reviewed-evidence lineage and enforce the complete seven-capture, three-rights, finalized-normalization contract, including the 2026 results capture.
- Tighten local provider schemas and source-rights authority to reflect exact field, operation, and contextual restrictions.

Enhancements:
- Serialize legacy and factual refresh callers under a shared idempotency namespace while preserving compatibility with retained no-change operations.
- Bind factual candidates to authenticated source captures, normalization runs, reconciliation sets, rights evidence, and the predecessor private-factual head.
- Retain explicit unavailable outcomes for missing, stale, mismatched, or unauthenticated source authority and keep factual refresh private and publication-prohibited.

Documentation:
- Document the fresh-disposable-database migration boundary, seven-capture preflight, and private factual refresh operating procedure.

Tests:
- Add unit and PostgreSQL integration coverage for exact capture validation, authority authentication, candidate composition, compare-and-swap advancement, idempotent replay, stale custody detection, unavailable outcomes, and unchanged public release state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a private factual valuation refresh flow with refreshed, already-current, and unavailable outcomes.
  - Improved source authorization checks using geographic, commercial, and audience restrictions.
  - Strengthened evidence validation with complete captures, rights artifacts, and finalized normalization records.

- **Bug Fixes**
  - Corrected local review lineage and updated AFL Tables field definitions.
  - Added safeguards against invalid or outdated evidence migrations.

- **Documentation**
  - Updated architecture, testing, and operations guidance for evidence review, migrations, and private valuation refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->