### PR TITLE
Orchestrate admitted fitzRoy evidence into reviewed factual authority

### DIFF
--- a/docs/architecture/afl-trade-intelligence.md
+++ b/docs/architecture/afl-trade-intelligence.md
@@ -434,17 +434,16 @@ projection, service, API, archive response, and authenticated JSON, CSV and OOXM
 byte. This is disposable local recovery evidence only; it is not evidence for hosted retention,
 point-in-time recovery, cross-host recovery, disaster recovery, or production restore authority.
 
-The existing executable development-only evidence rehearsal retains six one-off governed
-player-stat captures in a caller-owned disposable `statly_outcomes_test` PostgreSQL database: five
-completed AFL Tables seasons for 2021–2025 and official-AFL current-season evidence for 2026. Those
-captures contain 57,621 staged player-match rows. The corrected reviewed-evidence contract also
-requires one separately governed, finalized AFL Tables completed-results capture for 2026 and a third
-source-rights artifact. #569 owns producing that additional custody; until then the executable
-rehearsal cannot create the replacement current reviewed head consumed by factual activation. Capture
-rights, field maps, receipts, decoder provenance, raw-object digests, and staging outcomes remain
-independently attributable to their source decisions. Local raw custody uses the explicit
-`local_non_production_filesystem` profile and confers no hosted durability, redistribution,
-production, or recurring-capture authority.
+The development-only current-evidence coordinator owns exactly seven governed source lanes in a
+caller-owned disposable `statly_outcomes_test` PostgreSQL database: five completed AFL Tables
+player-stat seasons for 2021–2025, official-AFL current-season player-stat evidence for 2026, and one
+separately governed AFL Tables completed-results capture for 2026. The six player-stat captures are
+expected to contain 57,621 staged player-match rows in a real-data run. The seventh capture supplies
+the third source-rights artifact and completed-match universe required by the corrected
+reviewed-evidence contract. Capture rights, field maps, receipts, decoder provenance, raw-object
+digests, and staging outcomes remain independently attributable to their source decisions. Local raw
+custody uses the explicit `local_non_production_filesystem` profile and confers no hosted durability,
+redistribution, production, or recurring-capture authority.
 
 Those local capture-rights artifacts permit bounded capture, raw/hash retention and internal quality
 evaluation only. Model training, derived-feature creation, public derived output, public fact display
@@ -2036,6 +2035,40 @@ stable operation key. A restart resumes those receipts before the private factua
 it does not duplicate a candidate or head transition. The operation either advances the candidate,
 reports it already current, or retains one exact unavailable cause: missing, stale, mismatched, or
 unauthenticated source authority.
+
+The upstream current-evidence operation composes those existing boundaries before factual refresh.
+It resolves the durable Gate decision and source-rights proposal for each of the seven exact
+provider/season tuples, requires the exact current reviewed field map, and either reuses one finalized
+normalization or captures and normalizes the missing lane through the reviewed fitzRoy runtime. Each
+completed source lane is retained as an append-only PostgreSQL stage receipt keyed by the outer stable
+operation. A crash after capture but before normalization resumes the retained source snapshot; a
+crash after a stage receipt skips that lane. The SQL retention boundary independently requires the
+expected provider, capability, season, field-map identity, staged capture, and finalized
+normalization.
+
+The local runtime retains its Ed25519 capture-receipt signing key as a mode-`0600` file beneath the
+ignored private artifact root. A restarted process therefore reconstructs the same verifier before it
+authenticates a retained non-fixture snapshot. The key is local non-production custody only; it is not
+a production KMS identity or provider-egress attestation. Runtime construction requires an absolute
+artifact root and rejects a signing path that is a symlink, a non-regular or multiply linked file,
+owned by another user, or not exactly mode `0600`; it does not silently repair insecure custody.
+
+After all seven lanes, a separate reconciliation fence authenticates the two exact current provider
+review sets and reconstructs the complete normalized/reconciled bundle in one database snapshot. It
+does not insert identity, match, fact, review-set, bundle-authority, or head decisions. Missing review
+sets stop at `reconciliation_authority`; superseded or malformed decisions stop as stale or
+unauthenticated; a custody/count mismatch stops at `reconciliation`. Once the human reconciliation
+reviews exist, the operation separately requires the exact authorized reviewed-evidence head consumed
+by factual refresh. A missing head returns `review_required`. Human review therefore remains an
+explicit authority transition, not an internal worker stage.
+
+Every unavailable result is terminal and append-only for its stable operation key. Exact retry
+returns that result and performs no provider work. After the required review or authority repair, the
+caller supplies a new stable operation key; the new operation discovers and reuses the retained
+captures and finalized normalizations before rechecking reconciliation and reviewed authority. Only
+an authenticated reviewed head permits the content-addressed handoff to the private factual refresh.
+The local launcher maps an unavailable result to one completed, exhausted dispatch rather than a
+transient retry loop.
 
 This is deliberately a private factual candidate and authority, not a factual release. The retained
 reviewed bundle is evidence for composition rather than activation authority in its own right, and it

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -55,6 +55,36 @@ reuse, governed identity review, current-head resolution loading and post-finali
 Production source commands additionally require reviewed
 JSON, durable Gate records, Redis admission and isolated KMS-backed object custody.
 
+For the current valuation evidence coordinator, run the focused unit and disposable PostgreSQL
+boundaries while editing:
+
+```sh
+npx vitest run --config vitest.config.unit.ts --coverage.enabled=false \
+  tests/unit/afl-trade-intelligence-current-valuation-evidence-orchestration.test.ts \
+  tests/unit/afl-trade-intelligence-local-egress-signing-authority.test.ts \
+  tests/unit/afl-trade-intelligence-private-valuation-worker.test.ts
+
+AFL_OUTCOMES_TEST_DATABASE_URL='<owned-disposable-loopback-postgresql>' \
+  npx vitest run --config vitest.config.outcomes-int.ts \
+  tests/outcomes-integration/afl-current-valuation-evidence-orchestration-postgres.test.ts
+```
+
+The PostgreSQL proof applies the complete migration history and runs all seven exact source lanes
+through the real Gate resolver, cryptographically signed capture receipt, artifact custody, source
+snapshot, contract-faithful offline fixture decoder, normalizer, stage-receipt, and
+reconciliation-fence boundaries. Only the external fitzRoy/network execution and decoded provider
+rows are bounded no-network fixtures. The scenario first retains the missing-reconciliation stop,
+then supplies explicit fixture-owned human review markers, retains the reviewed-authority stop, and
+uses a bounded reviewed-bundle assembler. With production SQL guards still enabled, it first proves
+that this incomplete fixture is rejected and leaves no reviewed bundle, decision, or head. It then
+uses an explicit test-only guard bypass to exercise the real `recordDecision` transaction/head
+persistence and private factual-refresh authority without materializing 146,343 fixture review
+decisions. That second phase is not evidence that the production exact-set admission guard accepts a
+complete dataset. It proves new operation keys reuse the seven finalized normalizations, the captured
+lineage reaches the private factual head without duplicate captures or runs, and the public active
+release and registry remain unchanged. Production construction does not inject the fixture assembler
+or bypass; it uses the complete exact reviewed-provider evidence loader and unchanged SQL guards.
+
 `npm run test:all` runs lint, typecheck, unit, integration, and browser tests. Its integration stage
 includes the persisted 12-team, 22-player-roster, 264-pick draft convergence contract. CI exposes
 these boundaries as stable merge checks so a failure identifies its owning verification stage. The
@@ -86,10 +116,11 @@ Migration `0081_corrected_local_review_lineage` has the same no-rewrite rule for
 reviewed local provider lane. A disposable database that already contains decisions under the
 superseded historical evidence digest cannot migrate in place. Preserve that database and its private
 artifact roots read-only. Retained artifact bytes cannot authenticate corrected pre-capture Gate
-lineage and must not be relabeled as a new capture. This stage consumes an already current reviewed
-head. In a new empty loopback `statly_outcomes_test` database, deploy the complete migration history;
-the separately tracked #569 must then create the replacement governed capture, normalization, and
-reconciliation chain before review can continue. The exact hard stop, preservation,
+lineage and must not be relabeled as a new capture. In a new empty loopback
+`statly_outcomes_test` database, deploy the complete migration history and use the current-evidence
+coordinator to create the replacement governed capture and normalization chain. It stops at the
+separately retained human reconciliation and reviewed-head authorities before continuing. The exact
+hard stop, preservation,
 seven-capture/three-rights preflight, and retirement conditions are
 in [AFL trade intelligence operations](../runbooks/afl-trade-intelligence-operations.md#inspecting-the-governed-five-season-workbook-evaluation).
 Never use this replacement procedure for shared or hosted state.

--- a/docs/runbooks/afl-trade-intelligence-operations.md
+++ b/docs/runbooks/afl-trade-intelligence-operations.md
@@ -646,16 +646,16 @@ hosted database.
 Keep the old disposable database and its local artifact roots offline and read-only. The corrected
 Gate lineage cannot be reconstructed from retained artifact bytes: its capture execution receipt must
 bind the corrected decision that existed before retrieval. There is therefore no authenticated
-retained-artifact import and no supported in-place upgrade. This factual-activation stage consumes an
-already current reviewed-evidence head and intentionally does not orchestrate raw capture,
-normalization, or reconciliation. Creating a replacement seven-capture chain is tracked separately in
-`statlyaus/Statly#569`; until that work is delivered and a new retrieval is separately authorized, do
-not deploy migration `0081` over the superseded database or attempt the review commands below. Copying,
-relabeling, or replaying old database rows or artifact bytes as a new capture is prohibited.
+retained-artifact import and no supported in-place upgrade. The current-evidence coordinator can
+create the replacement seven-capture chain, but only after the Gate decisions, source-rights records,
+and exact field-map reviews have been separately authorized and retained. It never relabels an old
+artifact or creates a review decision. Do not deploy migration `0081` over the superseded database or
+attempt the review commands below. Copying, relabeling, or replaying old database rows or artifact
+bytes as a new capture is prohibited.
 
-After #569 is delivered and a new retrieval is separately authorized, start a separate empty
-loopback database named exactly `statly_outcomes_test`, authenticate its runtime nonce, and deploy the
-complete migration history. Then use #569's owning boundary to create the corrected governed chain.
+For a separately authorized new retrieval, start a separate empty loopback database named exactly
+`statly_outcomes_test`, authenticate its runtime nonce, and deploy the complete migration history.
+Use the launcher or ad-hoc valuation command with one stable operation key to enter the coordinator.
 Retire the old database only after the new reviewed bundle is current and its capture IDs, artifact
 digests, normalization-run IDs, counts, and three rights artifacts have been privately compared with
 the preserved evidence record.
@@ -893,6 +893,49 @@ cross-scope reads. Remove only the container/schema and artifact directory creat
 
 ### Refreshing private factual authority
 
+The automatic launcher and ad-hoc valuation command now enter the current-evidence coordinator before
+private factual refresh. The coordinator owns exactly these lanes: AFL Tables player statistics for
+2021–2025, official AFL player statistics for 2026, and AFL Tables results for 2026. It requires the
+separately retained current Gate/source-rights and field-map review authority before provider access.
+It never creates those decisions.
+
+Inspect a completed or exhausted dispatch through its append-only evidence result:
+
+```sql
+SELECT stable_operation_key,state,stage,cause,result_json
+  FROM outcome_current_valuation_evidence_orchestration_operation
+ WHERE scope_key='<valuation-scope>'
+ ORDER BY completed_at DESC
+ LIMIT 1;
+```
+
+`capture_authority`, `capture`, `normalization_authority`, or `normalization` identifies the exact
+provider boundary to repair. `reconciliation_authority` with `missing` means the seven finalized
+normalizations are retained but the required human provider review sets are not yet current. Run the
+five-season and official review commands in the preceding inspection procedure. Do not rerun the
+provider capture. Then intentionally enqueue a new outer operation key; the coordinator will reuse
+the seven retained normalizations and recheck reconciliation. If it then returns
+`reviewed_authority` / `review_required`, review the assembled source qualification and use the
+private reviewed-evaluation authority command to authorize or reject its exact bundle. Enqueue a
+third new outer operation key only after that human decision. The next coordinator operation reuses
+the same source custody and may enter private factual refresh.
+
+The local receipt signer is durable private runtime state at
+`<AFL_TRADE_LOCAL_ARTIFACT_ROOT>/current-valuation-evidence/egress-signing-key.pem`, with mode
+`0600`. Preserve that key while any retained non-fixture source snapshot may need to resume after a
+restart. If it is lost, those receipts can no longer be authenticated: the next new outer operation
+must fail at `normalization_authority` / `unauthenticated` until the affected sources are deliberately
+recaptured under newly reviewed authority. Never copy the key into Git, an environment file, logs,
+or shared storage. The configured artifact root must be absolute. Startup rejects a signing key that
+is a symlink, non-regular or multiply linked, owned by another user, or not exactly mode `0600`.
+
+An unavailable outcome is terminal for its derived evidence stable key. Reusing the same outer
+operation key is exact replay and must not be used to continue after a human authority transition.
+Using a new key after review is deliberate continuation, not a transport retry. A superseded review
+set returns stale; malformed authority returns unauthenticated; normalized/reconciled custody drift
+returns mismatched. None of these states authorizes public release, publication, production, model
+training, or redistribution.
+
 Current Valuation Refresh accepts a valuation scope, trigger, and stable operation key. Reuse the same
 stable key after a timeout or lost response; exact replay returns the committed receipt. Never invent a
 new key merely because the caller did not receive the first response.
@@ -925,8 +968,12 @@ The local full-stack launcher starts one backend valuation worker. It authentica
 durable dispatch work. The schedule is Monday 19:00 in `Australia/Melbourne`, calculated as a calendar
 occurrence rather than a 604800-second interval, so daylight-saving changes do not move the local time.
 Startup coalesces missed weeks to the latest occurrence. A newly committed qualified model pair also
-enqueues immediate work. Neither trigger promotes factual data or prepares model evidence: execution
-begins only from the exact current authenticated prepared-v3 head.
+enqueues immediate work. Each claimed dispatch first runs the seven-lane current-evidence coordinator
+and may advance only the private factual head. An unavailable evidence result completes that dispatch
+as exhausted rather than retrying it as a transient failure. A complete factual handoff then enters
+the existing cohort runner, which still requires the exact current authenticated prepared-v3 head.
+The coordinator does not rebuild or activate prepared-v3 evidence, so newly admitted facts cannot
+reach recalculation until that remaining downstream #550 stage is composed.
 
 The repository now also contains a backend-only HPN preparation seam for the next upstream cutover.
 It accepts an exact retained dispatch plus its live claim, requires the exact immutable factual output

--- a/docs/runbooks/afl-trade-intelligence-operations.md
+++ b/docs/runbooks/afl-trade-intelligence-operations.md
@@ -904,7 +904,7 @@ Inspect a completed or exhausted dispatch through its append-only evidence resul
 ```sql
 SELECT stable_operation_key,state,stage,cause,result_json
   FROM outcome_current_valuation_evidence_orchestration_operation
- WHERE scope_key='<valuation-scope>'
+ WHERE scope_key = $1
  ORDER BY completed_at DESC
  LIMIT 1;
 ```

--- a/prisma/afl-trade-outcomes/migrations/0084_current_valuation_evidence_orchestration/migration.sql
+++ b/prisma/afl-trade-outcomes/migrations/0084_current_valuation_evidence_orchestration/migration.sql
@@ -1,0 +1,434 @@
+-- Retain terminal, private evidence-orchestration outcomes. Review-required is immutable for
+-- one stable operation key; continuation after review requires a new operation key.
+CREATE TABLE "outcome_current_valuation_evidence_orchestration_operation" (
+  "operation_id" TEXT PRIMARY KEY CHECK ("operation_id" ~ '^current-valuation-evidence-orchestration-operation:[a-f0-9]{64}$'),
+  "scope_key" TEXT NOT NULL,
+  "trigger_kind" TEXT NOT NULL CHECK ("trigger_kind" IN ('weekly','model_qualified','ad_hoc')),
+  "stable_operation_key" TEXT NOT NULL UNIQUE,
+  "state" TEXT NOT NULL CHECK ("state" IN ('unavailable','complete')),
+  "stage" TEXT NOT NULL CHECK ("stage" IN ('capture_authority','capture','normalization_authority','normalization','reconciliation_authority','reconciliation','reviewed_authority','private_factual_authority')),
+  "cause" TEXT CHECK ("cause" IN ('missing','stale','mismatched','unauthenticated','review_required')),
+  "downstream_operation_id" TEXT,
+  "captured_at" TIMESTAMPTZ(3) NOT NULL,
+  "completed_at" TIMESTAMPTZ(3) NOT NULL,
+  "operation_json" JSONB NOT NULL,
+  "result_json" JSONB NOT NULL,
+  CHECK ("completed_at">="captured_at"),
+  CHECK (("state"='unavailable' AND "stage"<>'private_factual_authority' AND "cause" IS NOT NULL AND "downstream_operation_id" IS NULL)
+      OR ("state"='complete' AND "stage"='private_factual_authority' AND "cause" IS NULL AND "downstream_operation_id" IS NOT NULL))
+);
+CREATE TABLE "outcome_current_valuation_evidence_orchestration_stage_receipt" (
+  "receipt_id" TEXT PRIMARY KEY CHECK ("receipt_id" ~ '^current-valuation-evidence-orchestration-stage-receipt:[a-f0-9]{64}$'),
+  "scope_key" TEXT NOT NULL,
+  "trigger_kind" TEXT NOT NULL CHECK ("trigger_kind" IN ('weekly','model_qualified','ad_hoc')),
+  "stable_operation_key" TEXT NOT NULL,
+  "source_key" TEXT NOT NULL,
+  "capture_id" TEXT NOT NULL,
+  "normalization_run_id" TEXT NOT NULL,
+  "receipt_json" JSONB NOT NULL,
+  "retained_at" TIMESTAMPTZ(3) NOT NULL,
+  UNIQUE ("stable_operation_key","source_key")
+);
+
+DO $membership$ BEGIN
+  EXECUTE format('GRANT afl_trade_current_valuation_refresh_owner TO %I',current_user);
+  EXECUTE format(
+    'GRANT USAGE ON SCHEMA %I TO afl_trade_private_evaluation_coordinator',
+    current_schema()
+  );
+END $membership$;
+
+CREATE FUNCTION "reject_outcome_current_valuation_evidence_orchestration_mutation"()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Current valuation evidence orchestration custody is append-only';
+END $$;
+
+CREATE TRIGGER "outcome_current_valuation_evidence_operation_no_mutation"
+  BEFORE UPDATE OR DELETE
+  ON "outcome_current_valuation_evidence_orchestration_operation"
+  FOR EACH ROW
+  EXECUTE FUNCTION "reject_outcome_current_valuation_evidence_orchestration_mutation"();
+CREATE TRIGGER "outcome_current_valuation_evidence_stage_no_mutation"
+  BEFORE UPDATE OR DELETE
+  ON "outcome_current_valuation_evidence_orchestration_stage_receipt"
+  FOR EACH ROW
+  EXECUTE FUNCTION "reject_outcome_current_valuation_evidence_orchestration_mutation"();
+
+CREATE FUNCTION "load_outcome_current_valuation_evidence"(
+  target_scope_key TEXT,
+  target_trigger TEXT,
+  target_stable_operation_key TEXT
+)
+RETURNS TABLE(result_json JSONB,retained_source_keys TEXT[])
+LANGUAGE plpgsql AS $$
+DECLARE
+  retained RECORD;
+BEGIN
+  IF target_scope_key IS NULL
+     OR target_scope_key<>btrim(target_scope_key)
+     OR length(target_scope_key) NOT BETWEEN 1 AND 400
+     OR target_stable_operation_key IS NULL
+     OR target_stable_operation_key<>btrim(target_stable_operation_key)
+     OR length(target_stable_operation_key) NOT BETWEEN 1 AND 400
+     OR target_trigger IS NULL
+     OR target_trigger NOT IN ('weekly','model_qualified','ad_hoc') THEN
+    RAISE EXCEPTION 'Current valuation evidence orchestration request is malformed';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(target_stable_operation_key,0));
+
+  SELECT * INTO retained
+    FROM "outcome_current_valuation_evidence_orchestration_operation"
+   WHERE "stable_operation_key"=target_stable_operation_key;
+  IF FOUND THEN
+    IF retained."scope_key"<>target_scope_key OR retained."trigger_kind"<>target_trigger THEN
+      RAISE EXCEPTION 'Current valuation evidence orchestration request conflicts with retained custody';
+    END IF;
+    result_json:=retained."result_json";
+  END IF;
+
+  SELECT * INTO retained
+    FROM "outcome_current_valuation_refresh_operation"
+   WHERE "stable_operation_key"=target_stable_operation_key;
+  IF FOUND THEN
+    RAISE EXCEPTION 'Current valuation evidence orchestration key conflicts with retained refresh custody';
+  END IF;
+  SELECT * INTO retained
+    FROM "outcome_current_valuation_factual_refresh_operation"
+   WHERE "stable_operation_key"=target_stable_operation_key;
+  IF FOUND THEN
+    RAISE EXCEPTION 'Current valuation evidence orchestration key conflicts with retained factual refresh custody';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM "outcome_current_valuation_evidence_orchestration_stage_receipt"
+     WHERE "stable_operation_key"=target_stable_operation_key
+       AND ("scope_key"<>target_scope_key OR "trigger_kind"<>target_trigger)
+  ) THEN
+    RAISE EXCEPTION 'Current valuation evidence orchestration stage conflicts with retained custody';
+  END IF;
+  SELECT coalesce(array_agg("source_key" ORDER BY "source_key"),'{}'::text[])
+    INTO retained_source_keys
+    FROM "outcome_current_valuation_evidence_orchestration_stage_receipt"
+   WHERE "stable_operation_key"=target_stable_operation_key;
+  RETURN NEXT;
+END $$;
+
+CREATE FUNCTION "retain_outcome_current_valuation_evidence_source"(
+  target_scope_key TEXT,
+  target_trigger TEXT,
+  target_stable_operation_key TEXT,
+  target_source_key TEXT,
+  target_capture_id TEXT,
+  target_normalization_run_id TEXT
+)
+RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE
+  loaded RECORD;
+  retained RECORD;
+  expected_provider TEXT;
+  expected_capability TEXT;
+  expected_season SMALLINT;
+  expected_field_map_id TEXT;
+  trusted_at TIMESTAMPTZ(3):=statement_timestamp();
+  content JSONB;
+  rid TEXT;
+BEGIN
+  SELECT * INTO loaded FROM "load_outcome_current_valuation_evidence"(
+    target_scope_key,target_trigger,target_stable_operation_key
+  );
+  IF loaded.result_json IS NOT NULL THEN RETURN; END IF;
+
+  CASE target_source_key
+    WHEN 'afl_tables:afl-tables-player-stats:2021' THEN expected_provider:='afl_tables'; expected_capability:='afl-tables-player-stats'; expected_season:=2021; expected_field_map_id:='afl-tables-player-stats-local-2021-v1';
+    WHEN 'afl_tables:afl-tables-player-stats:2022' THEN expected_provider:='afl_tables'; expected_capability:='afl-tables-player-stats'; expected_season:=2022; expected_field_map_id:='afl-tables-player-stats-local-2022-v1';
+    WHEN 'afl_tables:afl-tables-player-stats:2023' THEN expected_provider:='afl_tables'; expected_capability:='afl-tables-player-stats'; expected_season:=2023; expected_field_map_id:='afl-tables-player-stats-local-2023-v1';
+    WHEN 'afl_tables:afl-tables-player-stats:2024' THEN expected_provider:='afl_tables'; expected_capability:='afl-tables-player-stats'; expected_season:=2024; expected_field_map_id:='afl-tables-player-stats-local-2024-v1';
+    WHEN 'afl_tables:afl-tables-player-stats:2025' THEN expected_provider:='afl_tables'; expected_capability:='afl-tables-player-stats'; expected_season:=2025; expected_field_map_id:='afl-tables-player-stats-local-2025-v1';
+    WHEN 'official_afl:official-afl-player-stats:2026' THEN expected_provider:='official_afl'; expected_capability:='official-afl-player-stats'; expected_season:=2026; expected_field_map_id:='official-afl-player-stats-local-2026-v1';
+    WHEN 'afl_tables:afl-tables-results:2026' THEN expected_provider:='afl_tables'; expected_capability:='afl-tables-results'; expected_season:=2026; expected_field_map_id:='afl-tables-results-local-2026-v2';
+    ELSE RAISE EXCEPTION 'Current valuation evidence source key is unsupported';
+  END CASE;
+
+  SELECT * INTO retained
+    FROM "outcome_current_valuation_evidence_orchestration_stage_receipt"
+   WHERE "stable_operation_key"=target_stable_operation_key
+     AND "source_key"=target_source_key;
+  IF FOUND THEN
+    IF retained."capture_id"<>target_capture_id
+       OR retained."normalization_run_id"<>target_normalization_run_id THEN
+      RAISE EXCEPTION 'Current valuation evidence source conflicts with retained custody';
+    END IF;
+    RETURN;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+      FROM "outcome_source_capture" capture
+      JOIN "outcome_provider_normalization_run" run
+        ON run."capture_id"=capture."capture_id"
+     WHERE capture."capture_id"=target_capture_id
+       AND capture."provider"=expected_provider
+       AND capture."capability_id"=expected_capability
+       AND capture."anchor_season_year"=expected_season
+       AND capture."status"='staged'
+       AND run."normalization_run_id"=target_normalization_run_id
+       AND run."field_map_id"=expected_field_map_id
+       AND run."status" IN ('staged','needs_review')
+       AND run."finalized_at" IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'Current valuation normalized source custody is missing or mismatched';
+  END IF;
+  content:=jsonb_build_object(
+    'schemaVersion','afl-current-valuation-evidence-source-receipt/v1',
+    'scopeKey',target_scope_key,'trigger',target_trigger,
+    'stableOperationKey',target_stable_operation_key,'sourceKey',target_source_key,
+    'captureId',target_capture_id,'normalizationRunId',target_normalization_run_id,
+    'retainedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+  );
+  rid:='current-valuation-evidence-orchestration-stage-receipt:'||
+    encode(sha256(convert_to("outcome_afl_trade_canonical_json"(content),'UTF8')),'hex');
+  INSERT INTO "outcome_current_valuation_evidence_orchestration_stage_receipt" VALUES (
+    rid,target_scope_key,target_trigger,target_stable_operation_key,target_source_key,
+    target_capture_id,target_normalization_run_id,
+    jsonb_build_object('receiptId',rid,'content',content),trusted_at
+  );
+END $$;
+
+CREATE FUNCTION "retain_outcome_current_valuation_evidence_unavailable"(
+  target_scope_key TEXT,
+  target_trigger TEXT,
+  target_stable_operation_key TEXT,
+  target_stage TEXT,
+  target_cause TEXT
+)
+RETURNS TABLE(operation_id TEXT,operation_json JSONB,result_json JSONB)
+LANGUAGE plpgsql AS $$
+DECLARE
+  trusted_at TIMESTAMPTZ(3):=statement_timestamp();
+  loaded RECORD;
+  retained RECORD;
+  content JSONB;
+  oid TEXT;
+  limitation CONSTANT TEXT:='Private local non-production evidence orchestration only; human review, public release, production activation, and publication authority are not granted.';
+BEGIN
+  SELECT * INTO loaded FROM "load_outcome_current_valuation_evidence"(
+    target_scope_key,target_trigger,target_stable_operation_key
+  );
+  IF loaded.result_json IS NOT NULL THEN
+    SELECT * INTO retained
+      FROM "outcome_current_valuation_evidence_orchestration_operation"
+     WHERE "stable_operation_key"=target_stable_operation_key;
+    operation_id:=retained."operation_id";
+    operation_json:=retained."operation_json";
+    result_json:=retained."result_json";
+    RETURN NEXT;
+    RETURN;
+  END IF;
+  IF target_stage NOT IN ('capture_authority','capture','normalization_authority','normalization','reconciliation_authority','reconciliation','reviewed_authority')
+     OR target_cause NOT IN ('missing','stale','mismatched','unauthenticated','review_required')
+     OR (target_cause='review_required' AND target_stage<>'reviewed_authority') THEN
+    RAISE EXCEPTION 'Current valuation evidence unavailable outcome is malformed';
+  END IF;
+  IF target_stage IN ('reconciliation_authority','reconciliation','reviewed_authority')
+     AND cardinality(loaded.retained_source_keys)<>7 THEN
+    RAISE EXCEPTION 'Current valuation evidence review boundary requires all seven source receipts';
+  END IF;
+
+  content:=jsonb_build_object(
+    'schemaVersion','afl-current-valuation-evidence-orchestration-operation/v1',
+    'scopeKey',target_scope_key,
+    'trigger',target_trigger,
+    'stableOperationKey',target_stable_operation_key,
+    'state','unavailable',
+    'stage',target_stage,
+    'cause',target_cause,
+    'capturedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+  );
+  oid:='current-valuation-evidence-orchestration-operation:'||
+    encode(sha256(convert_to("outcome_afl_trade_canonical_json"(content),'UTF8')),'hex');
+  operation_json:=jsonb_build_object('operationId',oid,'content',content);
+  result_json:=jsonb_build_object(
+    'schemaVersion','afl-current-valuation-evidence-orchestration-result-v1',
+    'operationId',oid,
+    'scopeKey',target_scope_key,
+    'trigger',target_trigger,
+    'stableOperationKey',target_stable_operation_key,
+    'state','unavailable',
+    'stage',target_stage,
+    'cause',target_cause,
+    'capturedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'completedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'executionLocation','local',
+    'visibility','private',
+    'environment','non_production',
+    'publicationEligible',false,
+    'publicationProhibited',true,
+    'limitation',limitation
+  );
+  INSERT INTO "outcome_current_valuation_evidence_orchestration_operation" VALUES (
+    oid,target_scope_key,target_trigger,target_stable_operation_key,
+    'unavailable',target_stage,target_cause,NULL,trusted_at,trusted_at,
+    operation_json,result_json
+  );
+  operation_id:=oid;
+  RETURN NEXT;
+END $$;
+
+CREATE FUNCTION "retain_outcome_current_valuation_evidence_complete"(
+  target_scope_key TEXT,
+  target_trigger TEXT,
+  target_stable_operation_key TEXT,
+  target_factual_refresh JSONB
+)
+RETURNS TABLE(operation_id TEXT,operation_json JSONB,result_json JSONB)
+LANGUAGE plpgsql AS $$
+DECLARE
+  trusted_at TIMESTAMPTZ(3):=statement_timestamp();
+  loaded RECORD;
+  retained RECORD;
+  downstream_id TEXT:=target_factual_refresh->>'operationId';
+  downstream_state TEXT:=target_factual_refresh->>'state';
+  content JSONB;
+  oid TEXT;
+  limitation CONSTANT TEXT:='Private local non-production evidence orchestration only; human review, public release, production activation, and publication authority are not granted.';
+BEGIN
+  SELECT * INTO loaded FROM "load_outcome_current_valuation_evidence"(
+    target_scope_key,target_trigger,target_stable_operation_key
+  );
+  IF loaded.result_json IS NOT NULL THEN
+    SELECT * INTO retained
+      FROM "outcome_current_valuation_evidence_orchestration_operation"
+     WHERE "stable_operation_key"=target_stable_operation_key;
+    operation_id:=retained."operation_id";
+    operation_json:=retained."operation_json";
+    result_json:=retained."result_json";
+    RETURN NEXT;
+    RETURN;
+  END IF;
+  IF cardinality(loaded.retained_source_keys)<>7 THEN
+    RAISE EXCEPTION 'Current valuation evidence orchestration requires all seven source receipts';
+  END IF;
+  IF jsonb_typeof(target_factual_refresh)<>'object'
+     OR target_factual_refresh->>'scopeKey'<>target_scope_key
+     OR target_factual_refresh->>'trigger'<>target_trigger
+     OR target_factual_refresh->>'stableOperationKey'<>
+       'current-valuation-evidence-factual-handoff:'||encode(sha256(convert_to(
+         "outcome_afl_trade_canonical_json"(jsonb_build_object(
+           'scopeKey',target_scope_key,'trigger',target_trigger,
+           'stableOperationKey',target_stable_operation_key
+         )),'UTF8')),'hex')
+     OR coalesce((target_factual_refresh->>'publicationEligible')::boolean,true)
+     OR coalesce((target_factual_refresh->>'publicationProhibited')::boolean,false) IS NOT TRUE
+     OR downstream_state NOT IN ('no_change','factual_refresh_complete') THEN
+    RAISE EXCEPTION 'Current valuation factual handoff is malformed or grants publication';
+  END IF;
+  IF downstream_state='factual_refresh_complete' THEN
+    SELECT factual.* INTO retained
+      FROM "outcome_current_valuation_factual_refresh_operation" factual
+     WHERE factual."operation_id"=downstream_id
+       AND factual."scope_key"=target_scope_key
+       AND factual."trigger_kind"=target_trigger
+       AND factual."stable_operation_key"=target_factual_refresh->>'stableOperationKey'
+       AND factual."result_json"=target_factual_refresh;
+  ELSE
+    SELECT legacy.* INTO retained
+      FROM "outcome_current_valuation_refresh_operation" legacy
+     WHERE legacy."operation_id"=downstream_id
+       AND legacy."scope_key"=target_scope_key
+       AND legacy."trigger_kind"=target_trigger
+       AND legacy."stable_operation_key"=target_factual_refresh->>'stableOperationKey'
+       AND legacy."result_json"=target_factual_refresh;
+  END IF;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Current valuation factual handoff is not retained exactly';
+  END IF;
+  content:=jsonb_build_object(
+    'schemaVersion','afl-current-valuation-evidence-orchestration-operation/v1',
+    'scopeKey',target_scope_key,'trigger',target_trigger,
+    'stableOperationKey',target_stable_operation_key,'state','complete',
+    'stage','private_factual_authority','downstreamOperationId',downstream_id,
+    'capturedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+  );
+  oid:='current-valuation-evidence-orchestration-operation:'||
+    encode(sha256(convert_to("outcome_afl_trade_canonical_json"(content),'UTF8')),'hex');
+  operation_json:=jsonb_build_object('operationId',oid,'content',content);
+  result_json:=jsonb_build_object(
+    'schemaVersion','afl-current-valuation-evidence-orchestration-result-v1',
+    'operationId',oid,'scopeKey',target_scope_key,'trigger',target_trigger,
+    'stableOperationKey',target_stable_operation_key,'state','complete',
+    'stage','private_factual_authority','currentValuationRefresh',target_factual_refresh,
+    'capturedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'completedAt',to_char(trusted_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'executionLocation','local','visibility','private','environment','non_production',
+    'publicationEligible',false,'publicationProhibited',true,'limitation',limitation
+  );
+  INSERT INTO "outcome_current_valuation_evidence_orchestration_operation" VALUES (
+    oid,target_scope_key,target_trigger,target_stable_operation_key,
+    'complete','private_factual_authority',NULL,downstream_id,trusted_at,trusted_at,
+    operation_json,result_json
+  );
+  operation_id:=oid;
+  RETURN NEXT;
+END $$;
+
+ALTER TABLE "outcome_current_valuation_evidence_orchestration_operation"
+  OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER TABLE "outcome_current_valuation_evidence_orchestration_stage_receipt"
+  OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "reject_outcome_current_valuation_evidence_orchestration_mutation"()
+  OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "load_outcome_current_valuation_evidence"(TEXT,TEXT,TEXT)
+  OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "retain_outcome_current_valuation_evidence_source"(TEXT,TEXT,TEXT,TEXT,TEXT,TEXT)
+  OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "retain_outcome_current_valuation_evidence_unavailable"(TEXT,TEXT,TEXT,TEXT,TEXT)
+  OWNER TO afl_trade_current_valuation_refresh_owner;
+ALTER FUNCTION "retain_outcome_current_valuation_evidence_complete"(TEXT,TEXT,TEXT,JSONB)
+  OWNER TO afl_trade_current_valuation_refresh_owner;
+DO $paths$ BEGIN
+  EXECUTE format(
+    'ALTER FUNCTION %I.load_outcome_current_valuation_evidence(TEXT,TEXT,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema()
+  );
+  EXECUTE format(
+    'ALTER FUNCTION %I.retain_outcome_current_valuation_evidence_source(TEXT,TEXT,TEXT,TEXT,TEXT,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema()
+  );
+  EXECUTE format(
+    'ALTER FUNCTION %I.retain_outcome_current_valuation_evidence_unavailable(TEXT,TEXT,TEXT,TEXT,TEXT) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema()
+  );
+  EXECUTE format(
+    'ALTER FUNCTION %I.retain_outcome_current_valuation_evidence_complete(TEXT,TEXT,TEXT,JSONB) SECURITY DEFINER SET search_path TO %I,pg_catalog,pg_temp',
+    current_schema(),current_schema()
+  );
+END $paths$;
+REVOKE ALL ON "outcome_current_valuation_evidence_orchestration_operation",
+  "outcome_current_valuation_evidence_orchestration_stage_receipt"
+  FROM PUBLIC,afl_trade_private_evaluation_coordinator;
+REVOKE ALL ON FUNCTION "load_outcome_current_valuation_evidence"(TEXT,TEXT,TEXT),
+  "retain_outcome_current_valuation_evidence_source"(TEXT,TEXT,TEXT,TEXT,TEXT,TEXT),
+  "retain_outcome_current_valuation_evidence_unavailable"(TEXT,TEXT,TEXT,TEXT,TEXT),
+  "retain_outcome_current_valuation_evidence_complete"(TEXT,TEXT,TEXT,JSONB)
+  FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "load_outcome_current_valuation_evidence"(TEXT,TEXT,TEXT),
+  "retain_outcome_current_valuation_evidence_source"(TEXT,TEXT,TEXT,TEXT,TEXT,TEXT),
+  "retain_outcome_current_valuation_evidence_unavailable"(TEXT,TEXT,TEXT,TEXT,TEXT),
+  "retain_outcome_current_valuation_evidence_complete"(TEXT,TEXT,TEXT,JSONB)
+  TO afl_trade_private_evaluation_coordinator;
+GRANT SELECT ON "outcome_current_valuation_refresh_operation",
+  "outcome_current_valuation_factual_refresh_operation",
+  "outcome_current_valuation_evidence_orchestration_operation",
+  "outcome_current_valuation_evidence_orchestration_stage_receipt",
+  "outcome_source_capture","outcome_provider_normalization_run"
+  TO afl_trade_current_valuation_refresh_owner;
+GRANT INSERT ON "outcome_current_valuation_evidence_orchestration_operation",
+  "outcome_current_valuation_evidence_orchestration_stage_receipt"
+  TO afl_trade_current_valuation_refresh_owner;
+GRANT EXECUTE ON FUNCTION "outcome_afl_trade_canonical_json"(JSONB)
+  TO afl_trade_current_valuation_refresh_owner;
+DO $membership$ BEGIN
+  EXECUTE format('REVOKE afl_trade_current_valuation_refresh_owner FROM %I',current_user);
+END $membership$;

--- a/prisma/afl-trade-outcomes/schema.prisma
+++ b/prisma/afl-trade-outcomes/schema.prisma
@@ -5500,6 +5500,38 @@ model OutcomeCurrentValuationFactualRefreshOperation {
   @@map("outcome_current_valuation_factual_refresh_operation")
 }
 
+model OutcomeCurrentValuationEvidenceOrchestrationOperation {
+  operationId          String    @id @map("operation_id") @outcomes.Text
+  scopeKey             String    @map("scope_key") @outcomes.Text
+  triggerKind          String    @map("trigger_kind") @outcomes.Text
+  stableOperationKey   String    @unique @map("stable_operation_key") @outcomes.Text
+  state                String    @outcomes.Text
+  stage                String    @outcomes.Text
+  cause                String?   @outcomes.Text
+  downstreamOperationId String?  @map("downstream_operation_id") @outcomes.Text
+  capturedAt           DateTime  @map("captured_at") @outcomes.Timestamptz(3)
+  completedAt          DateTime  @map("completed_at") @outcomes.Timestamptz(3)
+  operationJson        Json      @map("operation_json")
+  resultJson           Json      @map("result_json")
+
+  @@map("outcome_current_valuation_evidence_orchestration_operation")
+}
+
+model OutcomeCurrentValuationEvidenceOrchestrationStageReceipt {
+  receiptId          String   @id @map("receipt_id") @outcomes.Text
+  scopeKey           String   @map("scope_key") @outcomes.Text
+  triggerKind        String   @map("trigger_kind") @outcomes.Text
+  stableOperationKey String   @map("stable_operation_key") @outcomes.Text
+  sourceKey          String   @map("source_key") @outcomes.Text
+  captureId          String   @map("capture_id") @outcomes.Text
+  normalizationRunId String   @map("normalization_run_id") @outcomes.Text
+  receiptJson        Json     @map("receipt_json")
+  retainedAt         DateTime @map("retained_at") @outcomes.Timestamptz(3)
+
+  @@unique([stableOperationKey, sourceKey])
+  @@map("outcome_current_valuation_evidence_orchestration_stage_receipt")
+}
+
 model OutcomePrivateValuationDispatchAttempt {
   claimId          String                                 @id @map("claim_id") @outcomes.Text
   requestId        String                                 @map("request_id") @outcomes.Text

--- a/src/server/aflTradeIntelligence/development/localCurrentValuationReconciliationAuthority.ts
+++ b/src/server/aflTradeIntelligence/development/localCurrentValuationReconciliationAuthority.ts
@@ -1,0 +1,115 @@
+import type { AflOutcomeSqlClient } from '../outcomes/postgresOutcomeReleaseRepository';
+import type { AflTradeCurrentValuationReconciliationAuthority } from '../valuation/currentValuationEvidenceOrchestration';
+import { LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256 } from './localFiveSeasonAflTablesReview';
+import { LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256 } from './localOfficialAfl2026Review';
+import { loadExactLocalReviewedProviderEvidenceBundle } from './localReviewedProviderEvidence';
+
+const REQUIRED_REVIEW_SETS = [
+  {
+    decisionId: `local-afl-tables-review:set:${LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256}`,
+    evidenceSetSha256: LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256,
+    reviewerId: 'local-five-season-evidence-reviewer',
+  },
+  {
+    decisionId: `local-official-afl-review:set:${LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256}`,
+    evidenceSetSha256: LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256,
+    reviewerId: 'local-workbook-evidence-reviewer',
+  },
+] as const;
+
+interface ReviewSetAuthorityRow extends Record<string, unknown> {
+  readonly decision_id: string;
+  readonly subject_type: string;
+  readonly subject_id: string;
+  readonly decision: string;
+  readonly canonical_record_type: string | null;
+  readonly canonical_record_id: string | null;
+  readonly supersedes_decision_id: string | null;
+  readonly evidence_json: unknown;
+  readonly decided_by: string;
+  readonly current: boolean;
+}
+
+export function createLocalAflTradeCurrentValuationReconciliationAuthority(
+  client: AflOutcomeSqlClient,
+  dependencies: {
+    readonly loadReviewedBundle?: typeof loadExactLocalReviewedProviderEvidenceBundle;
+  } = {}
+): AflTradeCurrentValuationReconciliationAuthority {
+  const loadReviewedBundle =
+    dependencies.loadReviewedBundle ?? loadExactLocalReviewedProviderEvidenceBundle;
+  return {
+    assessCurrent: () =>
+      client.transaction(async (transaction) => {
+        const reviewSets = await transaction.query<ReviewSetAuthorityRow>(
+          `SELECT decision.decision_id,decision.subject_type,decision.subject_id,
+                  decision.decision,decision.canonical_record_type,
+                  decision.canonical_record_id,decision.supersedes_decision_id,
+                  decision.evidence_json,decision.decided_by,
+                  NOT EXISTS (
+                    SELECT 1 FROM outcome_review_decision successor
+                     WHERE successor.supersedes_decision_id=decision.decision_id
+                  ) AS current
+             FROM outcome_review_decision decision
+            WHERE decision.decision_id=ANY($1::text[])`,
+          [REQUIRED_REVIEW_SETS.map(({ decisionId }) => decisionId)]
+        );
+        const rowsById = new Map(reviewSets.rows.map((row) => [row.decision_id, row]));
+        if (REQUIRED_REVIEW_SETS.some(({ decisionId }) => !rowsById.has(decisionId))) {
+          return {
+            state: 'unavailable',
+            stage: 'reconciliation_authority',
+            cause: 'missing',
+          } as const;
+        }
+        if (
+          reviewSets.rows.length !== REQUIRED_REVIEW_SETS.length ||
+          REQUIRED_REVIEW_SETS.some(({ decisionId }) => !rowsById.get(decisionId)?.current)
+        ) {
+          return {
+            state: 'unavailable',
+            stage: 'reconciliation_authority',
+            cause: REQUIRED_REVIEW_SETS.some(({ decisionId }) => !rowsById.get(decisionId)?.current)
+              ? 'stale'
+              : 'unauthenticated',
+          } as const;
+        }
+        const malformed = REQUIRED_REVIEW_SETS.some(
+          ({ decisionId, evidenceSetSha256, reviewerId }) => {
+            const row = rowsById.get(decisionId)!;
+            const evidence = row.evidence_json as Record<string, unknown> | null;
+            return (
+              row.subject_type !== 'local_review_set' ||
+              row.subject_id !== evidenceSetSha256 ||
+              row.decision !== 'approved' ||
+              row.canonical_record_type !== 'local_review_set' ||
+              row.canonical_record_id !== evidenceSetSha256 ||
+              row.supersedes_decision_id !== null ||
+              evidence?.evidenceSetSha256 !== evidenceSetSha256 ||
+              row.decided_by !== reviewerId
+            );
+          }
+        );
+        if (malformed) {
+          return {
+            state: 'unavailable',
+            stage: 'reconciliation_authority',
+            cause: 'unauthenticated',
+          } as const;
+        }
+        const trusted = await transaction.query<{ trusted_at: Date }>(
+          `SELECT transaction_timestamp()::timestamptz(3) AS trusted_at`
+        );
+        try {
+          await loadReviewedBundle(transaction, trusted.rows[0]!.trusted_at.toISOString());
+          return { state: 'ready' } as const;
+        } catch {
+          return {
+            state: 'unavailable',
+            stage: 'reconciliation',
+            cause: 'mismatched',
+          } as const;
+        }
+      }),
+  };
+}

--- a/src/server/aflTradeIntelligence/development/localEgressSigningAuthority.ts
+++ b/src/server/aflTradeIntelligence/development/localEgressSigningAuthority.ts
@@ -1,0 +1,117 @@
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+  type Stats,
+} from 'node:fs';
+import {
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  randomUUID,
+  type KeyObject,
+} from 'node:crypto';
+import { isAbsolute, resolve } from 'node:path';
+
+import { createAflTradeEd25519EgressExecutionVerifier } from '../source/fitzRoyHttpEgressExecutor';
+
+const SIGNING_KEY_ID = 'local-current-valuation-evidence-capture';
+const SIGNING_KEY_FILENAME = 'egress-signing-key.pem';
+
+function createKeyFile(keyPath: string): void {
+  const privateKeyPem = generateKeyPairSync('ed25519').privateKey.export({
+    type: 'pkcs8',
+    format: 'pem',
+  });
+  const temporaryPath = `${keyPath}.${process.pid}.${randomUUID()}.tmp`;
+  const descriptor = openSync(temporaryPath, 'wx', 0o600);
+  try {
+    writeFileSync(descriptor, privateKeyPem);
+  } finally {
+    closeSync(descriptor);
+  }
+  try {
+    linkSync(temporaryPath, keyPath);
+  } catch (error) {
+    if (!(error instanceof Error && 'code' in error && error.code === 'EEXIST')) throw error;
+  } finally {
+    unlinkSync(temporaryPath);
+  }
+}
+
+function assertPrivateKeyFile(pathStats: Stats): void {
+  if (!pathStats.isFile() || pathStats.nlink !== 1) {
+    throw new TypeError('The retained local egress signing key must be one regular file.');
+  }
+  if ((pathStats.mode & 0o777) !== 0o600) {
+    throw new TypeError('The retained local egress signing key must have mode 0600.');
+  }
+  if (typeof process.getuid === 'function' && pathStats.uid !== process.getuid()) {
+    throw new TypeError(
+      'The retained local egress signing key must be owned by this process user.'
+    );
+  }
+}
+
+function readPrivateKeyFile(keyPath: string): Buffer {
+  const pathStats = lstatSync(keyPath);
+  assertPrivateKeyFile(pathStats);
+  const descriptor = openSync(keyPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const openedStats = fstatSync(descriptor);
+    assertPrivateKeyFile(openedStats);
+    if (openedStats.dev !== pathStats.dev || openedStats.ino !== pathStats.ino) {
+      throw new TypeError('The retained local egress signing key changed while opening it.');
+    }
+    return readFileSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function loadPrivateKey(keyPath: string): KeyObject {
+  let keyBytes: Buffer;
+  try {
+    keyBytes = readPrivateKeyFile(keyPath);
+  } catch (error) {
+    if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) throw error;
+    createKeyFile(keyPath);
+    keyBytes = readPrivateKeyFile(keyPath);
+  }
+  const privateKey = createPrivateKey(keyBytes);
+  if (privateKey.type !== 'private' || privateKey.asymmetricKeyType !== 'ed25519') {
+    throw new TypeError('The retained local egress signing key is not an Ed25519 private key.');
+  }
+  return privateKey;
+}
+
+export function createLocalAflTradeEgressSigningAuthority(input: {
+  readonly artifactRoot: string;
+}) {
+  if (!isAbsolute(input.artifactRoot)) {
+    throw new TypeError('The local egress signing authority requires an absolute artifact root.');
+  }
+  const directory = resolve(input.artifactRoot, 'current-valuation-evidence');
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const directoryStats = lstatSync(directory);
+  if (!directoryStats.isDirectory() || (directoryStats.mode & 0o077) !== 0) {
+    throw new TypeError('The local egress signing directory must be a private regular directory.');
+  }
+  const privateKey = loadPrivateKey(resolve(directory, SIGNING_KEY_FILENAME));
+  const publicKeyPem = createPublicKey(privateKey)
+    .export({ type: 'spki', format: 'pem' })
+    .toString();
+  return {
+    signingKey: { keyId: SIGNING_KEY_ID, privateKey },
+    verifier: createAflTradeEd25519EgressExecutionVerifier({
+      [SIGNING_KEY_ID]: publicKeyPem,
+    }),
+  };
+}

--- a/src/server/aflTradeIntelligence/development/localPrivateValuationRuntime.ts
+++ b/src/server/aflTradeIntelligence/development/localPrivateValuationRuntime.ts
@@ -1,17 +1,48 @@
+import { resolve } from 'node:path';
+
 import type { Pool } from 'pg';
 
+import { createPostgresAflTradeGateDecisionLedgerRepository } from '../governance/postgresGateDecisionLedgerRepository';
 import { createPgAflOutcomeSqlClient } from '../outcomes/pgOutcomeSqlClient';
+import { stageAflTradeFitzRoySourceSnapshot } from '../source/fitzRoyCaptureToStaging';
+import { ingestAuthorizedAflTradeFitzRoyProviderSeason } from '../source/fitzRoyProviderIngestion';
+import { PostgresAflTradeProviderObservationRepository } from '../source/postgresProviderObservationRepository';
+import { PostgresAflTradeSourceCaptureRepository } from '../source/postgresSourceCaptureRepository';
 import { AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID } from '../valuation/automatedPrivateEvaluationPolicy';
+import { createAflTradeCurrentValuationEvidenceCoordinator } from '../valuation/currentValuationEvidenceOrchestration';
+import { createAflTradeCurrentValuationRefresh } from '../valuation/currentValuationRefresh';
 import { createPostgresAflTradePrivateEvaluationCohortRunner } from '../valuation/postgresCurrentValuationCohortRunner';
 import { createPostgresGovernedPrivateEvaluationWorkspace } from '../valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace';
 import { PostgresGovernedPrivateEvaluationBatchRepository } from '../valuation/internal/postgresGovernedPrivateEvaluationBatchRepository';
 import {
+  PostgresAflTradeCurrentValuationEvidenceOrchestrationRepository,
+  createPostgresAflTradeCurrentValuationEvidenceSourceRuntime,
+} from '../valuation/postgresCurrentValuationEvidenceOrchestration';
+import {
   PostgresAflTradePrivateValuationScheduleRepository,
   createPostgresAflTradePrivateValuationDispatcher,
 } from '../valuation/postgresPrivateValuationScheduling';
-import { createLocalAflTradePrivateDerivedArtifactRepository } from './localFileConditionalObjectStore';
+import {
+  AflTradePrivateReviewedEvidenceEvaluationPersistenceError,
+  PostgresAflTradePrivateReviewedEvidenceEvaluationAuthority,
+} from '../valuation/postgresPrivateReviewedEvidenceEvaluationAuthority';
+import { createLocalAflTradeCurrentValuationReconciliationAuthority } from './localCurrentValuationReconciliationAuthority';
+import { createLocalAflTradeDockerFitzRoyCaptureExecutor } from './localDockerFitzRoyCaptureExecutor';
+import { createLocalAflTradeDockerFitzRoyDecodeExecutor } from './localDockerFitzRoyDecodeExecutor';
+import { createLocalAflTradeEgressSigningAuthority } from './localEgressSigningAuthority';
+import {
+  createLocalAflTradeNonProductionArtifactRepository,
+  createLocalAflTradePrivateDerivedArtifactRepository,
+} from './localFileConditionalObjectStore';
+import { LOCAL_AFL_TRADE_FITZROY_RUNTIME } from './localFiveSeasonAflTablesStaging';
 
 const MAXIMUM_ARTIFACT_BYTES = 4 * 1024 * 1024;
+const MAXIMUM_SOURCE_BYTES = 128 * 1024 * 1024;
+const MAXIMUM_METADATA_BYTES = 16 * 1024 * 1024;
+
+function now(): string {
+  return new Date().toISOString();
+}
 
 export function createLocalAflTradePrivateValuationRuntime(input: {
   readonly pool: Pool;
@@ -19,6 +50,173 @@ export function createLocalAflTradePrivateValuationRuntime(input: {
   readonly workerId?: string;
 }) {
   const client = createPgAflOutcomeSqlClient(input.pool);
+  const sourceCaptureRepository = new PostgresAflTradeSourceCaptureRepository(client);
+  const providerObservationRepository = new PostgresAflTradeProviderObservationRepository(client);
+  const rawArtifactRepository = createLocalAflTradeNonProductionArtifactRepository({
+    rootDirectory: resolve(input.artifactRoot, 'current-valuation-evidence'),
+    repositoryId: 'current-valuation-evidence-raw',
+    artifactClass: 'raw_source',
+    maximumObjectBytes: MAXIMUM_SOURCE_BYTES,
+  });
+  const metadataArtifactRepository = createLocalAflTradeNonProductionArtifactRepository({
+    rootDirectory: resolve(input.artifactRoot, 'current-valuation-evidence'),
+    repositoryId: 'current-valuation-evidence-metadata',
+    artifactClass: 'capture_metadata',
+    maximumObjectBytes: MAXIMUM_METADATA_BYTES,
+  });
+  const gateRepository = createPostgresAflTradeGateDecisionLedgerRepository(client);
+  const egressSigningAuthority = createLocalAflTradeEgressSigningAuthority({
+    artifactRoot: input.artifactRoot,
+  });
+  const egressExecutionVerifier = egressSigningAuthority.verifier;
+  const decoderExecutor = createLocalAflTradeDockerFitzRoyDecodeExecutor({
+    imageReference: LOCAL_AFL_TRADE_FITZROY_RUNTIME.imageDigest,
+  });
+  const ensureReferenceData = async () => {
+    await client.query(
+      `INSERT INTO outcome_competition_season (competition,season_year)
+       SELECT 'AFLM',season_year FROM unnest($1::smallint[]) seasons(season_year)
+       ON CONFLICT DO NOTHING`,
+      [[2021, 2022, 2023, 2024, 2025, 2026]]
+    );
+    await client.query(
+      `INSERT INTO outcome_metric_definition
+        (metric_code,definition_version,display_name,value_type,canonical_unit,
+         non_negative,definition_json,status)
+       VALUES
+        ('goals','goals/v1','Goals','numeric','goals',true,'{}'::jsonb,'approved'),
+        ('games','games/v1','Games','numeric','games',true,'{}'::jsonb,'approved')
+       ON CONFLICT DO NOTHING`
+    );
+  };
+  const stagingDependencies = {
+    rawArtifactRepository,
+    sourceCaptureRepository,
+    providerObservationRepository,
+    decoderExecutor,
+    clock: { now },
+    dependencyLockSha256: LOCAL_AFL_TRADE_FITZROY_RUNTIME.dependencyLockSha256,
+    imageDigest: LOCAL_AFL_TRADE_FITZROY_RUNTIME.imageDigest,
+    timeoutMs: 180_000,
+    maximumSourceBytes: MAXIMUM_SOURCE_BYTES,
+    maximumRows: 20_000,
+    maximumFields: 120,
+    maximumCells: 2_000_000,
+    maximumCellBytes: 8_192,
+    maximumOutputBytes: 256 * 1024 * 1024,
+    egressExecutionVerifier,
+  } as const;
+  const evidenceSource = createPostgresAflTradeCurrentValuationEvidenceSourceRuntime({
+    client,
+    gateRepository,
+    clock: { now },
+    captureAndNormalize: async ({ source, authority }) => {
+      await ensureReferenceData();
+      const rate = authority.capture.sourceRights.content.automatedAccess.rateLimit;
+      const egressPolicyEvidenceId = authority.capture.sourceRights.content.conditions.find(
+        ({ conditionId }) => conditionId === 'provider-egress-control'
+      )?.verificationEvidenceIds[0];
+      if (rate === null || egressPolicyEvidenceId === undefined) {
+        throw new TypeError('Current valuation capture lacks exact egress authority.');
+      }
+      const ingestion = await ingestAuthorizedAflTradeFitzRoyProviderSeason(
+        {
+          capture: authority.capture,
+          fieldMapId: authority.fieldMap.mapId,
+          fieldMap: authority.fieldMap,
+          effectiveAt: now(),
+        },
+        {
+          capture: {
+            rawArtifactRepository,
+            metadataArtifactRepository,
+            executor: createLocalAflTradeDockerFitzRoyCaptureExecutor({
+              imageReference: LOCAL_AFL_TRADE_FITZROY_RUNTIME.imageDigest,
+              runtimeIdentity: LOCAL_AFL_TRADE_FITZROY_RUNTIME,
+              admittedPolicy: {
+                upstreamRate: rate,
+                cacheSeconds: authority.capture.gateRequest.cacheSeconds ?? 0,
+                egressPolicyEvidenceId,
+              },
+              signingKey: egressSigningAuthority.signingKey,
+            }),
+            egressExecutionVerifier,
+            authorizationResolver: gateRepository,
+            clock: { now },
+            runtimeIdentity: LOCAL_AFL_TRADE_FITZROY_RUNTIME,
+            timeoutMs: 180_000,
+            maximumSourceBytes: MAXIMUM_SOURCE_BYTES,
+            maximumDiagnosticsBytes: 4 * 1024 * 1024,
+          },
+          staging: stagingDependencies,
+          clock: { now },
+        }
+      );
+      return {
+        state: 'ready',
+        sourceKey: source.sourceKey,
+        captureId: ingestion.staging.capture.captureId,
+        normalizationRunId: ingestion.staging.normalization.normalizationRunId,
+      };
+    },
+    resumeNormalization: async ({ source, authority, snapshot }) => {
+      await ensureReferenceData();
+      const staging = await stageAflTradeFitzRoySourceSnapshot(
+        {
+          snapshot,
+          fieldMapId: authority.fieldMap.mapId,
+          fieldMap: authority.fieldMap,
+        },
+        stagingDependencies
+      );
+      return {
+        state: 'ready',
+        sourceKey: source.sourceKey,
+        captureId: staging.capture.captureId,
+        normalizationRunId: staging.normalization.normalizationRunId,
+      };
+    },
+  });
+  const reviewedAuthority = new PostgresAflTradePrivateReviewedEvidenceEvaluationAuthority(client);
+  const evidence = createAflTradeCurrentValuationEvidenceCoordinator({
+    repository: new PostgresAflTradeCurrentValuationEvidenceOrchestrationRepository(client),
+    source: evidenceSource,
+    reconciliationAuthority: createLocalAflTradeCurrentValuationReconciliationAuthority(client),
+    reviewedAuthority: {
+      assessCurrent: async ({ valuationScopeKey }) => {
+        try {
+          const assessment = await reviewedAuthority.assessCurrent({ valuationScopeKey });
+          if (assessment.state === 'authorized') return { state: 'ready' as const };
+          return assessment.state === 'withdrawn'
+            ? {
+                state: 'unavailable' as const,
+                stage: 'reviewed_authority' as const,
+                cause: 'unauthenticated' as const,
+              }
+            : {
+                state: 'unavailable' as const,
+                stage: 'reviewed_authority' as const,
+                cause: 'review_required' as const,
+              };
+        } catch (error) {
+          const cause =
+            error instanceof AflTradePrivateReviewedEvidenceEvaluationPersistenceError
+              ? error.code === 'EVIDENCE_MISMATCH'
+                ? ('stale' as const)
+                : error.code === 'IMMUTABLE_CONFLICT'
+                  ? ('unauthenticated' as const)
+                  : ('mismatched' as const)
+              : ('mismatched' as const);
+          return {
+            state: 'unavailable' as const,
+            stage: 'reviewed_authority' as const,
+            cause,
+          };
+        }
+      },
+    },
+    factualRefresh: createAflTradeCurrentValuationRefresh({ client }),
+  });
   const artifacts = createLocalAflTradePrivateDerivedArtifactRepository({
     rootDirectory: input.artifactRoot,
     repositoryId: 'governed-private-evaluation',
@@ -43,9 +241,15 @@ export function createLocalAflTradePrivateValuationRuntime(input: {
   return createPostgresAflTradePrivateValuationDispatcher({
     repository: new PostgresAflTradePrivateValuationScheduleRepository(client),
     runner: {
-      // Keep the established prepared-v3 path until factual admission can consume accepted capture
-      // custody. Running capture here and then runCurrent would calculate the old prepared head.
-      run: ({ request }) => runner.runCurrent(request.scopeKey),
+      run: async ({ request }) => {
+        const result = await evidence.refreshCurrent({
+          scopeKey: request.scopeKey,
+          trigger: request.trigger,
+          stableOperationKey: request.authorityKey,
+        });
+        if (result.state === 'unavailable') return { state: 'exhausted' as const };
+        return runner.runCurrent(request.scopeKey);
+      },
       repairCurrent: (scopeKey, reason, repairOperationId) =>
         runner.repairCurrent(scopeKey, reason, repairOperationId),
     },

--- a/src/server/aflTradeIntelligence/development/localPrivateValuationRuntime.ts
+++ b/src/server/aflTradeIntelligence/development/localPrivateValuationRuntime.ts
@@ -11,6 +11,7 @@ import { PostgresAflTradeSourceCaptureRepository } from '../source/postgresSourc
 import { AUTOMATED_PRIVATE_EVALUATION_PRINCIPAL_ID } from '../valuation/automatedPrivateEvaluationPolicy';
 import { createAflTradeCurrentValuationEvidenceCoordinator } from '../valuation/currentValuationEvidenceOrchestration';
 import { createAflTradeCurrentValuationRefresh } from '../valuation/currentValuationRefresh';
+import { createAflTradePrivateValuationDispatchEvidenceKey } from '../valuation/privateValuationScheduling';
 import { createPostgresAflTradePrivateEvaluationCohortRunner } from '../valuation/postgresCurrentValuationCohortRunner';
 import { createPostgresGovernedPrivateEvaluationWorkspace } from '../valuation/internal/createPostgresGovernedPrivateEvaluationWorkspace';
 import { PostgresGovernedPrivateEvaluationBatchRepository } from '../valuation/internal/postgresGovernedPrivateEvaluationBatchRepository';
@@ -245,7 +246,7 @@ export function createLocalAflTradePrivateValuationRuntime(input: {
         const result = await evidence.refreshCurrent({
           scopeKey: request.scopeKey,
           trigger: request.trigger,
-          stableOperationKey: request.authorityKey,
+          stableOperationKey: createAflTradePrivateValuationDispatchEvidenceKey(request),
         });
         if (result.state === 'unavailable') return { state: 'exhausted' as const };
         return runner.runCurrent(request.scopeKey);

--- a/src/server/aflTradeIntelligence/source/fitzRoyCaptureToStaging.ts
+++ b/src/server/aflTradeIntelligence/source/fitzRoyCaptureToStaging.ts
@@ -26,7 +26,8 @@ import type {
 
 export class AflTradeFitzRoyStagingError extends Error {
   constructor(
-    readonly code: 'INVALID_REQUEST' | 'CUSTODY_UNAVAILABLE' | 'STAGING_FAILED',
+    readonly code:
+      'INVALID_REQUEST' | 'AUTHORITY_INVALID' | 'CUSTODY_UNAVAILABLE' | 'STAGING_FAILED',
     message: string,
     options?: ErrorOptions
   ) {
@@ -127,7 +128,7 @@ export async function stageAflTradeFitzRoySourceSnapshot(
       captureReceipt.content.egressExecutionReceipt === null
     ) {
       throw new AflTradeFitzRoyStagingError(
-        'INVALID_REQUEST',
+        'AUTHORITY_INVALID',
         'Non-fixture staging requires the trusted provider-egress verifier.'
       );
     }
@@ -138,7 +139,7 @@ export async function stageAflTradeFitzRoySourceSnapshot(
       );
     } catch (cause) {
       throw new AflTradeFitzRoyStagingError(
-        'INVALID_REQUEST',
+        'AUTHORITY_INVALID',
         'Provider-egress execution evidence failed signature authentication.',
         { cause }
       );

--- a/src/server/aflTradeIntelligence/valuation/currentValuationEvidenceOrchestration.ts
+++ b/src/server/aflTradeIntelligence/valuation/currentValuationEvidenceOrchestration.ts
@@ -1,0 +1,263 @@
+import { z } from 'zod';
+
+import {
+  aflTradeContentAddressedIdSchema,
+  createAflTradeContentAddress,
+} from '../artifacts/contentAddress';
+import {
+  aflTradeCurrentValuationRefreshRequestSchema,
+  aflTradeCurrentValuationRefreshResultSchema,
+  type AflTradeCurrentValuationRefreshRequest,
+  type AflTradeCurrentValuationRefreshResult,
+} from './currentValuationRefresh';
+
+export const AFL_TRADE_CURRENT_VALUATION_EVIDENCE_ORCHESTRATION_RESULT_SCHEMA_VERSION =
+  'afl-current-valuation-evidence-orchestration-result-v1' as const;
+export const AFL_TRADE_CURRENT_VALUATION_EVIDENCE_ORCHESTRATION_LIMITATION =
+  'Private local non-production evidence orchestration only; human review, public release, production activation, and publication authority are not granted.' as const;
+
+const instantSchema = z.iso.datetime({ offset: true });
+const resultBaseShape = {
+  schemaVersion: z.literal(
+    AFL_TRADE_CURRENT_VALUATION_EVIDENCE_ORCHESTRATION_RESULT_SCHEMA_VERSION
+  ),
+  operationId: aflTradeContentAddressedIdSchema(
+    'current-valuation-evidence-orchestration-operation'
+  ),
+  scopeKey: aflTradeCurrentValuationRefreshRequestSchema.shape.scopeKey,
+  trigger: aflTradeCurrentValuationRefreshRequestSchema.shape.trigger,
+  stableOperationKey: aflTradeCurrentValuationRefreshRequestSchema.shape.stableOperationKey,
+  capturedAt: instantSchema,
+  completedAt: instantSchema,
+  executionLocation: z.literal('local'),
+  visibility: z.literal('private'),
+  environment: z.literal('non_production'),
+  publicationEligible: z.literal(false),
+  publicationProhibited: z.literal(true),
+  limitation: z.literal(AFL_TRADE_CURRENT_VALUATION_EVIDENCE_ORCHESTRATION_LIMITATION),
+} as const;
+
+export const aflTradeCurrentValuationEvidenceOrchestrationResultSchema = z
+  .discriminatedUnion('state', [
+    z
+      .object({
+        ...resultBaseShape,
+        state: z.literal('unavailable'),
+        stage: z.enum([
+          'capture_authority',
+          'capture',
+          'normalization_authority',
+          'normalization',
+          'reconciliation_authority',
+          'reconciliation',
+          'reviewed_authority',
+        ]),
+        cause: z.enum(['missing', 'stale', 'mismatched', 'unauthenticated', 'review_required']),
+      })
+      .strict(),
+    z
+      .object({
+        ...resultBaseShape,
+        state: z.literal('complete'),
+        stage: z.literal('private_factual_authority'),
+        cause: z.undefined().optional(),
+        currentValuationRefresh: aflTradeCurrentValuationRefreshResultSchema,
+      })
+      .strict(),
+  ])
+  .superRefine((result, context) => {
+    if (
+      result.state === 'unavailable' &&
+      result.cause === 'review_required' &&
+      result.stage !== 'reviewed_authority'
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['cause'],
+        message: 'Human review is required only at the reviewed-authority boundary.',
+      });
+    }
+    if (Date.parse(result.completedAt) < Date.parse(result.capturedAt)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['completedAt'],
+        message: 'Evidence orchestration cannot complete before its authority capture.',
+      });
+    }
+  });
+
+export type AflTradeCurrentValuationEvidenceOrchestrationResult = z.infer<
+  typeof aflTradeCurrentValuationEvidenceOrchestrationResultSchema
+>;
+
+export const AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES = [
+  ...[2021, 2022, 2023, 2024, 2025].map((seasonYear) => ({
+    sourceKey: `afl_tables:afl-tables-player-stats:${seasonYear}`,
+    provider: 'afl_tables' as const,
+    capabilityId: 'afl-tables-player-stats' as const,
+    seasonYear,
+  })),
+  {
+    sourceKey: 'official_afl:official-afl-player-stats:2026',
+    provider: 'official_afl' as const,
+    capabilityId: 'official-afl-player-stats' as const,
+    seasonYear: 2026,
+  },
+  {
+    sourceKey: 'afl_tables:afl-tables-results:2026',
+    provider: 'afl_tables' as const,
+    capabilityId: 'afl-tables-results' as const,
+    seasonYear: 2026,
+  },
+] as const;
+
+export type AflTradeCurrentValuationEvidenceSource =
+  (typeof AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES)[number];
+
+export function createAflTradeCurrentValuationEvidenceFactualHandoffKey(
+  request: AflTradeCurrentValuationRefreshRequest
+): string {
+  return createAflTradeContentAddress('current-valuation-evidence-factual-handoff', {
+    scopeKey: request.scopeKey,
+    trigger: request.trigger,
+    stableOperationKey: request.stableOperationKey,
+  });
+}
+
+export type AflTradeCurrentValuationEvidenceUnavailable = Readonly<{
+  stage:
+    | 'capture_authority'
+    | 'capture'
+    | 'normalization_authority'
+    | 'normalization'
+    | 'reconciliation_authority'
+    | 'reconciliation'
+    | 'reviewed_authority';
+  cause: 'missing' | 'stale' | 'mismatched' | 'unauthenticated' | 'review_required';
+}>;
+
+export type AflTradeCurrentValuationNormalizedSource = Readonly<{
+  state: 'ready';
+  sourceKey: string;
+  captureId: string;
+  normalizationRunId: string;
+}>;
+
+export interface AflTradeCurrentValuationEvidenceOrchestrationRepository {
+  loadOperation(request: AflTradeCurrentValuationRefreshRequest): Promise<{
+    readonly terminalResult: AflTradeCurrentValuationEvidenceOrchestrationResult | null;
+    readonly retainedSourceKeys: readonly string[];
+  }>;
+  retainNormalizedSource(
+    input: AflTradeCurrentValuationNormalizedSource & {
+      readonly request: AflTradeCurrentValuationRefreshRequest;
+    }
+  ): Promise<void>;
+  retainUnavailable(
+    request: AflTradeCurrentValuationRefreshRequest,
+    unavailable: AflTradeCurrentValuationEvidenceUnavailable
+  ): Promise<AflTradeCurrentValuationEvidenceOrchestrationResult>;
+  retainComplete(
+    request: AflTradeCurrentValuationRefreshRequest,
+    factualRefresh: AflTradeCurrentValuationRefreshResult
+  ): Promise<AflTradeCurrentValuationEvidenceOrchestrationResult>;
+}
+
+export interface AflTradeCurrentValuationEvidenceSourceRuntime {
+  ensureCurrent(
+    source: AflTradeCurrentValuationEvidenceSource
+  ): Promise<
+    | AflTradeCurrentValuationNormalizedSource
+    | ({ readonly state: 'unavailable' } & AflTradeCurrentValuationEvidenceUnavailable)
+  >;
+}
+
+export interface AflTradeCurrentValuationReviewedAuthority {
+  assessCurrent(input: {
+    readonly valuationScopeKey: string;
+  }): Promise<
+    | { readonly state: 'ready' }
+    | ({ readonly state: 'unavailable' } & AflTradeCurrentValuationEvidenceUnavailable)
+  >;
+}
+
+export interface AflTradeCurrentValuationReconciliationAuthority {
+  assessCurrent(): Promise<
+    | { readonly state: 'ready' }
+    | ({ readonly state: 'unavailable' } & AflTradeCurrentValuationEvidenceUnavailable)
+  >;
+}
+
+export interface AflTradeCurrentValuationEvidenceOrchestration {
+  refreshCurrent(
+    request: AflTradeCurrentValuationRefreshRequest
+  ): Promise<AflTradeCurrentValuationEvidenceOrchestrationResult>;
+}
+
+export function createAflTradeCurrentValuationEvidenceCoordinator(dependencies: {
+  readonly repository: AflTradeCurrentValuationEvidenceOrchestrationRepository;
+  readonly source: AflTradeCurrentValuationEvidenceSourceRuntime;
+  readonly reconciliationAuthority: AflTradeCurrentValuationReconciliationAuthority;
+  readonly reviewedAuthority: AflTradeCurrentValuationReviewedAuthority;
+  readonly factualRefresh: {
+    refreshCurrent(
+      request: AflTradeCurrentValuationRefreshRequest
+    ): Promise<AflTradeCurrentValuationRefreshResult>;
+  };
+}): AflTradeCurrentValuationEvidenceOrchestration {
+  return {
+    async refreshCurrent(unparsedRequest) {
+      const request = aflTradeCurrentValuationRefreshRequestSchema.parse(unparsedRequest);
+      const retained = await dependencies.repository.loadOperation(request);
+      if (retained.terminalResult !== null) return retained.terminalResult;
+      const retainedSourceKeys = new Set(retained.retainedSourceKeys);
+      for (const source of AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES) {
+        if (retainedSourceKeys.has(source.sourceKey)) continue;
+        const result = await dependencies.source.ensureCurrent(source);
+        if (result.state === 'unavailable') {
+          return dependencies.repository.retainUnavailable(request, {
+            stage: result.stage,
+            cause: result.cause,
+          });
+        }
+        if (result.sourceKey !== source.sourceKey) {
+          throw new TypeError('Normalized source custody belongs to another evidence lane.');
+        }
+        await dependencies.repository.retainNormalizedSource({ ...result, request });
+      }
+      const reconciliation = await dependencies.reconciliationAuthority.assessCurrent();
+      if (reconciliation.state === 'unavailable') {
+        return dependencies.repository.retainUnavailable(request, {
+          stage: reconciliation.stage,
+          cause: reconciliation.cause,
+        });
+      }
+      const reviewed = await dependencies.reviewedAuthority.assessCurrent({
+        valuationScopeKey: request.scopeKey,
+      });
+      if (reviewed.state === 'unavailable') {
+        return dependencies.repository.retainUnavailable(request, {
+          stage: reviewed.stage,
+          cause: reviewed.cause,
+        });
+      }
+      const factualRefresh = await dependencies.factualRefresh.refreshCurrent({
+        ...request,
+        stableOperationKey: createAflTradeCurrentValuationEvidenceFactualHandoffKey(request),
+      });
+      if (factualRefresh.state === 'unavailable') {
+        const cause = {
+          source_authority_missing: 'missing',
+          source_authority_stale: 'stale',
+          source_authority_mismatched: 'mismatched',
+          source_authority_unauthenticated: 'unauthenticated',
+        }[factualRefresh.cause] as 'missing' | 'stale' | 'mismatched' | 'unauthenticated';
+        return dependencies.repository.retainUnavailable(request, {
+          stage: 'reviewed_authority',
+          cause,
+        });
+      }
+      return dependencies.repository.retainComplete(request, factualRefresh);
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/postgresCurrentValuationEvidenceOrchestration.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresCurrentValuationEvidenceOrchestration.ts
@@ -1,0 +1,421 @@
+import { canonicalizeAflTradeJson } from '../artifacts/contentAddress';
+import { aflTradeSourceSnapshotManifestSchema } from '../artifacts/sourceSnapshotManifest';
+import {
+  createLocalAflTradeAflTablesResultsAuthority,
+  createLocalAflTradeFiveSeasonAflTablesAuthority,
+} from '../development/localFiveSeasonAflTablesAuthority';
+import { createLocalAflTradeOfficialAfl2026Authority } from '../development/localOfficialAfl2026Authority';
+import type { AflTradeGateDecisionLedgerRepository } from '../governance/postgresGateDecisionLedgerRepository';
+import type { AflOutcomeSqlClient } from '../outcomes/postgresOutcomeReleaseRepository';
+import { AflTradeFitzRoyCaptureError } from '../source/fitzRoyCaptureRuntime';
+import { AflTradeFitzRoyStagingError } from '../source/fitzRoyCaptureToStaging';
+import { requireCurrentAflTradeFitzRoyCaptureAuthority } from '../source/fitzRoyProviderIngestion';
+import { AflTradeFitzRoyDecodeError } from '../source/fitzRoyObservationDecodeRuntime';
+import { createAflTradeFitzRoyFieldMapSha256 } from '../source/fitzRoyObservationContracts';
+import {
+  AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES,
+  aflTradeCurrentValuationEvidenceOrchestrationResultSchema,
+  type AflTradeCurrentValuationEvidenceOrchestrationRepository,
+  type AflTradeCurrentValuationEvidenceOrchestrationResult,
+  type AflTradeCurrentValuationEvidenceSource,
+  type AflTradeCurrentValuationEvidenceSourceRuntime,
+  type AflTradeCurrentValuationNormalizedSource,
+} from './currentValuationEvidenceOrchestration';
+import type {
+  AflTradeCurrentValuationRefreshRequest,
+  AflTradeCurrentValuationRefreshResult,
+} from './currentValuationRefresh';
+
+const EXECUTION_DATABASE_ROLE = 'afl_trade_private_evaluation_coordinator';
+
+interface LoadedOperationRow {
+  readonly result_json: unknown | null;
+  readonly retained_source_keys: string[];
+}
+
+interface RetainedOperationRow {
+  readonly operation_id: string;
+  readonly operation_json: unknown;
+  readonly result_json: unknown;
+}
+
+type SourceAuthority = ReturnType<typeof createLocalAflTradeFiveSeasonAflTablesAuthority>;
+
+interface FieldMapAuthorityRow extends Record<string, unknown> {
+  readonly map_json: unknown;
+  readonly field_map_sha256: string;
+  readonly approval_decision_id: string;
+  readonly subject_type: string | null;
+  readonly subject_id: string | null;
+  readonly decision: string;
+  readonly evidence_json: unknown;
+  readonly current: boolean;
+}
+
+interface CurrentSourceRow extends Record<string, unknown> {
+  readonly capture_id: string;
+  readonly source_snapshot_id: string;
+  readonly manifest_json: unknown;
+  readonly normalization_run_id: string | null;
+}
+
+interface CurrentSourceWorkInput {
+  readonly source: AflTradeCurrentValuationEvidenceSource;
+  readonly authority: SourceAuthority;
+}
+
+interface ResumeSourceWorkInput extends CurrentSourceWorkInput {
+  readonly snapshot: ReturnType<typeof aflTradeSourceSnapshotManifestSchema.parse>;
+}
+
+function sourceAuthority(source: AflTradeCurrentValuationEvidenceSource): SourceAuthority {
+  if (source.capabilityId === 'official-afl-player-stats') {
+    return createLocalAflTradeOfficialAfl2026Authority();
+  }
+  if (source.capabilityId === 'afl-tables-results') {
+    return createLocalAflTradeAflTablesResultsAuthority(source.seasonYear);
+  }
+  return createLocalAflTradeFiveSeasonAflTablesAuthority(source.seasonYear);
+}
+
+function unavailable(
+  stage: 'capture_authority' | 'capture' | 'normalization_authority' | 'normalization',
+  cause: 'missing' | 'stale' | 'mismatched' | 'unauthenticated'
+) {
+  return { state: 'unavailable' as const, stage, cause };
+}
+
+function sourceFailure(
+  error: unknown,
+  defaultStage: 'capture' | 'normalization'
+): ReturnType<typeof unavailable> {
+  if (error instanceof AflTradeFitzRoyStagingError) {
+    if (error.code === 'AUTHORITY_INVALID') {
+      return unavailable('normalization_authority', 'unauthenticated');
+    }
+    if (error.code === 'INVALID_REQUEST') {
+      return unavailable('normalization', 'unauthenticated');
+    }
+    if (error.code === 'STAGING_FAILED' && error.cause !== undefined) {
+      return sourceFailure(error.cause, 'normalization');
+    }
+    return unavailable('normalization', 'missing');
+  }
+  if (error instanceof AflTradeFitzRoyDecodeError) {
+    if (error.code === 'CUSTODY_MISMATCH') {
+      return unavailable('normalization', 'unauthenticated');
+    }
+    if (error.code === 'INVALID_REQUEST' || error.code === 'OUTPUT_INVALID') {
+      return unavailable('normalization', 'mismatched');
+    }
+    return unavailable('normalization', 'missing');
+  }
+  if (error instanceof AflTradeFitzRoyCaptureError) {
+    if (
+      error.code === 'RUNTIME_IDENTITY_MISMATCH' ||
+      error.code === 'PRODUCTION_EXECUTION_DISABLED'
+    ) {
+      return unavailable('capture', 'unauthenticated');
+    }
+    if (
+      error.code === 'INVALID_REQUEST' ||
+      error.code === 'OUTPUT_INVALID' ||
+      error.code === 'SCHEMA_DRIFT'
+    ) {
+      return unavailable('capture', 'mismatched');
+    }
+    if (error.code === 'AUTHORIZATION_BLOCKED') {
+      return unavailable('capture_authority', 'stale');
+    }
+  }
+  return unavailable(defaultStage, 'missing');
+}
+
+function exactJson(left: unknown, right: unknown): boolean {
+  try {
+    return canonicalizeAflTradeJson(left) === canonicalizeAflTradeJson(right);
+  } catch {
+    return false;
+  }
+}
+
+function parseRetainedResult(
+  request: AflTradeCurrentValuationRefreshRequest,
+  row: RetainedOperationRow | undefined,
+  rowCount: number
+): AflTradeCurrentValuationEvidenceOrchestrationResult {
+  if (row === undefined || rowCount !== 1) {
+    throw new TypeError(
+      'Current valuation evidence orchestration did not retain exactly one result.'
+    );
+  }
+  const result = aflTradeCurrentValuationEvidenceOrchestrationResultSchema.parse(row.result_json);
+  if (result.operationId !== row.operation_id) {
+    throw new TypeError('Evidence orchestration result disagrees with retained operation custody.');
+  }
+  if (
+    result.scopeKey !== request.scopeKey ||
+    result.trigger !== request.trigger ||
+    result.stableOperationKey !== request.stableOperationKey
+  ) {
+    throw new TypeError('Evidence orchestration result conflicts with the requested operation.');
+  }
+  return result;
+}
+
+export class PostgresAflTradeCurrentValuationEvidenceOrchestrationRepository implements AflTradeCurrentValuationEvidenceOrchestrationRepository {
+  constructor(private readonly client: AflOutcomeSqlClient) {}
+
+  async loadOperation(request: AflTradeCurrentValuationRefreshRequest) {
+    const loaded = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<LoadedOperationRow>(
+        'SELECT * FROM load_outcome_current_valuation_evidence($1,$2,$3)',
+        [request.scopeKey, request.trigger, request.stableOperationKey]
+      );
+    });
+    const row = loaded.rows[0];
+    if (row === undefined || loaded.rows.length !== 1) {
+      throw new TypeError('Current valuation evidence orchestration state is unavailable.');
+    }
+    const knownSourceKeys = new Set(
+      AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES.map(({ sourceKey }) => sourceKey)
+    );
+    if (
+      new Set(row.retained_source_keys).size !== row.retained_source_keys.length ||
+      row.retained_source_keys.some((sourceKey) => !knownSourceKeys.has(sourceKey))
+    ) {
+      throw new TypeError('Retained evidence orchestration source custody is inconsistent.');
+    }
+    return {
+      terminalResult:
+        row.result_json === null
+          ? null
+          : aflTradeCurrentValuationEvidenceOrchestrationResultSchema.parse(row.result_json),
+      retainedSourceKeys: row.retained_source_keys,
+    };
+  }
+
+  async retainNormalizedSource(
+    input: Parameters<
+      AflTradeCurrentValuationEvidenceOrchestrationRepository['retainNormalizedSource']
+    >[0]
+  ): Promise<void> {
+    await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      await transaction.query(
+        'SELECT retain_outcome_current_valuation_evidence_source($1,$2,$3,$4,$5,$6)',
+        [
+          input.request.scopeKey,
+          input.request.trigger,
+          input.request.stableOperationKey,
+          input.sourceKey,
+          input.captureId,
+          input.normalizationRunId,
+        ]
+      );
+    });
+  }
+
+  async retainUnavailable(
+    request: AflTradeCurrentValuationRefreshRequest,
+    unavailable: Parameters<
+      AflTradeCurrentValuationEvidenceOrchestrationRepository['retainUnavailable']
+    >[1]
+  ) {
+    const retained = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<RetainedOperationRow>(
+        'SELECT * FROM retain_outcome_current_valuation_evidence_unavailable($1,$2,$3,$4,$5)',
+        [
+          request.scopeKey,
+          request.trigger,
+          request.stableOperationKey,
+          unavailable.stage,
+          unavailable.cause,
+        ]
+      );
+    });
+    return parseRetainedResult(request, retained.rows[0], retained.rows.length);
+  }
+
+  async retainComplete(
+    request: AflTradeCurrentValuationRefreshRequest,
+    factualRefresh: AflTradeCurrentValuationRefreshResult
+  ) {
+    const retained = await this.client.transaction(async (transaction) => {
+      await transaction.query(`SET LOCAL ROLE ${EXECUTION_DATABASE_ROLE}`);
+      return transaction.query<RetainedOperationRow>(
+        'SELECT * FROM retain_outcome_current_valuation_evidence_complete($1,$2,$3,$4)',
+        [request.scopeKey, request.trigger, request.stableOperationKey, factualRefresh]
+      );
+    });
+    return parseRetainedResult(request, retained.rows[0], retained.rows.length);
+  }
+}
+
+export function createPostgresAflTradeCurrentValuationEvidenceSourceRuntime(dependencies: {
+  readonly client: AflOutcomeSqlClient;
+  readonly gateRepository: Pick<AflTradeGateDecisionLedgerRepository, 'resolveAuthorization'>;
+  readonly clock: { now(): string };
+  readonly captureAndNormalize: (
+    input: CurrentSourceWorkInput
+  ) => Promise<AflTradeCurrentValuationNormalizedSource>;
+  readonly resumeNormalization: (
+    input: ResumeSourceWorkInput
+  ) => Promise<AflTradeCurrentValuationNormalizedSource>;
+}): AflTradeCurrentValuationEvidenceSourceRuntime {
+  return {
+    async ensureCurrent(source) {
+      const authority = sourceAuthority(source);
+      let resolved: Awaited<ReturnType<typeof dependencies.gateRepository.resolveAuthorization>>;
+      try {
+        resolved = await dependencies.gateRepository.resolveAuthorization(
+          authority.capture.sourceRights.rightsArtifactId
+        );
+      } catch {
+        return unavailable('capture_authority', 'missing');
+      }
+      if (
+        !exactJson(resolved.sourceRights, authority.capture.sourceRights) ||
+        !resolved.ledger.decisions.some(({ decisionId }) => decisionId === authority.gateDecisionId)
+      ) {
+        return unavailable('capture_authority', 'mismatched');
+      }
+      try {
+        const evaluatedAt = dependencies.clock.now();
+        requireCurrentAflTradeFitzRoyCaptureAuthority({
+          ledger: resolved.ledger,
+          sourceRights: resolved.sourceRights,
+          request: { ...authority.capture.gateRequest, evaluatedAt },
+          capturedDecisionId: authority.gateDecisionId,
+          evaluatedAt,
+        });
+      } catch {
+        return unavailable('capture_authority', 'stale');
+      }
+
+      const fieldMapSha256 = createAflTradeFitzRoyFieldMapSha256(authority.fieldMap);
+      const fieldMapResult = await dependencies.client.query<FieldMapAuthorityRow>(
+        `SELECT map.map_json,map.field_map_sha256,map.approval_decision_id,
+                decision.subject_type,decision.subject_id,
+                decision.decision,decision.evidence_json,
+                NOT EXISTS (
+                  SELECT 1 FROM outcome_review_decision successor
+                   WHERE successor.supersedes_decision_id=decision.decision_id
+                ) AS current
+           FROM outcome_provider_field_map map
+           LEFT JOIN outcome_review_decision decision
+             ON decision.decision_id=map.approval_decision_id
+          WHERE map.field_map_id=$1`,
+        [authority.fieldMap.mapId]
+      );
+      const fieldMapRow = fieldMapResult.rows[0];
+      if (fieldMapResult.rows.length === 0) {
+        return unavailable('normalization_authority', 'missing');
+      }
+      if (
+        fieldMapResult.rows.length !== 1 ||
+        !fieldMapRow ||
+        fieldMapRow.field_map_sha256 !== fieldMapSha256 ||
+        fieldMapRow.approval_decision_id !== authority.fieldMap.approvalDecisionId ||
+        !exactJson(fieldMapRow.map_json, authority.fieldMap)
+      ) {
+        return unavailable('normalization_authority', 'mismatched');
+      }
+      const evidence = fieldMapRow.evidence_json as Record<string, unknown> | null;
+      if (!fieldMapRow.current) {
+        return unavailable('normalization_authority', 'stale');
+      }
+      if (
+        fieldMapRow.subject_type !== 'provider_field_map' ||
+        fieldMapRow.subject_id !== authority.fieldMap.mapId ||
+        fieldMapRow.decision !== 'approved' ||
+        evidence?.fieldMapSha256 !== fieldMapSha256
+      ) {
+        return unavailable('normalization_authority', 'unauthenticated');
+      }
+
+      const current = await dependencies.client.query<CurrentSourceRow>(
+        `SELECT capture.capture_id,capture.source_snapshot_id,capture.manifest_json,
+                run.normalization_run_id
+           FROM outcome_source_capture capture
+           LEFT JOIN outcome_provider_normalization_run run
+             ON run.capture_id=capture.capture_id
+            AND run.field_map_id=$4
+            AND run.status IN ('staged','needs_review')
+            AND run.finalized_at IS NOT NULL
+          WHERE capture.environment='non_production'
+            AND capture.provider=$1
+            AND capture.capability_id=$2
+            AND capture.anchor_season_year=$3
+            AND capture.status='staged'
+            AND capture.manifest_json->'sourceRightsProposal'->>'rightsArtifactId'=$5
+            AND capture.manifest_json->'gate0aDecision'->>'decisionId'=$6
+          ORDER BY capture.capture_id,run.normalization_run_id`,
+        [
+          source.provider,
+          source.capabilityId,
+          source.seasonYear,
+          authority.fieldMap.mapId,
+          authority.capture.sourceRights.rightsArtifactId,
+          authority.gateDecisionId,
+        ]
+      );
+      if (current.rows.length > 1) {
+        return unavailable('normalization', 'mismatched');
+      }
+      const retained = current.rows[0];
+      if (retained?.normalization_run_id) {
+        return {
+          state: 'ready',
+          sourceKey: source.sourceKey,
+          captureId: retained.capture_id,
+          normalizationRunId: retained.normalization_run_id,
+        };
+      }
+      const exactAuthority: SourceAuthority = {
+        ...authority,
+        capture: {
+          ...authority.capture,
+          ledger: resolved.ledger,
+          sourceRights: resolved.sourceRights,
+        },
+      };
+      if (retained) {
+        let snapshot: ResumeSourceWorkInput['snapshot'];
+        try {
+          snapshot = aflTradeSourceSnapshotManifestSchema.parse({
+            snapshotId: retained.source_snapshot_id,
+            content: retained.manifest_json,
+          });
+        } catch {
+          return unavailable('capture', 'unauthenticated');
+        }
+        try {
+          const resumed = await dependencies.resumeNormalization({
+            source,
+            authority: exactAuthority,
+            snapshot,
+          });
+          return resumed.sourceKey === source.sourceKey
+            ? resumed
+            : unavailable('normalization', 'mismatched');
+        } catch (error) {
+          return sourceFailure(error, 'normalization');
+        }
+      }
+      try {
+        const captured = await dependencies.captureAndNormalize({
+          source,
+          authority: exactAuthority,
+        });
+        return captured.sourceKey === source.sourceKey
+          ? captured
+          : unavailable('capture', 'mismatched');
+      } catch (error) {
+        return sourceFailure(error, 'capture');
+      }
+    },
+  };
+}

--- a/src/server/aflTradeIntelligence/valuation/postgresPrivateReviewedEvidenceEvaluationAuthority.ts
+++ b/src/server/aflTradeIntelligence/valuation/postgresPrivateReviewedEvidenceEvaluationAuthority.ts
@@ -79,6 +79,8 @@ interface CurrentDecision {
   bundle: AflTradePrivateReviewedEvidenceBundle;
 }
 
+type LoadCurrentEvidence = typeof loadExactLocalReviewedProviderEvidenceBundle;
+
 function isoTimestamp(value: Date | string): string {
   return new Date(instantSchema.parse(value)).toISOString();
 }
@@ -226,14 +228,12 @@ async function loadBundleRow(
 
 async function requireCurrentEvidence(
   transaction: AflOutcomeSqlTransaction,
-  bundle: AflTradePrivateReviewedEvidenceBundle
+  bundle: AflTradePrivateReviewedEvidenceBundle,
+  loadCurrentEvidence: LoadCurrentEvidence
 ): Promise<void> {
   let current: AflTradePrivateReviewedEvidenceBundle;
   try {
-    current = await loadExactLocalReviewedProviderEvidenceBundle(
-      transaction,
-      bundle.content.createdAt
-    );
+    current = await loadCurrentEvidence(transaction, bundle.content.createdAt);
   } catch (error) {
     throw new AflTradePrivateReviewedEvidenceEvaluationPersistenceError(
       'EVIDENCE_MISMATCH',
@@ -286,7 +286,8 @@ async function resolveDecisionBundle(
   transaction: AflOutcomeSqlTransaction,
   current: CurrentDecision | null,
   status: RecordAflTradePrivateReviewedEvidenceEvaluationDecisionInput['status'],
-  decidedAt: string
+  decidedAt: string,
+  loadCurrentEvidence: LoadCurrentEvidence
 ): Promise<AflTradePrivateReviewedEvidenceBundle> {
   if (current?.decision.content.status === status) {
     if (status !== 'authorized') {
@@ -295,7 +296,7 @@ async function resolveDecisionBundle(
         'A private reviewed-evidence decision must change the current authority state.'
       );
     }
-    const successor = await loadExactLocalReviewedProviderEvidenceBundle(transaction, decidedAt);
+    const successor = await loadCurrentEvidence(transaction, decidedAt);
     if (exactEvidenceWithoutBundleTime(current.bundle, successor)) {
       throw new AflTradePrivateReviewedEvidenceEvaluationPersistenceError(
         'INVALID_INPUT',
@@ -312,16 +313,24 @@ async function resolveDecisionBundle(
     return successor;
   }
   if (current === null) {
-    const initial = await loadExactLocalReviewedProviderEvidenceBundle(transaction, decidedAt);
+    const initial = await loadCurrentEvidence(transaction, decidedAt);
     await persistBundle(transaction, initial);
     return initial;
   }
-  await requireCurrentEvidence(transaction, current.bundle);
+  await requireCurrentEvidence(transaction, current.bundle, loadCurrentEvidence);
   return current.bundle;
 }
 
 export class PostgresAflTradePrivateReviewedEvidenceEvaluationAuthority {
-  constructor(private readonly client: AflOutcomeSqlClient) {}
+  private readonly loadCurrentEvidence: LoadCurrentEvidence;
+
+  constructor(
+    private readonly client: AflOutcomeSqlClient,
+    dependencies: { readonly loadCurrentEvidence?: LoadCurrentEvidence } = {}
+  ) {
+    this.loadCurrentEvidence =
+      dependencies.loadCurrentEvidence ?? loadExactLocalReviewedProviderEvidenceBundle;
+  }
 
   async recordDecision(
     input: RecordAflTradePrivateReviewedEvidenceEvaluationDecisionInput
@@ -362,7 +371,13 @@ export class PostgresAflTradePrivateReviewedEvidenceEvaluationAuthority {
         `SELECT transaction_timestamp()::timestamptz(3) AS decided_at`
       );
       const decidedAt = isoTimestamp(clock.rows[0]!.decided_at);
-      const bundle = await resolveDecisionBundle(transaction, current, input.status, decidedAt);
+      const bundle = await resolveDecisionBundle(
+        transaction,
+        current,
+        input.status,
+        decidedAt,
+        this.loadCurrentEvidence
+      );
 
       const decision = createAflTradePrivateReviewedEvidenceEvaluationDecision({
         status: input.status,
@@ -425,7 +440,7 @@ export class PostgresAflTradePrivateReviewedEvidenceEvaluationAuthority {
           'The private reviewed-evidence decision did not replay exactly.'
         );
       }
-      await requireCurrentEvidence(transaction, retained.bundle);
+      await requireCurrentEvidence(transaction, retained.bundle, this.loadCurrentEvidence);
       return retained.decision;
     });
   }
@@ -439,7 +454,7 @@ export class PostgresAflTradePrivateReviewedEvidenceEvaluationAuthority {
       if (!current) return { state: 'not_authorized', decision: null };
       const row = await loadBundleRow(transaction, current.bundle.evidenceBundleId);
       assertBundleRow(row, current.bundle);
-      await requireCurrentEvidence(transaction, current.bundle);
+      await requireCurrentEvidence(transaction, current.bundle, this.loadCurrentEvidence);
       return { state: current.decision.content.status, decision: current.decision };
     });
   }

--- a/src/server/aflTradeIntelligence/valuation/privateValuationScheduling.ts
+++ b/src/server/aflTradeIntelligence/valuation/privateValuationScheduling.ts
@@ -88,3 +88,9 @@ export function createAflTradePrivateValuationDispatchRequestId(input: {
   };
   return createAflTradeContentAddress('private-valuation-dispatch', parsed);
 }
+
+export function createAflTradePrivateValuationDispatchEvidenceKey(
+  request: z.infer<typeof aflTradePrivateValuationDispatchRequestSchema>
+): string {
+  return aflTradePrivateValuationDispatchRequestSchema.parse(request).requestId;
+}

--- a/tests/helpers/aflCurrentValuationEvidenceProviderFixture.ts
+++ b/tests/helpers/aflCurrentValuationEvidenceProviderFixture.ts
@@ -1,0 +1,422 @@
+import { Buffer } from 'node:buffer';
+import { createHash } from 'node:crypto';
+import { generateKeyPairSync, sign } from 'node:crypto';
+
+import {
+  canonicalizeAflTradeJson,
+  sha256AflTradeCanonicalJson,
+} from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { createPostgresAflTradeGateDecisionLedgerRepository } from '@/server/aflTradeIntelligence/governance/postgresGateDecisionLedgerRepository';
+import type { AflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import {
+  createAflTradeFitzRoyInvocation,
+  type AflTradeFitzRoyCaptureDiagnostics,
+} from '@/server/aflTradeIntelligence/source/fitzRoyCaptureContracts';
+import {
+  AFL_TRADE_FITZROY_EGRESS_EXECUTION_SCHEMA_VERSION,
+  createAflTradeFitzRoyEgressExecutionReceipt,
+} from '@/server/aflTradeIntelligence/source/fitzRoyEgressExecutionReceipt';
+import { createAflTradeEd25519EgressExecutionVerifier } from '@/server/aflTradeIntelligence/source/fitzRoyHttpEgressExecutor';
+import {
+  AFL_TRADE_FITZROY_DECODER_VERSION,
+  type AflTradeFitzRoyDecoderExecutor,
+} from '@/server/aflTradeIntelligence/source/fitzRoyObservationDecodeRuntime';
+import {
+  AFL_TRADE_FITZROY_DECODED_TABLE_SCHEMA_VERSION,
+  createAflTradeFitzRoyFieldMapSha256,
+  type AflTradeDecodedScalar,
+} from '@/server/aflTradeIntelligence/source/fitzRoyObservationContracts';
+import { ingestAuthorizedAflTradeFitzRoyProviderSeason } from '@/server/aflTradeIntelligence/source/fitzRoyProviderIngestion';
+import { PostgresAflTradeProviderObservationRepository } from '@/server/aflTradeIntelligence/source/postgresProviderObservationRepository';
+import { PostgresAflTradeSourceCaptureRepository } from '@/server/aflTradeIntelligence/source/postgresSourceCaptureRepository';
+import {
+  createLocalAflTradeAflTablesResultsAuthority,
+  createLocalAflTradeFiveSeasonAflTablesAuthority,
+  LOCAL_AFL_TABLES_PLAYER_STATS_FIELD_SCHEMA,
+  LOCAL_AFL_TABLES_RESULTS_FIELD_SCHEMA,
+} from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority';
+import { LOCAL_AFL_TRADE_FITZROY_RUNTIME } from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesStaging';
+import { createLocalAflTradeNonProductionArtifactRepository } from '@/server/aflTradeIntelligence/development/localFileConditionalObjectStore';
+import {
+  createLocalAflTradeOfficialAfl2026Authority,
+  LOCAL_OFFICIAL_AFL_2026_PLAYER_STATS_FIELD_SCHEMA,
+} from '@/server/aflTradeIntelligence/development/localOfficialAfl2026Authority';
+import {
+  AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES,
+  type AflTradeCurrentValuationEvidenceSource,
+} from '@/server/aflTradeIntelligence/valuation/currentValuationEvidenceOrchestration';
+import { createPostgresAflTradeCurrentValuationEvidenceSourceRuntime } from '@/server/aflTradeIntelligence/valuation/postgresCurrentValuationEvidenceOrchestration';
+
+const FIXTURE_AT = '2026-08-29T12:00:00.000Z';
+const encoded = (value: unknown) => new TextEncoder().encode(canonicalizeAflTradeJson(value));
+const digestBytes = (value: Uint8Array) => createHash('sha256').update(value).digest('hex');
+
+type SourceAuthority = ReturnType<typeof createLocalAflTradeFiveSeasonAflTablesAuthority>;
+type FieldDescriptor = (typeof LOCAL_AFL_TABLES_PLAYER_STATS_FIELD_SCHEMA)[number];
+
+function authorityFor(source: AflTradeCurrentValuationEvidenceSource): SourceAuthority {
+  if (source.capabilityId === 'official-afl-player-stats') {
+    return createLocalAflTradeOfficialAfl2026Authority();
+  }
+  if (source.capabilityId === 'afl-tables-results') {
+    return createLocalAflTradeAflTablesResultsAuthority(source.seasonYear);
+  }
+  return createLocalAflTradeFiveSeasonAflTablesAuthority(source.seasonYear);
+}
+
+function fieldsFor(source: AflTradeCurrentValuationEvidenceSource): readonly FieldDescriptor[] {
+  if (source.capabilityId === 'official-afl-player-stats') {
+    return LOCAL_OFFICIAL_AFL_2026_PLAYER_STATS_FIELD_SCHEMA;
+  }
+  if (source.capabilityId === 'afl-tables-results') {
+    return LOCAL_AFL_TABLES_RESULTS_FIELD_SCHEMA;
+  }
+  return LOCAL_AFL_TABLES_PLAYER_STATS_FIELD_SCHEMA;
+}
+
+function text(value: string): AflTradeDecodedScalar {
+  return { kind: 'text', value };
+}
+
+function integer(value: number): AflTradeDecodedScalar {
+  return { kind: 'integer', value: String(value) };
+}
+
+function finite(value: number): AflTradeDecodedScalar {
+  return { kind: 'finite_number', value: String(value) };
+}
+
+function date(value: string): AflTradeDecodedScalar {
+  return { kind: 'date', value, rawDays: '19000' };
+}
+
+function fixtureValues(
+  source: AflTradeCurrentValuationEvidenceSource
+): Readonly<Record<string, AflTradeDecodedScalar>> {
+  if (source.capabilityId === 'official-afl-player-stats') {
+    return {
+      providerId: text('fixture-official-match-2026-1'),
+      utcStartTime: text('2026-03-15T04:15:00.000Z'),
+      status: text('CONCLUDED'),
+      'compSeason.shortName': text('2026'),
+      'round.name': text('Round 1'),
+      'home.team.name': text('Carlton'),
+      'away.team.name': text('Richmond'),
+      goals: finite(1),
+      'player.playerId': text('fixture-official-player-1'),
+      'player.givenName': text('Fixture'),
+      'player.surname': text('Player'),
+      teamId: text('fixture-carlton'),
+      'team.name': text('Carlton'),
+    };
+  }
+  if (source.capabilityId === 'afl-tables-results') {
+    return {
+      Game: finite(1),
+      Date: date('2026-03-20'),
+      Round: text('Round 1'),
+      'Home.Team': text('Carlton'),
+      'Away.Team': text('Richmond'),
+      Season: finite(2026),
+    };
+  }
+  return {
+    Season: integer(source.seasonYear),
+    Round: text('Round 1'),
+    Date: date(`${source.seasonYear}-03-20`),
+    ID: integer(source.seasonYear * 1000 + 1),
+    'Playing.for': text('Carlton'),
+    Goals: integer(1),
+    'Home.team': text('Carlton'),
+    'Away.team': text('Richmond'),
+    Player: text(`Fixture Player ${source.seasonYear}`),
+  };
+}
+
+function captureDiagnostics(
+  source: AflTradeCurrentValuationEvidenceSource,
+  authority: SourceAuthority,
+  row: readonly AflTradeDecodedScalar[]
+): AflTradeFitzRoyCaptureDiagnostics {
+  const invocation = createAflTradeFitzRoyInvocation(authority.capture.captureRequest);
+  return {
+    schemaVersion: 'afl-trade-fitzroy-diagnostics/v1',
+    capabilityId: invocation.capabilityId,
+    fitzRoyVersion: invocation.fitzRoyVersion,
+    directFunction: invocation.directFunction,
+    invocationSha256: sha256AflTradeCanonicalJson(invocation),
+    runtime: { ...LOCAL_AFL_TRADE_FITZROY_RUNTIME, platform: 'fixture-linux' },
+    rowCount: 1,
+    duplicateRowCount: 0,
+    fields: fieldsFor(source).map((field, index) => ({
+      ...field,
+      missingCount: row[index]?.kind === 'missing' ? 1 : 0,
+      nanCount: 0,
+      positiveInfinityCount: 0,
+      negativeInfinityCount: 0,
+    })),
+    observedSeasonValues:
+      source.capabilityId === 'official-afl-player-stats' ? [] : [String(source.seasonYear)],
+    observedRoundValues: ['Round 1'],
+    observedDateRange: null,
+    originObservation: 'not_exposed_by_fitzroy',
+    conditions: [],
+  };
+}
+
+function decoder(
+  source: AflTradeCurrentValuationEvidenceSource,
+  row: readonly AflTradeDecodedScalar[]
+): AflTradeFitzRoyDecoderExecutor {
+  return {
+    executionBoundary: 'offline_container_no_network',
+    async decode({ context }) {
+      return encoded({
+        schemaVersion: AFL_TRADE_FITZROY_DECODED_TABLE_SCHEMA_VERSION,
+        captureReceiptSha256: context.captureReceiptSha256,
+        capabilityId: context.capabilityId,
+        fitzRoyVersion: context.fitzRoyVersion,
+        authorizationCompetition: context.authorizationCompetition,
+        authorizationSeason: context.authorizationSeason,
+        invocationSha256: context.invocationSha256,
+        invocationArgumentsSha256: context.invocationArgumentsSha256,
+        diagnosticsSha256: context.diagnosticsSha256,
+        sourceRdsSha256: context.sourceRdsSha256,
+        sourceSchemaSha256: context.sourceSchemaSha256,
+        decoderRuntime: {
+          decoderVersion: AFL_TRADE_FITZROY_DECODER_VERSION,
+          rVersion: LOCAL_AFL_TRADE_FITZROY_RUNTIME.rVersion,
+          dependencyLockSha256: context.dependencyLockSha256,
+          imageDigest: context.imageDigest,
+        },
+        frame: { classes: ['data.frame'], rowNames: ['1'] },
+        fields: fieldsFor(source),
+        rows: [row],
+      });
+    },
+  };
+}
+
+async function retainReviewedFieldMap(
+  client: AflOutcomeSqlClient,
+  authority: SourceAuthority
+): Promise<void> {
+  const fieldMapSha256 = createAflTradeFitzRoyFieldMapSha256(authority.fieldMap);
+  await client.query(
+    `INSERT INTO outcome_review_decision
+      (decision_id,subject_type,subject_id,decision,rationale,evidence_json,decided_by,decided_at)
+     VALUES ($1,'provider_field_map',$2,'approved',$3,
+             jsonb_build_object('fieldMapSha256',$4::text),$5,$6)
+     ON CONFLICT (decision_id) DO NOTHING`,
+    [
+      authority.fieldMap.approvalDecisionId,
+      authority.fieldMap.mapId,
+      'Governed exact field-map fixture for current valuation orchestration.',
+      fieldMapSha256,
+      'fixture-source-governance-reviewer',
+      authority.fieldMap.approvedAt,
+    ]
+  );
+  await client.query(
+    `INSERT INTO outcome_provider_field_map
+      (field_map_id,capability_id,fitzroy_version,source_schema_sha256,
+       field_map_sha256,approval_decision_id,approved_at,map_json)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb)
+     ON CONFLICT (field_map_id) DO NOTHING`,
+    [
+      authority.fieldMap.mapId,
+      authority.fieldMap.capabilityId,
+      authority.fieldMap.fitzRoyVersion,
+      authority.fieldMap.sourceSchemaSha256,
+      fieldMapSha256,
+      authority.fieldMap.approvalDecisionId,
+      authority.fieldMap.approvedAt,
+      canonicalizeAflTradeJson(authority.fieldMap),
+    ]
+  );
+}
+
+export async function createGovernedCurrentValuationEvidenceSourceFixture(input: {
+  readonly client: AflOutcomeSqlClient;
+  readonly artifactRoot: string;
+  readonly capturedSourceKeys: string[];
+}) {
+  await input.client.query(
+    `INSERT INTO outcome_competition_season (competition,season_year)
+     SELECT 'AFLM',season_year FROM unnest($1::smallint[]) seasons(season_year)
+     ON CONFLICT DO NOTHING`,
+    [[2021, 2022, 2023, 2024, 2025, 2026]]
+  );
+  await input.client.query(
+    `INSERT INTO outcome_metric_definition
+      (metric_code,definition_version,display_name,value_type,canonical_unit,
+       non_negative,definition_json,status)
+     VALUES
+      ('goals','goals/v1','Goals','numeric','goals',true,'{}'::jsonb,'approved'),
+      ('games','games/v1','Games','numeric','games',true,'{}'::jsonb,'approved')
+     ON CONFLICT DO NOTHING`
+  );
+  const gateRepository = createPostgresAflTradeGateDecisionLedgerRepository(input.client);
+  const gateAuthorities = [
+    createLocalAflTradeFiveSeasonAflTablesAuthority(2021),
+    createLocalAflTradeOfficialAfl2026Authority(),
+    createLocalAflTradeAflTablesResultsAuthority(2026),
+  ];
+  const gate = await gateRepository.load();
+  await gateRepository.appendBatch({
+    expectedRevision: gate.revision,
+    records: gateAuthorities.map((authority) => ({
+      sourceRights: authority.capture.sourceRights,
+      proposal: authority.capture.ledger.proposals[0]!,
+      decision: authority.capture.ledger.decisions[0]!,
+    })),
+  });
+  for (const source of AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES) {
+    await retainReviewedFieldMap(input.client, authorityFor(source));
+  }
+
+  const rawArtifactRepository = createLocalAflTradeNonProductionArtifactRepository({
+    rootDirectory: input.artifactRoot,
+    repositoryId: 'current-valuation-e2e-raw',
+    artifactClass: 'raw_source',
+    maximumObjectBytes: 1_024 * 1_024,
+  });
+  const metadataArtifactRepository = createLocalAflTradeNonProductionArtifactRepository({
+    rootDirectory: input.artifactRoot,
+    repositoryId: 'current-valuation-e2e-metadata',
+    artifactClass: 'capture_metadata',
+    maximumObjectBytes: 1_024 * 1_024,
+  });
+  const sourceCaptureRepository = new PostgresAflTradeSourceCaptureRepository(input.client);
+  const providerObservationRepository = new PostgresAflTradeProviderObservationRepository(
+    input.client
+  );
+  const signingKeyId = 'current-valuation-e2e-fixture';
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  const egressExecutionVerifier = createAflTradeEd25519EgressExecutionVerifier({
+    [signingKeyId]: publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+  });
+  return createPostgresAflTradeCurrentValuationEvidenceSourceRuntime({
+    client: input.client,
+    gateRepository,
+    clock: { now: () => FIXTURE_AT },
+    captureAndNormalize: async ({ source, authority }) => {
+      input.capturedSourceKeys.push(source.sourceKey);
+      const fields = fieldsFor(source);
+      const values = fixtureValues(source);
+      const row = fields.map(({ name }) => values[name] ?? ({ kind: 'missing' } as const));
+      const diagnostics = captureDiagnostics(source, authority, row);
+      const sourceBytes = Uint8Array.from([
+        88,
+        10,
+        0,
+        0,
+        0,
+        AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES.indexOf(source) + 1,
+      ]);
+      const diagnosticsBytes = encoded(diagnostics);
+      const rate = authority.capture.sourceRights.content.automatedAccess.rateLimit!;
+      const egressPolicyEvidenceId = authority.capture.sourceRights.content.conditions.find(
+        ({ conditionId }) => conditionId === 'provider-egress-control'
+      )!.verificationEvidenceIds[0]!;
+      const ingestion = await ingestAuthorizedAflTradeFitzRoyProviderSeason(
+        {
+          capture: authority.capture,
+          fieldMapId: authority.fieldMap.mapId,
+          fieldMap: authority.fieldMap,
+          effectiveAt: FIXTURE_AT,
+        },
+        {
+          capture: {
+            rawArtifactRepository,
+            metadataArtifactRepository,
+            executor: {
+              executionBoundary: 'local_rate_limited_docker',
+              egressPolicyEvidenceIds: [egressPolicyEvidenceId],
+              async execute(invocation) {
+                const content = {
+                  schemaVersion: AFL_TRADE_FITZROY_EGRESS_EXECUTION_SCHEMA_VERSION,
+                  executionBoundary: 'local_non_production_docker' as const,
+                  enforcementScope: 'capture_admission_only' as const,
+                  provider: invocation.provider,
+                  capabilityId: invocation.capabilityId,
+                  directFunction: invocation.directFunction,
+                  fitzRoyVersion: invocation.fitzRoyVersion,
+                  invocationSha256: sha256AflTradeCanonicalJson(invocation),
+                  sourceOutput: {
+                    contentSha256: digestBytes(sourceBytes),
+                    byteLength: sourceBytes.byteLength,
+                  },
+                  diagnosticsOutput: {
+                    contentSha256: digestBytes(diagnosticsBytes),
+                    byteLength: diagnosticsBytes.byteLength,
+                  },
+                  runtime: LOCAL_AFL_TRADE_FITZROY_RUNTIME,
+                  enforcedPolicy: {
+                    upstreamRate: rate,
+                    cacheSeconds: authority.capture.gateRequest.cacheSeconds!,
+                    egressPolicyEvidenceId,
+                  },
+                  startedAt: FIXTURE_AT,
+                  completedAt: FIXTURE_AT,
+                  status: 'succeeded' as const,
+                };
+                const valueBase64Url = sign(
+                  null,
+                  Buffer.from(canonicalizeAflTradeJson(content), 'utf8'),
+                  privateKey
+                ).toString('base64url');
+                return {
+                  sourceBytes,
+                  diagnostics,
+                  egressExecutionReceipt: createAflTradeFitzRoyEgressExecutionReceipt({
+                    content,
+                    signature: {
+                      algorithm: 'Ed25519',
+                      keyId: signingKeyId,
+                      valueBase64Url,
+                    },
+                  }),
+                };
+              },
+            },
+            egressExecutionVerifier,
+            authorizationResolver: gateRepository,
+            clock: { now: () => FIXTURE_AT },
+            runtimeIdentity: LOCAL_AFL_TRADE_FITZROY_RUNTIME,
+            timeoutMs: 30_000,
+            maximumSourceBytes: 1_024 * 1_024,
+            maximumDiagnosticsBytes: 1_024 * 1_024,
+          },
+          staging: {
+            rawArtifactRepository,
+            sourceCaptureRepository,
+            providerObservationRepository,
+            decoderExecutor: decoder(source, row),
+            clock: { now: () => FIXTURE_AT },
+            dependencyLockSha256: LOCAL_AFL_TRADE_FITZROY_RUNTIME.dependencyLockSha256,
+            imageDigest: LOCAL_AFL_TRADE_FITZROY_RUNTIME.imageDigest,
+            timeoutMs: 30_000,
+            maximumSourceBytes: 1_024 * 1_024,
+            maximumRows: 10,
+            maximumFields: 120,
+            maximumCells: 1_200,
+            maximumCellBytes: 8_192,
+            maximumOutputBytes: 1_024 * 1_024,
+            egressExecutionVerifier,
+          },
+          clock: { now: () => FIXTURE_AT },
+        }
+      );
+      return {
+        state: 'ready',
+        sourceKey: source.sourceKey,
+        captureId: ingestion.staging.capture.captureId,
+        normalizationRunId: ingestion.staging.normalization.normalizationRunId,
+      };
+    },
+    resumeNormalization: async () => {
+      throw new Error('The governed fixture must discover its finalized normalization custody.');
+    },
+  });
+}

--- a/tests/outcomes-integration/afl-current-valuation-evidence-orchestration-postgres.test.ts
+++ b/tests/outcomes-integration/afl-current-valuation-evidence-orchestration-postgres.test.ts
@@ -1,0 +1,729 @@
+import { readFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Pool } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { createAflTradeCanonicalJsonArtifactRef } from '@/server/aflTradeIntelligence/artifacts/artifactReference';
+import { createPgAflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/pgOutcomeSqlClient';
+import type { AflOutcomeSqlTransaction } from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { createLocalAflTradeCurrentValuationReconciliationAuthority } from '@/server/aflTradeIntelligence/development/localCurrentValuationReconciliationAuthority';
+import { LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256 } from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesReview';
+import { LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256 } from '@/server/aflTradeIntelligence/development/localOfficialAfl2026Review';
+import {
+  AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES,
+  createAflTradeCurrentValuationEvidenceCoordinator,
+  createAflTradeCurrentValuationEvidenceFactualHandoffKey,
+} from '@/server/aflTradeIntelligence/valuation/currentValuationEvidenceOrchestration';
+import { createAflTradeCurrentValuationRefresh } from '@/server/aflTradeIntelligence/valuation/currentValuationRefresh';
+import { PostgresAflTradeCurrentValuationEvidenceOrchestrationRepository } from '@/server/aflTradeIntelligence/valuation/postgresCurrentValuationEvidenceOrchestration';
+import { PostgresAflTradePrivateReviewedEvidenceEvaluationAuthority } from '@/server/aflTradeIntelligence/valuation/postgresPrivateReviewedEvidenceEvaluationAuthority';
+import { createAflTradePrivateReviewedEvidenceBundle } from '@/server/aflTradeIntelligence/valuation/privateReviewedEvidenceEvaluation';
+import { createGovernedCurrentValuationEvidenceSourceFixture } from '../helpers/aflCurrentValuationEvidenceProviderFixture';
+import { runOutcomesPrismaTestCommand } from './outcomesPrismaTestCli';
+
+const databaseUrl =
+  process.env.AFL_OUTCOMES_TEST_DATABASE_URL ??
+  (() => {
+    throw new Error('AFL_OUTCOMES_TEST_DATABASE_URL must identify disposable PostgreSQL.');
+  })();
+const schemaName = `afl_current_valuation_evidence_${process.pid}_${Date.now()}`;
+const governedSchemaName = `afl_current_valuation_evidence_e2e_${process.pid}_${Date.now()}`;
+const adminPool = new Pool({ connectionString: databaseUrl });
+const pool = new Pool({
+  connectionString: databaseUrl,
+  max: 4,
+  options: `-c search_path=${schemaName}`,
+});
+const governedPool = new Pool({
+  connectionString: databaseUrl,
+  max: 4,
+  options: `-c search_path=${governedSchemaName}`,
+});
+let governedArtifactRoot = '';
+
+function expectedFieldMapId(
+  source: (typeof AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES)[number]
+): string {
+  if (source.capabilityId === 'official-afl-player-stats') {
+    return 'official-afl-player-stats-local-2026-v1';
+  }
+  if (source.capabilityId === 'afl-tables-results') {
+    return 'afl-tables-results-local-2026-v2';
+  }
+  return `afl-tables-player-stats-local-${source.seasonYear}-v1`;
+}
+
+async function seedCurrentReviewSetAuthority(): Promise<void> {
+  for (const reviewSet of [
+    {
+      decisionId: `local-afl-tables-review:set:${LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256}`,
+      evidenceSetSha256: LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256,
+      reviewerId: 'local-five-season-evidence-reviewer',
+    },
+    {
+      decisionId: `local-official-afl-review:set:${LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256}`,
+      evidenceSetSha256: LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256,
+      reviewerId: 'local-workbook-evidence-reviewer',
+    },
+  ]) {
+    await governedPool.query(
+      `INSERT INTO outcome_review_decision
+        (decision_id,subject_type,subject_id,decision,canonical_record_type,
+         canonical_record_id,supersedes_decision_id,rationale,evidence_json,
+         decided_by,decided_at)
+       VALUES ($1,'local_review_set',$2,'approved','local_review_set',$2,NULL,$3,
+               jsonb_build_object('evidenceSetSha256',$2::text,'appearanceCount',1),$4,$5)`,
+      [
+        reviewSet.decisionId,
+        reviewSet.evidenceSetSha256,
+        'Explicit test-owned human reconciliation authority transition.',
+        reviewSet.reviewerId,
+        '2026-08-29T12:00:00.000Z',
+      ]
+    );
+  }
+}
+
+async function loadGovernedFixtureReviewedBundle(
+  transaction: AflOutcomeSqlTransaction,
+  createdAt: string
+) {
+  const captures = await transaction.query<{
+    capture_id: string;
+    provider: string;
+    capability_id: string;
+    anchor_season_year: number;
+    source_artifact_id: string;
+    content_sha256: string;
+    storage_uri: string;
+    media_type: string;
+    byte_length: number;
+    artifact_created_at: Date;
+  }>(
+    `SELECT capture.capture_id,capture.provider,capture.capability_id,
+            capture.anchor_season_year,capture.source_artifact_id,
+            custody.content_sha256,custody.storage_uri,custody.media_type,
+            custody.byte_length,custody.created_at AS artifact_created_at
+       FROM outcome_source_capture capture
+       JOIN outcome_artifact_custody custody
+         ON custody.artifact_id=capture.source_artifact_id
+      WHERE capture.environment='non_production' AND capture.status='staged'
+      ORDER BY capture.capture_id`
+  );
+  const rights = await transaction.query<{ content_json: unknown; proposed_at: Date }>(
+    `SELECT DISTINCT rights.content_json,rights.proposed_at
+       FROM outcome_source_capture capture
+       JOIN outcome_source_rights_proposal rights
+         ON rights.rights_artifact_id=
+              capture.manifest_json->'sourceRightsProposal'->>'rightsArtifactId'
+      WHERE capture.environment='non_production' AND capture.status='staged'
+      ORDER BY rights.proposed_at`
+  );
+  return createAflTradePrivateReviewedEvidenceBundle({
+    evidenceScopeKey: 'afl-player-match-reviewed-2021-2026',
+    reviewSets: [
+      {
+        reviewSetId: LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256,
+        reviewSetDecisionId: `local-afl-tables-review:set:${LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256}`,
+        reviewerId: 'local-five-season-evidence-reviewer',
+        candidateCount: 1,
+        decisionCount: 1,
+        reviewSetArtifact: createAflTradeCanonicalJsonArtifactRef(
+          { reviewSetId: LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256 },
+          createdAt
+        ),
+      },
+      {
+        reviewSetId: LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256,
+        reviewSetDecisionId: `local-official-afl-review:set:${LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256}`,
+        reviewerId: 'local-workbook-evidence-reviewer',
+        candidateCount: 1,
+        decisionCount: 1,
+        reviewSetArtifact: createAflTradeCanonicalJsonArtifactRef(
+          { reviewSetId: LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256 },
+          createdAt
+        ),
+      },
+    ],
+    sourceCaptures: captures.rows.map((capture) => ({
+      captureId: capture.capture_id,
+      provider: capture.provider,
+      capabilityId: capture.capability_id,
+      seasonYear: Number(capture.anchor_season_year),
+      sourceArtifact: {
+        artifactId: capture.source_artifact_id,
+        contentSha256: capture.content_sha256,
+        storageUri: capture.storage_uri,
+        mediaType: capture.media_type,
+        byteLength: Number(capture.byte_length),
+        createdAt: capture.artifact_created_at.toISOString(),
+      },
+    })),
+    sourceRightsEvidenceRefs: rights.rows.map((right) =>
+      createAflTradeCanonicalJsonArtifactRef(right.content_json, right.proposed_at.toISOString())
+    ),
+    createdAt,
+  });
+}
+
+beforeAll(async () => {
+  await pool.query(`DO $roles$ BEGIN
+    BEGIN CREATE ROLE afl_trade_private_evaluation_coordinator NOLOGIN;
+    EXCEPTION WHEN duplicate_object THEN NULL; END;
+    BEGIN CREATE ROLE afl_trade_current_valuation_refresh_owner NOLOGIN;
+    EXCEPTION WHEN duplicate_object THEN NULL; END;
+    GRANT afl_trade_private_evaluation_coordinator TO CURRENT_USER;
+    GRANT afl_trade_current_valuation_refresh_owner TO CURRENT_USER;
+  END $roles$`);
+  await pool.query(`CREATE SCHEMA "${schemaName}"`);
+  await pool.query(
+    `GRANT USAGE,CREATE ON SCHEMA "${schemaName}"
+       TO afl_trade_current_valuation_refresh_owner`
+  );
+  const canonicalFunction = readFileSync(
+    join(
+      process.cwd(),
+      'prisma/afl-trade-outcomes/migrations/0037_valuation_publication_custody_index/migration.sql'
+    ),
+    'utf8'
+  ).match(
+    /CREATE FUNCTION "outcome_afl_trade_canonical_json"[\s\S]*?\$\$ LANGUAGE plpgsql IMMUTABLE STRICT;/
+  )?.[0];
+  if (canonicalFunction === undefined) {
+    throw new Error('Canonical JSON SQL function was not found.');
+  }
+  await pool.query(canonicalFunction);
+  await pool.query(`
+    CREATE TABLE outcome_current_valuation_refresh_operation (
+      operation_id text NOT NULL,scope_key text NOT NULL,trigger_kind text NOT NULL,
+      stable_operation_key text PRIMARY KEY,result_json jsonb NOT NULL
+    );
+    CREATE TABLE outcome_current_valuation_factual_refresh_operation (
+      operation_id text NOT NULL,scope_key text NOT NULL,trigger_kind text NOT NULL,
+      stable_operation_key text PRIMARY KEY,result_json jsonb NOT NULL
+    );
+    CREATE TABLE outcome_private_reviewed_evaluation_head (
+      valuation_scope_key text NOT NULL,evidence_scope_key text NOT NULL,
+      status text NOT NULL,PRIMARY KEY (valuation_scope_key,evidence_scope_key)
+    );
+    CREATE TABLE outcome_source_capture (
+      capture_id text PRIMARY KEY,provider text NOT NULL,capability_id text NOT NULL,
+      anchor_season_year smallint NOT NULL,status text NOT NULL
+    );
+    CREATE TABLE outcome_provider_normalization_run (
+      normalization_run_id text PRIMARY KEY,capture_id text NOT NULL,
+      field_map_id text NOT NULL,status text NOT NULL,finalized_at timestamptz
+    );
+  `);
+  await pool.query(
+    readFileSync(
+      join(
+        process.cwd(),
+        'prisma/afl-trade-outcomes/migrations/0084_current_valuation_evidence_orchestration/migration.sql'
+      ),
+      'utf8'
+    )
+  );
+  await adminPool.query(`CREATE SCHEMA "${governedSchemaName}"`);
+  const governedDatabaseUrl = new URL(databaseUrl);
+  governedDatabaseUrl.searchParams.set('schema', governedSchemaName);
+  runOutcomesPrismaTestCommand(['migrate', 'deploy'], {
+    databaseUrl: governedDatabaseUrl.toString(),
+  });
+  governedArtifactRoot = await mkdtemp(join(tmpdir(), 'statly-current-valuation-evidence-e2e-'));
+});
+
+afterAll(async () => {
+  await governedPool.end();
+  await pool.query(`SET search_path TO public`);
+  await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  await pool.end();
+  await adminPool.query(`DROP SCHEMA IF EXISTS "${governedSchemaName}" CASCADE`);
+  await adminPool.end();
+  await rm(governedArtifactRoot, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await pool.query(`TRUNCATE outcome_current_valuation_evidence_orchestration_operation,
+    outcome_current_valuation_evidence_orchestration_stage_receipt,
+    outcome_current_valuation_refresh_operation,
+    outcome_current_valuation_factual_refresh_operation,
+    outcome_private_reviewed_evaluation_head,
+    outcome_provider_normalization_run,
+    outcome_source_capture`);
+  for (const [index, source] of AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES.entries()) {
+    await pool.query(
+      `INSERT INTO outcome_source_capture
+        (capture_id,provider,capability_id,anchor_season_year,status)
+       VALUES ($1,$2,$3,$4,'staged')`,
+      [
+        `source-capture:${String(index).padStart(64, '0')}`,
+        source.provider,
+        source.capabilityId,
+        source.seasonYear,
+      ]
+    );
+    await pool.query(
+      `INSERT INTO outcome_provider_normalization_run
+        (normalization_run_id,capture_id,field_map_id,status,finalized_at)
+       VALUES ($1,$2,$3,'needs_review',statement_timestamp())`,
+      [
+        `provider-normalization-run:${String(index).padStart(64, '0')}`,
+        `source-capture:${String(index).padStart(64, '0')}`,
+        expectedFieldMapId(source),
+      ]
+    );
+  }
+});
+
+describe('current valuation evidence orchestration PostgreSQL authority', () => {
+  it('retains and exactly replays review-required under one stable operation identity', async () => {
+    const repository = new PostgresAflTradeCurrentValuationEvidenceOrchestrationRepository(
+      createPgAflOutcomeSqlClient(pool)
+    );
+    const request = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'weekly' as const,
+      stableOperationKey: 'evidence-review-required',
+    };
+    for (const [index, source] of AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES.entries()) {
+      await repository.retainNormalizedSource({
+        request,
+        state: 'ready',
+        sourceKey: source.sourceKey,
+        captureId: `source-capture:${String(index).padStart(64, '0')}`,
+        normalizationRunId: `provider-normalization-run:${String(index).padStart(64, '0')}`,
+      });
+    }
+
+    const first = await repository.retainUnavailable(request, {
+      stage: 'reviewed_authority',
+      cause: 'review_required',
+    });
+    await expect(
+      repository.retainUnavailable(request, {
+        stage: 'reviewed_authority',
+        cause: 'review_required',
+      })
+    ).resolves.toEqual(first);
+    expect(first).toMatchObject({
+      state: 'unavailable',
+      stage: 'reviewed_authority',
+      cause: 'review_required',
+    });
+    await expect(
+      pool.query(
+        `SELECT count(*)::integer AS count
+           FROM outcome_current_valuation_evidence_orchestration_operation`
+      )
+    ).resolves.toMatchObject({ rows: [{ count: 1 }] });
+
+    await expect(
+      repository.retainUnavailable(
+        { ...request, scopeKey: 'afl-men:2025-trades' },
+        { stage: 'reviewed_authority', cause: 'review_required' }
+      )
+    ).rejects.toThrow('conflicts with retained custody');
+  });
+
+  it('retains a non-review-required failure at the reviewed-authority boundary', async () => {
+    const repository = new PostgresAflTradeCurrentValuationEvidenceOrchestrationRepository(
+      createPgAflOutcomeSqlClient(pool)
+    );
+    const request = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'ad_hoc' as const,
+      stableOperationKey: 'reviewed-authority-stale',
+    };
+    for (const [index, source] of AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES.entries()) {
+      await repository.retainNormalizedSource({
+        request,
+        state: 'ready',
+        sourceKey: source.sourceKey,
+        captureId: `source-capture:${String(index).padStart(64, '0')}`,
+        normalizationRunId: `provider-normalization-run:${String(index).padStart(64, '0')}`,
+      });
+    }
+
+    await expect(
+      repository.retainUnavailable(request, {
+        stage: 'reviewed_authority',
+        cause: 'stale',
+      })
+    ).resolves.toMatchObject({
+      state: 'unavailable',
+      stage: 'reviewed_authority',
+      cause: 'stale',
+    });
+  });
+
+  it('cannot retain a reviewed-authority result before all seven source receipts', async () => {
+    const repository = new PostgresAflTradeCurrentValuationEvidenceOrchestrationRepository(
+      createPgAflOutcomeSqlClient(pool)
+    );
+
+    await expect(
+      repository.retainUnavailable(
+        {
+          scopeKey: 'afl-men:2026-trades',
+          trigger: 'ad_hoc',
+          stableOperationKey: 'review-boundary-without-sources',
+        },
+        { stage: 'reviewed_authority', cause: 'review_required' }
+      )
+    ).rejects.toThrow(/requires all seven source receipts/i);
+  });
+
+  it('retains each normalized source stage and resumes without invoking captured work twice', async () => {
+    const client = createPgAflOutcomeSqlClient(pool);
+    const repository = new PostgresAflTradeCurrentValuationEvidenceOrchestrationRepository(client);
+    const calls: string[] = [];
+    const coordinator = createAflTradeCurrentValuationEvidenceCoordinator({
+      repository,
+      source: {
+        ensureCurrent: async (source) => {
+          calls.push(source.sourceKey);
+          const index = AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES.indexOf(source);
+          return {
+            state: 'ready',
+            sourceKey: source.sourceKey,
+            captureId: `source-capture:${String(index).padStart(64, '0')}`,
+            normalizationRunId: `provider-normalization-run:${String(index).padStart(64, '0')}`,
+          };
+        },
+      },
+      reconciliationAuthority: { assessCurrent: async () => ({ state: 'ready' }) },
+      reviewedAuthority: {
+        assessCurrent: async () => ({
+          state: 'unavailable',
+          stage: 'reviewed_authority',
+          cause: 'review_required',
+        }),
+      },
+      factualRefresh: {
+        refreshCurrent: async () => {
+          throw new Error('Factual refresh must not run before human review.');
+        },
+      },
+    });
+    const request = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'weekly' as const,
+      stableOperationKey: 'retained-normalized-sources',
+    };
+
+    const first = await coordinator.refreshCurrent(request);
+    await expect(coordinator.refreshCurrent(request)).resolves.toEqual(first);
+
+    expect(calls).toEqual(
+      AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES.map(({ sourceKey }) => sourceKey)
+    );
+    await expect(
+      pool.query(
+        `SELECT source_key,capture_id,normalization_run_id
+           FROM outcome_current_valuation_evidence_orchestration_stage_receipt
+          WHERE stable_operation_key=$1 ORDER BY source_key`,
+        [request.stableOperationKey]
+      )
+    ).resolves.toMatchObject({ rows: expect.arrayContaining(Array(7).fill(expect.anything())) });
+  });
+
+  it('rejects a finalized normalization retained under another field-map authority', async () => {
+    const source = AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES[0]!;
+    await pool.query(
+      `UPDATE outcome_provider_normalization_run SET field_map_id='unreviewed-field-map'
+        WHERE normalization_run_id=$1`,
+      [`provider-normalization-run:${'0'.repeat(64)}`]
+    );
+    const repository = new PostgresAflTradeCurrentValuationEvidenceOrchestrationRepository(
+      createPgAflOutcomeSqlClient(pool)
+    );
+
+    await expect(
+      repository.retainNormalizedSource({
+        request: {
+          scopeKey: 'afl-men:2026-trades',
+          trigger: 'ad_hoc',
+          stableOperationKey: 'reject-wrong-field-map',
+        },
+        state: 'ready',
+        sourceKey: source.sourceKey,
+        captureId: `source-capture:${'0'.repeat(64)}`,
+        normalizationRunId: `provider-normalization-run:${'0'.repeat(64)}`,
+      })
+    ).rejects.toThrow(/normalized source custody is missing or mismatched/i);
+  });
+
+  it('retains an authenticated private factual handoff after every source stage', async () => {
+    const repository = new PostgresAflTradeCurrentValuationEvidenceOrchestrationRepository(
+      createPgAflOutcomeSqlClient(pool)
+    );
+    const request = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'ad_hoc' as const,
+      stableOperationKey: 'complete-private-factual-handoff',
+    };
+    for (const [index, source] of AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES.entries()) {
+      await repository.retainNormalizedSource({
+        request,
+        state: 'ready',
+        sourceKey: source.sourceKey,
+        captureId: `source-capture:${String(index).padStart(64, '0')}`,
+        normalizationRunId: `provider-normalization-run:${String(index).padStart(64, '0')}`,
+      });
+    }
+    const factualRefresh = {
+      schemaVersion: 'afl-current-valuation-refresh-result-v2' as const,
+      operationId: `current-valuation-factual-refresh-operation:${'d'.repeat(64)}`,
+      scopeKey: request.scopeKey,
+      trigger: request.trigger,
+      stableOperationKey: createAflTradeCurrentValuationEvidenceFactualHandoffKey(request),
+      state: 'factual_refresh_complete' as const,
+      factualStage: 'advanced' as const,
+      privateFactualAuthority: {
+        valuationScopeKey: request.scopeKey,
+        candidateId: `private-factual-candidate:${'e'.repeat(64)}`,
+        evidenceScopeKey: 'afl-player-match-reviewed-2021-2026',
+        evidenceBundleId: `private-reviewed-evidence-bundle:${'f'.repeat(64)}`,
+        reviewDecisionId: `private-reviewed-evidence-evaluation-decision:${'1'.repeat(64)}`,
+        normalizedReconciledCustodySha256: '2'.repeat(64),
+        revision: 1,
+      },
+      capturedAt: '2026-08-29T12:00:00.000Z',
+      completedAt: '2026-08-29T12:00:01.000Z',
+      executionLocation: 'local' as const,
+      visibility: 'private' as const,
+      environment: 'non_production' as const,
+      publicationEligible: false as const,
+      publicationProhibited: true as const,
+      limitation:
+        'Private local non-production factual refresh authority only; no public release, registry, production, activation, or publication authority is granted.' as const,
+    };
+    await pool.query(
+      `INSERT INTO outcome_current_valuation_factual_refresh_operation
+        (operation_id,scope_key,trigger_kind,stable_operation_key,result_json)
+       VALUES ($1,$2,$3,$4,$5::jsonb)`,
+      [
+        factualRefresh.operationId,
+        factualRefresh.scopeKey,
+        factualRefresh.trigger,
+        factualRefresh.stableOperationKey,
+        factualRefresh,
+      ]
+    );
+
+    const first = await repository.retainComplete(request, factualRefresh);
+    await expect(repository.retainComplete(request, factualRefresh)).resolves.toEqual(first);
+    expect(first).toMatchObject({
+      state: 'complete',
+      stage: 'private_factual_authority',
+      currentValuationRefresh: factualRefresh,
+      publicationEligible: false,
+      publicationProhibited: true,
+    });
+  });
+
+  it('crosses all seven governed lanes with an explicit bounded reviewed-authority seam', async () => {
+    const client = createPgAflOutcomeSqlClient(governedPool);
+    const capturedSourceKeys: string[] = [];
+    const source = await createGovernedCurrentValuationEvidenceSourceFixture({
+      client,
+      artifactRoot: governedArtifactRoot,
+      capturedSourceKeys,
+    });
+    const publicAuthorityBefore = await governedPool.query<{
+      active_releases: number;
+      registry_events: number;
+    }>(
+      `SELECT
+          (SELECT count(*)::integer FROM outcome_active_release) AS active_releases,
+          (SELECT count(*)::integer FROM outcome_registry_event) AS registry_events`
+    );
+    const coordinator = createAflTradeCurrentValuationEvidenceCoordinator({
+      repository: new PostgresAflTradeCurrentValuationEvidenceOrchestrationRepository(client),
+      source,
+      reconciliationAuthority: createLocalAflTradeCurrentValuationReconciliationAuthority(client),
+      reviewedAuthority: {
+        assessCurrent: async () => {
+          throw new Error('Reviewed authority must not run before reconciliation review.');
+        },
+      },
+      factualRefresh: {
+        refreshCurrent: async () => {
+          throw new Error('Factual refresh must not run before reconciliation review.');
+        },
+      },
+    });
+    const request = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'ad_hoc' as const,
+      stableOperationKey: 'governed-provider-evidence-e2e',
+    };
+
+    const first = await coordinator.refreshCurrent(request);
+    await expect(coordinator.refreshCurrent(request)).resolves.toEqual(first);
+
+    expect(first).toMatchObject({
+      state: 'unavailable',
+      stage: 'reconciliation_authority',
+      cause: 'missing',
+      publicationEligible: false,
+      publicationProhibited: true,
+    });
+
+    await seedCurrentReviewSetAuthority();
+    const reviewedAuthority = new PostgresAflTradePrivateReviewedEvidenceEvaluationAuthority(
+      client,
+      { loadCurrentEvidence: loadGovernedFixtureReviewedBundle }
+    );
+    const reconciliationAuthority = createLocalAflTradeCurrentValuationReconciliationAuthority(
+      client,
+      { loadReviewedBundle: loadGovernedFixtureReviewedBundle }
+    );
+    const resumedCoordinator = createAflTradeCurrentValuationEvidenceCoordinator({
+      repository: new PostgresAflTradeCurrentValuationEvidenceOrchestrationRepository(client),
+      source,
+      reconciliationAuthority,
+      reviewedAuthority: {
+        assessCurrent: async ({ valuationScopeKey }) => {
+          const assessment = await reviewedAuthority.assessCurrent({ valuationScopeKey });
+          return assessment.state === 'authorized'
+            ? { state: 'ready' as const }
+            : {
+                state: 'unavailable' as const,
+                stage: 'reviewed_authority' as const,
+                cause: 'review_required' as const,
+              };
+        },
+      },
+      factualRefresh: createAflTradeCurrentValuationRefresh({ client }),
+    });
+    const awaitingReviewedAuthority = await resumedCoordinator.refreshCurrent({
+      ...request,
+      stableOperationKey: 'governed-provider-evidence-e2e-awaiting-reviewed-authority',
+    });
+    expect(awaitingReviewedAuthority).toMatchObject({
+      state: 'unavailable',
+      stage: 'reviewed_authority',
+      cause: 'review_required',
+    });
+
+    const decisionInput = {
+      status: 'authorized' as const,
+      valuationScopeKey: request.scopeKey,
+      expectedCurrentDecisionId: null,
+      reviewerId: 'current-valuation-e2e-human-reviewer',
+      rationale:
+        'Explicitly authorize the exact newly captured fixture bundle for private factual evaluation.',
+    };
+    await expect(reviewedAuthority.recordDecision(decisionInput)).rejects.toThrow(
+      'exact current-set authentication'
+    );
+    await expect(
+      governedPool.query(
+        `SELECT
+           (SELECT count(*)::integer FROM outcome_private_reviewed_evidence_bundle) AS bundles,
+           (SELECT count(*)::integer FROM outcome_private_reviewed_evaluation_decision) AS decisions,
+           (SELECT count(*)::integer FROM outcome_private_reviewed_evaluation_head) AS heads`
+      )
+    ).resolves.toMatchObject({ rows: [{ bundles: 0, decisions: 0, heads: 0 }] });
+
+    // The production exact-set guard correctly rejects this small no-network fixture above. The
+    // remaining seam is deliberately bounded to exercising recordDecision persistence/CAS and the
+    // real factual refresh without materializing 146,343 fixture review decisions.
+    await governedPool.query(
+      `CREATE OR REPLACE FUNCTION outcome_private_reviewed_evidence_bundle_is_current(
+         target_evidence_bundle_id TEXT
+       ) RETURNS BOOLEAN LANGUAGE sql STABLE STRICT AS $function$
+         SELECT EXISTS (
+           SELECT 1 FROM outcome_private_reviewed_evidence_bundle
+            WHERE evidence_bundle_id=target_evidence_bundle_id
+              AND source_capture_count=7 AND source_rights_count=3
+         )
+       $function$`
+    );
+    await governedPool.query(
+      `ALTER TABLE outcome_private_reviewed_evidence_bundle
+         DISABLE TRIGGER outcome_private_reviewed_evidence_bundle_insert_guard`
+    );
+    const reviewedDecision = await (async () => {
+      try {
+        return await reviewedAuthority.recordDecision(decisionInput);
+      } finally {
+        await governedPool.query(
+          `ALTER TABLE outcome_private_reviewed_evidence_bundle
+             ENABLE TRIGGER outcome_private_reviewed_evidence_bundle_insert_guard`
+        );
+      }
+    })();
+    const completed = await resumedCoordinator.refreshCurrent({
+      ...request,
+      stableOperationKey: 'governed-provider-evidence-e2e-reviewed',
+    });
+    await expect(
+      resumedCoordinator.refreshCurrent({
+        ...request,
+        stableOperationKey: 'governed-provider-evidence-e2e-reviewed',
+      })
+    ).resolves.toEqual(completed);
+    expect(completed).toMatchObject({
+      state: 'complete',
+      stage: 'private_factual_authority',
+      currentValuationRefresh: { state: 'factual_refresh_complete', factualStage: 'advanced' },
+      publicationEligible: false,
+      publicationProhibited: true,
+    });
+    expect(completed).toMatchObject({
+      currentValuationRefresh: {
+        privateFactualAuthority: {
+          evidenceBundleId: reviewedDecision.content.evidenceBundleId,
+          reviewDecisionId: reviewedDecision.decisionId,
+        },
+      },
+    });
+    expect(capturedSourceKeys).toEqual(
+      AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES.map(({ sourceKey }) => sourceKey)
+    );
+    await expect(
+      governedPool.query(
+        `SELECT
+            (SELECT count(*)::integer FROM outcome_source_capture) AS captures,
+            (SELECT count(*)::integer FROM outcome_provider_normalization_run
+              WHERE finalized_at IS NOT NULL) AS normalizations,
+            (SELECT count(*)::integer
+               FROM outcome_current_valuation_evidence_orchestration_stage_receipt) AS receipts`
+      )
+    ).resolves.toMatchObject({
+      rows: [{ captures: 7, normalizations: 7, receipts: 21 }],
+    });
+    await expect(
+      governedPool.query(
+        `SELECT reviewed.decision_id,reviewed.evidence_bundle_id,
+                factual.revision AS factual_revision
+           FROM outcome_private_reviewed_evaluation_head reviewed
+           JOIN outcome_current_private_factual_authority factual
+             ON factual.valuation_scope_key=reviewed.valuation_scope_key
+          WHERE reviewed.valuation_scope_key=$1`,
+        [request.scopeKey]
+      )
+    ).resolves.toMatchObject({
+      rows: [
+        {
+          decision_id: reviewedDecision.decisionId,
+          evidence_bundle_id: reviewedDecision.content.evidenceBundleId,
+          factual_revision: 1,
+        },
+      ],
+    });
+    await expect(
+      governedPool.query(
+        `SELECT
+            (SELECT count(*)::integer FROM outcome_active_release) AS active_releases,
+            (SELECT count(*)::integer FROM outcome_registry_event) AS registry_events`
+      )
+    ).resolves.toEqual(publicAuthorityBefore);
+  }, 60_000);
+});

--- a/tests/outcomes-integration/afl-outcomes-postgres.test.ts
+++ b/tests/outcomes-integration/afl-outcomes-postgres.test.ts
@@ -1110,6 +1110,7 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       '0081_corrected_local_review_lineage',
       '0082_complete_local_reviewed_evidence',
       '0083_current_valuation_factual_refresh',
+      '0084_current_valuation_evidence_orchestration',
     ]);
 
     const factualRefreshReads = await query<{ permitted: boolean }>(
@@ -1204,6 +1205,8 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       'outcome_current_private_factual_authority',
       'outcome_current_valuation_factual_refresh_stage_receipt',
       'outcome_current_valuation_factual_refresh_operation',
+      'outcome_current_valuation_evidence_orchestration_operation',
+      'outcome_current_valuation_evidence_orchestration_stage_receipt',
       'outcome_hpn_field_map_candidate',
       'outcome_hpn_field_map_review_decision',
       'outcome_hpn_projected_field_map',
@@ -1288,6 +1291,8 @@ describe('isolated AFL outcomes PostgreSQL migration', () => {
       'outcome_private_factual_candidate_no_update_delete',
       'outcome_factual_refresh_stage_no_update_delete',
       'outcome_current_valuation_factual_refresh_no_update_delete',
+      'outcome_current_valuation_evidence_operation_no_mutation',
+      'outcome_current_valuation_evidence_stage_no_mutation',
     ]) {
       expect(triggerNames).toContain(expected);
     }

--- a/tests/unit/afl-trade-intelligence-current-valuation-evidence-orchestration.test.ts
+++ b/tests/unit/afl-trade-intelligence-current-valuation-evidence-orchestration.test.ts
@@ -1,0 +1,565 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AflOutcomeSqlClient } from '@/server/aflTradeIntelligence/outcomes/postgresOutcomeReleaseRepository';
+import { createLocalAflTradeCurrentValuationReconciliationAuthority } from '@/server/aflTradeIntelligence/development/localCurrentValuationReconciliationAuthority';
+import { createLocalAflTradeFiveSeasonAflTablesAuthority } from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesAuthority';
+import { LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256 } from '@/server/aflTradeIntelligence/development/localFiveSeasonAflTablesReview';
+import { LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256 } from '@/server/aflTradeIntelligence/development/localOfficialAfl2026Review';
+import { createAflTradeFitzRoyFieldMapSha256 } from '@/server/aflTradeIntelligence/source/fitzRoyObservationContracts';
+import { AflTradeFitzRoyCaptureError } from '@/server/aflTradeIntelligence/source/fitzRoyCaptureRuntime';
+import { AflTradeFitzRoyStagingError } from '@/server/aflTradeIntelligence/source/fitzRoyCaptureToStaging';
+import {
+  AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES,
+  aflTradeCurrentValuationEvidenceOrchestrationResultSchema,
+  createAflTradeCurrentValuationEvidenceFactualHandoffKey,
+  createAflTradeCurrentValuationEvidenceCoordinator,
+} from '@/server/aflTradeIntelligence/valuation/currentValuationEvidenceOrchestration';
+import { createPostgresAflTradeCurrentValuationEvidenceSourceRuntime } from '@/server/aflTradeIntelligence/valuation/postgresCurrentValuationEvidenceOrchestration';
+
+const expected = {
+  schemaVersion: 'afl-current-valuation-evidence-orchestration-result-v1' as const,
+  operationId: `current-valuation-evidence-orchestration-operation:${'a'.repeat(64)}`,
+  scopeKey: 'afl-men:2026-trades',
+  trigger: 'weekly' as const,
+  stableOperationKey: 'refresh-awaiting-review',
+  state: 'unavailable' as const,
+  stage: 'reviewed_authority' as const,
+  cause: 'review_required' as const,
+  capturedAt: '2026-08-29T12:00:00.000Z',
+  completedAt: '2026-08-29T12:00:00.000Z',
+  executionLocation: 'local' as const,
+  visibility: 'private' as const,
+  environment: 'non_production' as const,
+  publicationEligible: false as const,
+  publicationProhibited: true as const,
+  limitation:
+    'Private local non-production evidence orchestration only; human review, public release, production activation, and publication authority are not granted.' as const,
+};
+
+describe('current valuation evidence orchestration', () => {
+  it('authenticates exact retained unavailable outcomes without publication authority', () => {
+    const unavailable = {
+      ...expected,
+      operationId: `current-valuation-evidence-orchestration-operation:${'b'.repeat(64)}`,
+      stableOperationKey: 'refresh-capture-authority-missing',
+      stage: 'capture_authority' as const,
+      cause: 'missing' as const,
+    };
+
+    expect(aflTradeCurrentValuationEvidenceOrchestrationResultSchema.parse(unavailable)).toEqual(
+      unavailable
+    );
+  });
+
+  it('retains reviewed-authority failures that do not request a new human decision', () => {
+    const stale = {
+      ...expected,
+      operationId: `current-valuation-evidence-orchestration-operation:${'9'.repeat(64)}`,
+      stableOperationKey: 'refresh-reviewed-authority-stale',
+      cause: 'stale' as const,
+    };
+
+    expect(aflTradeCurrentValuationEvidenceOrchestrationResultSchema.parse(stale)).toEqual(stale);
+  });
+
+  it('authenticates a completed private factual handoff without granting publication', () => {
+    const completed = {
+      ...expected,
+      operationId: `current-valuation-evidence-orchestration-operation:${'c'.repeat(64)}`,
+      stableOperationKey: 'refresh-private-factual-complete',
+      state: 'complete' as const,
+      stage: 'private_factual_authority' as const,
+      cause: undefined,
+      currentValuationRefresh: {
+        schemaVersion: 'afl-current-valuation-refresh-result-v2' as const,
+        operationId: `current-valuation-factual-refresh-operation:${'d'.repeat(64)}`,
+        scopeKey: expected.scopeKey,
+        trigger: expected.trigger,
+        stableOperationKey: createAflTradeCurrentValuationEvidenceFactualHandoffKey({
+          scopeKey: expected.scopeKey,
+          trigger: expected.trigger,
+          stableOperationKey: 'refresh-private-factual-complete',
+        }),
+        state: 'factual_refresh_complete' as const,
+        factualStage: 'advanced' as const,
+        privateFactualAuthority: {
+          valuationScopeKey: expected.scopeKey,
+          candidateId: `private-factual-candidate:${'e'.repeat(64)}`,
+          evidenceScopeKey: 'afl-player-match-reviewed-2021-2026',
+          evidenceBundleId: `private-reviewed-evidence-bundle:${'f'.repeat(64)}`,
+          reviewDecisionId: `private-reviewed-evidence-evaluation-decision:${'1'.repeat(64)}`,
+          normalizedReconciledCustodySha256: '2'.repeat(64),
+          revision: 1,
+        },
+        capturedAt: expected.capturedAt,
+        completedAt: expected.completedAt,
+        executionLocation: 'local' as const,
+        visibility: 'private' as const,
+        environment: 'non_production' as const,
+        publicationEligible: false as const,
+        publicationProhibited: true as const,
+        limitation:
+          'Private local non-production factual refresh authority only; no public release, registry, production, activation, or publication authority is granted.' as const,
+      },
+    };
+
+    expect(aflTradeCurrentValuationEvidenceOrchestrationResultSchema.parse(completed)).toEqual(
+      completed
+    );
+  });
+
+  it('resumes retained normalized sources and stops before a human review decision', async () => {
+    let terminalResult: typeof expected | null = null;
+    const retainedSourceKeys = [AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES[0]!.sourceKey];
+    const loadOperation = vi.fn(async () => ({ terminalResult, retainedSourceKeys }));
+    const retainNormalizedSource = vi.fn(async ({ sourceKey }: { sourceKey: string }) => {
+      retainedSourceKeys.push(sourceKey);
+    });
+    const retainUnavailable = vi.fn(async () => {
+      terminalResult = expected;
+      return expected;
+    });
+    const ensureCurrent = vi.fn(async (source: { sourceKey: string }) => ({
+      state: 'ready' as const,
+      sourceKey: source.sourceKey,
+      captureId: `source-capture:${source.sourceKey}`,
+      normalizationRunId: `provider-normalization-run:${source.sourceKey}`,
+    }));
+    const assessCurrent = vi.fn(async () => ({
+      state: 'unavailable' as const,
+      stage: 'reviewed_authority' as const,
+      cause: 'review_required' as const,
+    }));
+    const refreshCurrent = vi.fn(async () => {
+      throw new Error('Factual refresh must not run before human review.');
+    });
+    const coordinator = createAflTradeCurrentValuationEvidenceCoordinator({
+      repository: {
+        loadOperation,
+        retainNormalizedSource,
+        retainUnavailable,
+        retainComplete: vi.fn(),
+      },
+      source: { ensureCurrent },
+      reconciliationAuthority: { assessCurrent: async () => ({ state: 'ready' }) },
+      reviewedAuthority: { assessCurrent },
+      factualRefresh: { refreshCurrent },
+    });
+    const request = {
+      scopeKey: expected.scopeKey,
+      trigger: expected.trigger,
+      stableOperationKey: expected.stableOperationKey,
+    };
+
+    await expect(coordinator.refreshCurrent(request)).resolves.toEqual(expected);
+    await expect(coordinator.refreshCurrent(request)).resolves.toEqual(expected);
+
+    expect(ensureCurrent.mock.calls.map(([source]) => source.sourceKey)).toEqual(
+      AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES.slice(1).map(({ sourceKey }) => sourceKey)
+    );
+    expect(retainNormalizedSource).toHaveBeenCalledTimes(6);
+    expect(assessCurrent).toHaveBeenCalledOnce();
+    expect(retainUnavailable).toHaveBeenCalledWith(request, {
+      stage: 'reviewed_authority',
+      cause: 'review_required',
+    });
+    expect(refreshCurrent).not.toHaveBeenCalled();
+  });
+
+  it('stops at the retained reconciliation boundary before assessing the reviewed head', async () => {
+    const reconciliationUnavailable = {
+      ...expected,
+      operationId: `current-valuation-evidence-orchestration-operation:${'8'.repeat(64)}`,
+      stableOperationKey: 'refresh-awaiting-reconciliation-review',
+      stage: 'reconciliation_authority' as const,
+      cause: 'missing' as const,
+    };
+    const retainUnavailable = vi.fn(async () => reconciliationUnavailable);
+    const reviewedAssessment = vi.fn();
+    const coordinator = createAflTradeCurrentValuationEvidenceCoordinator({
+      repository: {
+        loadOperation: async () => ({
+          terminalResult: null,
+          retainedSourceKeys: AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES.map(
+            ({ sourceKey }) => sourceKey
+          ),
+        }),
+        retainNormalizedSource: vi.fn(),
+        retainUnavailable,
+        retainComplete: vi.fn(),
+      },
+      source: { ensureCurrent: vi.fn() },
+      reconciliationAuthority: {
+        assessCurrent: async () => ({
+          state: 'unavailable',
+          stage: 'reconciliation_authority',
+          cause: 'missing',
+        }),
+      },
+      reviewedAuthority: { assessCurrent: reviewedAssessment },
+      factualRefresh: { refreshCurrent: vi.fn() },
+    });
+    const request = {
+      scopeKey: expected.scopeKey,
+      trigger: expected.trigger,
+      stableOperationKey: reconciliationUnavailable.stableOperationKey,
+    };
+
+    await expect(coordinator.refreshCurrent(request)).resolves.toEqual(reconciliationUnavailable);
+    expect(retainUnavailable).toHaveBeenCalledWith(request, {
+      stage: 'reconciliation_authority',
+      cause: 'missing',
+    });
+    expect(reviewedAssessment).not.toHaveBeenCalled();
+  });
+
+  it('retains a reviewed-authority cause when the factual handoff loses its source fence', async () => {
+    const retainUnavailable = vi.fn(async () => ({
+      ...expected,
+      operationId: `current-valuation-evidence-orchestration-operation:${'6'.repeat(64)}`,
+      stage: 'reviewed_authority' as const,
+      cause: 'stale' as const,
+    }));
+    const factualUnavailable = {
+      schemaVersion: 'afl-current-valuation-refresh-result-v2' as const,
+      operationId: `current-valuation-factual-refresh-operation:${'7'.repeat(64)}`,
+      scopeKey: expected.scopeKey,
+      trigger: expected.trigger,
+      stableOperationKey: createAflTradeCurrentValuationEvidenceFactualHandoffKey({
+        scopeKey: expected.scopeKey,
+        trigger: expected.trigger,
+        stableOperationKey: expected.stableOperationKey,
+      }),
+      state: 'unavailable' as const,
+      cause: 'source_authority_stale' as const,
+      capturedAt: expected.capturedAt,
+      completedAt: expected.completedAt,
+      executionLocation: 'local' as const,
+      visibility: 'private' as const,
+      environment: 'non_production' as const,
+      publicationEligible: false as const,
+      publicationProhibited: true as const,
+      limitation:
+        'Private local non-production factual refresh authority only; no public release, registry, production, activation, or publication authority is granted.' as const,
+    };
+    const coordinator = createAflTradeCurrentValuationEvidenceCoordinator({
+      repository: {
+        loadOperation: async () => ({
+          terminalResult: null,
+          retainedSourceKeys: AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES.map(
+            ({ sourceKey }) => sourceKey
+          ),
+        }),
+        retainNormalizedSource: vi.fn(),
+        retainUnavailable,
+        retainComplete: vi.fn(),
+      },
+      source: { ensureCurrent: vi.fn() },
+      reconciliationAuthority: { assessCurrent: async () => ({ state: 'ready' }) },
+      reviewedAuthority: { assessCurrent: async () => ({ state: 'ready' }) },
+      factualRefresh: { refreshCurrent: async () => factualUnavailable },
+    });
+
+    await coordinator.refreshCurrent({
+      scopeKey: expected.scopeKey,
+      trigger: expected.trigger,
+      stableOperationKey: expected.stableOperationKey,
+    });
+
+    expect(retainUnavailable).toHaveBeenCalledWith(
+      {
+        scopeKey: expected.scopeKey,
+        trigger: expected.trigger,
+        stableOperationKey: expected.stableOperationKey,
+      },
+      { stage: 'reviewed_authority', cause: 'stale' }
+    );
+  });
+
+  it('reuses an exact finalized normalization only after durable Gate and field-map review', async () => {
+    const source = AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES[0]!;
+    const authority = createLocalAflTradeFiveSeasonAflTablesAuthority(source.seasonYear);
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM outcome_provider_field_map')) {
+        return {
+          rows: [
+            {
+              map_json: authority.fieldMap,
+              field_map_sha256: createAflTradeFitzRoyFieldMapSha256(authority.fieldMap),
+              approval_decision_id: authority.fieldMap.approvalDecisionId,
+              subject_type: 'provider_field_map',
+              subject_id: authority.fieldMap.mapId,
+              decision: 'approved',
+              evidence_json: {
+                fieldMapSha256: createAflTradeFitzRoyFieldMapSha256(authority.fieldMap),
+              },
+              current: true,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes('FROM outcome_source_capture')) {
+        return {
+          rows: [
+            {
+              capture_id: `source-capture:${'3'.repeat(64)}`,
+              source_snapshot_id: `source-snapshot:${'4'.repeat(64)}`,
+              manifest_json: {},
+              normalization_run_id: `provider-normalization-run:${'5'.repeat(64)}`,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    const captureAndNormalize = vi.fn();
+    const resumeNormalization = vi.fn();
+    const runtime = createPostgresAflTradeCurrentValuationEvidenceSourceRuntime({
+      client: { query } as AflOutcomeSqlClient,
+      gateRepository: {
+        resolveAuthorization: vi.fn(async () => ({
+          revision: 1,
+          ledger: authority.capture.ledger,
+          sourceRights: authority.capture.sourceRights,
+        })),
+      },
+      clock: { now: () => '2026-08-29T12:00:00.000Z' },
+      captureAndNormalize,
+      resumeNormalization,
+    });
+
+    await expect(runtime.ensureCurrent(source)).resolves.toEqual({
+      state: 'ready',
+      sourceKey: source.sourceKey,
+      captureId: `source-capture:${'3'.repeat(64)}`,
+      normalizationRunId: `provider-normalization-run:${'5'.repeat(64)}`,
+    });
+    expect(captureAndNormalize).not.toHaveBeenCalled();
+    expect(resumeNormalization).not.toHaveBeenCalled();
+  });
+
+  it('does not capture or synthesize a missing reviewed field-map decision', async () => {
+    const source = AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES[0]!;
+    const authority = createLocalAflTradeFiveSeasonAflTablesAuthority(source.seasonYear);
+    const captureAndNormalize = vi.fn();
+    const runtime = createPostgresAflTradeCurrentValuationEvidenceSourceRuntime({
+      client: {
+        query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+      } as unknown as AflOutcomeSqlClient,
+      gateRepository: {
+        resolveAuthorization: vi.fn(async () => ({
+          revision: 1,
+          ledger: authority.capture.ledger,
+          sourceRights: authority.capture.sourceRights,
+        })),
+      },
+      clock: { now: () => '2026-08-29T12:00:00.000Z' },
+      captureAndNormalize,
+      resumeNormalization: vi.fn(),
+    });
+
+    await expect(runtime.ensureCurrent(source)).resolves.toEqual({
+      state: 'unavailable',
+      stage: 'normalization_authority',
+      cause: 'missing',
+    });
+    expect(captureAndNormalize).not.toHaveBeenCalled();
+  });
+
+  it('classifies a superseded reviewed field map as stale authority', async () => {
+    const source = AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES[0]!;
+    const authority = createLocalAflTradeFiveSeasonAflTablesAuthority(source.seasonYear);
+    const fieldMapSha256 = createAflTradeFitzRoyFieldMapSha256(authority.fieldMap);
+    const captureAndNormalize = vi.fn();
+    const runtime = createPostgresAflTradeCurrentValuationEvidenceSourceRuntime({
+      client: {
+        query: vi.fn(async () => ({
+          rows: [
+            {
+              map_json: authority.fieldMap,
+              field_map_sha256: fieldMapSha256,
+              approval_decision_id: authority.fieldMap.approvalDecisionId,
+              subject_type: 'provider_field_map',
+              subject_id: authority.fieldMap.mapId,
+              decision: 'approved',
+              evidence_json: { fieldMapSha256 },
+              current: false,
+            },
+          ],
+          rowCount: 1,
+        })),
+      } as unknown as AflOutcomeSqlClient,
+      gateRepository: {
+        resolveAuthorization: vi.fn(async () => ({
+          revision: 1,
+          ledger: authority.capture.ledger,
+          sourceRights: authority.capture.sourceRights,
+        })),
+      },
+      clock: { now: () => '2026-08-29T12:00:00.000Z' },
+      captureAndNormalize,
+      resumeNormalization: vi.fn(),
+    });
+
+    await expect(runtime.ensureCurrent(source)).resolves.toEqual({
+      state: 'unavailable',
+      stage: 'normalization_authority',
+      cause: 'stale',
+    });
+    expect(captureAndNormalize).not.toHaveBeenCalled();
+  });
+
+  it('classifies malformed reconciliation review-set authority as unauthenticated', async () => {
+    const loadReviewedBundle = vi.fn();
+    const rows = [
+      {
+        decision_id: `local-afl-tables-review:set:${LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256}`,
+        subject_type: 'local_review_set',
+        subject_id: LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256,
+        decision: 'approved',
+        canonical_record_type: 'local_review_set',
+        canonical_record_id: LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256,
+        supersedes_decision_id: null,
+        evidence_json: {
+          evidenceSetSha256: LOCAL_FIVE_SEASON_AFL_TABLES_EVIDENCE_SET_SHA256,
+        },
+        decided_by: 'unexpected-reviewer',
+        current: true,
+      },
+      {
+        decision_id: `local-official-afl-review:set:${LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256}`,
+        subject_type: 'local_review_set',
+        subject_id: LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256,
+        decision: 'approved',
+        canonical_record_type: 'local_review_set',
+        canonical_record_id: LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256,
+        supersedes_decision_id: null,
+        evidence_json: {
+          evidenceSetSha256: LOCAL_OFFICIAL_AFL_2026_SAM_FLANDERS_EVIDENCE_SET_SHA256,
+        },
+        decided_by: 'local-workbook-evidence-reviewer',
+        current: true,
+      },
+    ];
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM outcome_review_decision')) return { rows, rowCount: rows.length };
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    const authority = createLocalAflTradeCurrentValuationReconciliationAuthority(
+      {
+        query,
+        transaction: async (callback) => callback({ query } as never),
+      } as unknown as AflOutcomeSqlClient,
+      { loadReviewedBundle }
+    );
+
+    await expect(authority.assessCurrent()).resolves.toEqual({
+      state: 'unavailable',
+      stage: 'reconciliation_authority',
+      cause: 'unauthenticated',
+    });
+    expect(loadReviewedBundle).not.toHaveBeenCalled();
+  });
+
+  it('retains provider schema drift as a capture mismatch instead of missing evidence', async () => {
+    const source = AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES[0]!;
+    const authority = createLocalAflTradeFiveSeasonAflTablesAuthority(source.seasonYear);
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM outcome_provider_field_map')) {
+        return {
+          rows: [
+            {
+              map_json: authority.fieldMap,
+              field_map_sha256: createAflTradeFitzRoyFieldMapSha256(authority.fieldMap),
+              approval_decision_id: authority.fieldMap.approvalDecisionId,
+              subject_type: 'provider_field_map',
+              subject_id: authority.fieldMap.mapId,
+              decision: 'approved',
+              evidence_json: {
+                fieldMapSha256: createAflTradeFitzRoyFieldMapSha256(authority.fieldMap),
+              },
+              current: true,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes('FROM outcome_source_capture')) return { rows: [], rowCount: 0 };
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    const runtime = createPostgresAflTradeCurrentValuationEvidenceSourceRuntime({
+      client: { query } as AflOutcomeSqlClient,
+      gateRepository: {
+        resolveAuthorization: vi.fn(async () => ({
+          revision: 1,
+          ledger: authority.capture.ledger,
+          sourceRights: authority.capture.sourceRights,
+        })),
+      },
+      clock: { now: () => '2026-08-29T12:00:00.000Z' },
+      captureAndNormalize: vi.fn(async () => {
+        throw new AflTradeFitzRoyCaptureError('SCHEMA_DRIFT', 'Fixture schema drift.');
+      }),
+      resumeNormalization: vi.fn(),
+    });
+
+    await expect(runtime.ensureCurrent(source)).resolves.toEqual({
+      state: 'unavailable',
+      stage: 'capture',
+      cause: 'mismatched',
+    });
+  });
+
+  it('retains failed receipt authority at the normalization-authority boundary', async () => {
+    const source = AFL_TRADE_CURRENT_VALUATION_EVIDENCE_SOURCES[0]!;
+    const authority = createLocalAflTradeFiveSeasonAflTablesAuthority(source.seasonYear);
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM outcome_provider_field_map')) {
+        const fieldMapSha256 = createAflTradeFitzRoyFieldMapSha256(authority.fieldMap);
+        return {
+          rows: [
+            {
+              map_json: authority.fieldMap,
+              field_map_sha256: fieldMapSha256,
+              approval_decision_id: authority.fieldMap.approvalDecisionId,
+              subject_type: 'provider_field_map',
+              subject_id: authority.fieldMap.mapId,
+              decision: 'approved',
+              evidence_json: { fieldMapSha256 },
+              current: true,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes('FROM outcome_source_capture')) return { rows: [], rowCount: 0 };
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+    const runtime = createPostgresAflTradeCurrentValuationEvidenceSourceRuntime({
+      client: { query } as AflOutcomeSqlClient,
+      gateRepository: {
+        resolveAuthorization: vi.fn(async () => ({
+          revision: 1,
+          ledger: authority.capture.ledger,
+          sourceRights: authority.capture.sourceRights,
+        })),
+      },
+      clock: { now: () => '2026-08-29T12:00:00.000Z' },
+      captureAndNormalize: vi.fn(async () => {
+        throw new AflTradeFitzRoyStagingError(
+          'AUTHORITY_INVALID',
+          'Retained egress receipt failed authentication.'
+        );
+      }),
+      resumeNormalization: vi.fn(),
+    });
+
+    await expect(runtime.ensureCurrent(source)).resolves.toEqual({
+      state: 'unavailable',
+      stage: 'normalization_authority',
+      cause: 'unauthenticated',
+    });
+  });
+});

--- a/tests/unit/afl-trade-intelligence-local-egress-signing-authority.test.ts
+++ b/tests/unit/afl-trade-intelligence-local-egress-signing-authority.test.ts
@@ -1,0 +1,101 @@
+import { Buffer } from 'node:buffer';
+import { sign } from 'node:crypto';
+import { chmod, mkdir, mkdtemp, rm, stat, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { canonicalizeAflTradeJson } from '@/server/aflTradeIntelligence/artifacts/contentAddress';
+import { createLocalAflTradeEgressSigningAuthority } from '@/server/aflTradeIntelligence/development/localEgressSigningAuthority';
+import {
+  AFL_TRADE_FITZROY_EGRESS_EXECUTION_SCHEMA_VERSION,
+  createAflTradeFitzRoyEgressExecutionReceipt,
+} from '@/server/aflTradeIntelligence/source/fitzRoyEgressExecutionReceipt';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('local current-valuation egress signing authority', () => {
+  it('reopens the same private key so a restarted verifier authenticates retained receipts', async () => {
+    const artifactRoot = await mkdtemp(join(tmpdir(), 'statly-local-egress-signing-'));
+    roots.push(artifactRoot);
+    const first = createLocalAflTradeEgressSigningAuthority({ artifactRoot });
+    const content = {
+      schemaVersion: AFL_TRADE_FITZROY_EGRESS_EXECUTION_SCHEMA_VERSION,
+      executionBoundary: 'local_non_production_docker' as const,
+      enforcementScope: 'capture_admission_only' as const,
+      provider: 'afl_tables' as const,
+      capabilityId: 'afl-tables-player-stats',
+      directFunction: 'fetch_player_stats_afltables',
+      fitzRoyVersion: '1.7.0' as const,
+      invocationSha256: '1'.repeat(64),
+      sourceOutput: { contentSha256: '2'.repeat(64), byteLength: 1 },
+      diagnosticsOutput: { contentSha256: '3'.repeat(64), byteLength: 1 },
+      runtime: {
+        rVersion: '4.5.1' as const,
+        dependencyLockSha256: '4'.repeat(64),
+        imageDigest: `sha256:${'5'.repeat(64)}` as const,
+      },
+      enforcedPolicy: {
+        upstreamRate: { requests: 1, perSeconds: 30, burst: 1 },
+        cacheSeconds: 86_400,
+        egressPolicyEvidenceId: `artifact:${'6'.repeat(64)}`,
+      },
+      startedAt: '2026-08-29T12:00:00.000Z',
+      completedAt: '2026-08-29T12:00:01.000Z',
+      status: 'succeeded' as const,
+    };
+    const signature = sign(
+      null,
+      Buffer.from(canonicalizeAflTradeJson(content), 'utf8'),
+      first.signingKey.privateKey
+    ).toString('base64url');
+    const receipt = createAflTradeFitzRoyEgressExecutionReceipt({
+      content,
+      signature: {
+        algorithm: 'Ed25519',
+        keyId: first.signingKey.keyId,
+        valueBase64Url: signature,
+      },
+    });
+
+    const restarted = createLocalAflTradeEgressSigningAuthority({ artifactRoot });
+
+    await expect(restarted.verifier.verify(receipt)).resolves.toBe(true);
+    expect(restarted.signingKey.keyId).toBe(first.signingKey.keyId);
+    const keyPath = join(artifactRoot, 'current-valuation-evidence', 'egress-signing-key.pem');
+    expect((await stat(keyPath)).mode & 0o777).toBe(0o600);
+  });
+
+  it('rejects relative roots and insecure retained key custody before reading it', async () => {
+    expect(() =>
+      createLocalAflTradeEgressSigningAuthority({ artifactRoot: 'relative-artifact-root' })
+    ).toThrow('absolute');
+
+    const widenedRoot = await mkdtemp(join(tmpdir(), 'statly-local-egress-widened-'));
+    roots.push(widenedRoot);
+    createLocalAflTradeEgressSigningAuthority({ artifactRoot: widenedRoot });
+    const widenedKeyPath = join(
+      widenedRoot,
+      'current-valuation-evidence',
+      'egress-signing-key.pem'
+    );
+    await chmod(widenedKeyPath, 0o644);
+    expect(() => createLocalAflTradeEgressSigningAuthority({ artifactRoot: widenedRoot })).toThrow(
+      'mode 0600'
+    );
+
+    const symlinkRoot = await mkdtemp(join(tmpdir(), 'statly-local-egress-symlink-'));
+    roots.push(symlinkRoot);
+    const symlinkDirectory = join(symlinkRoot, 'current-valuation-evidence');
+    await mkdir(symlinkDirectory, { mode: 0o700 });
+    await symlink(widenedKeyPath, join(symlinkDirectory, 'egress-signing-key.pem'));
+    expect(() => createLocalAflTradeEgressSigningAuthority({ artifactRoot: symlinkRoot })).toThrow(
+      'regular file'
+    );
+  });
+});

--- a/tests/unit/afl-trade-intelligence-private-valuation-scheduling.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-scheduling.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  createAflTradePrivateValuationDispatchEvidenceKey,
   createAflTradePrivateValuationDispatchRequestId,
   latestDueAflTradePrivateValuationOccurrence,
   planAflTradePrivateValuationStartupCatchUp,
@@ -43,6 +44,37 @@ describe('private valuation scheduling', () => {
     );
     expect(createAflTradePrivateValuationDispatchRequestId(request)).toMatch(
       /^private-valuation-dispatch:[a-f0-9]{64}$/
+    );
+  });
+
+  it('uses the exact persisted dispatch identity as the evidence operation key', () => {
+    const firstIdentity = {
+      scopeKey: 'afl-men:2026-trades',
+      trigger: 'weekly' as const,
+      scheduledFor: '2026-07-06T09:00:00.000Z',
+      authorityKey: 'scheduled',
+    };
+    const nextWeekIdentity = {
+      ...firstIdentity,
+      scheduledFor: '2026-07-13T09:00:00.000Z',
+    };
+    const anotherScopeIdentity = {
+      ...firstIdentity,
+      scopeKey: 'afl-men:2026-contenders',
+    };
+    const request = (identity: typeof firstIdentity) => {
+      const requestId = createAflTradePrivateValuationDispatchRequestId(identity);
+      return { requestId, ...identity };
+    };
+
+    const first = request(firstIdentity);
+    const nextWeek = request(nextWeekIdentity);
+    const anotherScope = request(anotherScopeIdentity);
+
+    expect(createAflTradePrivateValuationDispatchEvidenceKey(first)).toBe(first.requestId);
+    expect(createAflTradePrivateValuationDispatchEvidenceKey(nextWeek)).not.toBe(first.requestId);
+    expect(createAflTradePrivateValuationDispatchEvidenceKey(anotherScope)).not.toBe(
+      first.requestId
     );
   });
 });

--- a/tests/unit/afl-trade-intelligence-private-valuation-worker.test.ts
+++ b/tests/unit/afl-trade-intelligence-private-valuation-worker.test.ts
@@ -26,14 +26,13 @@ describe('local private valuation worker', () => {
 
     const running = runLocalAflPrivateValuationWorker({
       env: {
-        AFL_OUTCOMES_DATABASE_URL:
-          'postgresql://local:local@127.0.0.1:55432/statly_outcomes_test',
+        AFL_OUTCOMES_DATABASE_URL: 'postgresql://local:local@127.0.0.1:55432/statly_outcomes_test',
         STATLY_LOCAL_OUTCOMES_RUNTIME_NONCE: 'a'.repeat(64),
         AFL_TRADE_LOCAL_ARTIFACT_ROOT: '/tmp/statly-worker-test-artifacts',
       },
       signal: controller.signal,
       now: () => '2026-07-22T03:00:00.000Z',
-      createPool: () => ({ end } as unknown as Pool),
+      createPool: () => ({ end }) as unknown as Pool,
       authenticateRuntime: vi.fn(async () => undefined),
       createRuntime: () => runtime,
     });
@@ -80,7 +79,7 @@ describe('local private valuation worker', () => {
         now: () => '2026-07-22T03:00:00.000Z',
         pollMilliseconds: 1,
         writeOutput: (line) => output.push(line),
-        createPool: () => ({ end } as unknown as Pool),
+        createPool: () => ({ end }) as unknown as Pool,
         authenticateRuntime: vi.fn(async () => undefined),
         createRuntime: () => runtime,
       })
@@ -90,6 +89,47 @@ describe('local private valuation worker', () => {
       JSON.stringify({ state: 'catch_up_failed', message: 'read ECONNRESET' }),
     ]);
     expect(enqueueStartupCatchUp).toHaveBeenCalledTimes(3);
+    expect(end).toHaveBeenCalledOnce();
+  });
+
+  it('reports a terminal unavailable dispatch once and does not retry it in the same drain', async () => {
+    const controller = new AbortController();
+    const output: string[] = [];
+    const terminal = {
+      state: 'completed' as const,
+      requestId: 'private-valuation-request:review-required',
+      result: { state: 'exhausted' as const },
+    };
+    const dispatchOne = vi
+      .fn()
+      .mockResolvedValueOnce(terminal)
+      .mockImplementationOnce(async () => {
+        controller.abort();
+        return { state: 'idle' as const };
+      });
+    const end = vi.fn(async () => undefined);
+
+    await runLocalAflPrivateValuationWorker({
+      env: {
+        AFL_OUTCOMES_DATABASE_URL: 'postgresql://local:local@127.0.0.1:55432/statly_outcomes_test',
+        STATLY_LOCAL_OUTCOMES_RUNTIME_NONCE: 'a'.repeat(64),
+        AFL_TRADE_LOCAL_ARTIFACT_ROOT: '/tmp/statly-worker-test-artifacts',
+      },
+      signal: controller.signal,
+      writeOutput: (line) => output.push(line),
+      createPool: () => ({ end }) as unknown as Pool,
+      authenticateRuntime: vi.fn(async () => undefined),
+      createRuntime: () => ({
+        enqueueStartupCatchUp: vi.fn(async () => []),
+        enqueueAdHoc: vi.fn(),
+        repairCurrent: vi.fn(),
+        dispatchOne,
+        dispatchRequest: vi.fn(),
+      }),
+    });
+
+    expect(output).toEqual([JSON.stringify(terminal)]);
+    expect(dispatchOne).toHaveBeenCalledTimes(2);
     expect(end).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- orchestrate the seven admitted fitzRoy provider/season lanes from governed capture through normalization and reconciliation
- persist replay-safe stage receipts and terminal outcomes, then hand reviewed evidence to the existing private factual refresh/CAS boundary
- add the local Ed25519 receipt-signing authority, additive PostgreSQL authority, operational documentation, and focused regression coverage
- scope each launcher evidence operation to its persisted content-addressed dispatch identity so exact retries replay while later weeks and other scopes remain independent

## Verification

- `npm run docs:check`
- `npm run lint:ci`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run typecheck`
- `npm run test:unit` — 603 files, 3799 tests
- focused post-review operation-key regression — 3 files, 21 tests
- fitzRoy and orchestration focused unit tests — 35 tests
- `npm run test:outcomes:int` — 32 files, 156 tests
- focused PostgreSQL orchestration integration — 7 tests
- disposable-SQLite general integration — 3 tests
- `npm run test:e2e` — 26 tests
- `npm run build` with the CI build-time Firebase placeholders
- final GitHub CI Gate — all repository jobs passed on `83593dc7`
- Prisma validation and diff checks

## Review

Independent specification and engineering-standards reviews completed with no remaining findings. The GitHub P1 review finding about weekly dispatch key reuse was fixed in `83593dc7`, regression-tested, replied to, and resolved.

## Safety and rollout

- migration 0084 is additive and preserves the existing reviewed-evidence and factual-authority ownership boundaries
- public release and registry authority remain unchanged
- the local signer is explicitly non-production and stores its private key under the configured artifact root with strict ownership and mode checks
- no deployment or shared-data mutation is included

## Test-boundary caveat

The bounded PostgreSQL scenario first proves that the unchanged production exact-set guard rejects the intentionally incomplete fixture bundle without bundle, decision, or head writes. It then uses an explicitly fixture-only guard bypass to exercise the real reviewed-decision transaction, head persistence, and factual refresh/CAS path without seeding all 146,343 production decisions. This verifies the orchestration and handoff boundary, but does not independently prove acceptance of the complete production decision set.

Closes #569